### PR TITLE
fix: add encoding='utf-8' to open() calls and handle headless see test (fixes #108, fixes #130)

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -361,8 +361,25 @@ def _has_gui_backend() -> bool:
 _GUI = _has_gui_backend()
 
 
+def _expected_see_exit() -> int:
+    """Return expected exit code for ``see`` with no args.
+
+    On Windows with a desktop session ``see`` succeeds (0).  On non-Windows
+    or headless/SSH Windows it returns 1 (no display).
+    """
+    if platform.system() != "Windows":
+        return 1
+    # Headless Windows (SSH / CI without desktop) also returns 1
+    try:
+        import ctypes
+        desktop = ctypes.windll.user32.GetDesktopWindow()
+        return 0 if desktop else 1
+    except Exception:
+        return 1
+
+
 @pytest.mark.parametrize("cmd,expected_exit", [
-    (["see"], 1 if platform.system() != "Windows" else 0),
+    (["see"], _expected_see_exit()),
     pytest.param(["capture", "live"], 0, marks=pytest.mark.skipif(platform.system() != "Windows", reason="capture live needs desktop session")),
 ])
 def test_placeholder_commands_run(runner, cmd, expected_exit):

--- a/tests/test_window_management.py
+++ b/tests/test_window_management.py
@@ -679,57 +679,57 @@ class TestMCPWindowToolsExist:
     def test_focus_window_function_exists(self):
         from naturo import mcp_server
         # Check the module has the functions
-        source = open(mcp_server.__file__).read()
+        source = open(mcp_server.__file__, encoding='utf-8').read()
         assert "def focus_window(" in source or "def window_focus(" in source
 
     def test_window_close_function_exists(self):
         from naturo import mcp_server
-        source = open(mcp_server.__file__).read()
+        source = open(mcp_server.__file__, encoding='utf-8').read()
         assert "def window_close(" in source
 
     def test_window_minimize_function_exists(self):
         from naturo import mcp_server
-        source = open(mcp_server.__file__).read()
+        source = open(mcp_server.__file__, encoding='utf-8').read()
         assert "def window_minimize(" in source
 
     def test_window_maximize_function_exists(self):
         from naturo import mcp_server
-        source = open(mcp_server.__file__).read()
+        source = open(mcp_server.__file__, encoding='utf-8').read()
         assert "def window_maximize(" in source
 
     def test_window_restore_function_exists(self):
         from naturo import mcp_server
-        source = open(mcp_server.__file__).read()
+        source = open(mcp_server.__file__, encoding='utf-8').read()
         assert "def window_restore(" in source
 
     def test_window_move_function_exists(self):
         from naturo import mcp_server
-        source = open(mcp_server.__file__).read()
+        source = open(mcp_server.__file__, encoding='utf-8').read()
         assert "def window_move(" in source
 
     def test_window_resize_function_exists(self):
         from naturo import mcp_server
-        source = open(mcp_server.__file__).read()
+        source = open(mcp_server.__file__, encoding='utf-8').read()
         assert "def window_resize(" in source
 
     def test_window_set_bounds_function_exists(self):
         from naturo import mcp_server
-        source = open(mcp_server.__file__).read()
+        source = open(mcp_server.__file__, encoding='utf-8').read()
         assert "def window_set_bounds(" in source
 
     def test_app_hide_function_exists(self):
         from naturo import mcp_server
-        source = open(mcp_server.__file__).read()
+        source = open(mcp_server.__file__, encoding='utf-8').read()
         assert "def app_hide(" in source
 
     def test_app_unhide_function_exists(self):
         from naturo import mcp_server
-        source = open(mcp_server.__file__).read()
+        source = open(mcp_server.__file__, encoding='utf-8').read()
         assert "def app_unhide(" in source
 
     def test_app_switch_function_exists(self):
         from naturo import mcp_server
-        source = open(mcp_server.__file__).read()
+        source = open(mcp_server.__file__, encoding='utf-8').read()
         assert "def app_switch(" in source
 
 


### PR DESCRIPTION
## Changes

### #108 — UnicodeDecodeError on Windows GBK locale
All 11 `open(mcp_server.__file__).read()` calls in `test_window_management.py` now use `encoding='utf-8'`, preventing GBK decode failures.

### #130 — see test expects exit code 0 on headless Windows
`test_placeholder_commands_run` now uses `_expected_see_exit()` helper that checks for an actual desktop session via `GetDesktopWindow()`. On headless/SSH Windows, expected exit code is 1 (matching reality).

**Tests:** 1334 passed, 465 skipped locally.