### PR TITLE
feat: standardize CLI parameter names across all commands (fixes #166)

### DIFF
--- a/naturo/cli/core.py
+++ b/naturo/cli/core.py
@@ -72,9 +72,10 @@ def capture():
 
 
 @capture.command()
-@click.option("--app", help="Application name to capture")
-@click.option("--window-title", help="Window title pattern")
-@click.option("--hwnd", type=int, help="Window handle (HWND)")
+@click.option("--app", help="Target application (name or partial match)")
+@click.option("--window", "window_title", default=None, help="Window title pattern (substring match)")
+@click.option("--window-title", "window_title", default=None, hidden=True, help="")
+@click.option("--hwnd", type=int, default=None, help="Window handle (HWND)")
 @click.option("--screen", "-s", type=int, default=0, help="Screen/monitor index")
 @click.option("--path", "-p", default=None, help="Output file path (default: capture.<format>)")
 @click.option("--format", "fmt", type=click.Choice(["png", "jpg", "bmp"]), default="png", help="Image format (default: png)")
@@ -177,9 +178,10 @@ def live(app, window_title, hwnd, screen, path, fmt, store_snapshot, json_output
 
 
 @capture.command(hidden=True)
-@click.option("--app", help="Application name")
-@click.option("--window-title", help="Window title pattern")
-@click.option("--hwnd", type=int, help="Window handle (HWND)")
+@click.option("--app", help="Target application (name or partial match)")
+@click.option("--window", "window_title", default=None, help="Window title pattern (substring match)")
+@click.option("--window-title", "window_title", default=None, hidden=True, help="")
+@click.option("--hwnd", type=int, default=None, help="Window handle (HWND)")
 @click.option("--screen", "-s", type=int, help="Screen/monitor index")
 @click.option("--duration", "-d", type=float, default=5.0, help="Duration in seconds")
 @click.option("--fps", type=int, default=30, help="Frames per second")
@@ -196,9 +198,10 @@ def video(app, window_title, hwnd, screen, duration, fps, path, json_output):
 
 
 @capture.command(hidden=True)
-@click.option("--app", help="Application name")
-@click.option("--window-title", help="Window title pattern")
-@click.option("--hwnd", type=int, help="Window handle (HWND)")
+@click.option("--app", help="Target application (name or partial match)")
+@click.option("--window", "window_title", default=None, help="Window title pattern (substring match)")
+@click.option("--window-title", "window_title", default=None, hidden=True, help="")
+@click.option("--hwnd", type=int, default=None, help="Window handle (HWND)")
 @click.option("--interval", type=float, default=1.0, help="Check interval in seconds")
 @click.option("--timeout", type=float, help="Max watch time in seconds")
 @click.option("--path", "-p", help="Output directory")
@@ -233,11 +236,11 @@ def apps(ctx, show_all, json_output):
 
 
 @list_cmd.command()
-@click.option("--app", help="Filter by application name")
-@click.option("--process-name", help="Filter by process name")
-@click.option("--pid", type=int, help="Filter by process ID")
+@click.option("--app", help="Target application (name or partial match)")
+@click.option("--process-name", "app", default=None, hidden=True, help="")
+@click.option("--pid", type=int, help="Process ID")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def windows(app, process_name, pid, json_output):
+def windows(app, pid, json_output):
     """List open windows.
 
     Shows all visible top-level windows with their handles, titles,
@@ -258,10 +261,9 @@ def windows(app, process_name, pid, json_output):
         # Apply filters
         if app:
             app_lower = app.lower()
-            win_list = [w for w in win_list if app_lower in w.title.lower()]
-        if process_name:
-            pn_lower = process_name.lower()
-            win_list = [w for w in win_list if pn_lower in w.process_name.lower()]
+            win_list = [w for w in win_list
+                        if app_lower in w.title.lower()
+                        or app_lower in w.process_name.lower()]
         if pid:
             win_list = [w for w in win_list if w.pid == pid]
 
@@ -385,9 +387,10 @@ def permissions(json_output):
 
 
 @click.command()
-@click.option("--app", help="Application name")
-@click.option("--window-title", help="Window title pattern")
-@click.option("--hwnd", type=int, help="Window handle (HWND)")
+@click.option("--app", help="Target application (name or partial match)")
+@click.option("--window", "window_title", default=None, help="Window title pattern (substring match)")
+@click.option("--window-title", "window_title", default=None, hidden=True, help="")
+@click.option("--hwnd", type=int, default=None, help="Window handle (HWND)")
 @click.option("--pid", type=int, help="Process ID")
 @click.option(
     "--mode",

--- a/naturo/cli/get_cmd.py
+++ b/naturo/cli/get_cmd.py
@@ -39,11 +39,13 @@ def _get_backend():
               help="Element name filter")
 @click.option("--property", "-p", "prop", default=None,
               help="Return only a specific property (value, name, role, pattern)")
-@click.option("--app", default=None, help="Target application name")
-@click.option("--window-title", "--title", default=None,
-              help="Target window title (partial match)")
+@click.option("--app", default=None, help="Target application (name or partial match)")
+@click.option("--window", "window_title", default=None,
+              help="Window title pattern (substring match)")
+@click.option("--window-title", "window_title", default=None, hidden=True, help="")
+@click.option("--title", "window_title", default=None, hidden=True, help="")
 @click.option("--hwnd", default=None, type=int,
-              help="Target window handle")
+              help="Window handle (HWND)")
 @click.option("--json", "-j", "json_output", is_flag=True, default=None,
               help="JSON output")
 @click.pass_context

--- a/naturo/cli/interaction.py
+++ b/naturo/cli/interaction.py
@@ -220,15 +220,17 @@ def _auto_route(
 
 @click.command("click")
 @click.argument("query", required=False)
-@click.option("--on", "on_text", help="Text/element to click on")
+@click.option("--on", "on_text", help="Target element (eN ref or text label)")
 @click.option("--id", "element_id", help="Automation element ID")
 @click.option("--coords", nargs=2, type=int, metavar="X Y", help="X Y coordinates")
 @click.option("--double", is_flag=True, help="Double-click")
 @click.option("--right", is_flag=True, help="Right-click")
-@click.option("--app", help="Application name")
+@click.option("--app", help="Target application (name or partial match)")
 @click.option("--pid", type=int, help="Process ID")
-@click.option("--window-title", help="Window title pattern")
-@click.option("--window-id", "--hwnd", "window_id", type=int, help="Window handle (HWND)")
+@click.option("--window", "window_title", default=None, help="Window title pattern (substring match)")
+@click.option("--window-title", "window_title", default=None, hidden=True, help="")
+@click.option("--hwnd", type=int, default=None, help="Window handle (HWND)")
+@click.option("--window-id", "hwnd", type=int, default=None, hidden=True, help="")
 @click.option("--wait-for", type=float, help="Wait for element (seconds)", hidden=True)
 @click.option(
     "--input-mode",
@@ -237,10 +239,10 @@ def _auto_route(
     help="Input method: normal (SendInput), hardware (Phys32 driver), hook (MinHook injection)",
 )
 @_method_option
-@click.option("--process-name", help="Filter by process name")
+@click.option("--process-name", "app", default=None, hidden=True, help="")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 def click_cmd(query, on_text, element_id, coords, double, right, app, pid,
-              window_title, window_id, wait_for, input_mode, method, process_name,
+              window_title, hwnd, wait_for, input_mode, method,
               json_output):
     """Click on a UI element, text, or coordinates.
 
@@ -345,9 +347,10 @@ def click_cmd(query, on_text, element_id, coords, double, right, app, pid,
 @click.option("--paste", "paste_mode", is_flag=True, help="Paste via clipboard (Ctrl+V) instead of typing")
 @click.option("--file", "file_path", type=click.Path(), help="Read text from file (use with --paste)")
 @click.option("--restore/--no-restore", default=True, help="Restore clipboard after --paste", show_default=True)
-@click.option("--app", help="Application name")
-@click.option("--window-title", help="Window title pattern")
-@click.option("--hwnd", type=int, help="Window handle (HWND)")
+@click.option("--app", help="Target application (name or partial match)")
+@click.option("--window", "window_title", default=None, help="Window title pattern (substring match)")
+@click.option("--window-title", "window_title", default=None, hidden=True, help="")
+@click.option("--hwnd", type=int, default=None, help="Window handle (HWND)")
 @click.option(
     "--input-mode",
     type=click.Choice(["normal", "hardware", "hook"]),
@@ -355,11 +358,11 @@ def click_cmd(query, on_text, element_id, coords, double, right, app, pid,
     help="Input method: normal (SendInput), hardware (Phys32), hook (MinHook)",
 )
 @_method_option
-@click.option("--process-name", help="Filter by process name")
+@click.option("--process-name", "app", default=None, hidden=True, help="")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 def type_cmd(text, delay, profile, wpm, press_return, tab_count, escape,
              delete, clear, paste_mode, file_path, restore, app, window_title,
-             hwnd, input_mode, method, process_name, json_output):
+             hwnd, input_mode, method, json_output):
     """Type text with configurable speed and profile.
 
     TEXT is the string to type. Supports human-like variable-speed typing
@@ -455,9 +458,10 @@ def type_cmd(text, delay, profile, wpm, press_return, tab_count, escape,
 @click.argument("key", required=False, default=None)
 @click.option("--count", "-n", type=int, default=1, help="Number of times to press", show_default=True)
 @click.option("--delay", type=float, default=50.0, help="Delay between presses (ms)", show_default=True)
-@click.option("--app", help="Application name")
-@click.option("--window-title", help="Window title pattern")
-@click.option("--hwnd", type=int, help="Window handle (HWND)")
+@click.option("--app", help="Target application (name or partial match)")
+@click.option("--window", "window_title", default=None, help="Window title pattern (substring match)")
+@click.option("--window-title", "window_title", default=None, hidden=True, help="")
+@click.option("--hwnd", type=int, default=None, help="Window handle (HWND)")
 @click.option(
     "--input-mode",
     type=click.Choice(["normal", "hardware", "hook"]),
@@ -517,9 +521,10 @@ def press(key, count, delay, app, window_title, hwnd, input_mode, method, json_o
 @click.argument("keys", required=False)
 @click.option("--keys", "keys_option", multiple=True, help="Key names (repeatable)")
 @click.option("--hold-duration", type=float, help="Hold duration in ms")
-@click.option("--app", help="Application name")
-@click.option("--window-title", help="Window title pattern")
-@click.option("--hwnd", type=int, help="Window handle (HWND)")
+@click.option("--app", help="Target application (name or partial match)")
+@click.option("--window", "window_title", default=None, help="Window title pattern (substring match)")
+@click.option("--window-title", "window_title", default=None, hidden=True, help="")
+@click.option("--hwnd", type=int, default=None, help="Window handle (HWND)")
 @click.option(
     "--input-mode",
     type=click.Choice(["normal", "hardware", "hook"]),
@@ -597,9 +602,10 @@ def hotkey(keys, keys_option, hold_duration, app, window_title, hwnd,
 @click.option("--coords", nargs=2, type=int, metavar="X Y", help="Coordinates to scroll at")
 @click.option("--smooth", is_flag=True, help="Smooth scrolling (Phase 3)")
 @click.option("--delay", type=float, help="Delay between scroll steps (ms)")
-@click.option("--app", help="Application name")
-@click.option("--window-title", help="Window title pattern")
-@click.option("--hwnd", type=int, help="Window handle (HWND)")
+@click.option("--app", help="Target application (name or partial match)")
+@click.option("--window", "window_title", default=None, help="Window title pattern (substring match)")
+@click.option("--window-title", "window_title", default=None, hidden=True, help="")
+@click.option("--hwnd", type=int, default=None, help="Window handle (HWND)")
 @_method_option
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 def scroll(direction_arg, direction_option, amount, on_text, element_id, coords,
@@ -708,9 +714,10 @@ def scroll(direction_arg, direction_option, amount, on_text, element_id, coords,
     default="linear",
     help="Motion profile",
 )
-@click.option("--app", help="Application name")
-@click.option("--window-title", help="Window title pattern")
-@click.option("--hwnd", type=int, help="Window handle (HWND)")
+@click.option("--app", help="Target application (name or partial match)")
+@click.option("--window", "window_title", default=None, help="Window title pattern (substring match)")
+@click.option("--window-title", "window_title", default=None, hidden=True, help="")
+@click.option("--hwnd", type=int, default=None, help="Window handle (HWND)")
 @_method_option
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 def drag(from_text, from_coords, to_text, to_coords, duration, steps,
@@ -770,9 +777,10 @@ def drag(from_text, from_coords, to_text, to_coords, duration, steps,
 @click.option("--coords", nargs=2, type=int, metavar="X Y", help="Target X Y coordinates")
 @click.option("--id", "element_id", help="Target element automation ID")
 @click.option("--duration", type=float, default=0.0, help="Move duration (seconds)", hidden=True)
-@click.option("--app", help="Application name")
-@click.option("--window-title", help="Window title pattern")
-@click.option("--hwnd", type=int, help="Window handle (HWND)")
+@click.option("--app", help="Target application (name or partial match)")
+@click.option("--window", "window_title", default=None, help="Window title pattern (substring match)")
+@click.option("--window-title", "window_title", default=None, hidden=True, help="")
+@click.option("--hwnd", type=int, default=None, help="Window handle (HWND)")
 @_method_option
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 def move(to_text, coords, element_id, duration, app, window_title, hwnd,

--- a/naturo/cli/options.py
+++ b/naturo/cli/options.py
@@ -1,0 +1,105 @@
+"""Shared CLI option decorators for consistent parameter naming.
+
+Defines reusable Click option decorators so every command uses the same
+parameter names, Python variable names, and help text.  Old aliases
+(``--window-title``, ``--process-name``, ``--window-id``) are kept as
+hidden options for backward compatibility but excluded from ``--help``.
+
+Usage::
+
+    from naturo.cli.options import app_option, window_option, hwnd_option, pid_option
+
+    @click.command()
+    @app_option
+    @window_option
+    @hwnd_option
+    @pid_option
+    def my_cmd(app, window, hwnd, pid, ...):
+        ...
+"""
+from __future__ import annotations
+
+import click
+
+
+# ── Primary options (visible in --help) ──────────────────────────────────────
+
+def app_option(func):
+    """``--app`` — target application (partial name match)."""
+    return click.option(
+        "--app",
+        default=None,
+        help="Target application (name or partial match)",
+    )(func)
+
+
+def window_option(func):
+    """``--window`` — window title pattern (substring match).
+
+    Keeps ``--window-title`` and ``--title`` as hidden aliases.
+    The Python parameter is always ``window``.
+    """
+    # Hidden aliases first so the primary ``--window`` wins in --help
+    func = click.option(
+        "--window-title", "window", default=None, hidden=True, help="",
+    )(func)
+    func = click.option(
+        "--title", "window", default=None, hidden=True, help="",
+    )(func)
+    func = click.option(
+        "--window", "window", default=None,
+        help="Window title pattern (substring match)",
+    )(func)
+    return func
+
+
+def hwnd_option(func):
+    """``--hwnd`` — window handle (exact, for scripting).
+
+    Keeps ``--window-id`` as a hidden alias.
+    """
+    func = click.option(
+        "--window-id", "hwnd", default=None, type=int, hidden=True, help="",
+    )(func)
+    func = click.option(
+        "--hwnd", default=None, type=int,
+        help="Window handle (HWND)",
+    )(func)
+    return func
+
+
+def pid_option(func):
+    """``--pid`` — process ID (exact)."""
+    return click.option(
+        "--pid", default=None, type=int,
+        help="Process ID",
+    )(func)
+
+
+def on_option(func):
+    """``--on`` — target element ref (eN) or text label."""
+    return click.option(
+        "--on", "on_ref", default=None,
+        help="Target element (eN ref or text label)",
+    )(func)
+
+
+def json_option(func):
+    """``--json / -j`` — JSON output mode."""
+    return click.option(
+        "--json", "-j", "json_output", is_flag=True,
+        help="JSON output",
+    )(func)
+
+
+# ── Hidden backward-compat aliases ──────────────────────────────────────────
+
+def process_name_option(func):
+    """Hidden ``--process-name`` alias for ``--app``.
+
+    Maps to the same Python parameter ``app`` so existing scripts
+    using ``--process-name`` continue to work.
+    """
+    return click.option(
+        "--process-name", "app", default=None, hidden=True, help="",
+    )(func)

--- a/naturo/cli/system.py
+++ b/naturo/cli/system.py
@@ -60,9 +60,10 @@ def menu():
 
 @menu.command(name="click")
 @click.argument("path")
-@click.option("--app", help="Application name")
-@click.option("--window-title", help="Window title pattern")
-@click.option("--hwnd", type=int, help="Window handle")
+@click.option("--app", help="Target application (name or partial match)")
+@click.option("--window", "window_title", default=None, help="Window title pattern (substring match)")
+@click.option("--window-title", "window_title", default=None, hidden=True, help="")
+@click.option("--hwnd", type=int, default=None, help="Window handle (HWND)")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 def menu_click(path, app, window_title, hwnd, json_output):
     """Click a menu item by path (e.g. 'File > Save As')."""
@@ -70,9 +71,10 @@ def menu_click(path, app, window_title, hwnd, json_output):
 
 
 @menu.command(name="list")
-@click.option("--app", help="Application name")
-@click.option("--window-title", help="Window title pattern")
-@click.option("--hwnd", type=int, help="Window handle")
+@click.option("--app", help="Target application (name or partial match)")
+@click.option("--window", "window_title", default=None, help="Window title pattern (substring match)")
+@click.option("--window-title", "window_title", default=None, hidden=True, help="")
+@click.option("--hwnd", type=int, default=None, help="Window handle (HWND)")
 @click.option("--depth", type=int, default=3, help="Menu tree depth")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 def menu_list(app, window_title, hwnd, depth, json_output):

--- a/naturo/cli/window_cmd.py
+++ b/naturo/cli/window_cmd.py
@@ -456,12 +456,12 @@ def set_bounds(ctx, app, title, hwnd, x, y, width, height, json_output):
 
 
 @window.command(name="list")
-@click.option("--app", help="Filter by application/process name")
-@click.option("--process-name", help="Filter by process name")
-@click.option("--pid", type=int, help="Filter by process ID")
+@click.option("--app", help="Target application (name or partial match)")
+@click.option("--process-name", "app", default=None, hidden=True, help="")
+@click.option("--pid", type=int, help="Process ID")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def window_list(ctx, app, process_name, pid, json_output):
+def window_list(ctx, app, pid, json_output):
     """List open windows."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
     from naturo.errors import NaturoError
@@ -474,9 +474,6 @@ def window_list(ctx, app, process_name, pid, json_output):
         if app:
             app_lower = app.lower()
             windows = [w for w in windows if app_lower in w.process_name.lower() or app_lower in w.title.lower()]
-        if process_name:
-            pn_lower = process_name.lower()
-            windows = [w for w in windows if pn_lower in w.process_name.lower()]
         if pid is not None:
             windows = [w for w in windows if w.pid == pid]
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -60,7 +60,7 @@ def test_capture_live_help(runner):
     result = runner.invoke(main, ["capture", "live", "--help"])
     assert result.exit_code == 0
     assert "--app" in result.output
-    assert "--window-title" in result.output
+    assert "--window" in result.output
     assert "--hwnd" in result.output
     assert "--path" in result.output
 
@@ -78,7 +78,7 @@ def test_see_help(runner):
     result = runner.invoke(main, ["see", "--help"])
     assert result.exit_code == 0
     assert "--app" in result.output
-    assert "--window-title" in result.output
+    assert "--window" in result.output
     assert "--mode" in result.output
     assert "--path" in result.output
     assert "--annotate" in result.output
@@ -110,14 +110,15 @@ def test_click_help(runner):
     assert "--double" in result.output
     assert "--right" in result.output
     assert "--app" in result.output
-    assert "--window-title" in result.output
+    assert "--window" in result.output
     # --wait-for is hidden (BUG-035: declared but not implemented)
     assert "--wait-for" not in result.output
     assert "--input-mode" in result.output
     assert "normal" in result.output
     assert "hardware" in result.output
     assert "hook" in result.output
-    assert "--process-name" in result.output
+    # --process-name is now a hidden alias for --app
+    assert "--process-name" not in result.output
     assert "--json" in result.output
 
 
@@ -135,7 +136,8 @@ def test_type_help(runner):
     assert "--delete" in result.output
     assert "--clear" in result.output
     assert "--input-mode" in result.output
-    assert "--process-name" in result.output
+    # --process-name is now a hidden alias for --app
+    assert "--process-name" not in result.output
     assert "--json" in result.output
 
 

--- a/tests/test_cli_phase1.py
+++ b/tests/test_cli_phase1.py
@@ -39,7 +39,8 @@ def test_list_windows_has_filters(runner):
     result = runner.invoke(main, ["list", "windows", "--help"])
     assert result.exit_code == 0
     assert "--app" in result.output
-    assert "--process-name" in result.output
+    # --process-name is now a hidden alias for --app
+    assert "--process-name" not in result.output
     assert "--pid" in result.output
 
 

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -135,10 +135,10 @@ class TestSeeCLISelectorOptions:
         assert result.exit_code == 0
         assert "--app" in result.output
 
-    def test_see_window_title_option(self, runner):
-        """T200 – see --window-title option is documented."""
+    def test_see_window_option(self, runner):
+        """T200 – see --window option is documented (renamed from --window-title)."""
         result = runner.invoke(main, ["see", "--help"])
-        assert "--window-title" in result.output
+        assert "--window" in result.output
 
     def test_see_json_option(self, runner):
         """T297 – see --json option is documented."""


### PR DESCRIPTION
## Summary

Standardize CLI parameter naming for consistency across all commands per #166.

### Changes

**New standard names:**
- `--window` replaces `--window-title`, `--title` (window title pattern)
- `--hwnd` replaces `--window-id` (window handle)
- `--app` absorbs `--process-name` (target application filter)
- Help text unified: identical wording for same parameter across all commands

**Backward compatibility:**
- Old names (`--window-title`, `--title`, `--window-id`, `--process-name`) kept as hidden aliases
- Existing scripts continue to work — old flags just don't show in `--help`

**New file:**
- `naturo/cli/options.py` — shared option decorators (single source of truth for future commands)

**Affected commands:** click, type, press, hotkey, scroll, drag, move, capture live/video/watch, see, get, list windows, window list, menu click/list

### Testing
- All 1424 tests pass (467 skipped — platform-specific)
- Verified hidden alias backward compat works