### PR TITLE
fix: capture uses timestamped filenames to avoid overwriting (fixes #152)

### DIFF
--- a/naturo/cli/core.py
+++ b/naturo/cli/core.py
@@ -96,9 +96,12 @@ def live(app, window_title, hwnd, screen, path, fmt, store_snapshot, json_output
             click.echo(msg)
         raise SystemExit(1)
 
-    # Resolve output path: use --path if given, else capture.<format>
+    # Resolve output path: use --path if given, else timestamped name
     if path is None:
-        path = f"capture.{fmt}"
+        from datetime import datetime
+        timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        app_label = (app or "screen").lower().replace(" ", "-")
+        path = f"naturo-{app_label}-{timestamp}.{fmt}"
 
     try:
         backend = _get_backend()


### PR DESCRIPTION
## Problem
`naturo capture live` always saves to `capture.png`, overwriting previous captures.

## Fix
Default filename is now `naturo-{app}-{YYYYMMDD}-{HHMMSS}.{fmt}`:
- `naturo capture live --app terminal` → `naturo-terminal-20260323-145500.png`
- `naturo capture live` → `naturo-screen-20260323-145500.png`
- `naturo capture live --path my.png` → `my.png` (explicit path unchanged)

## Tests
All capture tests pass (21 passed, 18 skipped).