### PR TITLE
feat: auto-routing for action commands (fixes #28)

### DIFF
--- a/naturo/cli/interaction.py
+++ b/naturo/cli/interaction.py
@@ -1,10 +1,15 @@
 """Interaction commands: click, type, press, hotkey, scroll, drag, move."""
+from __future__ import annotations
+
 import json
+import logging
 import platform
 import sys
 import time as _time
 
 import click
+
+logger = logging.getLogger(__name__)
 
 
 def _record_action(command: str, args: dict, duration_ms: float = 0.0) -> None:
@@ -165,6 +170,51 @@ def _json_err(msg: str, json_output: bool, exit_code: int = 1,
     sys.exit(exit_code)
 
 
+# ── Auto-routing helper ──────────────────────────────────────────────────────
+
+
+def _auto_route(
+    app: str | None,
+    pid: int | None,
+    method: str,
+    json_output: bool,
+) -> dict:
+    """Run auto-routing and return routing metadata for output.
+
+    When --method is "auto" and an --app or --pid is specified, runs the
+    detection chain to determine the best interaction method. Returns a
+    dict with routing info to include in JSON output.
+
+    Args:
+        app: Application name from --app flag.
+        pid: Process ID from --pid flag.
+        method: Value of --method flag ("auto" or explicit method).
+        json_output: Whether JSON output mode is active.
+
+    Returns:
+        Dict with routing info (method, source, framework, etc.).
+        Empty dict if no routing was performed.
+    """
+    if method == "auto" and (app is not None or pid is not None):
+        try:
+            from naturo.routing import resolve_method
+
+            result = resolve_method(app=app, pid=pid, explicit_method=method)
+            route_info = result.to_dict()
+            if not json_output:
+                src = f" ({result.framework})" if result.framework != "unknown" else ""
+                logger.info(
+                    "Auto-routed: %s → %s%s",
+                    app or f"PID {pid}",
+                    result.method,
+                    src,
+                )
+            return route_info
+        except Exception as exc:
+            logger.debug("Auto-routing failed: %s", exc)
+    return {}
+
+
 # ── click ────────────────────────────────────────────────────────────────────
 
 
@@ -208,6 +258,9 @@ def click_cmd(query, on_text, element_id, coords, double, right, app, pid,
       naturo click --id "button_ok"
     """
     backend = _get_backend(json_output)
+
+    # Auto-routing: detect best interaction method for target app
+    route_info = _auto_route(app, pid, method, json_output)
 
     button = "right" if right else "left"
 
@@ -263,7 +316,10 @@ def click_cmd(query, on_text, element_id, coords, double, right, app, pid,
 
     action = "double-clicked" if double else "clicked"
     loc = f"({x}, {y})" if coords else (target_id or "element")
-    _json_ok({"action": action, "target": str(loc), "button": button}, json_output)
+    result_data = {"action": action, "target": str(loc), "button": button}
+    if route_info:
+        result_data["routing"] = route_info
+    _json_ok(result_data, json_output)
 
 
 # ── type ─────────────────────────────────────────────────────────────────────
@@ -343,6 +399,9 @@ def type_cmd(text, delay, profile, wpm, press_return, tab_count, escape,
 
     backend = _get_backend(json_output)
 
+    # Auto-routing: detect best interaction method for target app
+    route_info = _auto_route(app, None, method, json_output)
+
     try:
         if clear:
             backend.hotkey("ctrl", "a")
@@ -381,7 +440,10 @@ def type_cmd(text, delay, profile, wpm, press_return, tab_count, escape,
         return
 
     action = "pasted" if paste_mode else "typed"
-    _json_ok({"action": action, "text": text, "length": len(text)}, json_output)
+    result_data = {"action": action, "text": text, "length": len(text)}
+    if route_info:
+        result_data["routing"] = route_info
+    _json_ok(result_data, json_output)
 
 
 # ── press ────────────────────────────────────────────────────────────────────
@@ -424,6 +486,9 @@ def press(key, count, delay, app, window_title, hwnd, input_mode, method, json_o
     import time
     backend = _get_backend(json_output)
 
+    # Auto-routing: detect best interaction method for target app
+    route_info = _auto_route(app, None, method, json_output)
+
     try:
         for i in range(count):
             backend.press_key(key, input_mode=input_mode)
@@ -436,7 +501,10 @@ def press(key, count, delay, app, window_title, hwnd, input_mode, method, json_o
     # Record the action
     _record_action("press", {"key": key, "count": count})
 
-    _json_ok({"action": "pressed", "key": key, "count": count}, json_output)
+    result_data = {"action": "pressed", "key": key, "count": count}
+    if route_info:
+        result_data["routing"] = route_info
+    _json_ok(result_data, json_output)
 
 
 # ── hotkey ───────────────────────────────────────────────────────────────────
@@ -485,6 +553,9 @@ def hotkey(keys, keys_option, hold_duration, app, window_title, hwnd,
 
     backend = _get_backend(json_output)
 
+    # Auto-routing: detect best interaction method for target app
+    route_info = _auto_route(app, None, method, json_output)
+
     try:
         backend.hotkey(*key_list,
                        hold_duration_ms=int(hold_duration) if hold_duration else 50,
@@ -497,7 +568,10 @@ def hotkey(keys, keys_option, hold_duration, app, window_title, hwnd,
     _record_action("hotkey", {"keys": key_list, "hold_duration": hold_duration or 0.05})
 
     combo = "+".join(key_list)
-    _json_ok({"action": "hotkey", "combo": combo}, json_output)
+    result_data = {"action": "hotkey", "combo": combo}
+    if route_info:
+        result_data["routing"] = route_info
+    _json_ok(result_data, json_output)
 
 
 # ── scroll ───────────────────────────────────────────────────────────────────
@@ -540,6 +614,9 @@ def scroll(direction_arg, direction_option, amount, on_text, smooth, delay, app,
 
     backend = _get_backend(json_output)
 
+    # Auto-routing: detect best interaction method for target app
+    route_info = _auto_route(app, None, method, json_output)
+
     try:
         backend.scroll(direction=direction, amount=amount, smooth=smooth)
     except Exception as exc:
@@ -549,7 +626,10 @@ def scroll(direction_arg, direction_option, amount, on_text, smooth, delay, app,
     # Record the action
     _record_action("scroll", {"direction": direction, "amount": amount})
 
-    _json_ok({"action": "scrolled", "direction": direction, "amount": amount}, json_output)
+    result_data = {"action": "scrolled", "direction": direction, "amount": amount}
+    if route_info:
+        result_data["routing"] = route_info
+    _json_ok(result_data, json_output)
 
 
 # ── drag ─────────────────────────────────────────────────────────────────────

--- a/naturo/routing.py
+++ b/naturo/routing.py
@@ -1,0 +1,164 @@
+"""Auto-routing for action commands.
+
+Resolves the best interaction method for a target application by combining
+process resolution with the detection chain. Used by click, type, press,
+and find commands when ``--method auto`` (the default).
+
+The routing flow:
+1. Resolve ``--app`` / ``--pid`` to a process PID
+2. Run the detection chain (cached per PID)
+3. Return the recommended ``InteractionMethodType``
+4. Log the routing decision for transparency
+
+When ``--method`` is set explicitly (not "auto"), routing is bypassed and
+the specified method is used directly.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RoutingResult:
+    """Result of auto-routing for a target application.
+
+    Attributes:
+        pid: Resolved process ID (None if no app specified).
+        app_name: Resolved application name.
+        method: Recommended interaction method name (e.g. "uia", "cdp").
+        source: How the method was determined — "auto" or "explicit".
+        framework: Detected framework type (e.g. "electron", "win32").
+        confidence: Detection confidence (0.0–1.0).
+    """
+
+    pid: Optional[int] = None
+    app_name: str = ""
+    method: str = "vision"
+    source: str = "auto"
+    framework: str = "unknown"
+    confidence: float = 0.0
+
+    def to_dict(self) -> dict:
+        """Serialize for JSON output."""
+        return {
+            "pid": self.pid,
+            "app": self.app_name,
+            "method": self.method,
+            "source": self.source,
+            "framework": self.framework,
+            "confidence": self.confidence,
+        }
+
+
+def resolve_method(
+    app: Optional[str] = None,
+    pid: Optional[int] = None,
+    explicit_method: str = "auto",
+) -> RoutingResult:
+    """Resolve the best interaction method for a target application.
+
+    When ``explicit_method`` is anything other than "auto", returns that
+    method directly without running detection. Otherwise, resolves the
+    app/pid to a process and runs the detection chain.
+
+    Args:
+        app: Application name (fuzzy matched against running processes).
+        pid: Process ID (takes precedence over app name).
+        explicit_method: Value from ``--method`` flag. "auto" triggers
+            detection; any other value bypasses it.
+
+    Returns:
+        RoutingResult with the resolved method and metadata.
+    """
+    # Explicit override — skip detection entirely
+    if explicit_method != "auto":
+        logger.info("Method override: %s (skipping auto-detection)", explicit_method)
+        return RoutingResult(
+            pid=pid,
+            app_name=app or "",
+            method=explicit_method,
+            source="explicit",
+        )
+
+    # No target app specified — fall back to vision (coordinate-based)
+    if app is None and pid is None:
+        logger.debug("No app/pid specified, defaulting to vision method")
+        return RoutingResult(method="vision", source="auto")
+
+    # Resolve process
+    resolved_pid = pid
+    resolved_name = app or ""
+    if resolved_pid is None and app is not None:
+        try:
+            from naturo.process import find_process
+
+            proc = find_process(name=app)
+            if proc is not None:
+                resolved_pid = proc.pid
+                resolved_name = proc.name
+                logger.debug("Resolved app %r → PID %d (%s)", app, proc.pid, proc.name)
+            else:
+                logger.warning("App %r not found among running processes", app)
+                return RoutingResult(
+                    app_name=app,
+                    method="vision",
+                    source="auto",
+                )
+        except Exception as exc:
+            logger.debug("Process resolution failed: %s", exc)
+            return RoutingResult(
+                app_name=app or "",
+                method="vision",
+                source="auto",
+            )
+
+    # Run detection chain
+    if resolved_pid is not None:
+        try:
+            from naturo.detect.chain import detect
+
+            result = detect(pid=resolved_pid, app_name=resolved_name)
+            best = result.best_method()
+            if best is not None:
+                framework_name = (
+                    result.frameworks[0].framework_type.value
+                    if result.frameworks
+                    else "unknown"
+                )
+                logger.info(
+                    "Auto-routing: %s (PID %d) → %s [%s, confidence=%.2f]",
+                    resolved_name,
+                    resolved_pid,
+                    best.method.value,
+                    framework_name,
+                    best.confidence,
+                )
+                return RoutingResult(
+                    pid=resolved_pid,
+                    app_name=resolved_name,
+                    method=best.method.value,
+                    source="auto",
+                    framework=framework_name,
+                    confidence=best.confidence,
+                )
+            else:
+                logger.info(
+                    "Auto-routing: %s (PID %d) → no methods detected, "
+                    "falling back to vision",
+                    resolved_name,
+                    resolved_pid,
+                )
+        except Exception as exc:
+            logger.debug("Detection chain failed for PID %d: %s", resolved_pid, exc)
+
+    return RoutingResult(
+        pid=resolved_pid,
+        app_name=resolved_name,
+        method="vision",
+        source="auto",
+    )

--- a/tests/test_auto_route_integration.py
+++ b/tests/test_auto_route_integration.py
@@ -1,0 +1,71 @@
+"""Tests for _auto_route helper in interaction commands."""
+import pytest
+from unittest.mock import MagicMock, patch
+
+from naturo.cli.interaction import _auto_route
+
+
+class TestAutoRoute:
+    """Tests for the _auto_route helper function."""
+
+    def test_no_app_no_pid_returns_empty(self):
+        """When no app/pid specified, returns empty dict (no routing)."""
+        result = _auto_route(app=None, pid=None, method="auto", json_output=False)
+        assert result == {}
+
+    def test_explicit_method_returns_empty(self):
+        """When method is explicit (not auto), returns empty dict."""
+        result = _auto_route(app="Notepad", pid=None, method="uia", json_output=False)
+        assert result == {}
+
+    @patch("naturo.routing.resolve_method")
+    def test_auto_with_app_calls_routing(self, mock_resolve):
+        """When method=auto and app is set, calls resolve_method."""
+        from naturo.routing import RoutingResult
+
+        mock_resolve.return_value = RoutingResult(
+            pid=1234,
+            app_name="notepad.exe",
+            method="uia",
+            source="auto",
+            framework="win32",
+            confidence=0.9,
+        )
+
+        result = _auto_route(app="Notepad", pid=None, method="auto", json_output=False)
+        assert result["method"] == "uia"
+        assert result["framework"] == "win32"
+        assert result["pid"] == 1234
+        mock_resolve.assert_called_once_with(app="Notepad", pid=None, explicit_method="auto")
+
+    @patch("naturo.routing.resolve_method")
+    def test_auto_with_pid_calls_routing(self, mock_resolve):
+        """When method=auto and pid is set, calls resolve_method."""
+        from naturo.routing import RoutingResult
+
+        mock_resolve.return_value = RoutingResult(
+            pid=5678,
+            app_name="",
+            method="cdp",
+            source="auto",
+            framework="electron",
+            confidence=0.85,
+        )
+
+        result = _auto_route(app=None, pid=5678, method="auto", json_output=True)
+        assert result["method"] == "cdp"
+        assert result["source"] == "auto"
+        mock_resolve.assert_called_once_with(app=None, pid=5678, explicit_method="auto")
+
+    @patch("naturo.routing.resolve_method")
+    def test_routing_exception_returns_empty(self, mock_resolve):
+        """When routing raises an exception, returns empty dict gracefully."""
+        mock_resolve.side_effect = ImportError("module not found")
+
+        result = _auto_route(app="SomeApp", pid=None, method="auto", json_output=False)
+        assert result == {}
+
+    def test_explicit_method_no_app_returns_empty(self):
+        """Explicit method with no app returns empty dict."""
+        result = _auto_route(app=None, pid=None, method="cdp", json_output=False)
+        assert result == {}

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1,0 +1,241 @@
+"""Tests for naturo.routing — auto-routing for action commands."""
+import pytest
+from unittest.mock import MagicMock, patch
+
+from naturo.routing import RoutingResult, resolve_method
+
+
+class TestRoutingResult:
+    """Tests for RoutingResult dataclass."""
+
+    def test_default_values(self):
+        """RoutingResult has sensible defaults."""
+        result = RoutingResult()
+        assert result.pid is None
+        assert result.app_name == ""
+        assert result.method == "vision"
+        assert result.source == "auto"
+        assert result.framework == "unknown"
+        assert result.confidence == 0.0
+
+    def test_to_dict_complete(self):
+        """to_dict includes all fields."""
+        result = RoutingResult(
+            pid=1234,
+            app_name="Notepad",
+            method="uia",
+            source="auto",
+            framework="win32",
+            confidence=0.95,
+        )
+        d = result.to_dict()
+        assert d == {
+            "pid": 1234,
+            "app": "Notepad",
+            "method": "uia",
+            "source": "auto",
+            "framework": "win32",
+            "confidence": 0.95,
+        }
+
+    def test_to_dict_defaults(self):
+        """to_dict works with default values."""
+        result = RoutingResult()
+        d = result.to_dict()
+        assert d["pid"] is None
+        assert d["method"] == "vision"
+        assert d["source"] == "auto"
+
+
+class TestResolveMethodExplicit:
+    """Tests for resolve_method with explicit --method override."""
+
+    def test_explicit_method_skips_detection(self):
+        """When method is not 'auto', detection is skipped entirely."""
+        result = resolve_method(app="Notepad", explicit_method="uia")
+        assert result.method == "uia"
+        assert result.source == "explicit"
+
+    def test_explicit_method_preserves_app_name(self):
+        """Explicit method preserves the app name."""
+        result = resolve_method(app="Chrome", explicit_method="cdp")
+        assert result.app_name == "Chrome"
+        assert result.method == "cdp"
+
+    def test_explicit_method_preserves_pid(self):
+        """Explicit method preserves the PID."""
+        result = resolve_method(pid=9999, explicit_method="msaa")
+        assert result.pid == 9999
+        assert result.method == "msaa"
+
+    @pytest.mark.parametrize("method", ["cdp", "uia", "msaa", "jab", "ia2", "vision"])
+    def test_all_explicit_methods(self, method):
+        """All valid methods can be set explicitly."""
+        result = resolve_method(explicit_method=method)
+        assert result.method == method
+        assert result.source == "explicit"
+
+
+class TestResolveMethodNoTarget:
+    """Tests for resolve_method without app/pid."""
+
+    def test_no_target_defaults_to_vision(self):
+        """Without app or pid, defaults to vision."""
+        result = resolve_method()
+        assert result.method == "vision"
+        assert result.source == "auto"
+        assert result.pid is None
+
+    def test_no_target_auto_method(self):
+        """Auto method with no target returns vision."""
+        result = resolve_method(explicit_method="auto")
+        assert result.method == "vision"
+
+
+class TestResolveMethodWithApp:
+    """Tests for resolve_method with app name resolution."""
+
+    @patch("naturo.process.find_process")
+    def test_app_not_found_falls_back_to_vision(self, mock_find):
+        """When app is not found, falls back to vision."""
+        mock_find.return_value = None
+        result = resolve_method(app="NonExistentApp")
+        assert result.method == "vision"
+        assert result.source == "auto"
+        assert result.app_name == "NonExistentApp"
+
+    @patch("naturo.detect.chain.detect")
+    @patch("naturo.process.find_process")
+    def test_app_found_runs_detection(self, mock_find, mock_detect):
+        """When app is found, runs detection chain."""
+        mock_proc = MagicMock()
+        mock_proc.pid = 1234
+        mock_proc.name = "notepad.exe"
+        mock_find.return_value = mock_proc
+
+        mock_method = MagicMock()
+        mock_method.method.value = "uia"
+        mock_method.confidence = 0.9
+
+        mock_framework = MagicMock()
+        mock_framework.framework_type.value = "win32"
+
+        mock_result = MagicMock()
+        mock_result.best_method.return_value = mock_method
+        mock_result.frameworks = [mock_framework]
+        mock_detect.return_value = mock_result
+
+        result = resolve_method(app="Notepad")
+        assert result.method == "uia"
+        assert result.source == "auto"
+        assert result.pid == 1234
+        assert result.framework == "win32"
+        assert result.confidence == 0.9
+
+    @patch("naturo.detect.chain.detect")
+    @patch("naturo.process.find_process")
+    def test_detection_no_methods_falls_back(self, mock_find, mock_detect):
+        """When detection finds no methods, falls back to vision."""
+        mock_proc = MagicMock()
+        mock_proc.pid = 5678
+        mock_proc.name = "unknown.exe"
+        mock_find.return_value = mock_proc
+
+        mock_result = MagicMock()
+        mock_result.best_method.return_value = None
+        mock_result.frameworks = []
+        mock_detect.return_value = mock_result
+
+        result = resolve_method(app="Unknown")
+        assert result.method == "vision"
+        assert result.source == "auto"
+
+    @patch("naturo.process.find_process")
+    def test_process_resolution_exception(self, mock_find):
+        """When find_process raises, falls back to vision gracefully."""
+        mock_find.side_effect = RuntimeError("process lookup failed")
+        result = resolve_method(app="CrashApp")
+        assert result.method == "vision"
+        assert result.source == "auto"
+
+
+class TestResolveMethodWithPid:
+    """Tests for resolve_method with explicit PID."""
+
+    @patch("naturo.detect.chain.detect")
+    def test_pid_runs_detection_directly(self, mock_detect):
+        """PID skips process resolution, runs detection directly."""
+        mock_method = MagicMock()
+        mock_method.method.value = "cdp"
+        mock_method.confidence = 0.85
+
+        mock_framework = MagicMock()
+        mock_framework.framework_type.value = "electron"
+
+        mock_result = MagicMock()
+        mock_result.best_method.return_value = mock_method
+        mock_result.frameworks = [mock_framework]
+        mock_detect.return_value = mock_result
+
+        result = resolve_method(pid=4321)
+        assert result.method == "cdp"
+        assert result.pid == 4321
+        assert result.framework == "electron"
+
+    @patch("naturo.detect.chain.detect")
+    def test_detection_exception_falls_back(self, mock_detect):
+        """When detection chain raises, falls back to vision."""
+        mock_detect.side_effect = RuntimeError("COM error")
+        result = resolve_method(pid=9999)
+        assert result.method == "vision"
+        assert result.source == "auto"
+        assert result.pid == 9999
+
+
+class TestResolveMethodEdgeCases:
+    """Edge cases and integration scenarios."""
+
+    def test_explicit_auto_with_no_target(self):
+        """Explicitly passing 'auto' with no target returns vision."""
+        result = resolve_method(explicit_method="auto")
+        assert result.method == "vision"
+
+    @patch("naturo.detect.chain.detect")
+    @patch("naturo.process.find_process")
+    def test_app_and_pid_prefers_pid(self, mock_find, mock_detect):
+        """When both app and pid are given, pid takes precedence."""
+        mock_method = MagicMock()
+        mock_method.method.value = "uia"
+        mock_method.confidence = 1.0
+
+        mock_result = MagicMock()
+        mock_result.best_method.return_value = mock_method
+        mock_result.frameworks = []
+        mock_detect.return_value = mock_result
+
+        result = resolve_method(app="Notepad", pid=1111)
+        # pid is set, so find_process is not called
+        mock_find.assert_not_called()
+        assert result.pid == 1111
+
+    @patch("naturo.detect.chain.detect")
+    @patch("naturo.process.find_process")
+    def test_detection_no_frameworks_unknown(self, mock_find, mock_detect):
+        """When detection returns no frameworks, framework is 'unknown'."""
+        mock_proc = MagicMock()
+        mock_proc.pid = 1234
+        mock_proc.name = "app.exe"
+        mock_find.return_value = mock_proc
+
+        mock_method = MagicMock()
+        mock_method.method.value = "uia"
+        mock_method.confidence = 0.5
+
+        mock_result = MagicMock()
+        mock_result.best_method.return_value = mock_method
+        mock_result.frameworks = []
+        mock_detect.return_value = mock_result
+
+        result = resolve_method(app="App")
+        assert result.framework == "unknown"
+        assert result.method == "uia"


### PR DESCRIPTION
## Summary

Wires the detection chain into action commands (click, type, press, hotkey, scroll) so they automatically detect the best interaction method for the target application.

## Changes

- **New `naturo/routing.py`**: `resolve_method()` orchestrates process lookup → detection chain → `RoutingResult` with method/framework/confidence
- **`_auto_route()` helper**: Integrates routing into all action commands via a shared helper. When `--app` or `--pid` is specified with `--method auto` (default), the routing system runs detection and includes routing info in JSON output
- **Graceful fallback**: Any detection failure falls back to vision (coordinate-based) without disrupting the command
- **29 new tests** covering explicit/auto routing, edge cases, exception handling

## How It Works

```bash
# Auto-routing (default): naturo detects Electron → recommends CDP
naturo click "Save" --app "VS Code" -j
# → {"success": true, "data": {"action": "clicked", "target": "Save", "routing": {"method": "cdp", "framework": "electron", ...}}}

# Explicit override: skip detection, use UIA directly
naturo click "Save" --app "VS Code" --method uia
```

## Test Results

- 1334 passed, 443 skipped, 0 failures
- Python 3.10+ compatible