### PR TITLE
fix: find --actionable works without QUERY, press --json returns proper error (fixes #124, fixes #123)

### DIFF
--- a/naturo/cli/core.py
+++ b/naturo/cli/core.py
@@ -646,12 +646,16 @@ def find_cmd(query, query_opt, role, actionable, depth, limit, ai, provider, scr
     # Resolve query: --query option takes precedence over positional arg
     query = query_opt if query_opt is not None else query
     if query is None:
-        msg = "Missing argument 'QUERY'. Provide as positional arg or --query/-q option."
-        if json_output:
-            click.echo(_json_error_str("INVALID_INPUT", msg))
+        if actionable or role:
+            # When filtering by --actionable or --role, default to wildcard match-all
+            query = "*"
         else:
-            click.echo(f"Error: {msg}", err=True)
-        raise SystemExit(1)
+            msg = "Missing argument 'QUERY'. Provide as positional arg or --query/-q option."
+            if json_output:
+                click.echo(_json_error_str("INVALID_INPUT", msg))
+            else:
+                click.echo(f"Error: {msg}", err=True)
+            raise SystemExit(1)
 
     # AI vision mode — natural language element finding
     if ai:

--- a/naturo/cli/interaction.py
+++ b/naturo/cli/interaction.py
@@ -388,7 +388,7 @@ def type_cmd(text, delay, profile, wpm, press_return, tab_count, escape,
 
 
 @click.command()
-@click.argument("key")
+@click.argument("key", required=False, default=None)
 @click.option("--count", "-n", type=int, default=1, help="Number of times to press", show_default=True)
 @click.option("--delay", type=float, default=50.0, help="Delay between presses (ms)", show_default=True)
 @click.option("--app", help="Application name")
@@ -412,6 +412,11 @@ def press(key, count, delay, app, window_title, hwnd, input_mode, method, json_o
       naturo press tab --count 3
       naturo press f5
     """
+    if key is None:
+        _json_err("KEY argument is required. Specify which key to press (e.g., enter, tab, escape).",
+                  json_output, code="INVALID_INPUT")
+        return
+
     if count < 1:
         _json_err(f"--count must be >= 1, got {count}", json_output, code="INVALID_INPUT")
         return

--- a/tests/test_find_query_option.py
+++ b/tests/test_find_query_option.py
@@ -1,14 +1,17 @@
-"""Tests for find command --query option (fixes #112).
+"""Tests for CLI argument handling improvements.
 
-The --query/-q named option is an alternative to the positional QUERY
-argument, specifically to avoid shell glob expansion of wildcards like ``*``.
+- find command --query option (fixes #112)
+- find --actionable without QUERY (fixes #124)
+- press missing KEY returns JSON error (fixes #123)
 """
 
+import json
 import pytest
 from unittest.mock import patch, MagicMock
 from click.testing import CliRunner
 
 from naturo.cli.core import find_cmd
+from naturo.cli.interaction import press
 
 
 @pytest.fixture
@@ -71,3 +74,47 @@ class TestFindQueryOption:
         result = runner.invoke(find_cmd, [])
         assert result.exit_code != 0
         assert "QUERY" in (result.output or "") or "Missing" in (result.output or "")
+
+
+class TestFindActionableWithoutQuery:
+    """Tests for --actionable and --role without QUERY (fixes #124)."""
+
+    def test_actionable_without_query(self, runner, mock_backend):
+        """--actionable without QUERY should default to wildcard '*'."""
+        result = runner.invoke(find_cmd, ["--actionable", "--json"])
+        assert "Missing argument" not in (result.output or "")
+        assert "INVALID_INPUT" not in (result.output or "")
+        mock_backend.get_element_tree.assert_called()
+
+    def test_role_without_query(self, runner, mock_backend):
+        """--role without QUERY should default to wildcard '*'."""
+        result = runner.invoke(find_cmd, ["--role", "Button", "--json"])
+        assert "Missing argument" not in (result.output or "")
+        assert "INVALID_INPUT" not in (result.output or "")
+        mock_backend.get_element_tree.assert_called()
+
+    def test_actionable_and_role_without_query(self, runner, mock_backend):
+        """--actionable --role without QUERY should default to wildcard '*'."""
+        result = runner.invoke(find_cmd, ["--actionable", "--role", "Edit", "--json"])
+        assert "Missing argument" not in (result.output or "")
+        assert "INVALID_INPUT" not in (result.output or "")
+        mock_backend.get_element_tree.assert_called()
+
+
+class TestPressMissingKey:
+    """Tests for press command missing KEY argument (fixes #123)."""
+
+    def test_press_no_key_json_error(self, runner):
+        """press --json without KEY should return JSON error, not Click usage error."""
+        result = runner.invoke(press, ["--json"])
+        assert result.exit_code != 0
+        data = json.loads(result.output)
+        assert data["success"] is False
+        assert data["error"]["code"] == "INVALID_INPUT"
+        assert "KEY" in data["error"]["message"]
+
+    def test_press_no_key_plain_error(self, runner):
+        """press without KEY and without --json should show readable error."""
+        result = runner.invoke(press, [])
+        assert result.exit_code != 0
+        assert "KEY" in (result.output or "")


### PR DESCRIPTION
## Changes

### fix #124: find --actionable requires QUERY arg
When `--actionable` or `--role` is set and no QUERY is provided, default to `*` (match-all wildcard) instead of returning an error. This is the natural behavior — `naturo find --actionable` should list all actionable elements without needing a redundant wildcard argument.

### fix #123: press --json returns raw Click error
Made KEY argument optional in Click decorator and moved validation into the function body. When `--json` flag is set, missing KEY now returns proper JSON error `{"success": false, "error": {"code": "INVALID_INPUT", ...}}` instead of raw Click usage text.

### Tests
- 3 new tests for find --actionable/--role without QUERY
- 2 new tests for press missing KEY (JSON and plain modes)
- All 1300 tests pass, 443 skipped (non-Windows)