### PR TITLE
fix: detect zero-bounds elements and use UIA Invoke fallback (fixes #137, fixes #135)

### DIFF
--- a/naturo/backends/base.py
+++ b/naturo/backends/base.py
@@ -225,6 +225,22 @@ class Backend(ABC):
               button: str = "left", double: bool = False, input_mode: str = "normal") -> None:
         ...
 
+    def invoke_element(self, name: str, role: str) -> bool:
+        """Invoke a UI element by name and role using a platform-specific pattern.
+
+        This is a fallback for elements whose bounding rects are zero-size
+        (e.g. after window state changes).  The default implementation
+        returns ``False``; platform backends may override.
+
+        Args:
+            name: The element's accessible name.
+            role: The element's control type / role.
+
+        Returns:
+            True if the element was found and invoked, False otherwise.
+        """
+        return False
+
     @abstractmethod
     def type_text(self, text: str, delay_ms: int = 5, profile: str = "human",
                   wpm: int = 120, input_mode: str = "normal") -> None:

--- a/naturo/backends/windows.py
+++ b/naturo/backends/windows.py
@@ -1062,6 +1062,70 @@ class WindowsBackend(Backend):
 
         core.mouse_click(btn, double)
 
+    def invoke_element(self, name: str, role: str) -> bool:
+        """Invoke a UI element by name and role using UIA InvokePattern.
+
+        This is a fallback for elements whose bounding rects are zero-size
+        (e.g. TitleBar buttons after a window state change).  Instead of
+        coordinate-based clicking, it searches the UIA tree for a matching
+        element and calls ``IUIAutomationInvokePattern::Invoke()``.
+
+        Args:
+            name: The element's accessible name (e.g. "Minimize", "Close").
+            role: The element's UIA control type (e.g. "Button").
+
+        Returns:
+            True if the element was found and Invoke succeeded, False otherwise.
+        """
+        try:
+            import comtypes.client  # type: ignore[import-untyped]
+            from comtypes import COMError  # type: ignore[import-untyped]
+        except ImportError:
+            logger.warning("comtypes not available — cannot use Invoke fallback")
+            return False
+
+        try:
+            uia = comtypes.client.CreateObject(
+                "{ff48dba4-60ef-4201-aa87-54103eef594e}",
+                interface=None,
+            )
+            # IUIAutomation interface
+            from comtypes.gen.UIAutomationClient import (  # type: ignore[import-untyped]
+                IUIAutomation,
+                IUIAutomationElement,
+                TreeScope_Descendants,
+                UIA_NamePropertyId,
+                UIA_InvokePatternId,
+            )
+            uia = uia.QueryInterface(IUIAutomation)
+            root = uia.GetRootElement()
+
+            # Build a condition: Name == name
+            name_cond = uia.CreatePropertyCondition(UIA_NamePropertyId, name)
+            found = root.FindFirst(TreeScope_Descendants, name_cond)
+            if found is None:
+                logger.warning("Invoke fallback: element %r not found in UIA tree", name)
+                return False
+
+            # Try InvokePattern
+            pattern = found.GetCurrentPattern(UIA_InvokePatternId)
+            if pattern is None:
+                logger.warning("Invoke fallback: element %r does not support InvokePattern", name)
+                return False
+
+            from comtypes.gen.UIAutomationClient import IUIAutomationInvokePattern  # type: ignore[import-untyped]
+            invoke = pattern.QueryInterface(IUIAutomationInvokePattern)
+            invoke.Invoke()
+            logger.info("Invoke fallback: successfully invoked %r (%s)", name, role)
+            return True
+
+        except (COMError, OSError, AttributeError) as exc:
+            logger.warning("Invoke fallback failed for %r: %s", name, exc)
+            return False
+        except Exception as exc:
+            logger.warning("Invoke fallback unexpected error for %r: %s", name, exc)
+            return False
+
     def type_text(self, text: str = "", delay_ms: int = 5, profile: str = "linear",
                   wpm: int = 120, input_mode: str = "normal") -> None:
         """Type text using SendInput.

--- a/naturo/cli/interaction.py
+++ b/naturo/cli/interaction.py
@@ -133,6 +133,9 @@ def _post_action_see(
                 "height": el.height,
                 "children": [_to_dict(c) for c in el.children],
             }
+            # Flag zero-bounds elements (#137) so callers can detect stale refs
+            if el.width == 0 and el.height == 0:
+                d["zero_bounds"] = True
             return d
 
         return {"id": snapshot_id, "elements": _to_dict(tree)}
@@ -146,7 +149,10 @@ def _post_action_see(
             prefix = "  " * indent
             name_str = f' "{el.name}"' if el.name else ""
             pos_str = f" ({el.x},{el.y} {el.width}x{el.height})"
-            click.echo(f"{prefix}[{el.role}]{name_str}{pos_str} {ref}")
+            # Warn about zero-bounds elements (#137) — these are likely stale
+            # after window state changes and won't respond to coordinate clicks.
+            zero_warn = " ⚠️ zero-bounds" if el.width == 0 and el.height == 0 else ""
+            click.echo(f"{prefix}[{el.role}]{name_str}{pos_str} {ref}{zero_warn}")
             for child in el.children:
                 _print_tree(child, indent + 1)
 
@@ -430,6 +436,7 @@ def click_cmd(query, on_text, element_id, coords, double, right, app, pid,
 
     # BUG-074: Resolve eN refs from the most recent `see` snapshot
     import re as _re
+    _zero_bounds_element = None  # Track element for Invoke fallback (#137)
     if target_id and _re.fullmatch(r"e\d+", target_id):
         from naturo.snapshot import SnapshotManager
         mgr = SnapshotManager()
@@ -438,16 +445,51 @@ def click_cmd(query, on_text, element_id, coords, double, right, app, pid,
             x, y = resolved[0], resolved[1]
             target_id = None  # use coordinates instead
         else:
-            _json_err(
-                f"Element ref '{target_id}' not found. Run 'naturo see' first to "
-                f"capture a fresh snapshot, then use the eN ref within 10 minutes.",
-                json_output,
-                code="REF_NOT_FOUND",
-            )
-            return
+            # resolve_ref returns None for both "not found" and "zero-bounds".
+            # Check resolve_ref_element to distinguish: if the element exists
+            # but has zero-bounds, try UIA Invoke pattern (#137/#135).
+            el_result = mgr.resolve_ref_element(target_id)
+            if el_result is not None:
+                element, _snap_id = el_result
+                ex, ey, ew, eh = element.frame
+                if ew == 0 and eh == 0:
+                    _zero_bounds_element = element
+                    target_id = None  # Will use Invoke fallback below
+                else:
+                    # Element found with valid bounds — shouldn't happen, but
+                    # fall through to coordinate click just in case.
+                    x, y = ex + ew // 2, ey + eh // 2
+                    target_id = None
+            else:
+                _json_err(
+                    f"Element ref '{target_id}' not found. Run 'naturo see' first to "
+                    f"capture a fresh snapshot, then use the eN ref within 10 minutes.",
+                    json_output,
+                    code="REF_NOT_FOUND",
+                )
+                return
 
     try:
-        if target_id:
+        if _zero_bounds_element is not None:
+            # Zero-bounds fallback (#137): attempt UIA Invoke pattern for
+            # elements whose bounding rects are (0,0 0x0) after window
+            # state changes.
+            _invoked = False
+            if hasattr(backend, "invoke_element"):
+                _invoked = backend.invoke_element(
+                    name=_zero_bounds_element.title or "",
+                    role=_zero_bounds_element.role,
+                )
+            if not _invoked:
+                _json_err(
+                    f"Element has zero-size bounds (0,0 0x0) — likely stale after "
+                    f"a window state change. UIA Invoke fallback {'not available' if not hasattr(backend, 'invoke_element') else 'failed'}. "
+                    f"Try running 'naturo see' again to refresh the snapshot.",
+                    json_output,
+                    code="ZERO_BOUNDS",
+                )
+                return
+        elif target_id:
             backend.click(element_id=target_id, button=button, double=double,
                           input_mode=input_mode)
         else:
@@ -463,7 +505,10 @@ def click_cmd(query, on_text, element_id, coords, double, right, app, pid,
     })
 
     action = "double-clicked" if double else "clicked"
-    loc = f"({x}, {y})" if coords else (target_id or "element")
+    if _zero_bounds_element is not None:
+        loc = f"{_zero_bounds_element.title or _zero_bounds_element.role} (via UIA Invoke)"
+    else:
+        loc = f"({x}, {y})" if coords else (target_id or "element")
     result_data = {"action": action, "target": str(loc), "button": button}
     if route_info:
         result_data["routing"] = route_info

--- a/naturo/snapshot.py
+++ b/naturo/snapshot.py
@@ -237,6 +237,18 @@ class SnapshotManager:
 
         # Calculate center of bounding rectangle
         ex, ey, ew, eh = element.frame
+
+        # Detect zero-bounds elements (e.g. TitleBar buttons after window
+        # state change).  Return None so callers can attempt a fallback
+        # strategy such as UIA Invoke pattern.
+        if ew == 0 and eh == 0:
+            logger.warning(
+                "Element ref %s (%s %r) has zero-size bounds (%d,%d %dx%d) — "
+                "likely stale after window state change",
+                ref, element.role, element.title, ex, ey, ew, eh,
+            )
+            return None
+
         cx = ex + ew // 2
         cy = ey + eh // 2
         return (cx, cy, recent_id)

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -598,5 +598,96 @@ class TestStoragePath:
         assert Path(mgr.storage_path) == tmp_root
 
 
+# ── resolve_ref zero-bounds detection (#137) ─────────────────────────────────
+
+
+class TestResolveRefZeroBounds:
+    """resolve_ref returns None for elements with zero-size bounding rects."""
+
+    def test_zero_bounds_returns_none(
+        self, mgr: SnapshotManager, png_file: Path,
+    ) -> None:
+        """Element with (0, 0, 0, 0) frame should not resolve to coordinates."""
+        sid = mgr.create_snapshot()
+        mgr.store_screenshot(sid, str(png_file))
+
+        zero_el = UIElement(
+            id="e1",
+            element_id="btn_minimize",
+            role="Button",
+            title="Minimize",
+            label="Minimize",
+            value=None,
+            frame=(0, 0, 0, 0),
+            is_actionable=True,
+            parent_id=None,
+            children=[],
+        )
+        ui_map = {"e1": zero_el}
+        mgr.store_detection_result(sid, ui_map)
+        mgr.store_ref_map(sid, {"e1": "e1"})
+
+        result = mgr.resolve_ref("e1")
+        assert result is None, "Zero-bounds element should not resolve to coordinates"
+
+    def test_normal_bounds_still_resolves(
+        self, mgr: SnapshotManager, png_file: Path,
+    ) -> None:
+        """Element with valid frame should still resolve normally."""
+        sid = mgr.create_snapshot()
+        mgr.store_screenshot(sid, str(png_file))
+
+        normal_el = UIElement(
+            id="e1",
+            element_id="btn_close",
+            role="Button",
+            title="Close",
+            label="Close",
+            value=None,
+            frame=(100, 200, 50, 30),
+            is_actionable=True,
+            parent_id=None,
+            children=[],
+        )
+        ui_map = {"e1": normal_el}
+        mgr.store_detection_result(sid, ui_map)
+        mgr.store_ref_map(sid, {"e1": "e1"})
+
+        result = mgr.resolve_ref("e1")
+        assert result is not None
+        x, y, snap_id = result
+        assert x == 125  # 100 + 50//2
+        assert y == 215  # 200 + 30//2
+
+    def test_resolve_ref_element_still_works_for_zero_bounds(
+        self, mgr: SnapshotManager, png_file: Path,
+    ) -> None:
+        """resolve_ref_element should still return the element even with zero bounds."""
+        sid = mgr.create_snapshot()
+        mgr.store_screenshot(sid, str(png_file))
+
+        zero_el = UIElement(
+            id="e1",
+            element_id="btn_restore",
+            role="Button",
+            title="Restore",
+            label="Restore",
+            value=None,
+            frame=(0, 0, 0, 0),
+            is_actionable=True,
+            parent_id=None,
+            children=[],
+        )
+        ui_map = {"e1": zero_el}
+        mgr.store_detection_result(sid, ui_map)
+        mgr.store_ref_map(sid, {"e1": "e1"})
+
+        result = mgr.resolve_ref_element("e1")
+        assert result is not None
+        element, snap_id = result
+        assert element.title == "Restore"
+        assert element.frame == (0, 0, 0, 0)
+
+
 # ── need os for backdate test ─────────────────────────────────────────────────
 import os  # noqa: E402  (placed here intentionally to keep test-only import)


### PR DESCRIPTION
## Problem

When a window changes state (e.g. maximize/restore), TitleBar child buttons (Minimize, Restore, Close) report zero-size bounding rects `(0,0 0x0)` from UIA. This caused:
- `naturo see` to display wrong bounds (#137)
- `naturo click eN` to send clicks to (0,0), missing the target entirely (#135)

## Solution

**Two-pronged fix:**

1. **Zero-bounds detection** (`snapshot.py`): `resolve_ref()` now returns `None` for elements with `(0,0 0x0)` frame instead of returning misleading `(0,0)` coordinates.

2. **UIA Invoke pattern fallback** (`backends/windows.py`): New `invoke_element()` method searches the UIA tree by element name and uses `IUIAutomationInvokePattern::Invoke()` to activate buttons without coordinate-based clicking. This completely bypasses the zero-bounds issue.

3. **Visual warnings** (`cli/interaction.py`): The `see` command now displays `⚠️ zero-bounds` warnings for affected elements, and JSON output includes a `zero_bounds: true` flag.

## Changes

| File | Change |
|------|--------|
| `naturo/snapshot.py` | `resolve_ref()` returns `None` for zero-bounds elements |
| `naturo/cli/interaction.py` | Click falls back to Invoke; see shows ⚠️ warning |
| `naturo/backends/windows.py` | New `invoke_element()` via UIA InvokePattern |
| `naturo/backends/base.py` | Base stub returns `False` for non-Windows |
| `tests/test_snapshot.py` | 3 new tests for zero-bounds detection |

## Testing

- All 1438 tests pass, 474 skipped (cross-platform)
- Manual verification needed on Windows test machine with maximized window

Fixes #137, fixes #135