### PR TITLE
feat(snapshot): Phase 1.5 — Snapshot System

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,35 @@ naturo find "Edit:filename"
 | Command | Description | Phase |
 |---------|-------------|-------|
 | `version` | Show version info | ✅ 0 |
-| `capture` | Screenshot screen/window | 🔜 1 |
-| `list` | List windows/processes | 🔜 1 |
-| `see` | Inspect UI element tree | 🔜 1 |
+| `capture` | Screenshot screen/window | ✅ 1 |
+| `list` | List windows/processes | ✅ 1 |
+| `see` | Inspect UI element tree | ✅ 1 |
+| `snapshot list` | List stored snapshots | ✅ 1.5 |
+| `snapshot clean` | Remove old snapshots | ✅ 1.5 |
 | `find` | Find UI element | 🔜 2 |
 | `click` | Click element/coordinates | 🔜 2 |
 | `type` | Type text | 🔜 2 |
 | `press` | Press key combination | 🔜 2 |
+
+## Snapshot System
+
+Every `see` and `capture live` call automatically persists a **snapshot** — a
+directory under `~/.naturo/snapshots/` containing the screenshot and full UI
+element map.
+
+```bash
+# List all snapshots
+naturo snapshot list
+
+# Remove snapshots older than 7 days
+naturo snapshot clean --days 7
+
+# Remove all snapshots
+naturo snapshot clean --all --yes
+```
+
+Snapshots expire after **10 minutes** when queried via `get_most_recent_snapshot`,
+mirroring Peekaboo's validity window.
 
 ## Architecture
 
@@ -67,6 +89,8 @@ naturo find "Edit:filename"
 │  AI Agent    │  Python SDK / MCP Server
 ├─────────────┤
 │  CLI (click) │  naturo CLI
+├─────────────┤
+│  Snapshot    │  naturo/snapshot.py + naturo/models/snapshot.py
 ├─────────────┤
 │  Python      │  ctypes bridge
 ├─────────────┤

--- a/TEST_PLAN.md
+++ b/TEST_PLAN.md
@@ -1,0 +1,200 @@
+# Naturo Test Plan
+
+## Test Execution
+
+```bash
+# All non-UI tests (runs on macOS/Linux/Windows without a display)
+pytest tests/ -m "not ui and not windows and not e2e"
+
+# Full Windows suite (requires Windows + naturo_core.dll)
+pytest tests/ --run-ui --run-windows
+
+# With coverage
+pytest tests/ --cov=naturo --cov-report=term-missing
+```
+
+---
+
+## Phase 0 — Foundation
+
+| ID | Description | File | Priority |
+|----|-------------|------|----------|
+| P0-01 | Version string matches `__version__` | `test_version.py` | P0 |
+| P0-02 | Python 3.9–3.13 compatibility | `test_python_compat.py` | P0 |
+| P0-03 | Version consistency across package | `test_version_consistency.py` | P0 |
+
+---
+
+## Phase 1 — See (Capture + List + See)
+
+| ID | Description | File | Priority |
+|----|-------------|------|----------|
+| P1-01 | `capture live` saves screenshot on Windows | `test_capture.py` | P1 |
+| P1-02 | `list windows` returns window list on Windows | `test_list_windows.py` | P1 |
+| P1-03 | `see` returns element tree on Windows | `test_element_tree.py` | P1 |
+| P1-04 | Backend selector picks correct platform backend | `test_backends.py` | P1 |
+| P1-05 | Selector engine parses CSS-like queries | `test_selector.py` | P1 |
+
+---
+
+## Phase 1.5 — Snapshot System
+
+Aligned with Peekaboo's `UIAutomationSnapshot` / `SnapshotManager` architecture.
+Storage: `~/.naturo/snapshots/<snapshot_id>/` (atomic JSON, thread-safe).
+
+### Data Model (`tests/test_snapshot.py`)
+
+| ID | Description | Class | Priority |
+|----|-------------|-------|----------|
+| P1.5-01 | `UIElement.to_dict()` / `from_dict()` round-trip preserves all fields | `TestJSONRoundTrip` | P1.5 |
+| P1.5-02 | Optional UIElement fields survive None round-trip | `TestJSONRoundTrip` | P1.5 |
+| P1.5-03 | `Snapshot.to_json()` / `from_json()` full round-trip | `TestJSONRoundTrip` | P1.5 |
+| P1.5-04 | Snapshot without optional fields serialises/restores cleanly | `TestJSONRoundTrip` | P1.5 |
+| P1.5-05 | Full persist → load via SnapshotManager (integration) | `TestJSONRoundTrip` | P1.5 |
+
+### SnapshotManager — create (`tests/test_snapshot.py`)
+
+| ID | Description | Class | Priority |
+|----|-------------|-------|----------|
+| P1.5-06 | `create_snapshot()` returns a non-empty string ID | `TestCreateSnapshot` | P1.5 |
+| P1.5-07 | Snapshot ID has `<ms>-<suffix>` format | `TestCreateSnapshot` | P1.5 |
+| P1.5-08 | Creates snapshot directory on disk | `TestCreateSnapshot` | P1.5 |
+| P1.5-09 | Creates valid skeleton `snapshot.json` | `TestCreateSnapshot` | P1.5 |
+| P1.5-10 | 10 consecutive calls produce unique IDs | `TestCreateSnapshot` | P1.5 |
+
+### SnapshotManager — store_screenshot (`tests/test_snapshot.py`)
+
+| ID | Description | Class | Priority |
+|----|-------------|-------|----------|
+| P1.5-11 | Copies screenshot file to `raw.png` | `TestStoreScreenshot` | P1.5 |
+| P1.5-12 | Updates `screenshot_path` in persisted JSON | `TestStoreScreenshot` | P1.5 |
+| P1.5-13 | Persists all metadata fields | `TestStoreScreenshot` | P1.5 |
+| P1.5-14 | Raises `SnapshotStorageError` for missing source file | `TestStoreScreenshot` | P1.5 |
+
+### SnapshotManager — store_detection_result (`tests/test_snapshot.py`)
+
+| ID | Description | Class | Priority |
+|----|-------------|-------|----------|
+| P1.5-15 | Persists ui_map to JSON | `TestStoreDetectionResult` | P1.5 |
+| P1.5-16 | All UIElement fields survive persist → load | `TestStoreDetectionResult` | P1.5 |
+| P1.5-17 | Second call replaces previous ui_map | `TestStoreDetectionResult` | P1.5 |
+
+### SnapshotManager — store_annotated (`tests/test_snapshot.py`)
+
+| ID | Description | Class | Priority |
+|----|-------------|-------|----------|
+| P1.5-18 | Copies annotated screenshot to `annotated.png` | `TestStoreAnnotated` | P1.5 |
+| P1.5-19 | Updates `annotated_path` in persisted JSON | `TestStoreAnnotated` | P1.5 |
+| P1.5-20 | Raises `SnapshotStorageError` for missing source | `TestStoreAnnotated` | P1.5 |
+
+### SnapshotManager — get_snapshot (`tests/test_snapshot.py`)
+
+| ID | Description | Class | Priority |
+|----|-------------|-------|----------|
+| P1.5-21 | Raises `SnapshotNotFoundError` for unknown ID | `TestGetSnapshot` | P1.5 |
+| P1.5-22 | Raises `SnapshotVersionError` on schema mismatch | `TestGetSnapshot` | P1.5 |
+| P1.5-23 | Loads full snapshot with correct fields | `TestGetSnapshot` | P1.5 |
+
+### SnapshotManager — get_most_recent_snapshot (`tests/test_snapshot.py`)
+
+| ID | Description | Class | Priority |
+|----|-------------|-------|----------|
+| P1.5-24 | Returns `None` when storage is empty | `TestGetMostRecentSnapshot` | P1.5 |
+| P1.5-25 | Returns ID of a fresh snapshot | `TestGetMostRecentSnapshot` | P1.5 |
+| P1.5-26 | Returns `None` for expired snapshot (validity=0s) | `TestGetMostRecentSnapshot` | P1.5 |
+| P1.5-27 | Returns the newest of two valid snapshots | `TestGetMostRecentSnapshot` | P1.5 |
+| P1.5-28 | Filters by `app_name` (exact substring) | `TestGetMostRecentSnapshot` | P1.5 |
+| P1.5-29 | `app_name` filter is case-insensitive | `TestGetMostRecentSnapshot` | P1.5 |
+
+### SnapshotManager — list_snapshots (`tests/test_snapshot.py`)
+
+| ID | Description | Class | Priority |
+|----|-------------|-------|----------|
+| P1.5-30 | Returns empty list when storage is empty | `TestListSnapshots` | P1.5 |
+| P1.5-31 | Returns all created snapshots | `TestListSnapshots` | P1.5 |
+| P1.5-32 | List sorted newest first | `TestListSnapshots` | P1.5 |
+| P1.5-33 | `screenshot_count` reflects actual PNG files | `TestListSnapshots` | P1.5 |
+| P1.5-34 | `application_name` populated from metadata | `TestListSnapshots` | P1.5 |
+| P1.5-35 | Returns `SnapshotInfo` instances | `TestListSnapshots` | P1.5 |
+
+### SnapshotManager — clean_snapshot (`tests/test_snapshot.py`)
+
+| ID | Description | Class | Priority |
+|----|-------------|-------|----------|
+| P1.5-36 | Removes snapshot directory | `TestCleanSnapshot` | P1.5 |
+| P1.5-37 | No error when snapshot does not exist | `TestCleanSnapshot` | P1.5 |
+| P1.5-38 | `get_snapshot` raises after clean | `TestCleanSnapshot` | P1.5 |
+
+### SnapshotManager — clean_older_than (`tests/test_snapshot.py`)
+
+| ID | Description | Class | Priority |
+|----|-------------|-------|----------|
+| P1.5-39 | Fresh snapshots are not deleted | `TestCleanOlderThan` | P1.5 |
+| P1.5-40 | Backdated snapshots are deleted | `TestCleanOlderThan` | P1.5 |
+| P1.5-41 | Returns count of deleted snapshots | `TestCleanOlderThan` | P1.5 |
+
+### SnapshotManager — clean_all (`tests/test_snapshot.py`)
+
+| ID | Description | Class | Priority |
+|----|-------------|-------|----------|
+| P1.5-42 | Removes all snapshots | `TestCleanAll` | P1.5 |
+| P1.5-43 | Returns count | `TestCleanAll` | P1.5 |
+| P1.5-44 | Safe on empty storage | `TestCleanAll` | P1.5 |
+
+### Thread Safety (`tests/test_snapshot.py`)
+
+| ID | Description | Class | Priority |
+|----|-------------|-------|----------|
+| P1.5-45 | 20 concurrent `create_snapshot()` produce unique IDs with no errors | `TestThreadSafety` | P1.5 |
+| P1.5-46 | Concurrent readers and writers do not corrupt snapshot data | `TestThreadSafety` | P1.5 |
+
+### Atomic Write (`tests/test_snapshot.py`)
+
+| ID | Description | Class | Priority |
+|----|-------------|-------|----------|
+| P1.5-47 | Skeleton JSON is fully readable immediately after `create_snapshot()` | `TestAtomicWrite` | P1.5 |
+
+### storage_path property (`tests/test_snapshot.py`)
+
+| ID | Description | Class | Priority |
+|----|-------------|-------|----------|
+| P1.5-48 | `storage_path` matches configured root | `TestStoragePath` | P1.5 |
+
+**Phase 1.5 total: 48 tests (all automated, platform-independent)**
+
+---
+
+## Phase 2 — Interact (Click + Type + Press)
+
+| ID | Description | File | Priority |
+|----|-------------|------|----------|
+| P2-01 | `click` dispatches correct coordinates | `test_cli_phase2.py` | P2 |
+| P2-02 | `type` sends text via SendInput | `test_input_keyboard.py` | P2 |
+| P2-03 | `press ctrl+s` sends correct VK codes | `test_input_keyboard.py` | P2 |
+| P2-04 | `scroll` sends wheel events | `test_input_mouse.py` | P2 |
+| P2-05 | `drag` sends correct mouse sequence | `test_input_mouse.py` | P2 |
+| P2-06 | Menu navigation works end-to-end | `test_menu_system.py` | P2 |
+| P2-07 | Clipboard read/write round-trip | `test_clipboard.py` | P2 |
+| P2-08 | `app launch/close` works | `test_app_control.py` | P2 |
+| P2-09 | Security validation rejects invalid input | `test_security.py` | P2 |
+
+---
+
+## Phase 3 — AI Agent + MCP
+
+| ID | Description | File | Priority |
+|----|-------------|------|----------|
+| P3-01 | `agent` command calls AI provider | TBD | P3 |
+| P3-02 | MCP server starts and accepts tool calls | TBD | P3 |
+| P3-03 | AI vision identifies UI elements from screenshot | TBD | P3 |
+| P3-04 | End-to-end: agent fills a form in Notepad | TBD | P3 |
+
+---
+
+## Notes
+
+- Tests marked `@pytest.mark.ui` require a live Windows desktop session.
+- Tests marked `@pytest.mark.windows` require Windows + `naturo_core.dll`.
+- Phase 1.5 snapshot tests run on **all platforms** (no Windows dependency).
+- CI matrix: `ubuntu-latest` + `macos-latest` run Python-only; `windows-latest`
+  runs the full stack.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -66,6 +66,7 @@ One unified API, multiple native backends.
 | **System** | app, window, menu, menubar, clipboard, dialog, dock, space, open | app, window, menu, clipboard, dialog, open, taskbar, tray, desktop | Platform equivalents |
 | **AI** | agent | agent | Same concept |
 | **MCP** | mcp | mcp | Same protocol |
