### PR TITLE
fix: standardize get command JSON error format (fixes #121)

### DIFF
--- a/naturo/cli/get_cmd.py
+++ b/naturo/cli/get_cmd.py
@@ -10,7 +10,7 @@ import sys
 
 import click
 
-from naturo.cli.error_helpers import json_error as _json_error_str
+from naturo.cli.error_helpers import emit_error, emit_exception_error
 from naturo.errors import NaturoError
 
 
@@ -86,20 +86,21 @@ def get_cmd(ctx, target, ref, automation_id, role, name, prop, app,
                 automation_id = target
 
     if not ref and not automation_id and not role and not name:
-        msg = "Specify a target: element ref (e47), --automation-id, or --role/--name"
-        if json_output:
-            click.echo(json_module.dumps({"error": msg}))
-        else:
-            click.echo(f"Error: {msg}", err=True)
-        sys.exit(1)
+        emit_error(
+            "INVALID_INPUT",
+            "Specify a target: element ref (e47), --automation-id, or --role/--name",
+            json_output,
+            suggested_action="Provide a target element using a ref (e47), "
+            "--automation-id, or --role/--name. Run 'naturo see' to inspect "
+            "available elements.",
+        )
 
     if platform.system() not in ("Windows",) and not _has_peekaboo():
-        msg = "naturo get requires Windows (UIA patterns) or macOS (Peekaboo)"
-        if json_output:
-            click.echo(json_module.dumps({"error": msg}))
-        else:
-            click.echo(f"Error: {msg}", err=True)
-        sys.exit(1)
+        emit_error(
+            "PLATFORM_ERROR",
+            "naturo get requires Windows (UIA patterns) or macOS (Peekaboo)",
+            json_output,
+        )
 
     try:
         backend = _get_backend()
@@ -113,16 +114,16 @@ def get_cmd(ctx, target, ref, automation_id, role, name, prop, app,
         )
 
         if result is None:
-            msg = f"Element not found"
+            msg = "Element not found"
             if ref:
                 msg += f" (ref={ref})"
             if automation_id:
                 msg += f" (automation_id={automation_id})"
-            if json_output:
-                click.echo(json_module.dumps({"error": msg, "found": False}))
-            else:
-                click.echo(f"Error: {msg}", err=True)
-            sys.exit(1)
+            emit_error(
+                "ELEMENT_NOT_FOUND",
+                msg,
+                json_output,
+            )
 
         if json_output:
             output = {
@@ -169,17 +170,9 @@ def get_cmd(ctx, target, ref, automation_id, role, name, prop, app,
                 click.echo(f"Pattern: {pattern}")
 
     except NaturoError as exc:
-        if json_output:
-            click.echo(json_module.dumps({"error": str(exc)}))
-        else:
-            click.echo(f"Error: {exc}", err=True)
-        sys.exit(1)
+        emit_exception_error(exc, json_output)
     except Exception as exc:
-        if json_output:
-            click.echo(json_module.dumps({"error": str(exc)}))
-        else:
-            click.echo(f"Error: {exc}", err=True)
-        sys.exit(1)
+        emit_exception_error(exc, json_output, fallback_code="UNKNOWN_ERROR")
 
 
 def _has_peekaboo() -> bool:

--- a/tests/test_get_cmd.py
+++ b/tests/test_get_cmd.py
@@ -326,6 +326,44 @@ class TestGetCLI:
         data = json.loads(result.output)
         assert data["value"] == "Hello World"
 
+    def test_get_no_target_json_error_format(self):
+        """No target in JSON mode returns standard error format with code."""
+        runner = CliRunner()
+        result = runner.invoke(main, ["--json", "get"])
+        assert result.exit_code != 0
+        data = json.loads(result.output)
+        assert data["success"] is False
+        assert data["error"]["code"] == "INVALID_INPUT"
+        assert "message" in data["error"]
+
+    def test_get_not_found_json_error_format(self):
+        """Element not found in JSON mode returns standard error format."""
+        mock = _make_mock_backend(not_found=True)
+        runner = CliRunner()
+
+        with _apply_patches(mock):
+            result = runner.invoke(main, ["--json", "get", "e99"])
+
+        assert result.exit_code != 0
+        data = json.loads(result.output)
+        assert data["success"] is False
+        assert data["error"]["code"] == "ELEMENT_NOT_FOUND"
+        assert "suggested_action" in data["error"]
+
+    def test_get_naturo_error_json_format(self):
+        """NaturoError in JSON mode returns standard error format."""
+        mock = _make_mock_backend(error="backend failure")
+        runner = CliRunner()
+
+        with _apply_patches(mock):
+            result = runner.invoke(main, ["--json", "get", "e1"])
+
+        assert result.exit_code != 0
+        data = json.loads(result.output)
+        assert data["success"] is False
+        assert "error" in data
+        assert "code" in data["error"]
+
 
 # ── Bridge Tests (unit-level mock) ───────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
Standardize `naturo get` JSON error output to use the same structured format as all other commands.

## Problem
`naturo get --json` errors used a flat format `{"error": "msg"}` while every other command uses the standard format:
```json
{"success": false, "error": {"code": "...", "message": "...", "suggested_action": "..."}}
```

## Changes
- Replace manual `json.dumps({"error": msg})` calls with `emit_error()` from `error_helpers`
- Replace manual exception handling with `emit_exception_error()`
- Proper error codes: `INVALID_INPUT`, `PLATFORM_ERROR`, `ELEMENT_NOT_FOUND`
- Recovery hints auto-populated from the standard registry

## Verified
- `naturo get --json` → `{"success": false, "error": {"code": "INVALID_INPUT", ...}}`
- `naturo get --aid nonexistent --json` → `{"success": false, "error": {"code": "ELEMENT_NOT_FOUND", ..., "recoverable": true}}`
- All 1292 tests pass, 0 failures

Fixes #121