### PR TITLE
fix: add mouse_down/mouse_up API and fix drag to hold button during movement (fixes #155)

### DIFF
--- a/core/include/naturo/exports.h
+++ b/core/include/naturo/exports.h
@@ -143,6 +143,20 @@ NATURO_API int naturo_mouse_move(int x, int y);
 NATURO_API int naturo_mouse_click(int button, int double_click);
 
 /**
+ * @brief Press a mouse button down (without releasing).
+ * @param button Mouse button: 0 = left, 1 = right, 2 = middle.
+ * @return 0 on success, -1 on invalid argument, -2 on system error.
+ */
+NATURO_API int naturo_mouse_down(int button);
+
+/**
+ * @brief Release a mouse button.
+ * @param button Mouse button: 0 = left, 1 = right, 2 = middle.
+ * @return 0 on success, -1 on invalid argument, -2 on system error.
+ */
+NATURO_API int naturo_mouse_up(int button);
+
+/**
  * @brief Scroll the mouse wheel.
  * @param delta Positive = scroll up/forward, negative = scroll down/backward.
  *              Typically ±120 per notch (Windows WHEEL_DELTA).

--- a/core/src/input.cpp
+++ b/core/src/input.cpp
@@ -167,6 +167,40 @@ extern "C" NATURO_API int naturo_mouse_click(int button, int double_click) {
     return 0;
 }
 
+/* ── naturo_mouse_down ─────────────────────────────── */
+
+extern "C" NATURO_API int naturo_mouse_down(int button) {
+    if (button < 0 || button > 2) return -1;
+
+    DWORD down_flag;
+    switch (button) {
+        case 0:  down_flag = MOUSEEVENTF_LEFTDOWN;   break;
+        case 1:  down_flag = MOUSEEVENTF_RIGHTDOWN;  break;
+        case 2:  down_flag = MOUSEEVENTF_MIDDLEDOWN; break;
+        default: return -1;
+    }
+
+    INPUT inp = make_mouse_input(down_flag);
+    return send_inputs(&inp, 1);
+}
+
+/* ── naturo_mouse_up ──────────────────────────────── */
+
+extern "C" NATURO_API int naturo_mouse_up(int button) {
+    if (button < 0 || button > 2) return -1;
+
+    DWORD up_flag;
+    switch (button) {
+        case 0:  up_flag = MOUSEEVENTF_LEFTUP;   break;
+        case 1:  up_flag = MOUSEEVENTF_RIGHTUP;  break;
+        case 2:  up_flag = MOUSEEVENTF_MIDDLEUP; break;
+        default: return -1;
+    }
+
+    INPUT inp = make_mouse_input(up_flag);
+    return send_inputs(&inp, 1);
+}
+
 /* ── naturo_mouse_scroll ──────────────────────────── */
 
 extern "C" NATURO_API int naturo_mouse_scroll(int delta, int horizontal) {
@@ -550,6 +584,8 @@ extern "C" NATURO_API int naturo_phys_key_hotkey(int modifiers, const char* key_
 
 extern "C" NATURO_API int naturo_mouse_move(int, int)               { return -1; }
 extern "C" NATURO_API int naturo_mouse_click(int, int)              { return -1; }
+extern "C" NATURO_API int naturo_mouse_down(int)                    { return -1; }
+extern "C" NATURO_API int naturo_mouse_up(int)                      { return -1; }
 extern "C" NATURO_API int naturo_mouse_scroll(int, int)             { return -1; }
 extern "C" NATURO_API int naturo_key_type(const char*, int)         { return -1; }
 extern "C" NATURO_API int naturo_key_press(const char*)             { return -1; }

--- a/core/tests/test_input.cpp
+++ b/core/tests/test_input.cpp
@@ -46,6 +46,34 @@ static int test_mouse_click_valid() {
     return 0;
 }
 
+/* ── naturo_mouse_down / naturo_mouse_up ──────────── */
+
+static int test_mouse_down_invalid_button() {
+    int rc = naturo_mouse_down(5);
+    CHECK(rc == -1, "mouse_down(button=5) returns -1");
+    return 0;
+}
+
+static int test_mouse_down_valid() {
+    int rc = naturo_mouse_down(0);  // left press
+    CHECK(rc == 0 || rc == -2, "mouse_down(left) returns 0 or -2");
+    // Immediately release to avoid stuck button
+    if (rc == 0) naturo_mouse_up(0);
+    return 0;
+}
+
+static int test_mouse_up_invalid_button() {
+    int rc = naturo_mouse_up(5);
+    CHECK(rc == -1, "mouse_up(button=5) returns -1");
+    return 0;
+}
+
+static int test_mouse_up_valid() {
+    int rc = naturo_mouse_up(0);  // left release (even if not held, should succeed)
+    CHECK(rc == 0 || rc == -2, "mouse_up(left) returns 0 or -2");
+    return 0;
+}
+
 /* ── naturo_mouse_scroll ──────────────────────────── */
 
 static int test_mouse_scroll_down() {
@@ -154,6 +182,10 @@ int main() {
     failures += test_mouse_move_valid();
     failures += test_mouse_click_invalid_button();
     failures += test_mouse_click_valid();
+    failures += test_mouse_down_invalid_button();
+    failures += test_mouse_down_valid();
+    failures += test_mouse_up_invalid_button();
+    failures += test_mouse_up_valid();
     failures += test_mouse_scroll_down();
     failures += test_mouse_scroll_horizontal();
     failures += test_key_press_null();

--- a/naturo/backends/windows.py
+++ b/naturo/backends/windows.py
@@ -1186,18 +1186,18 @@ class WindowsBackend(Backend):
         delay_s = (duration_ms / 1000.0) / steps
 
         core.mouse_move(from_x, from_y)
-        core.mouse_click(0, False)  # Press: we simulate hold via move+release
+        time.sleep(0.05)  # Brief settle before pressing
+        core.mouse_down(0)  # Press and hold left button
 
-        # Actually we need press-down + move + release-up.
-        # NaturoCore.mouse_click does down+up; we need separate press/release.
-        # For now, use a rapid move sequence with brief hold simulation.
-        # This is sufficient for Phase 2; Phase 3 will add proper hold support.
-        for i in range(1, steps + 1):
-            t = i / steps
-            ix = int(from_x + (to_x - from_x) * t)
-            iy = int(from_y + (to_y - from_y) * t)
-            core.mouse_move(ix, iy)
-            time.sleep(delay_s)
+        try:
+            for i in range(1, steps + 1):
+                t = i / steps
+                ix = int(from_x + (to_x - from_x) * t)
+                iy = int(from_y + (to_y - from_y) * t)
+                core.mouse_move(ix, iy)
+                time.sleep(delay_s)
+        finally:
+            core.mouse_up(0)  # Always release, even on error
 
     def move_mouse(self, x: int = 0, y: int = 0) -> None:
         """Move the mouse cursor to absolute screen coordinates.

--- a/naturo/bridge.py
+++ b/naturo/bridge.py
@@ -220,6 +220,12 @@ class NaturoCore:
         self._lib.naturo_mouse_click.restype = ctypes.c_int
         self._lib.naturo_mouse_click.argtypes = [ctypes.c_int, ctypes.c_int]
 
+        self._lib.naturo_mouse_down.restype = ctypes.c_int
+        self._lib.naturo_mouse_down.argtypes = [ctypes.c_int]
+
+        self._lib.naturo_mouse_up.restype = ctypes.c_int
+        self._lib.naturo_mouse_up.argtypes = [ctypes.c_int]
+
         self._lib.naturo_mouse_scroll.restype = ctypes.c_int
         self._lib.naturo_mouse_scroll.argtypes = [ctypes.c_int, ctypes.c_int]
 
@@ -653,6 +659,37 @@ class NaturoCore:
         rc = self._lib.naturo_mouse_click(button, 1 if double else 0)
         if rc != 0:
             raise NaturoCoreError(rc, "mouse_click")
+
+    def mouse_down(self, button: int = 0) -> None:
+        """Press a mouse button down without releasing.
+
+        Used for drag operations where the button must remain held
+        during cursor movement.
+
+        Args:
+            button: Mouse button: 0 = left, 1 = right, 2 = middle.
+
+        Raises:
+            NaturoCoreError: On invalid argument or system error.
+        """
+        rc = self._lib.naturo_mouse_down(button)
+        if rc != 0:
+            raise NaturoCoreError(rc, "mouse_down")
+
+    def mouse_up(self, button: int = 0) -> None:
+        """Release a mouse button.
+
+        Used to complete drag operations by releasing the held button.
+
+        Args:
+            button: Mouse button: 0 = left, 1 = right, 2 = middle.
+
+        Raises:
+            NaturoCoreError: On invalid argument or system error.
+        """
+        rc = self._lib.naturo_mouse_up(button)
+        if rc != 0:
+            raise NaturoCoreError(rc, "mouse_up")
 
     def mouse_scroll(self, delta: int, horizontal: bool = False) -> None:
         """Scroll the mouse wheel.

--- a/tests/test_input_mouse.py
+++ b/tests/test_input_mouse.py
@@ -515,3 +515,55 @@ class TestMouseFunctionalWindows:
             "--steps", "5",
         ])
         assert result.exit_code == 0
+
+
+# ── Drag uses mouse_down/mouse_up (not mouse_click) ──────────────────────────
+
+
+class TestDragHoldBehavior:
+    """Verify drag() uses proper press-hold-release via mouse_down/mouse_up."""
+
+    def test_drag_calls_mouse_down_and_up(self):
+        """Drag must call mouse_down at start and mouse_up at end, not mouse_click."""
+        from unittest.mock import MagicMock, call
+        from naturo.backends.windows import WindowsBackend
+
+        backend = WindowsBackend.__new__(WindowsBackend)
+        mock_core = MagicMock()
+        backend._core = mock_core
+        backend._ensure_core = MagicMock(return_value=mock_core)
+
+        backend.drag(from_x=10, from_y=20, to_x=100, to_y=200, duration_ms=50, steps=2)
+
+        # Must call mouse_down(0) to press, mouse_up(0) to release
+        mock_core.mouse_down.assert_called_once_with(0)
+        mock_core.mouse_up.assert_called_once_with(0)
+        # Must NOT call mouse_click (old broken behavior)
+        mock_core.mouse_click.assert_not_called()
+
+    def test_drag_releases_on_error(self):
+        """mouse_up must be called even if mouse_move raises during drag."""
+        from unittest.mock import MagicMock
+        from naturo.backends.windows import WindowsBackend
+
+        backend = WindowsBackend.__new__(WindowsBackend)
+        mock_core = MagicMock()
+        backend._core = mock_core
+        backend._ensure_core = MagicMock(return_value=mock_core)
+
+        # Make mouse_move raise on the second call (during interpolation)
+        call_count = [0]
+        original_move = mock_core.mouse_move
+
+        def move_side_effect(x, y):
+            call_count[0] += 1
+            if call_count[0] > 1:  # Fail on first interpolation step
+                raise RuntimeError("Simulated move failure")
+
+        mock_core.mouse_move.side_effect = move_side_effect
+
+        with pytest.raises(RuntimeError, match="Simulated move failure"):
+            backend.drag(from_x=0, from_y=0, to_x=100, to_y=100, duration_ms=50, steps=2)
+
+        # mouse_up MUST still be called (finally block)
+        mock_core.mouse_up.assert_called_once_with(0)


### PR DESCRIPTION
## Problem
`naturo drag` moved the cursor from A to B but nothing was actually dragged. The drag command was fundamentally broken.

## Root Cause
`drag()` called `mouse_click(0, False)` which sends both DOWN+UP events immediately, then moved the cursor without holding any button. The OS saw: click at A, then cursor movement — no drag.

## Fix
- **C++ API**: Added `naturo_mouse_down(button)` and `naturo_mouse_up(button)` — separate press/release using `SendInput` with individual `MOUSEEVENTF_*DOWN` / `MOUSEEVENTF_*UP` flags
- **Python bridge**: Added `mouse_down()` and `mouse_up()` bindings
- **WindowsBackend.drag()**: Now uses `mouse_down(0)` → interpolated moves → `mouse_up(0)` with `try/finally` to guarantee release even on error

## Tests
- C++ unit tests for mouse_down/mouse_up (valid buttons + invalid button rejection)
- Python unit tests verifying drag calls mouse_down/mouse_up (not mouse_click)
- Python test for mouse_up release on error (finally block)
- All 1409 existing tests pass (465 skipped — platform-gated)

## Impact
This is a P0 fix — drag is a fundamental interaction primitive.