+| **Snapshot** | (internal) | snapshot list / snapshot clean | Phase 1.5 |
 | **Extensions** | — | excel, java, sap, registry, service | Windows-only (for now) |
 | **Guides** | learn, tools | learn, tools | Full parity |
 
@@ -79,6 +80,87 @@ These parameters are available on Windows but not other platforms:
   - `hook`: MinHook injection (injects into target process, for apps that block external input)
 - `--hwnd` — Direct window handle targeting
 - `--process-name` — Target by process name
+
+---
+
+## Phase 1.5 — Snapshot System
+
+Naturo implements a persistent snapshot system aligned with Peekaboo's
+`UIAutomationSnapshot` / `SnapshotManager` architecture.
+
+### Purpose
+
+Every `see` or `capture live` call produces a **snapshot** — a directory on disk
+containing the raw screenshot, an optional annotated screenshot, and a
+`snapshot.json` file with the full UI element map.  Subsequent commands can
+reference elements by snapshot ID without re-scanning the UI tree.
+
+### Storage Layout
+
+```
+~/.naturo/snapshots/
+└── <snapshot_id>/          # e.g. 1742363045123-7321
+    ├── snapshot.json       # full Snapshot JSON (atomic write)
+    ├── raw.png             # raw screenshot (copied from capture output)
+    └── annotated.png       # annotated screenshot (optional)
+```
+
+**Snapshot ID format:** `<unix-milliseconds>-<4-digit-random>` — sortable
+chronologically, no UUID dependency, compatible with cross-process use.
+
+### Data Model
+
+```
+naturo/models/snapshot.py
+├── UIElement          — single accessibility element
+│     id, element_id, role, title, label, value, description,
+│     identifier, frame(x,y,w,h), is_actionable,
+│     parent_id, children, keyboard_shortcut
+├── Snapshot           — full snapshot (mirrors UIAutomationSnapshot)
+│     snapshot_id, version, screenshot_path, annotated_path,
+│     ui_map{id→UIElement}, last_update_time,
+│     application_name, application_pid,
+│     window_title, window_bounds(x,y,w,h), window_handle(HWND)
+├── SnapshotInfo       — lightweight list summary
+└── SnapshotError / SnapshotNotFoundError / SnapshotVersionError / SnapshotStorageError
+```
+
+### SnapshotManager API
+
+```
+naturo/snapshot.py — SnapshotManager
+├── create_snapshot() → str
+├── store_screenshot(id, path, metadata)
+├── store_detection_result(id, ui_elements)
+├── store_annotated(id, path)
+├── get_snapshot(id) → Snapshot
+├── get_most_recent_snapshot(app_name?) → str | None
+├── list_snapshots() → List[SnapshotInfo]
+├── clean_snapshot(id)
+├── clean_older_than(days) → int
+└── clean_all() → int
+```
+
+**Design guarantees:**
+
+| Property | Mechanism |
+|----------|-----------|
+| Atomic writes | `tempfile` → `os.replace()` |
+| Thread safety | `threading.Lock` wraps all mutations |
+| Validity window | 10 minutes (configurable), same as Peekaboo |
+| Version check | `SnapshotVersionError` on schema mismatch |
+
+### CLI Commands
+
+| Command | Description |
+|---------|-------------|
+| `naturo see` | Inspect UI tree → auto-stores snapshot, prints snapshot_id |
+| `naturo capture live` | Screenshot → auto-stores snapshot, prints snapshot_id |
+| `naturo snapshot list` | List all snapshots (id, time, app, size) |
+| `naturo snapshot clean --days N` | Delete snapshots older than N days |
+| `naturo snapshot clean --all` | Delete all snapshots |
+
+---
 
 ### C++ Core Architecture (Windows)
 

--- a/naturo/cli/__init__.py
+++ b/naturo/cli/__init__.py
@@ -11,6 +11,7 @@ from naturo.cli.system import (
 )
 from naturo.cli.ai import agent, mcp
 from naturo.cli.extensions import excel, java, sap, registry, service
+from naturo.cli.snapshot import snapshot
 
 
 @click.group()
@@ -76,3 +77,6 @@ main.add_command(java)
 main.add_command(sap)
 main.add_command(registry)
 main.add_command(service)
+
+# ── Snapshot ────────────────────────────────────
+main.add_command(snapshot)

--- a/naturo/cli/core.py
+++ b/naturo/cli/core.py
@@ -36,12 +36,14 @@ def capture():
 @click.option("--screen", "-s", type=int, default=0, help="Screen/monitor index")
 @click.option("--path", "-p", default="capture.bmp", help="Output file path")
 @click.option("--format", "fmt", type=click.Choice(["png", "jpg", "bmp"]), default="bmp", help="Image format")
+@click.option("--snapshot/--no-snapshot", "store_snapshot", default=True, help="Store result in snapshot (default: on)")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def live(app, window_title, hwnd, screen, path, fmt, json_output):
+def live(app, window_title, hwnd, screen, path, fmt, store_snapshot, json_output):
     """Capture a live screenshot.
 
     Captures the screen or a specific window and saves to a file.
     Use --hwnd to capture a specific window, or --screen to select a monitor.
+    The screenshot is automatically stored in a snapshot (use --no-snapshot to skip).
     """
     if platform.system() != "Windows":
         click.echo("Screen capture requires Windows (naturo_core.dll).")
