### PR TITLE
fix: global --json flag propagates to all subcommands (fixes #177)

### DIFF
--- a/naturo/cli/__init__.py
+++ b/naturo/cli/__init__.py
@@ -41,6 +41,42 @@ from naturo.cli.extensions import excel
 from naturo.cli.electron_cmd import electron, chrome
 
 
+def _patch_json_flag(cmd) -> None:
+    """Patch --json/-j flag on a Click command to inherit from parent ctx.obj['json'].
+
+    Replaces the ``json_output`` flag's callback so that when the flag is not
+    explicitly passed on the command line, it checks ``ctx.obj["json"]``
+    (set by the root ``naturo --json``).
+    """
+    for param in cmd.params:
+        if param.name == "json_output" and isinstance(param, click.Option):
+            original_callback = param.callback
+
+            def _json_callback(ctx, _param, value, _orig=original_callback):
+                # If the user explicitly passed --json on the subcommand, use it
+                if value:
+                    return True if _orig is None else _orig(ctx, _param, True)
+                # Otherwise check parent context chain for global --json
+                check = ctx
+                while check is not None:
+                    obj = getattr(check, "obj", None)
+                    if obj and obj.get("json"):
+                        return True if _orig is None else _orig(ctx, _param, True)
+                    check = check.parent
+                return False if _orig is None else _orig(ctx, _param, False)
+
+            param.callback = _json_callback
+            break
+
+
+def _patch_all_commands(group: click.BaseCommand) -> None:
+    """Recursively patch all commands under a group for --json propagation."""
+    if isinstance(group, click.Group):
+        for cmd in group.commands.values():
+            _patch_all_commands(cmd)
+    _patch_json_flag(group)
+
+
 @click.group()
 @click.version_option(__version__, prog_name="naturo")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
@@ -120,3 +156,7 @@ app.add_command(app_hide, "hide")
 app.add_command(app_unhide, "unhide")
 app.add_command(app_switch, "switch")
 app.add_command(app_inspect, "inspect")
+
+
+# ── Patch all commands to propagate global --json to subcommands ─────────────
+_patch_all_commands(main)

--- a/naturo/cli/options.py
+++ b/naturo/cli/options.py
@@ -84,6 +84,7 @@ def on_option(func):
     )(func)
 
 
+
 def json_option(func):
     """``--json / -j`` — JSON output mode."""
     return click.option(

--- a/tests/test_global_json_flag.py
+++ b/tests/test_global_json_flag.py
@@ -1,0 +1,111 @@
+"""Tests for global --json flag propagation to subcommands (fixes #177).
+
+The global ``naturo --json <command>`` should produce the same output as
+``naturo <command> --json``.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from naturo.cli import main
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+class TestGlobalJsonPropagation:
+    """Verify --json placed before the command name propagates correctly."""
+
+    def test_version_json(self, runner):
+        """naturo --json should not crash (version doesn't use json, but group should not error)."""
+        result = runner.invoke(main, ["--json", "--version"])
+        # --version always outputs text, but should not crash
+        assert result.exit_code == 0
+
+    def test_global_json_propagates_to_list_screens(self, runner):
+        """naturo --json list screens should produce JSON output."""
+        # Run with global --json
+        result_global = runner.invoke(main, ["--json", "list", "screens"])
+        # Run with per-command --json
+        result_local = runner.invoke(main, ["list", "screens", "-j"])
+
+        # Both should succeed
+        # On non-Windows, both may fail with same error — that's fine,
+        # what matters is they behave identically
+        assert result_global.exit_code == result_local.exit_code
+
+        # If they succeeded, verify both produce valid JSON
+        if result_global.exit_code == 0 and result_global.output.strip():
+            try:
+                json.loads(result_global.output)
+                global_is_json = True
+            except json.JSONDecodeError:
+                global_is_json = False
+
+            try:
+                json.loads(result_local.output)
+                local_is_json = True
+            except json.JSONDecodeError:
+                local_is_json = False
+
+            assert global_is_json == local_is_json, (
+                f"Global --json produces JSON={global_is_json}, "
+                f"local -j produces JSON={local_is_json}"
+            )
+
+    def test_global_json_propagates_to_snapshot_list(self, runner):
+        """naturo --json snapshot list should produce JSON."""
+        result_global = runner.invoke(main, ["--json", "snapshot", "list"])
+        result_local = runner.invoke(main, ["snapshot", "list", "-j"])
+        assert result_global.exit_code == result_local.exit_code
+
+    def test_ctx_obj_json_is_set(self, runner):
+        """Verify ctx.obj['json'] is set when --json is passed globally."""
+        import click
+        from naturo.cli import _patch_json_flag
+
+        captured = {}
+
+        @main.command("_test_json_ctx")
+        @click.option("--json", "-j", "json_output", is_flag=True)
+        @click.pass_context
+        def test_cmd(ctx, json_output):
+            captured["local"] = json_output
+            captured["ctx_json"] = ctx.obj.get("json", False)
+
+        # Patch the dynamically-added command (normally done at import time)
+        _patch_json_flag(test_cmd)
+
+        try:
+            runner.invoke(main, ["--json", "_test_json_ctx"])
+            # When global --json is used, ctx.obj["json"] should be True
+            assert captured.get("ctx_json") is True
+            # And the local json_output should also be True via callback
+            assert captured.get("local") is True
+        finally:
+            main.commands.pop("_test_json_ctx", None)
+
+    def test_no_json_when_not_passed(self, runner):
+        """Verify no JSON propagation when --json is not passed."""
+        import click
+
+        captured = {}
+
+        @main.command("_test_no_json")
+        @click.option("--json", "-j", "json_output", is_flag=True)
+        @click.pass_context
+        def test_cmd(ctx, json_output):
+            captured["local"] = json_output
+            captured["ctx_json"] = ctx.obj.get("json", False)
+
+        try:
+            runner.invoke(main, ["_test_no_json"])
+            assert captured.get("ctx_json") is False
+            assert captured.get("local") is False
+        finally:
+            main.commands.pop("_test_no_json", None)


### PR DESCRIPTION
## Summary
Fix the global `--json` flag (`naturo --json <command>`) to correctly propagate to all subcommands at any nesting depth.

## Problem
`naturo --json list screens` silently ignored the `--json` flag and produced plain text output, while `naturo list screens -j` worked correctly. This affected AI agents that reasonably place `--json` before the command name (a common CLI pattern).

## Solution
At import time, recursively patch all `--json/-j` flag callbacks across every registered command. The patched callback walks the Click context chain to check if any parent set `ctx.obj['json'] = True` (which the root group does when `naturo --json` is passed).

- `_patch_json_flag(cmd)` — replaces a single command's json_output callback
- `_patch_all_commands(group)` — recursively patches all commands under a group
- Zero changes needed to individual command functions
- Works for deeply nested groups (e.g., `list screens`, `app inspect`)

## Tests
- `test_global_json_flag.py` — 5 tests covering propagation through nested groups, context isolation, and version compatibility

## Before/After
```bash
# Before: plain text (WRONG)
naturo --json list screens

# After: JSON output (CORRECT)
naturo --json list screens
```

Fixes #177