### PR TITLE
fix: detect interactive schtasks /it sessions via WTS API (fixes #183)

### DIFF
--- a/naturo/cli/interaction.py
+++ b/naturo/cli/interaction.py
@@ -206,6 +206,64 @@ def _validate_method(method: str, json_output: bool) -> bool:
 # ── Shared helper ────────────────────────────────────────────────────────────
 
 
+def _is_current_session_interactive() -> bool:
+    """Check if the current process runs in an active Console or RDP session.
+
+    Uses the Windows Terminal Services (WTS) API via ctypes and the
+    ``query session`` command to determine whether the session hosting
+    this process is interactive.  This handles cases where ``SESSIONNAME``
+    is not set (e.g. Task Scheduler ``/it`` tasks) but the process *is*
+    running in a desktop session.
+
+    Returns:
+        True if the process session is an active Console or RDP session.
+        False otherwise or on any error.
+    """
+    try:
+        import ctypes
+        import ctypes.wintypes
+        import subprocess
+
+        # Get the Terminal Services session ID for the current process.
+        pid = ctypes.windll.kernel32.GetCurrentProcessId()  # type: ignore[attr-defined]
+        session_id = ctypes.wintypes.DWORD(0)
+        ok = ctypes.windll.kernel32.ProcessIdToSessionId(  # type: ignore[attr-defined]
+            pid, ctypes.byref(session_id),
+        )
+        if not ok:
+            return False
+        sid = session_id.value
+
+        # Session 0 is always the non-interactive services session.
+        if sid == 0:
+            return False
+
+        # Use ``query session`` to check whether our session is Active.
+        result = subprocess.run(
+            ["query", "session"],
+            capture_output=True, text=True, timeout=5,
+            encoding="utf-8", errors="replace",
+        )
+        if result.returncode != 0:
+            return False
+
+        # Parse output.  Each line has columns like:
+        #   SESSIONNAME  USERNAME  ID  STATE  TYPE  DEVICE
+        # The active user line may start with ">" marker.
+        # We look for our session ID and check the next token is "Active".
+        for line in result.stdout.splitlines():
+            parts = line.replace(">", " ").split()
+            if not parts:
+                continue
+            for i, token in enumerate(parts):
+                if token == str(sid) and i + 1 < len(parts):
+                    if parts[i + 1].lower() == "active":
+                        return True
+        return False
+    except Exception:
+        return False
+
+
 def _check_desktop_session() -> None:
     """Raise NoDesktopSessionError if running without an interactive desktop.
 
@@ -214,11 +272,12 @@ def _check_desktop_session() -> None:
 
     Detection logic:
     1. SESSIONNAME == "Console" or starts with "RDP-Tcp" → interactive desktop, OK.
-    2. SESSIONNAME == "Services" or empty/unset → likely non-interactive.
-       - If empty AND explorer.exe is running, this is the SSH-into-desktop-machine
-         scenario: another session owns the desktop but *this* session cannot
-         interact with it. Raise a clear error instead of letting COM fail.
-    3. Any other SESSIONNAME value → assume interactive (e.g., Citrix, VNC).
+    2. SESSIONNAME == "Services" → non-interactive, reject.
+    3. SESSIONNAME empty/unset → check via WTS API whether the current process
+       session is an active Console or RDP session (handles schtasks /it tasks
+       that run interactively but do not set SESSIONNAME).  If the WTS check
+       fails, fall back to explorer.exe heuristic for a descriptive error.
+    4. Any other SESSIONNAME value → assume interactive (e.g., Citrix, VNC).
 
     No-op on other platforms.
     """
@@ -239,11 +298,16 @@ def _check_desktop_session() -> None:
         from naturo.errors import NoDesktopSessionError
         raise NoDesktopSessionError()
 
-    # Empty/unset SESSIONNAME — SSH or headless service
+    # Empty/unset SESSIONNAME — could be SSH, headless service, or schtasks /it
     if not session:
-        # Even if explorer.exe is running (from an RDP/Console session),
-        # this SSH session cannot interact with that desktop.
-        # Provide a specific error message for this scenario.
+        # First, check if the *current* process session is an active
+        # Console or RDP session via WTS API.  Task Scheduler /it tasks
+        # run in the interactive session but do NOT set SESSIONNAME.
+        if _is_current_session_interactive():
+            return
+
+        # Not in an interactive session — check explorer as a hint for
+        # a better error message.
         import subprocess
         explorer_running = False
         try:

--- a/tests/test_desktop_session.py
+++ b/tests/test_desktop_session.py
@@ -1,9 +1,10 @@
-"""Tests for _check_desktop_session SSH-into-RDP detection (fixes #113).
+"""Tests for _check_desktop_session SSH-into-RDP detection (fixes #113, #183).
 
 Verifies that the desktop session check correctly distinguishes between:
 - Console/RDP sessions (interactive desktop — OK)
 - SSH sessions to a machine with active RDP (no desktop access — error)
 - Pure headless/service sessions (no desktop — error)
+- Task Scheduler /it sessions with no SESSIONNAME but active desktop (OK)
 """
 
 import pytest
@@ -13,8 +14,14 @@ import subprocess
 
 # Import conditionally — the function only does work on Windows but
 # we test the logic by mocking platform.system().
-from naturo.cli.interaction import _check_desktop_session
+from naturo.cli.interaction import (
+    _check_desktop_session,
+    _is_current_session_interactive,
+)
 from naturo.errors import NoDesktopSessionError
+
+# Shorthand for patching the WTS interactive check used when SESSIONNAME is empty.
+_PATCH_WTS = "naturo.cli.interaction._is_current_session_interactive"
 
 
 class TestCheckDesktopSession:
@@ -45,17 +52,18 @@ class TestCheckDesktopSession:
                 _check_desktop_session()
 
     def test_empty_sessionname_no_explorer_raises(self):
-        """Empty SESSIONNAME + no explorer = pure headless — should raise."""
+        """Empty SESSIONNAME + WTS non-interactive + no explorer = headless."""
         mock_result = MagicMock()
         mock_result.stdout = "INFO: No tasks are running which match the specified criteria."
         with patch("platform.system", return_value="Windows"), \
              patch.dict("os.environ", {"SESSIONNAME": ""}, clear=False), \
+             patch(_PATCH_WTS, return_value=False), \
              patch("subprocess.run", return_value=mock_result):
             with pytest.raises(NoDesktopSessionError):
                 _check_desktop_session()
 
     def test_empty_sessionname_with_explorer_raises_ssh_error(self):
-        """Empty SESSIONNAME + explorer running = SSH into desktop machine.
+        """Empty SESSIONNAME + WTS non-interactive + explorer = SSH scenario.
 
         This is the key scenario from #113: SSH session cannot interact
         with the desktop even though explorer.exe is running.
@@ -64,6 +72,7 @@ class TestCheckDesktopSession:
         mock_result.stdout = '"explorer.exe","27552","Console","1","294,880 K"'
         with patch("platform.system", return_value="Windows"), \
              patch.dict("os.environ", {"SESSIONNAME": ""}, clear=False), \
+             patch(_PATCH_WTS, return_value=False), \
              patch("subprocess.run", return_value=mock_result):
             with pytest.raises(NoDesktopSessionError) as exc_info:
                 _check_desktop_session()
@@ -71,12 +80,13 @@ class TestCheckDesktopSession:
             assert "SSH" in str(exc_info.value) or "ssh" in str(exc_info.value).lower()
 
     def test_unset_sessionname_with_explorer_raises(self):
-        """Completely unset SESSIONNAME + explorer running = SSH scenario."""
+        """Completely unset SESSIONNAME + WTS non-interactive + explorer = SSH."""
         mock_result = MagicMock()
         mock_result.stdout = '"explorer.exe","1234","Console","1","100,000 K"'
         env = {"PATH": "/usr/bin"}  # SESSIONNAME not present
         with patch("platform.system", return_value="Windows"), \
              patch.dict("os.environ", env, clear=True), \
+             patch(_PATCH_WTS, return_value=False), \
              patch("subprocess.run", return_value=mock_result):
             with pytest.raises(NoDesktopSessionError):
                 _check_desktop_session()
@@ -88,9 +98,54 @@ class TestCheckDesktopSession:
             _check_desktop_session()  # Should not raise
 
     def test_tasklist_failure_still_raises(self):
-        """If tasklist fails, empty SESSIONNAME should still raise."""
+        """If tasklist and WTS both fail, empty SESSIONNAME should still raise."""
         with patch("platform.system", return_value="Windows"), \
              patch.dict("os.environ", {"SESSIONNAME": ""}, clear=False), \
+             patch(_PATCH_WTS, return_value=False), \
              patch("subprocess.run", side_effect=subprocess.TimeoutExpired("tasklist", 5)):
             with pytest.raises(NoDesktopSessionError):
                 _check_desktop_session()
+
+    def test_schtasks_interactive_session_passes(self):
+        """Empty SESSIONNAME but WTS confirms active desktop session — schtasks /it.
+
+        This is the key scenario from #183: Task Scheduler /it tasks run
+        in the interactive session but do NOT set SESSIONNAME.  The WTS
+        check should detect the active session and allow through.
+        """
+        with patch("platform.system", return_value="Windows"), \
+             patch.dict("os.environ", {"SESSIONNAME": ""}, clear=False), \
+             patch(_PATCH_WTS, return_value=True):
+            _check_desktop_session()  # Should not raise
+
+    def test_unset_sessionname_wts_interactive_passes(self):
+        """Completely unset SESSIONNAME but WTS interactive — should pass."""
+        env = {"PATH": "/usr/bin"}
+        with patch("platform.system", return_value="Windows"), \
+             patch.dict("os.environ", env, clear=True), \
+             patch(_PATCH_WTS, return_value=True):
+            _check_desktop_session()  # Should not raise
+
+
+class TestIsCurrentSessionInteractive:
+    """Tests for the WTS-based interactive session detection."""
+
+    def test_non_windows_returns_false(self):
+        """On non-Windows (no ctypes.windll), should safely return False."""
+        # _is_current_session_interactive uses ctypes.windll which only
+        # exists on Windows.  On macOS/Linux it raises AttributeError
+        # which the function catches and returns False.
+        import platform
+        if platform.system() == "Windows":
+            pytest.skip("This test validates non-Windows fallback behavior")
+        result = _is_current_session_interactive()
+        assert result is False
+
+    @pytest.mark.skipif(
+        __import__("platform").system() != "Windows",
+        reason="WTS API only available on Windows",
+    )
+    def test_returns_bool(self):
+        """On Windows, the function should return a boolean."""
+        result = _is_current_session_interactive()
+        assert isinstance(result, bool)


### PR DESCRIPTION
## Problem

Interaction commands (`click`, `type`, `drag`, `press`) fail with `NO_DESKTOP_SESSION` in Task Scheduler `/it` (interactive) context, while read-only commands (`see`, `capture`) work fine.

**Root cause:** `_check_desktop_session()` relies solely on the `SESSIONNAME` env var, which is not set in schtasks `/it` context — even though the process IS running in an active desktop session.

## Fix

Added `_is_current_session_interactive()` — a WTS API-based check that:
1. Gets the current process's Terminal Services session ID via `ProcessIdToSessionId`
2. Rejects session 0 (always non-interactive services session)
3. Runs `query session` to verify the session is in "Active" state

When `SESSIONNAME` is empty, this WTS check runs **before** the explorer.exe heuristic. If the process is in an active session, it passes through. If not, the existing SSH/headless detection still works.

## Changes

- `naturo/cli/interaction.py`: Added `_is_current_session_interactive()` helper; updated `_check_desktop_session()` to call it when SESSIONNAME is empty
- `tests/test_desktop_session.py`: Added tests for schtasks /it scenario + WTS function; updated existing empty-SESSIONNAME tests to mock the new WTS check

## Testing

- All 1441 tests pass locally (475 skipped — Windows-only)
- The fix is conservative: only changes behavior when SESSIONNAME is empty AND WTS confirms active session
- On non-Windows, `_is_current_session_interactive()` safely returns False (no ctypes.windll)