@@ -54,15 +56,32 @@ def live(app, window_title, hwnd, screen, path, fmt, json_output):
         else:
             result = backend.capture_screen(screen_index=screen, output_path=path)
 
+        snapshot_id = None
+        if store_snapshot:
+            from naturo.snapshot import SnapshotManager
+            mgr = SnapshotManager()
+            snapshot_id = mgr.create_snapshot()
+            metadata = {
+                "window_handle": hwnd,
+                "application_name": app,
+                "window_title": window_title,
+            }
+            mgr.store_screenshot(snapshot_id, result.path, metadata)
+
         if json_output:
-            click.echo(json_module.dumps({
+            out = {
                 "path": result.path,
                 "width": result.width,
                 "height": result.height,
                 "format": result.format,
-            }))
+            }
+            if snapshot_id:
+                out["snapshot_id"] = snapshot_id
+            click.echo(json_module.dumps(out))
         else:
             click.echo(f"Saved: {result.path} ({result.width}x{result.height})")
+            if snapshot_id:
+                click.echo(f"Snapshot: {snapshot_id}")
     except Exception as e:
         click.echo(f"Error: {e}", err=True)
         raise SystemExit(1)
@@ -205,13 +224,15 @@ def permissions(json_output):
 @click.option("--depth", "-d", type=int, default=3, help="Maximum tree depth (1-10)")
 @click.option("--path", "-p", help="Save screenshot to path")
 @click.option("--annotate", is_flag=True, help="Annotate screenshot with element labels")
+@click.option("--snapshot/--no-snapshot", "store_snapshot", default=True, help="Store result in snapshot (default: on)")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def see(app, window_title, hwnd, pid, mode, depth, path, annotate, json_output):
+def see(app, window_title, hwnd, pid, mode, depth, path, annotate, store_snapshot, json_output):
     """Capture screenshot and analyze UI elements.
 
     Inspects the UI element tree of the foreground window (or a specific
     window identified by --hwnd). Shows the element hierarchy with roles,
-    names, and bounding rectangles.
+    names, and bounding rectangles.  Results are stored in a snapshot so
+    subsequent commands can reference elements by ID.
     """
     if platform.system() != "Windows":
         click.echo("UI inspection requires Windows (naturo_core.dll).")
@@ -224,6 +245,47 @@ def see(app, window_title, hwnd, pid, mode, depth, path, annotate, json_output):
         if tree is None:
             click.echo("No window found or UI tree is empty.")
             return
+
+        snapshot_id = None
+        if store_snapshot:
+            from naturo.snapshot import SnapshotManager
+            from naturo.models.snapshot import UIElement
+
+            mgr = SnapshotManager()
+            snapshot_id = mgr.create_snapshot()
+
+            # Flatten element tree into ui_map
+            ui_map = {}
+
+            def _flatten(el, parent_id=None):
+                child_ids = [c.id for c in el.children]
+                ui_map[el.id] = UIElement(
+                    id=el.id,
+                    element_id=f"element_{el.id}",
+                    role=el.role,
+                    title=el.name,
+                    label=el.name,
+                    value=el.value,
+                    frame=(el.x, el.y, el.width, el.height),
+                    is_actionable=getattr(el, "is_actionable", False),
+                    parent_id=parent_id,
+                    children=child_ids,
+                )
+                for child in el.children:
+                    _flatten(child, parent_id=el.id)
+
+            _flatten(tree)
+            mgr.store_detection_result(snapshot_id, ui_map)
+
+            # Optionally capture screenshot into snapshot
+            if path:
+                result = backend.capture_screen(output_path=path)
+                metadata = {
+                    "window_handle": hwnd,
+                    "application_name": app,
+                    "window_title": window_title,
+                }
+                mgr.store_screenshot(snapshot_id, result.path, metadata)
 
         if json_output:
             def to_dict(el):
@@ -239,7 +301,10 @@ def see(app, window_title, hwnd, pid, mode, depth, path, annotate, json_output):
                     "height": el.height,
                     "children": [to_dict(c) for c in el.children],
                 }
-            click.echo(json_module.dumps(to_dict(tree), indent=2))
+            out = to_dict(tree)
+            if snapshot_id:
+                out["snapshot_id"] = snapshot_id
+            click.echo(json_module.dumps(out, indent=2))
         else:
             def print_tree(el, indent=0):
                 """Print element tree in a readable indented format."""
@@ -251,9 +316,11 @@ def see(app, window_title, hwnd, pid, mode, depth, path, annotate, json_output):
                     print_tree(child, indent + 1)
 
             print_tree(tree)
+            if snapshot_id:
+                click.echo(f"\nSnapshot: {snapshot_id}")
 
-        # Optionally capture screenshot
-        if path:
+        # Capture screenshot (when not already done above)
+        if path and not store_snapshot:
             result = backend.capture_screen(output_path=path)
             click.echo(f"\nScreenshot saved: {result.path}")
 

--- a/naturo/cli/snapshot.py
+++ b/naturo/cli/snapshot.py
@@ -1,0 +1,119 @@
+"""CLI commands for snapshot management.
+
+Commands
+--------
+``naturo snapshot list``
+    List all stored snapshots with creation time, size, and app name.
+
+``naturo snapshot clean``
+    Remove snapshots by age or remove all.
+"""
+
+from __future__ import annotations
+
+import json as json_module
+
+import click
+
+from naturo.snapshot import SnapshotManager
+
+
+def _get_manager() -> SnapshotManager:
+    return SnapshotManager()
+
+
+@click.group()
+def snapshot() -> None:
+    """Manage UI automation snapshots."""
+    pass
+
+
+@snapshot.command("list")
+@click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
+def snapshot_list(json_output: bool) -> None:
+    """List all stored snapshots.
+
+    Shows snapshot ID, creation time, last update, size, screenshot count,
+    and the captured application name.
+    """
+    mgr = _get_manager()
+    infos = mgr.list_snapshots()
+
+    if json_output:
+        data = [
+            {
+                "id": s.id,
+                "created_at": s.created_at.isoformat(),
+                "last_accessed_at": s.last_accessed_at.isoformat(),
+                "size_bytes": s.size_in_bytes,
+                "screenshot_count": s.screenshot_count,
+                "application_name": s.application_name,
+            }
+            for s in infos
+        ]
+        click.echo(json_module.dumps(data, indent=2))
+    else:
+        if not infos:
+            click.echo("No snapshots found.")
+            click.echo(f"Storage: {mgr.storage_path}")
+            return
+
+        click.echo(f"{'ID':<28} {'CREATED':<24} {'APP':<24} {'SIZE':>10}  {'IMGS':>4}")
+        click.echo("-" * 94)
+        for s in infos:
+            app = (s.application_name or "-")[:24]
+            size = _human_size(s.size_in_bytes)
+            click.echo(
+                f"{s.id:<28} {s.created_at.strftime('%Y-%m-%d %H:%M:%S'):<24} "
+                f"{app:<24} {size:>10}  {s.screenshot_count:>4}"
+            )
+        click.echo(f"\n{len(infos)} snapshot(s) found.  Storage: {mgr.storage_path}")
+
+
+@snapshot.command("clean")
+@click.option("--days", "-d", type=int, default=None, help="Delete snapshots older than N days")
+@click.option("--all", "clean_all", is_flag=True, help="Delete all snapshots")
+@click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt")
+@click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
+def snapshot_clean(days: int | None, clean_all: bool, yes: bool, json_output: bool) -> None:
+    """Clean up stored snapshots.
+
+    Use ``--days N`` to remove snapshots older than N days, or ``--all``
+    to wipe everything.  Without either flag the command shows a help message.
+    """
+    if not clean_all and days is None:
+        click.echo("Specify --days N or --all.  Run with --help for usage.")
+        raise SystemExit(0)
+
+    mgr = _get_manager()
+
+    if not yes:
+        if clean_all:
+            msg = "Delete ALL snapshots? [y/N] "
+        else:
+            msg = f"Delete snapshots older than {days} day(s)? [y/N] "
+        confirmed = click.prompt(msg, default="n")
+        if confirmed.lower() not in ("y", "yes"):
+            click.echo("Aborted.")
+            raise SystemExit(0)
+
+    if clean_all:
+        count = mgr.clean_all()
+    else:
+        count = mgr.clean_older_than(days)  # type: ignore[arg-type]
+
+    if json_output:
+        click.echo(json_module.dumps({"deleted": count}))
+    else:
+        click.echo(f"Deleted {count} snapshot(s).")
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def _human_size(n: int) -> str:
+    for unit in ("B", "KB", "MB", "GB"):
+        if n < 1024:
+            return f"{n:.0f} {unit}"
+        n //= 1024
+    return f"{n:.0f} TB"

--- a/naturo/models/__init__.py
+++ b/naturo/models/__init__.py
@@ -1,0 +1,5 @@
+"""Naturo data models."""
+
+from naturo.models.snapshot import UIElement, Snapshot, SnapshotInfo, SnapshotError
+
+__all__ = ["UIElement", "Snapshot", "SnapshotInfo", "SnapshotError"]

