### PR TITLE
fix: escape commit message in Feishu CI notification via env vars + jq

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,24 +132,40 @@ jobs:
       - name: Send Feishu notification
         env:
           FEISHU_WEBHOOK_URL: ${{ secrets.FEISHU_WEBHOOK_URL }}
+          CI_STATUS: ${{ steps.status.outputs.result }}
+          CI_EMOJI: ${{ steps.status.outputs.emoji }}
+          CI_COMMIT: ${{ github.sha }}
+          CI_BRANCH: ${{ github.ref_name }}
+          CI_ACTOR: ${{ github.actor }}
+          CI_REPO: ${{ github.repository }}
+          CI_RUN_ID: ${{ github.run_id }}
+          CI_COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
-          STATUS="${{ steps.status.outputs.result }}"
-          EMOJI="${{ steps.status.outputs.emoji }}"
-          COMMIT="${{ github.sha }}"
-          SHORT_COMMIT="${COMMIT:0:7}"
-          BRANCH="${{ github.ref_name }}"
-          ACTOR="${{ github.actor }}"
-          RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          COMMIT_MSG=$(echo '${{ github.event.head_commit.message }}' | head -1)
+          SHORT_COMMIT="${CI_COMMIT:0:7}"
+          RUN_URL="https://github.com/${CI_REPO}/actions/runs/${CI_RUN_ID}"
+          # Use first line of commit message only
+          FIRST_LINE=$(printf '%s' "$CI_COMMIT_MSG" | head -1)
+
+          # Build JSON safely with jq to handle any special characters in commit message
+          PAYLOAD=$(jq -n \
+            --arg emoji "$CI_EMOJI" \
+            --arg status "$CI_STATUS" \
+            --arg repo "$CI_REPO" \
+            --arg branch "$CI_BRANCH" \
+            --arg commit "$SHORT_COMMIT" \
+            --arg msg "$FIRST_LINE" \
+            --arg actor "$CI_ACTOR" \
+            --arg url "$RUN_URL" \
+            '{
+              msg_type: "text",
+              content: {
+                text: ("🚀 Naturo CI Notification\n" + $emoji + " Status: " + $status + "\n📦 Repo: " + $repo + "\n🌿 Branch: " + $branch + "\n📝 Commit: " + $commit + " — " + $msg + "\n👤 Triggered by: " + $actor + "\n🔗 Details: " + $url)
+              }
+            }')
 
           curl -s -X POST "$FEISHU_WEBHOOK_URL" \
             -H "Content-Type: application/json" \
-            -d "{
-              \"msg_type\": \"text\",
-              \"content\": {
-                \"text\": \"🚀 Naturo CI Notification\n${EMOJI} Status: ${STATUS}\n📦 Repo: ${{ github.repository }}\n🌿 Branch: ${BRANCH}\n📝 Commit: ${SHORT_COMMIT} — ${COMMIT_MSG}\n👤 Triggered by: ${ACTOR}\n🔗 Details: ${RUN_URL}\"
-              }
-            }"
+            -d "$PAYLOAD"
 
   release:
     name: Release


### PR DESCRIPTION
## Problem

The Feishu notification step interpolated `${{ github.event.head_commit.message }}` directly into the shell script. When a commit message contains bash metacharacters — parentheses, quotes, or keywords like `deny` — the shell failed to parse the script.

**Error from run 23280321726:**
```
/home/runner/work/_temp/08ed54de...sh: line 46: syntax error near unexpected token `deny'
```

## Fix

- Move all GitHub context values (`commit message`, `sha`, `branch`, etc.) into **environment variables** so the shell never sees them as code
- Use `jq -n --arg` to safely construct the JSON payload, properly escaping any special characters in the commit message

## Test plan

- Merge this PR → CI run will include a commit message with `deny` in it → Feishu notification step should succeed
- Any commit message content (quotes, parens, bash keywords) will be safe