### PR TITLE
fix: app switch excludes calling terminal from matches (fixes #151)

### DIFF
--- a/naturo/cli/app_cmd.py
+++ b/naturo/cli/app_cmd.py
@@ -4,10 +4,44 @@ Replaces the stub implementations in system.py with working process management.
 These are registered as subcommands of the existing ``app`` group.
 """
 import json
+import os
 
 from naturo.cli.error_helpers import json_error as _json_error_str
 import sys
 import click
+
+
+def _match_windows(windows, name_lower):
+    """Match windows by name, excluding the calling process and prioritizing process name.
+
+    Returns a list of matching windows sorted so that process-name matches
+    come before title-only matches.  The calling process (own PID and its
+    parent, to cover the terminal hosting the command) is excluded so that
+    ``naturo app switch feishu`` doesn't accidentally match the terminal
+    whose title contains the typed command.
+
+    Args:
+        windows: Iterable of window info objects with ``.process_name``,
+            ``.title``, and ``.pid`` attributes.
+        name_lower: Lowercased search term.
+
+    Returns:
+        List of matching windows (process-name matches first, then
+        title-only matches), excluding windows owned by this process.
+    """
+    own_pid = os.getpid()
+    parent_pid = os.getppid()
+
+    process_matches = []
+    title_matches = []
+    for w in windows:
+        if w.pid in (own_pid, parent_pid):
+            continue
+        if name_lower in w.process_name.lower():
+            process_matches.append(w)
+        elif name_lower in w.title.lower():
+            title_matches.append(w)
+    return process_matches + title_matches
 
 
 def _safe_echo(text: str, **kwargs) -> None:
@@ -234,7 +268,7 @@ def app_hide(ctx, name, json_output):
         backend = get_backend()
         windows = backend.list_windows()
         name_lower = name.lower()
-        matched = [w for w in windows if name_lower in w.process_name.lower() or name_lower in w.title.lower()]
+        matched = _match_windows(windows, name_lower)
         if not matched:
             from naturo.errors import AppNotFoundError
             raise AppNotFoundError(name)
@@ -271,7 +305,7 @@ def app_unhide(ctx, name, json_output):
         backend = get_backend()
         windows = backend.list_windows()
         name_lower = name.lower()
-        matched = [w for w in windows if name_lower in w.process_name.lower() or name_lower in w.title.lower()]
+        matched = _match_windows(windows, name_lower)
         if not matched:
             from naturo.errors import AppNotFoundError
             raise AppNotFoundError(name)
@@ -308,7 +342,7 @@ def app_switch(ctx, name, json_output):
         backend = get_backend()
         windows = backend.list_windows()
         name_lower = name.lower()
-        matched = [w for w in windows if name_lower in w.process_name.lower() or name_lower in w.title.lower()]
+        matched = _match_windows(windows, name_lower)
         if not matched:
             from naturo.errors import AppNotFoundError
             raise AppNotFoundError(name)

--- a/tests/test_app_control.py
+++ b/tests/test_app_control.py
@@ -445,3 +445,75 @@ class TestAppLifecycleE2EWindows:
                 proc.wait(timeout=3)
             except Exception:
                 pass
+
+
+# ── _match_windows helper tests (fixes #151) ─────────────────────────────────
+
+
+class _FakeWindow:
+    """Minimal window stub for testing _match_windows."""
+
+    def __init__(self, process_name: str, title: str, pid: int):
+        self.process_name = process_name
+        self.title = title
+        self.pid = pid
+        self.handle = 0
+
+
+class TestMatchWindows:
+    """Unit tests for the _match_windows helper that excludes the calling
+    process and prioritizes process-name matches over title-only matches."""
+
+    def test_excludes_own_pid(self):
+        """Windows belonging to the calling process are excluded."""
+        from naturo.cli.app_cmd import _match_windows
+
+        own_pid = os.getpid()
+        windows = [
+            _FakeWindow("feishu", "Feishu Chat", 1000),
+            _FakeWindow("cmd", "naturo app switch feishu", own_pid),
+        ]
+        matched = _match_windows(windows, "feishu")
+        assert len(matched) == 1
+        assert matched[0].process_name == "feishu"
+
+    def test_excludes_parent_pid(self):
+        """Windows belonging to the parent process are also excluded."""
+        from naturo.cli.app_cmd import _match_windows
+
+        parent_pid = os.getppid()
+        windows = [
+            _FakeWindow("feishu", "Feishu Chat", 1000),
+            _FakeWindow("bash", "naturo app switch feishu", parent_pid),
+        ]
+        matched = _match_windows(windows, "feishu")
+        assert len(matched) == 1
+        assert matched[0].process_name == "feishu"
+
+    def test_process_name_match_before_title_match(self):
+        """Process-name matches appear before title-only matches."""
+        from naturo.cli.app_cmd import _match_windows
+
+        windows = [
+            _FakeWindow("explorer", "feishu download folder", 2000),
+            _FakeWindow("feishu", "Feishu Main Window", 3000),
+        ]
+        matched = _match_windows(windows, "feishu")
+        assert len(matched) == 2
+        assert matched[0].process_name == "feishu"
+        assert matched[1].process_name == "explorer"
+
+    def test_no_match_returns_empty(self):
+        """When nothing matches, an empty list is returned."""
+        from naturo.cli.app_cmd import _match_windows
+
+        windows = [_FakeWindow("notepad", "Untitled - Notepad", 4000)]
+        assert _match_windows(windows, "feishu") == []
+
+    def test_case_insensitive_matching(self):
+        """Matching is case-insensitive."""
+        from naturo.cli.app_cmd import _match_windows
+
+        windows = [_FakeWindow("Feishu", "FEISHU Chat", 5000)]
+        matched = _match_windows(windows, "feishu")
+        assert len(matched) == 1


### PR DESCRIPTION
## Problem
`naturo app switch feishu` matches the invoking terminal window because its title contains the command line text including "feishu".

## Fix
- Extract shared `_match_windows()` helper in `app_cmd.py` that:
  1. **Excludes own PID and parent PID** from results (terminal/shell)
  2. **Prioritizes process-name matches** over title-only matches (feishu.exe > window title containing "feishu")
- Replace inline matching in `app_switch`, `app_hide`, and `app_unhide` with the shared helper
- Add 5 unit tests covering PID exclusion, priority ordering, empty results, and case insensitivity

## Testing
- `pytest tests/test_app_control.py::TestMatchWindows -x -q` — 5/5 pass
- Full suite: 1424 passed, 467 skipped