--- a/naturo/models/snapshot.py
+++ b/naturo/models/snapshot.py
@@ -1,0 +1,235 @@
+"""Snapshot data models — aligned with Peekaboo's UIAutomationSnapshot architecture.
+
+Mirrors the Swift UIElement and UIAutomationSnapshot structs from Peekaboo,
+adapted for Python / Windows (no CoreGraphics dependency).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Dict, List, Optional, Tuple
+
+
+@dataclass
+class UIElement:
+    """A single UI element captured in a snapshot.
+
+    Mirrors Peekaboo's ``UIElement`` struct (Swift), adapted for cross-platform use.
+
+    Attributes:
+        id: Unique element identifier within this snapshot (e.g. ``"e1"``).
+        element_id: Stable element reference (e.g. ``"element_0"``).
+        role: Accessibility role (e.g. ``"AXButton"``, ``"Edit"``, ``"Button"``).
+        title: Element title / name.
+        label: Accessibility label.
+        value: Current value (e.g. text content of an edit control).
+        description: Human-readable description.
+        identifier: Automation identifier / AutomationId.
+        frame: Bounding rectangle as (x, y, width, height) in screen coordinates.
+        is_actionable: Whether the element accepts user input.
+        parent_id: Parent element's ``id``, or ``None`` for root elements.
+        children: Ordered list of child element ``id`` values.
+        keyboard_shortcut: Associated keyboard shortcut string (e.g. ``"Ctrl+S"``).
+    """
+
+    id: str
+    element_id: str
+    role: str
+    title: Optional[str] = None
+    label: Optional[str] = None
+    value: Optional[str] = None
+    description: Optional[str] = None
+    identifier: Optional[str] = None
+    frame: Tuple[int, int, int, int] = (0, 0, 0, 0)  # x, y, width, height
+    is_actionable: bool = False
+    parent_id: Optional[str] = None
+    children: List[str] = field(default_factory=list)
+    keyboard_shortcut: Optional[str] = None
+
+    # ── Serialisation ────────────────────────────────────────────────────────
+
+    def to_dict(self) -> dict:
+        """Convert to a JSON-serialisable dictionary."""
+        return {
+            "id": self.id,
+            "elementId": self.element_id,
+            "role": self.role,
+            "title": self.title,
+            "label": self.label,
+            "value": self.value,
+            "description": self.description,
+            "identifier": self.identifier,
+            "frame": list(self.frame),
+            "isActionable": self.is_actionable,
+            "parentId": self.parent_id,
+            "children": self.children,
+            "keyboardShortcut": self.keyboard_shortcut,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "UIElement":
+        """Restore a ``UIElement`` from a dictionary (as produced by :meth:`to_dict`)."""
+        frame_raw = data.get("frame", [0, 0, 0, 0])
+        return cls(
+            id=data["id"],
+            element_id=data.get("elementId", data.get("element_id", "")),
+            role=data.get("role", ""),
+            title=data.get("title"),
+            label=data.get("label"),
+            value=data.get("value"),
+            description=data.get("description"),
+            identifier=data.get("identifier"),
+            frame=tuple(int(v) for v in frame_raw[:4]),  # type: ignore[assignment]
+            is_actionable=data.get("isActionable", data.get("is_actionable", False)),
+            parent_id=data.get("parentId", data.get("parent_id")),
+            children=data.get("children", []),
+            keyboard_shortcut=data.get("keyboardShortcut", data.get("keyboard_shortcut")),
+        )
+
+
+@dataclass
+class Snapshot:
+    """Full UI automation snapshot — screenshot + element map + window metadata.
+
+    Mirrors Peekaboo's ``UIAutomationSnapshot`` struct, adapted for Windows /
+    cross-platform use (``window_handle`` replaces ``windowID``/``windowAXIdentifier``).
+
+    Attributes:
+        snapshot_id: Unique snapshot identifier (timestamp + random suffix).
+        version: Schema version; always :attr:`CURRENT_VERSION`.
+        screenshot_path: Absolute path to the raw screenshot (``raw.png``).
+        annotated_path: Absolute path to the annotated screenshot (``annotated.png``).
+        ui_map: Mapping of ``element.id`` → :class:`UIElement`.
+        last_update_time: Timestamp of the most recent update.
+        application_name: Display name of the captured application.
+        application_pid: Process ID of the captured application.
+        window_title: Title of the captured window.
+        window_bounds: Window bounding rectangle as (x, y, width, height).
+        window_handle: Platform window handle (HWND on Windows, ``None`` on other platforms).
+    """
+
+    CURRENT_VERSION: int = field(default=1, init=False, repr=False, compare=False)
+
+    snapshot_id: str
+    version: int = 1
+    screenshot_path: Optional[str] = None
+    annotated_path: Optional[str] = None
+    ui_map: Dict[str, UIElement] = field(default_factory=dict)
+    last_update_time: datetime = field(default_factory=datetime.utcnow)
+    application_name: Optional[str] = None
+    application_pid: Optional[int] = None
+    window_title: Optional[str] = None
+    window_bounds: Optional[Tuple[int, int, int, int]] = None
+    window_handle: Optional[int] = None  # HWND on Windows
+
+    # ── Serialisation ────────────────────────────────────────────────────────
+
+    def to_dict(self) -> dict:
+        """Convert to a JSON-serialisable dictionary."""
+        return {
+            "version": self.version,
+            "snapshotId": self.snapshot_id,
+            "screenshotPath": self.screenshot_path,
+            "annotatedPath": self.annotated_path,
+            "uiMap": {k: v.to_dict() for k, v in self.ui_map.items()},
+            "lastUpdateTime": self.last_update_time.isoformat(),
+            "applicationName": self.application_name,
+            "applicationPid": self.application_pid,
+            "windowTitle": self.window_title,
+            "windowBounds": list(self.window_bounds) if self.window_bounds else None,
+            "windowHandle": self.window_handle,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "Snapshot":
+        """Restore a :class:`Snapshot` from a dictionary."""
+        ui_map_raw = data.get("uiMap", {})
+        ui_map = {k: UIElement.from_dict(v) for k, v in ui_map_raw.items()}
+
+        wb_raw = data.get("windowBounds")
+        window_bounds: Optional[Tuple[int, int, int, int]] = (
+            tuple(int(v) for v in wb_raw[:4])  # type: ignore[assignment]
+            if wb_raw
+            else None
+        )
+
+        last_update_raw = data.get("lastUpdateTime")
+        if last_update_raw:
+            # Handle both ISO strings and unix timestamps
+            if isinstance(last_update_raw, (int, float)):
+                last_update_time = datetime.utcfromtimestamp(last_update_raw)
+            else:
+                last_update_time = datetime.fromisoformat(str(last_update_raw).rstrip("Z"))
+        else:
+            last_update_time = datetime.utcnow()
+
+        return cls(
+            snapshot_id=data.get("snapshotId", data.get("snapshot_id", "")),
+            version=data.get("version", 1),
+            screenshot_path=data.get("screenshotPath", data.get("screenshot_path")),
+            annotated_path=data.get("annotatedPath", data.get("annotated_path")),
+            ui_map=ui_map,
+            last_update_time=last_update_time,
+            application_name=data.get("applicationName", data.get("application_name")),
+            application_pid=data.get("applicationPid", data.get("application_pid")),
+            window_title=data.get("windowTitle", data.get("window_title")),
+            window_bounds=window_bounds,
+            window_handle=data.get("windowHandle", data.get("window_handle")),
+        )
+
+    def to_json(self, indent: int = 2) -> str:
+        """Serialise snapshot to a JSON string."""
+        return json.dumps(self.to_dict(), indent=indent, ensure_ascii=False)
+
+    @classmethod
+    def from_json(cls, text: str) -> "Snapshot":
+        """Deserialise snapshot from a JSON string."""
+        return cls.from_dict(json.loads(text))
+
+
+@dataclass
+class SnapshotInfo:
+    """Lightweight summary of a stored snapshot, returned by :meth:`SnapshotManager.list_snapshots`.
+
+    Attributes:
+        id: Snapshot identifier.
+        created_at: Directory creation timestamp.
+        last_accessed_at: Time of most recent data update.
+        size_in_bytes: Total on-disk size of the snapshot directory.
+        screenshot_count: Number of ``*.png`` files inside the directory.
+        application_name: Captured application name (may be ``None``).
+    """
+
+    id: str
+    created_at: datetime
+    last_accessed_at: datetime
+    size_in_bytes: int = 0
+    screenshot_count: int = 0
+    application_name: Optional[str] = None
+
+
+class SnapshotError(Exception):
+    """Base class for snapshot-related errors."""
+
+
+class SnapshotNotFoundError(SnapshotError):
+    """Raised when a requested snapshot does not exist or has expired."""
+
+    def __init__(self, snapshot_id: str) -> None:
+        super().__init__(f"Snapshot not found or expired: {snapshot_id}")
+        self.snapshot_id = snapshot_id
+
+
+class SnapshotVersionError(SnapshotError):
+    """Raised when the on-disk schema version is incompatible."""
+
+    def __init__(self, found: int, expected: int) -> None:
+        super().__init__(f"Snapshot version mismatch (found: {found}, expected: {expected})")
+        self.found = found
+        self.expected = expected
+
+
+class SnapshotStorageError(SnapshotError):
+    """Raised on I/O or serialisation failures."""

--- a/naturo/snapshot.py
+++ b/naturo/snapshot.py
@@ -1,0 +1,456 @@
+"""SnapshotManager — thread-safe snapshot storage aligned with Peekaboo's SnapshotManager.
+
+Storage layout::
+
+    ~/.naturo/snapshots/
+    └── <snapshot_id>/          # e.g. 1742363045123-7321
+        ├── snapshot.json       # full Snapshot serialisation
+        ├── raw.png             # copied raw screenshot (optional)
+        └── annotated.png       # annotated screenshot (optional)
+
+Design notes
+------------
+* **Atomic writes** — JSON is written to a temp file in the same directory, then
+  ``os.replace()``-d into place, so readers never see partial data.
+* **Thread safety** — a single :class:`threading.Lock` guards all mutations.
+  For async callers, wrap calls in ``asyncio.get_event_loop().run_in_executor``.
+* **Snapshot ID format** — ``<unix-ms>-<4-digit-random>`` for easy chronological sorting
+  without a UUID dependency.
+* **Validity window** — 10 minutes, matching Peekaboo's ``snapshotValidityWindow``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import tempfile
+import threading
+import time
+import uuid
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from naturo.models.snapshot import (
+    Snapshot,
+    SnapshotInfo,
+    SnapshotNotFoundError,
+    SnapshotStorageError,
+    SnapshotVersionError,
+    UIElement,
+)
+
+logger = logging.getLogger(__name__)
+
+#: Snapshot validity window — matches Peekaboo (10 minutes).
+SNAPSHOT_VALIDITY_SECONDS: int = 600
+
+#: Default storage root.
+DEFAULT_STORAGE_ROOT: Path = Path.home() / ".naturo" / "snapshots"
+
+
+class SnapshotManager:
+    """Manages snapshot lifecycle: create, store, load, query, and clean.
+
+    Parameters
+    ----------
+    storage_root:
+        Override the default storage path (``~/.naturo/snapshots``).
+        Useful for testing.
+    validity_seconds:
+        How old a snapshot may be before :meth:`get_most_recent_snapshot`
+        ignores it.  Defaults to 600 s (10 minutes).
+    """
+
+    def __init__(
+        self,
+        storage_root: Optional[Path] = None,
+        validity_seconds: int = SNAPSHOT_VALIDITY_SECONDS,
+    ) -> None:
+        self._root = Path(storage_root) if storage_root else DEFAULT_STORAGE_ROOT
+        self._validity_seconds = validity_seconds
+        self._lock = threading.Lock()
+        self._root.mkdir(parents=True, exist_ok=True)
+
+    # ── Public API ───────────────────────────────────────────────────────────
+
+    def create_snapshot(self) -> str:
+        """Generate a new snapshot ID and initialise its storage directory.
+
+        Returns
+        -------
+        str
+            The new snapshot ID (``"<unix-ms>-<4-digit-random>"``).
+        """
+        ts_ms = int(time.time() * 1000)
+        suffix = str(uuid.uuid4().int)[:4]
+        snapshot_id = f"{ts_ms}-{suffix}"
+
+        snap_dir = self._snap_dir(snapshot_id)
+        with self._lock:
+            snap_dir.mkdir(parents=True, exist_ok=True)
+            # Write an empty skeleton so the directory is valid immediately.
+            skeleton = Snapshot(snapshot_id=snapshot_id)
+            self._write_json_atomic(snap_dir / "snapshot.json", skeleton.to_dict())
+
+        logger.debug("Created snapshot: %s", snapshot_id)
+        return snapshot_id
+
+    def store_screenshot(
+        self,
+        snapshot_id: str,
+        screenshot_path: str,
+        metadata: Optional[Dict] = None,
+    ) -> None:
+        """Copy a screenshot into the snapshot directory and persist metadata.
+
+        Parameters
+        ----------
+        snapshot_id:
+            Target snapshot.
+        screenshot_path:
+            Source image file (must exist).
+        metadata:
+            Optional dict with keys: ``application_name``, ``application_pid``,
+            ``window_title``, ``window_bounds`` (4-tuple), ``window_handle``.
+        """
+        src = Path(screenshot_path)
+        if not src.exists():
+            raise SnapshotStorageError(f"Screenshot not found: {screenshot_path}")
+
+        snap_dir = self._snap_dir(snapshot_id)
+        with self._lock:
+            snap_dir.mkdir(parents=True, exist_ok=True)
+            snapshot = self._load_or_create(snapshot_id)
+
+            # Copy image
+            dst = snap_dir / "raw.png"
+            shutil.copy2(src, dst)
+            snapshot.screenshot_path = str(dst)
+
+            # Apply metadata
+            if metadata:
+                snapshot.application_name = metadata.get("application_name", snapshot.application_name)
+                snapshot.application_pid = metadata.get("application_pid", snapshot.application_pid)
+                snapshot.window_title = metadata.get("window_title", snapshot.window_title)
+                snapshot.window_bounds = metadata.get("window_bounds", snapshot.window_bounds)
+                snapshot.window_handle = metadata.get("window_handle", snapshot.window_handle)
+
+            snapshot.last_update_time = datetime.utcnow()
+            self._write_json_atomic(snap_dir / "snapshot.json", snapshot.to_dict())
+
+        logger.debug("Stored screenshot for snapshot %s → %s", snapshot_id, dst)
+
+    def store_detection_result(
+        self,
+        snapshot_id: str,
+        ui_elements: Dict[str, UIElement],
+    ) -> None:
+        """Update the ``ui_map`` of an existing snapshot.
+
+        Parameters
+        ----------
+        snapshot_id:
+            Target snapshot.
+        ui_elements:
+            New element map (replaces any existing ``ui_map``).
+        """
+        snap_dir = self._snap_dir(snapshot_id)
+        with self._lock:
+            snapshot = self._load_or_create(snapshot_id)
+            snapshot.ui_map = ui_elements
+            snapshot.last_update_time = datetime.utcnow()
+            self._write_json_atomic(snap_dir / "snapshot.json", snapshot.to_dict())
+
+        logger.debug(
+            "Stored detection result for snapshot %s (%d elements)",
+            snapshot_id,
+            len(ui_elements),
+        )
+
+    def store_annotated(self, snapshot_id: str, annotated_path: str) -> None:
+        """Copy an annotated screenshot into the snapshot directory.
+
+        Parameters
+        ----------
+        snapshot_id:
+            Target snapshot.
+        annotated_path:
+            Source annotated image file (must exist).
+        """
+        src = Path(annotated_path)
+        if not src.exists():
+            raise SnapshotStorageError(f"Annotated screenshot not found: {annotated_path}")
+
+        snap_dir = self._snap_dir(snapshot_id)
+        with self._lock:
+            snap_dir.mkdir(parents=True, exist_ok=True)
+            snapshot = self._load_or_create(snapshot_id)
+
+            dst = snap_dir / "annotated.png"
+            shutil.copy2(src, dst)
+            snapshot.annotated_path = str(dst)
+            snapshot.last_update_time = datetime.utcnow()
+            self._write_json_atomic(snap_dir / "snapshot.json", snapshot.to_dict())
+
+        logger.debug("Stored annotated screenshot for snapshot %s → %s", snapshot_id, dst)
+
+    def get_snapshot(self, snapshot_id: str) -> Snapshot:
+        """Load and return a snapshot by ID.
+
+        Raises
+        ------
+        SnapshotNotFoundError
+            If the snapshot directory or ``snapshot.json`` does not exist.
+        SnapshotVersionError
+            If the stored schema version does not match :attr:`Snapshot.CURRENT_VERSION`.
+        SnapshotStorageError
+            On JSON decode failures.
+        """
+        snap_dir = self._snap_dir(snapshot_id)
+        json_path = snap_dir / "snapshot.json"
+
+        with self._lock:
+            if not json_path.exists():
+                raise SnapshotNotFoundError(snapshot_id)
+
+            try:
+                data = json.loads(json_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError) as exc:
+                raise SnapshotStorageError(f"Failed to read snapshot {snapshot_id}: {exc}") from exc
+
+            version = data.get("version", 1)
+            if version != Snapshot.CURRENT_VERSION:
+                raise SnapshotVersionError(found=version, expected=Snapshot.CURRENT_VERSION)
+
+            return Snapshot.from_dict(data)
+
+    def get_most_recent_snapshot(self, app_name: Optional[str] = None) -> Optional[str]:
+        """Return the ID of the most recent valid snapshot within the validity window.
+
+        Parameters
+        ----------
+        app_name:
+            If provided, only consider snapshots whose ``application_name``
+            matches (case-insensitive substring match).
+
+        Returns
+        -------
+        str | None
+            The snapshot ID, or ``None`` if no valid snapshot exists.
+        """
+        cutoff = datetime.utcnow() - timedelta(seconds=self._validity_seconds)
+        candidates: List[tuple] = []  # (mtime, snapshot_id)
+
+        with self._lock:
+            if not self._root.exists():
+                return None
+
+            for entry in self._root.iterdir():
+                if not entry.is_dir():
+                    continue
+                json_path = entry / "snapshot.json"
+                if not json_path.exists():
+                    continue
+
+                try:
+                    mtime = datetime.utcfromtimestamp(entry.stat().st_mtime)
+                except OSError:
+                    continue
+
+                if mtime < cutoff:
+                    continue
+
+                snapshot_id = entry.name
+
+                # Filter by app name if requested
+                if app_name:
+                    try:
+                        data = json.loads(json_path.read_text(encoding="utf-8"))
+                        stored_app = data.get("applicationName") or ""
+                        if app_name.lower() not in stored_app.lower():
+                            continue
+                    except (OSError, json.JSONDecodeError):
+                        continue
+
+                candidates.append((mtime, snapshot_id))
+
+        if not candidates:
+            logger.debug("No valid snapshots found within %ds window", self._validity_seconds)
+            return None
+
+        candidates.sort(key=lambda x: x[0], reverse=True)
+        best = candidates[0][1]
+        logger.debug("Most recent valid snapshot: %s", best)
+        return best
+
+    def list_snapshots(self) -> List[SnapshotInfo]:
+        """Return summary information for all stored snapshots, newest first."""
+        infos: List[SnapshotInfo] = []
+
+        with self._lock:
+            if not self._root.exists():
+                return infos
+
+            for entry in self._root.iterdir():
+                if not entry.is_dir():
+                    continue
+                snapshot_id = entry.name
+                json_path = entry / "snapshot.json"
+
+                try:
+                    stat = entry.stat()
+                    created_at = datetime.utcfromtimestamp(stat.st_ctime)
+                except OSError:
+                    continue
+
+                last_accessed = created_at
+                app_name: Optional[str] = None
+
+                if json_path.exists():
+                    try:
+                        data = json.loads(json_path.read_text(encoding="utf-8"))
+                        lu_raw = data.get("lastUpdateTime")
+                        if lu_raw:
+                            last_accessed = datetime.fromisoformat(str(lu_raw).rstrip("Z"))
+                        app_name = data.get("applicationName")
+                    except (OSError, json.JSONDecodeError, ValueError):
+                        pass
+
+                size_bytes = self._dir_size(entry)
+                png_count = sum(1 for f in entry.iterdir() if f.suffix == ".png")
+
+                infos.append(
+                    SnapshotInfo(
+                        id=snapshot_id,
+                        created_at=created_at,
+                        last_accessed_at=last_accessed,
+                        size_in_bytes=size_bytes,
+                        screenshot_count=png_count,
+                        application_name=app_name,
+                    )
+                )
+
+        infos.sort(key=lambda s: s.created_at, reverse=True)
+        return infos
+
+    def clean_snapshot(self, snapshot_id: str) -> None:
+        """Delete a single snapshot directory.
+
+        Silently succeeds if the snapshot does not exist.
+        """
+        snap_dir = self._snap_dir(snapshot_id)
+        with self._lock:
+            if snap_dir.exists():
+                shutil.rmtree(snap_dir)
+                logger.info("Cleaned snapshot: %s", snapshot_id)
+            else:
+                logger.debug("Snapshot %s does not exist, skipping", snapshot_id)
+
+    def clean_older_than(self, days: int) -> int:
+        """Delete all snapshots whose directory mtime is older than *days* days.
+
+        Returns
+        -------
+        int
+            Number of snapshots deleted.
+        """
+        cutoff = datetime.utcnow() - timedelta(days=days)
+        cleaned = 0
+
+        with self._lock:
+            if not self._root.exists():
+                return 0
+
+            for entry in self._root.iterdir():
+                if not entry.is_dir():
+                    continue
+                try:
+                    mtime = datetime.utcfromtimestamp(entry.stat().st_mtime)
+                except OSError:
+                    continue
+
+                if mtime < cutoff:
+                    shutil.rmtree(entry)
+                    logger.info("Cleaned old snapshot: %s", entry.name)
+                    cleaned += 1
+
+        return cleaned
+
+    def clean_all(self) -> int:
+        """Delete every snapshot in the storage directory.
+
+        Returns
+        -------
+        int
+            Number of snapshots deleted.
+        """
+        cleaned = 0
+        with self._lock:
+            if not self._root.exists():
+                return 0
+            for entry in self._root.iterdir():
+                if entry.is_dir():
+                    shutil.rmtree(entry)
+                    cleaned += 1
+
+        logger.info("Cleaned all %d snapshots", cleaned)
+        return cleaned
+
+    @property
+    def storage_path(self) -> str:
+        """Absolute path to the snapshot storage root."""
+        return str(self._root)
+
+    # ── Private helpers ──────────────────────────────────────────────────────
+
+    def _snap_dir(self, snapshot_id: str) -> Path:
+        return self._root / snapshot_id
+
+    def _load_or_create(self, snapshot_id: str) -> Snapshot:
+        """Load existing snapshot or create a new skeleton (caller holds lock)."""
+        json_path = self._snap_dir(snapshot_id) / "snapshot.json"
+        if json_path.exists():
+            try:
+                data = json.loads(json_path.read_text(encoding="utf-8"))
+                return Snapshot.from_dict(data)
+            except (OSError, json.JSONDecodeError, KeyError):
+                pass
+        return Snapshot(snapshot_id=snapshot_id)
+
+    @staticmethod
+    def _write_json_atomic(path: Path, data: dict) -> None:
+        """Write *data* as JSON to *path* atomically (write temp → rename)."""
+        path.parent.mkdir(parents=True, exist_ok=True)
+        dir_fd = path.parent
+
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=dir_fd,
+            prefix=".tmp_",
+            suffix=".json",
+            delete=False,
+        ) as tmp:
+            json.dump(data, tmp, indent=2, ensure_ascii=False)
+            tmp_path = tmp.name
+
+        try:
+            os.replace(tmp_path, path)
+        except OSError:
+            os.unlink(tmp_path)
+            raise
+
+    @staticmethod
+    def _dir_size(path: Path) -> int:
+        """Return total byte size of all files under *path*."""
+        total = 0
+        for f in path.rglob("*"):
+            if f.is_file():
+                try:
+                    total += f.stat().st_size
+                except OSError:
+                    pass
+        return total

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -1,0 +1,602 @@
+"""Tests for the Phase 1.5 Snapshot System.
+
+Covers:
+- SnapshotManager create / store / load round-trip
+- Screenshot and annotated-screenshot storage
+- ui_map persistence via store_detection_result
+- Validity-window filtering in get_most_recent_snapshot
+- app_name filter in get_most_recent_snapshot
+- list_snapshots ordering and content
+- clean_snapshot, clean_older_than, clean_all
+- Thread-safety (concurrent creates)
+- JSON serialisation / deserialisation for UIElement and Snapshot
+- SnapshotVersionError on schema mismatch
+- SnapshotNotFoundError for missing IDs
+
+All tests use a temporary directory so they never touch ~/.naturo.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import tempfile
+import threading
+import time
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Dict
+from unittest.mock import patch
+
+import pytest
+
+from naturo.models.snapshot import (
+    Snapshot,
+    SnapshotInfo,
+    SnapshotNotFoundError,
+    SnapshotStorageError,
+    SnapshotVersionError,
+    UIElement,
+)
+from naturo.snapshot import SnapshotManager
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def tmp_root(tmp_path: Path) -> Path:
+    """Isolated snapshot storage root."""
+    root = tmp_path / "snapshots"
+    root.mkdir()
+    return root
+
+
+@pytest.fixture()
+def mgr(tmp_root: Path) -> SnapshotManager:
+    """SnapshotManager backed by a temporary directory."""
+    return SnapshotManager(storage_root=tmp_root)
+
+
+@pytest.fixture()
+def sample_element() -> UIElement:
+    return UIElement(
+        id="e1",
+        element_id="element_0",
+        role="AXButton",
+        title="Save",
+        label="Save",
+        value=None,
+        frame=(10, 20, 80, 30),
+        is_actionable=True,
+        parent_id=None,
+        children=[],
+        keyboard_shortcut="Ctrl+S",
+    )
+
+
+@pytest.fixture()
+def sample_ui_map(sample_element: UIElement) -> Dict[str, UIElement]:
+    edit = UIElement(
+        id="e2",
+        element_id="element_1",
+        role="AXTextField",
+        title="Filename",
+        label="Filename",
+        value="document.txt",
+        frame=(100, 50, 200, 25),
+        is_actionable=True,
+        parent_id=None,
+        children=[],
+    )
+    return {"e1": sample_element, "e2": edit}
+
+
+@pytest.fixture()
+def png_file(tmp_path: Path) -> Path:
+    """Tiny valid PNG file for screenshot tests."""
+    # 1×1 white PNG (minimal valid PNG bytes)
+    png_bytes = (
+        b"\x89PNG\r\n\x1a\n"  # signature
+        b"\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x02"
+        b"\x00\x00\x00\x90wS\xde\x00\x00\x00\x0cIDATx\x9cc\xf8\x0f\x00"
+        b"\x00\x01\x01\x00\x05\x18\xd8N\x00\x00\x00\x00IEND\xaeB`\x82"
+    )
+    p = tmp_path / "test.png"
+    p.write_bytes(png_bytes)
+    return p
+
+
+# ── create_snapshot ───────────────────────────────────────────────────────────
+
+
+class TestCreateSnapshot:
+    def test_returns_string_id(self, mgr: SnapshotManager) -> None:
+        sid = mgr.create_snapshot()
+        assert isinstance(sid, str)
+        assert len(sid) > 0
+
+    def test_id_format(self, mgr: SnapshotManager) -> None:
+        """ID is <unix-ms>-<suffix> format."""
+        sid = mgr.create_snapshot()
+        parts = sid.split("-")
+        assert len(parts) == 2
+        assert parts[0].isdigit()
+
+    def test_creates_directory(self, mgr: SnapshotManager, tmp_root: Path) -> None:
+        sid = mgr.create_snapshot()
+        assert (tmp_root / sid).is_dir()
+
+    def test_creates_skeleton_json(self, mgr: SnapshotManager, tmp_root: Path) -> None:
+        sid = mgr.create_snapshot()
+        json_path = tmp_root / sid / "snapshot.json"
+        assert json_path.exists()
+        data = json.loads(json_path.read_text())
+        assert data["snapshotId"] == sid
+
+    def test_unique_ids(self, mgr: SnapshotManager) -> None:
+        ids = {mgr.create_snapshot() for _ in range(10)}
+        assert len(ids) == 10
+
+
+# ── store_screenshot ──────────────────────────────────────────────────────────
+
+
+class TestStoreScreenshot:
+    def test_copies_file(self, mgr: SnapshotManager, tmp_root: Path, png_file: Path) -> None:
+        sid = mgr.create_snapshot()
+        mgr.store_screenshot(sid, str(png_file))
+        assert (tmp_root / sid / "raw.png").exists()
+
+    def test_updates_screenshot_path_in_json(
+        self, mgr: SnapshotManager, tmp_root: Path, png_file: Path
+    ) -> None:
+        sid = mgr.create_snapshot()
+        mgr.store_screenshot(sid, str(png_file))
+        snapshot = mgr.get_snapshot(sid)
+        assert snapshot.screenshot_path is not None
+        assert "raw.png" in snapshot.screenshot_path
+
+    def test_stores_metadata(self, mgr: SnapshotManager, png_file: Path) -> None:
+        sid = mgr.create_snapshot()
+        meta = {
+            "application_name": "Notepad",
+            "application_pid": 1234,
+            "window_title": "Untitled",
+            "window_bounds": (0, 0, 800, 600),
+            "window_handle": 999,
+        }
+        mgr.store_screenshot(sid, str(png_file), meta)
+        snap = mgr.get_snapshot(sid)
+        assert snap.application_name == "Notepad"
+        assert snap.application_pid == 1234
+        assert snap.window_title == "Untitled"
+        assert snap.window_bounds == (0, 0, 800, 600)
+        assert snap.window_handle == 999
+
+    def test_raises_on_missing_source(self, mgr: SnapshotManager) -> None:
+        sid = mgr.create_snapshot()
+        with pytest.raises(SnapshotStorageError):
+            mgr.store_screenshot(sid, "/nonexistent/path/image.png")
+
+
+# ── store_detection_result ────────────────────────────────────────────────────
+
+
+class TestStoreDetectionResult:
+    def test_persists_ui_map(
+        self,
+        mgr: SnapshotManager,
+        sample_ui_map: Dict[str, UIElement],
+    ) -> None:
+        sid = mgr.create_snapshot()
+        mgr.store_detection_result(sid, sample_ui_map)
+        snap = mgr.get_snapshot(sid)
+        assert len(snap.ui_map) == 2
+
+    def test_element_fields_round_trip(
+        self,
+        mgr: SnapshotManager,
+        sample_element: UIElement,
+    ) -> None:
+        sid = mgr.create_snapshot()
+        mgr.store_detection_result(sid, {"e1": sample_element})
+        snap = mgr.get_snapshot(sid)
+        el = snap.ui_map["e1"]
+        assert el.id == "e1"
+        assert el.role == "AXButton"
+        assert el.title == "Save"
+        assert el.frame == (10, 20, 80, 30)
+        assert el.is_actionable is True
+        assert el.keyboard_shortcut == "Ctrl+S"
+
+    def test_replaces_existing_map(
+        self,
+        mgr: SnapshotManager,
+        sample_ui_map: Dict[str, UIElement],
+    ) -> None:
+        sid = mgr.create_snapshot()
+        mgr.store_detection_result(sid, sample_ui_map)
+        # Store only one element
+        single = {"e1": sample_ui_map["e1"]}
+        mgr.store_detection_result(sid, single)
+        snap = mgr.get_snapshot(sid)
+        assert len(snap.ui_map) == 1
+
+
+# ── store_annotated ───────────────────────────────────────────────────────────
+
+
+class TestStoreAnnotated:
+    def test_copies_annotated(
+        self, mgr: SnapshotManager, tmp_root: Path, png_file: Path
+    ) -> None:
+        sid = mgr.create_snapshot()
+        mgr.store_annotated(sid, str(png_file))
+        assert (tmp_root / sid / "annotated.png").exists()
+
+    def test_updates_annotated_path(
+        self, mgr: SnapshotManager, png_file: Path
+    ) -> None:
+        sid = mgr.create_snapshot()
+        mgr.store_annotated(sid, str(png_file))
+        snap = mgr.get_snapshot(sid)
+        assert snap.annotated_path is not None
+        assert "annotated.png" in snap.annotated_path
+
+    def test_raises_on_missing_source(self, mgr: SnapshotManager) -> None:
+        sid = mgr.create_snapshot()
+        with pytest.raises(SnapshotStorageError):
+            mgr.store_annotated(sid, "/nonexistent/annotated.png")
+
+
+# ── get_snapshot ──────────────────────────────────────────────────────────────
+
+
+class TestGetSnapshot:
+    def test_raises_for_unknown_id(self, mgr: SnapshotManager) -> None:
+        with pytest.raises(SnapshotNotFoundError):
+            mgr.get_snapshot("no-such-id")
+
+    def test_raises_version_mismatch(self, mgr: SnapshotManager, tmp_root: Path) -> None:
+        sid = mgr.create_snapshot()
+        json_path = tmp_root / sid / "snapshot.json"
+        data = json.loads(json_path.read_text())
+        data["version"] = 999
+        json_path.write_text(json.dumps(data))
+        with pytest.raises(SnapshotVersionError):
+            mgr.get_snapshot(sid)
+
+    def test_loads_full_snapshot(
+        self,
+        mgr: SnapshotManager,
+        sample_ui_map: Dict[str, UIElement],
+    ) -> None:
+        sid = mgr.create_snapshot()
+        mgr.store_detection_result(sid, sample_ui_map)
+        snap = mgr.get_snapshot(sid)
+        assert snap.snapshot_id == sid
+        assert snap.version == 1
+        assert len(snap.ui_map) == 2
+
+
+# ── get_most_recent_snapshot ──────────────────────────────────────────────────
+
+
+class TestGetMostRecentSnapshot:
+    def test_returns_none_when_empty(self, mgr: SnapshotManager) -> None:
+        assert mgr.get_most_recent_snapshot() is None
+
+    def test_returns_id_of_fresh_snapshot(self, mgr: SnapshotManager) -> None:
+        sid = mgr.create_snapshot()
+        assert mgr.get_most_recent_snapshot() == sid
+
+    def test_returns_none_for_expired_snapshot(
+        self, tmp_root: Path
+    ) -> None:
+        # Very short validity window
+        mgr = SnapshotManager(storage_root=tmp_root, validity_seconds=0)
+        mgr.create_snapshot()
+        time.sleep(0.01)
+        assert mgr.get_most_recent_snapshot() is None
+
+    def test_returns_most_recent_of_two(self, mgr: SnapshotManager) -> None:
+        sid1 = mgr.create_snapshot()
+        time.sleep(0.02)  # ensure different mtime
+        sid2 = mgr.create_snapshot()
+        result = mgr.get_most_recent_snapshot()
+        assert result == sid2
+
+    def test_filters_by_app_name(
+        self, mgr: SnapshotManager, png_file: Path
+    ) -> None:
+        sid_notepad = mgr.create_snapshot()
+        mgr.store_screenshot(sid_notepad, str(png_file), {"application_name": "Notepad"})
+        sid_calc = mgr.create_snapshot()
+        mgr.store_screenshot(sid_calc, str(png_file), {"application_name": "Calculator"})
+
+        assert mgr.get_most_recent_snapshot(app_name="Notepad") == sid_notepad
+        assert mgr.get_most_recent_snapshot(app_name="Calculator") == sid_calc
+        assert mgr.get_most_recent_snapshot(app_name="NoSuchApp") is None
+
+    def test_app_name_case_insensitive(
+        self, mgr: SnapshotManager, png_file: Path
+    ) -> None:
+        sid = mgr.create_snapshot()
+        mgr.store_screenshot(sid, str(png_file), {"application_name": "Notepad"})
+        assert mgr.get_most_recent_snapshot(app_name="notepad") == sid
+        assert mgr.get_most_recent_snapshot(app_name="NOTE") == sid
+
+
+# ── list_snapshots ────────────────────────────────────────────────────────────
+
+
+class TestListSnapshots:
+    def test_empty_returns_empty_list(self, mgr: SnapshotManager) -> None:
+        assert mgr.list_snapshots() == []
+
+    def test_returns_all_created(self, mgr: SnapshotManager) -> None:
+        ids = {mgr.create_snapshot() for _ in range(3)}
+        infos = mgr.list_snapshots()
+        assert {s.id for s in infos} == ids
+
+    def test_sorted_newest_first(self, mgr: SnapshotManager) -> None:
+        sids = []
+        for _ in range(3):
+            sids.append(mgr.create_snapshot())
+            time.sleep(0.01)
+        infos = mgr.list_snapshots()
+        assert infos[0].id == sids[-1]
+
+    def test_includes_screenshot_count(
+        self, mgr: SnapshotManager, png_file: Path
+    ) -> None:
+        sid = mgr.create_snapshot()
+        mgr.store_screenshot(sid, str(png_file))
+        infos = mgr.list_snapshots()
+        info = next(i for i in infos if i.id == sid)
+        assert info.screenshot_count >= 1
+
+    def test_includes_app_name(
+        self, mgr: SnapshotManager, png_file: Path
+    ) -> None:
+        sid = mgr.create_snapshot()
+        mgr.store_screenshot(sid, str(png_file), {"application_name": "Notepad"})
+        infos = mgr.list_snapshots()
+        info = next(i for i in infos if i.id == sid)
+        assert info.application_name == "Notepad"
+
+    def test_snapshot_info_type(self, mgr: SnapshotManager) -> None:
+        mgr.create_snapshot()
+        infos = mgr.list_snapshots()
+        assert all(isinstance(i, SnapshotInfo) for i in infos)
+
+
+# ── clean_snapshot ────────────────────────────────────────────────────────────
+
+
+class TestCleanSnapshot:
+    def test_removes_directory(self, mgr: SnapshotManager, tmp_root: Path) -> None:
+        sid = mgr.create_snapshot()
+        assert (tmp_root / sid).exists()
+        mgr.clean_snapshot(sid)
+        assert not (tmp_root / sid).exists()
+
+    def test_no_error_on_missing(self, mgr: SnapshotManager) -> None:
+        mgr.clean_snapshot("nonexistent-snapshot")  # should not raise
+
+    def test_snapshot_gone_after_clean(self, mgr: SnapshotManager) -> None:
+        sid = mgr.create_snapshot()
+        mgr.clean_snapshot(sid)
+        with pytest.raises(SnapshotNotFoundError):
+            mgr.get_snapshot(sid)
+
+
+# ── clean_older_than ──────────────────────────────────────────────────────────
+
+
+class TestCleanOlderThan:
+    def test_keeps_fresh_snapshots(self, mgr: SnapshotManager) -> None:
+        sid = mgr.create_snapshot()
+        deleted = mgr.clean_older_than(days=1)
+        assert deleted == 0
+        assert mgr.get_snapshot(sid) is not None
+
+    def test_deletes_old_snapshots(self, tmp_root: Path) -> None:
+        mgr = SnapshotManager(storage_root=tmp_root)
+        sid = mgr.create_snapshot()
+        snap_dir = tmp_root / sid
+
+        # Backdate the directory mtime to 2 days ago
+        old_time = time.time() - 2 * 86400
+        os.utime(snap_dir, (old_time, old_time))
+
+        deleted = mgr.clean_older_than(days=1)
+        assert deleted == 1
+        assert not snap_dir.exists()
+
+    def test_returns_count(self, tmp_root: Path) -> None:
+        import os as _os
+        mgr = SnapshotManager(storage_root=tmp_root)
+        for _ in range(3):
+            sid = mgr.create_snapshot()
+            snap_dir = tmp_root / sid
+            old_time = time.time() - 5 * 86400
+            _os.utime(snap_dir, (old_time, old_time))
+        assert mgr.clean_older_than(days=1) == 3
+
+
+# ── clean_all ─────────────────────────────────────────────────────────────────
+
+
+class TestCleanAll:
+    def test_removes_all(self, mgr: SnapshotManager) -> None:
+        for _ in range(5):
+            mgr.create_snapshot()
+        count = mgr.clean_all()
+        assert count == 5
+        assert mgr.list_snapshots() == []
+
+    def test_returns_count(self, mgr: SnapshotManager) -> None:
+        for _ in range(3):
+            mgr.create_snapshot()
+        assert mgr.clean_all() == 3
+
+    def test_empty_root(self, mgr: SnapshotManager) -> None:
+        assert mgr.clean_all() == 0
+
+
+# ── Thread-safety ─────────────────────────────────────────────────────────────
+
+
+class TestThreadSafety:
+    def test_concurrent_creates(self, mgr: SnapshotManager) -> None:
+        results = []
+        errors = []
+
+        def worker():
+            try:
+                sid = mgr.create_snapshot()
+                results.append(sid)
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=worker) for _ in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == [], f"Concurrent create raised: {errors}"
+        assert len(set(results)) == 20, "Expected 20 unique snapshot IDs"
+
+    def test_concurrent_read_write(
+        self, mgr: SnapshotManager, sample_ui_map: Dict[str, UIElement]
+    ) -> None:
+        """Writers and readers should not corrupt data."""
+        sid = mgr.create_snapshot()
+        errors = []
+
+        def writer():
+            try:
+                for _ in range(5):
+                    mgr.store_detection_result(sid, sample_ui_map)
+            except Exception as exc:
+                errors.append(exc)
+
+        def reader():
+            try:
+                for _ in range(5):
+                    try:
+                        mgr.get_snapshot(sid)
+                    except (SnapshotNotFoundError, SnapshotStorageError):
+                        pass  # race is acceptable; corruption is not
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=writer) for _ in range(4)]
+        threads += [threading.Thread(target=reader) for _ in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == []
+
+
+# ── JSON serialisation / deserialisation ──────────────────────────────────────
+
+
+class TestJSONRoundTrip:
+    def test_ui_element_round_trip(self, sample_element: UIElement) -> None:
+        d = sample_element.to_dict()
+        restored = UIElement.from_dict(d)
+        assert restored.id == sample_element.id
+        assert restored.role == sample_element.role
+        assert restored.frame == sample_element.frame
+        assert restored.is_actionable == sample_element.is_actionable
+        assert restored.keyboard_shortcut == sample_element.keyboard_shortcut
+
+    def test_ui_element_optional_fields_none(self) -> None:
+        el = UIElement(id="x", element_id="element_0", role="AXGroup")
+        d = el.to_dict()
+        restored = UIElement.from_dict(d)
+        assert restored.title is None
+        assert restored.label is None
+        assert restored.parent_id is None
+        assert restored.children == []
+
+    def test_snapshot_round_trip(self, sample_ui_map: Dict[str, UIElement]) -> None:
+        snap = Snapshot(
+            snapshot_id="test-snap-001",
+            screenshot_path="/tmp/raw.png",
+            annotated_path="/tmp/annotated.png",
+            ui_map=sample_ui_map,
+            last_update_time=datetime(2025, 1, 1, 12, 0, 0),
+            application_name="Notepad",
+            application_pid=9999,
+            window_title="test.txt",
+            window_bounds=(0, 0, 1920, 1080),
+            window_handle=12345,
+        )
+        json_str = snap.to_json()
+        restored = Snapshot.from_json(json_str)
+
+        assert restored.snapshot_id == "test-snap-001"
+        assert restored.screenshot_path == "/tmp/raw.png"
+        assert restored.application_name == "Notepad"
+        assert restored.application_pid == 9999
+        assert restored.window_bounds == (0, 0, 1920, 1080)
+        assert restored.window_handle == 12345
+        assert len(restored.ui_map) == 2
+
+    def test_snapshot_without_optional_fields(self) -> None:
+        snap = Snapshot(snapshot_id="minimal")
+        restored = Snapshot.from_json(snap.to_json())
+        assert restored.snapshot_id == "minimal"
+        assert restored.screenshot_path is None
+        assert restored.window_bounds is None
+        assert restored.ui_map == {}
+
+    def test_snapshot_persist_load_via_manager(
+        self,
+        mgr: SnapshotManager,
+        sample_ui_map: Dict[str, UIElement],
+        png_file: Path,
+    ) -> None:
+        sid = mgr.create_snapshot()
+        mgr.store_detection_result(sid, sample_ui_map)
+        mgr.store_screenshot(
+            sid,
+            str(png_file),
+            {"application_name": "TestApp", "window_bounds": (10, 20, 800, 600)},
+        )
+        snap = mgr.get_snapshot(sid)
+        assert snap.application_name == "TestApp"
+        assert snap.window_bounds == (10, 20, 800, 600)
+        assert "e1" in snap.ui_map
+        assert "e2" in snap.ui_map
+
+
+# ── Atomic write ──────────────────────────────────────────────────────────────
+
+
+class TestAtomicWrite:
+    def test_no_partial_file_visible(self, mgr: SnapshotManager, tmp_root: Path) -> None:
+        """After create_snapshot the JSON must be fully readable."""
+        sid = mgr.create_snapshot()
+        json_path = tmp_root / sid / "snapshot.json"
+        data = json.loads(json_path.read_text())
+        assert data["snapshotId"] == sid
+
+
+# ── storage_path property ─────────────────────────────────────────────────────
+
+
+class TestStoragePath:
+    def test_returns_correct_path(self, mgr: SnapshotManager, tmp_root: Path) -> None:
+        assert Path(mgr.storage_path) == tmp_root
+
+
+# ── need os for backdate test ─────────────────────────────────────────────────
+import os  # noqa: E402  (placed here intentionally to keep test-only import)


### PR DESCRIPTION
## Summary

Implements the full Phase 1.5 Snapshot System, aligned with Peekaboo's `UIAutomationSnapshot` / `SnapshotManager` architecture.

## Changes

### New Files
- `naturo/models/snapshot.py` — `UIElement`, `Snapshot`, `SnapshotInfo`, error types
- `naturo/models/__init__.py`
- `naturo/snapshot.py` — `SnapshotManager` (thread-safe, atomic writes)
- `naturo/cli/snapshot.py` — `naturo snapshot list` / `snapshot clean`
- `tests/test_snapshot.py` — 48 tests
- `TEST_PLAN.md` — full P1.5 test inventory

### Modified Files
- `naturo/cli/__init__.py` — register `snapshot` command group
- `naturo/cli/core.py` — `see` and `capture live` auto-store snapshots
- `docs/ARCHITECTURE.md` — Phase 1.5 section
- `README.md` — Snapshot System section + CLI table

## Architecture Alignment with Peekaboo

| Peekaboo (Swift) | Naturo (Python) |
|---|---|
| `UIElement` struct | `UIElement` dataclass |
| `UIAutomationSnapshot` | `Snapshot` dataclass |
| `SnapshotManager` actor | `SnapshotManager` class |
| `SnapshotStorageActor` | `threading.Lock` |
| `~/.peekaboo/snapshots/` | `~/.naturo/snapshots/` |
| 10-min validity window | Same |
| Atomic `.write(options: .atomic)` | `tempfile` → `os.replace()` |

## Tests
- **48 tests**, all passing on macOS/Linux (no Windows dependency)
- Covers: CRUD, validity window, app-name filter, thread-safety (20 concurrent creates), JSON round-trip, error paths, atomic write

## CI
All platform-independent tests pass on ubuntu/macos/windows.