### PR TITLE
fix: add --all flag to find command for SSH-safe wildcard search (fixes #112)

### DIFF
--- a/naturo/cli/core.py
+++ b/naturo/cli/core.py
@@ -605,6 +605,8 @@ def see(app, window_title, hwnd, pid, mode, depth, path, annotate, store_snapsho
 @click.argument("query", required=False, default=None)
 @click.option("--query", "-q", "query_opt", default=None,
               help="Search query (alternative to positional arg; survives shell glob expansion)")
+@click.option("--all", "find_all", is_flag=True,
+              help="Find all elements (equivalent to query \"*\"). Safe from shell glob expansion.")
 @click.option("--role", help="Filter by element role (e.g., Button, Edit)")
 @click.option("--actionable", is_flag=True, help="Only show actionable elements")
 @click.option("--depth", "-d", type=int, default=5, help="Maximum tree depth (1-10)")
@@ -622,7 +624,7 @@ def see(app, window_title, hwnd, pid, mode, depth, path, annotate, store_snapsho
     default="uia",
     help="Accessibility backend / interaction method: uia (default), msaa (legacy apps), ia2 (Firefox/Thunderbird), jab (Java/Swing), auto",
 )
-def find_cmd(query, query_opt, role, actionable, depth, limit, ai, provider, screenshot, ai_app, json_output, backend):
+def find_cmd(query, query_opt, find_all, role, actionable, depth, limit, ai, provider, screenshot, ai_app, json_output, backend):
     """Search for UI elements matching a query.
 
     Supports fuzzy name matching, role filtering, and combined queries.
@@ -635,14 +637,19 @@ def find_cmd(query, query_opt, role, actionable, depth, limit, ai, provider, scr
         naturo find "Save"                      # fuzzy name search
         naturo find "Button:Save"               # role + name
         naturo find "role:Edit"                  # by role only
-        naturo find "*" --actionable             # all actionable elements
-        naturo find --query "*" --actionable     # same, safe from shell glob
+        naturo find --all --actionable           # all actionable elements (SSH-safe)
+        naturo find --all --role Button          # all buttons
         naturo find "the save button" --ai       # AI vision search
         naturo find "search field" --ai --app "Chrome"  # AI + specific app
         naturo find "OK" --backend msaa          # MSAA for legacy apps
     """
-    # Resolve query: --query option takes precedence over positional arg
-    query = query_opt if query_opt is not None else query
+    # Resolve query: --all flag → wildcard, --query option → override positional
+    if find_all:
+        query = "*"
+    elif query_opt is not None:
+        query = query_opt
+    # else: query is the positional arg (may be None)
+
     if query is None:
         # When --actionable or --role is set, treat missing query as wildcard
         if actionable or role:

--- a/tests/test_find_query_option.py
+++ b/tests/test_find_query_option.py
@@ -1,7 +1,10 @@
-"""Tests for find command --query option (fixes #112).
+"""Tests for find command --query and --all options (fixes #112).
 
 The --query/-q named option is an alternative to the positional QUERY
 argument, specifically to avoid shell glob expansion of wildcards like ``*``.
+
+The --all flag sets query to ``*`` internally without any shell-expandable
+characters, making it fully safe for SSH and cmd.exe on Windows.
 """
 
 import pytest
@@ -88,3 +91,31 @@ class TestFindQueryOption:
         """--actionable --role without QUERY should work (fixes #124)."""
         result = runner.invoke(find_cmd, ["--actionable", "--role", "Button", "--json"])
         assert "Missing argument" not in (result.output or "")
+
+
+class TestFindAllFlag:
+    """Tests for the --all flag (fixes #112 — shell glob expansion on Windows)."""
+
+    def test_all_flag_sets_wildcard(self, runner, mock_backend):
+        """--all flag should work as equivalent to query '*'."""
+        result = runner.invoke(find_cmd, ["--all", "--json"])
+        assert "Missing argument" not in (result.output or "")
+        mock_backend.get_element_tree.assert_called()
+
+    def test_all_with_actionable(self, runner, mock_backend):
+        """--all --actionable finds all actionable elements (SSH-safe wildcard)."""
+        result = runner.invoke(find_cmd, ["--all", "--actionable", "--json"])
+        assert "Missing argument" not in (result.output or "")
+        mock_backend.get_element_tree.assert_called()
+
+    def test_all_with_role_filter(self, runner, mock_backend):
+        """--all --role Button finds all buttons."""
+        result = runner.invoke(find_cmd, ["--all", "--role", "Button", "--json"])
+        assert "Missing argument" not in (result.output or "")
+        mock_backend.get_element_tree.assert_called()
+
+    def test_all_overrides_positional(self, runner, mock_backend):
+        """--all takes precedence even if a positional query is given."""
+        result = runner.invoke(find_cmd, ["Save", "--all", "--json"])
+        assert "Missing argument" not in (result.output or "")
+        mock_backend.get_element_tree.assert_called()


### PR DESCRIPTION
## Problem
`naturo find "*"` and `naturo find --query "*"` fail on Windows via SSH because cmd.exe expands `*` to filenames in the current directory before Python/Click sees the argument.

## Fix
Add `--all` flag to `find` command that sets query to `"*"` internally — no glob character ever reaches the shell.

**Usage:**
```bash
naturo find --all --actionable        # all actionable elements
naturo find --all --role Button       # all buttons
naturo find --all --json --limit 5    # all elements, JSON, limit 5
```

## Tests
- 4 new tests in `TestFindAllFlag` class
- All 1305 tests pass locally

Fixes #112