### PR TITLE
fix: find --actionable standalone + press --json error (fixes #123, fixes #124)

### DIFF
--- a/naturo/cli/core.py
+++ b/naturo/cli/core.py
@@ -646,12 +646,16 @@ def find_cmd(query, query_opt, role, actionable, depth, limit, ai, provider, scr
     # Resolve query: --query option takes precedence over positional arg
     query = query_opt if query_opt is not None else query
     if query is None:
-        msg = "Missing argument 'QUERY'. Provide as positional arg or --query/-q option."
-        if json_output:
-            click.echo(_json_error_str("INVALID_INPUT", msg))
+        # When --actionable or --role is set, treat missing query as wildcard
+        if actionable or role:
+            query = "*"
         else:
-            click.echo(f"Error: {msg}", err=True)
-        raise SystemExit(1)
+            msg = "Missing argument 'QUERY'. Provide as positional arg or --query/-q option."
+            if json_output:
+                click.echo(_json_error_str("INVALID_INPUT", msg))
+            else:
+                click.echo(f"Error: {msg}", err=True)
+            raise SystemExit(1)
 
     # AI vision mode — natural language element finding
     if ai:

--- a/naturo/cli/interaction.py
+++ b/naturo/cli/interaction.py
@@ -388,7 +388,7 @@ def type_cmd(text, delay, profile, wpm, press_return, tab_count, escape,
 
 
 @click.command()
-@click.argument("key")
+@click.argument("key", required=False, default=None)
 @click.option("--count", "-n", type=int, default=1, help="Number of times to press", show_default=True)
 @click.option("--delay", type=float, default=50.0, help="Delay between presses (ms)", show_default=True)
 @click.option("--app", help="Application name")
@@ -412,6 +412,11 @@ def press(key, count, delay, app, window_title, hwnd, input_mode, method, json_o
       naturo press tab --count 3
       naturo press f5
     """
+    if key is None:
+        _json_err("Missing argument 'KEY'. Provide a key name (e.g., enter, tab, f1).",
+                  json_output, code="INVALID_INPUT")
+        return
+
     if count < 1:
         _json_err(f"--count must be >= 1, got {count}", json_output, code="INVALID_INPUT")
         return

--- a/tests/test_cli_phase2.py
+++ b/tests/test_cli_phase2.py
@@ -116,6 +116,25 @@ class TestPressCommandRegistration:
         assert "--delay" in result.output
 
 
+class TestPressJsonError:
+    """Press command returns JSON error when KEY is missing (fixes #123)."""
+
+    def test_press_missing_key_json_error(self, runner):
+        """naturo press --json without KEY returns JSON error, not Click usage text."""
+        result = runner.invoke(main, ["press", "--json"])
+        assert result.exit_code != 0
+        import json
+        data = json.loads(result.output)
+        assert data["success"] is False
+        assert data["error"]["code"] == "INVALID_INPUT"
+
+    def test_press_missing_key_plain_error(self, runner):
+        """naturo press without KEY returns readable error."""
+        result = runner.invoke(main, ["press"])
+        assert result.exit_code != 0
+        assert "KEY" in result.output or "Missing" in result.output
+
+
 class TestHotkeyCommandRegistration:
     """Phase 2 hotkey command is registered and documented."""
 

--- a/tests/test_find_query_option.py
+++ b/tests/test_find_query_option.py
@@ -71,3 +71,20 @@ class TestFindQueryOption:
         result = runner.invoke(find_cmd, [])
         assert result.exit_code != 0
         assert "QUERY" in (result.output or "") or "Missing" in (result.output or "")
+
+    def test_actionable_without_query_uses_wildcard(self, runner, mock_backend):
+        """--actionable without QUERY should implicitly use '*' wildcard (fixes #124)."""
+        result = runner.invoke(find_cmd, ["--actionable", "--json"])
+        assert "Missing argument" not in (result.output or "")
+        mock_backend.get_element_tree.assert_called()
+
+    def test_role_without_query_uses_wildcard(self, runner, mock_backend):
+        """--role without QUERY should implicitly use '*' wildcard (fixes #124)."""
+        result = runner.invoke(find_cmd, ["--role", "Button", "--json"])
+        assert "Missing argument" not in (result.output or "")
+        mock_backend.get_element_tree.assert_called()
+
+    def test_actionable_with_role_without_query(self, runner, mock_backend):
+        """--actionable --role without QUERY should work (fixes #124)."""
+        result = runner.invoke(find_cmd, ["--actionable", "--role", "Button", "--json"])
+        assert "Missing argument" not in (result.output or "")


### PR DESCRIPTION
## Changes

### #124 — find --actionable requires QUERY arg
When `--actionable` or `--role` is set without a QUERY argument, implicitly use `*` wildcard. This makes `naturo find --actionable --json` work as expected — list all actionable elements without needing an explicit query.

### #123 — press --json returns raw Click error
Changed `press` KEY argument from `required=True` to `required=False` and validate in the function body. Now `naturo press --json` returns a proper JSON error (`INVALID_INPUT`) instead of Click's raw usage text.

### Tests
- 3 new tests for #124 (actionable/role without query)
- 2 new tests for #123 (press missing KEY, JSON + plain)
- All 1295 tests pass