### PR TITLE
fix: prefer ApplicationFrameHost window for UWP apps in --app matching (fixes #185)

### DIFF
--- a/naturo/backends/windows.py
+++ b/naturo/backends/windows.py
@@ -834,6 +834,27 @@ class WindowsBackend(Backend):
                 best_window = w
 
         if best_window is not None:
+            # UWP/WinUI apps: the real UI tree lives under
+            # ApplicationFrameHost.exe, not the inner process window
+            # (e.g. CalculatorApp.exe).  When we matched a non-frame
+            # process, check for an ApplicationFrameHost window with the
+            # same title and prefer it — its element tree is complete.
+            best_proc = best_window.process_name.lower()
+            if best_proc.endswith(".exe"):
+                best_proc = best_proc[:-4]
+            if best_proc != "applicationframehost":
+                for w in windows:
+                    frame_proc = w.process_name.lower()
+                    if frame_proc.endswith(".exe"):
+                        frame_proc = frame_proc[:-4]
+                    if (
+                        frame_proc == "applicationframehost"
+                        and w.title == best_window.title
+                        and w.handle != best_window.handle
+                    ):
+                        best_window = w
+                        break
+
             return best_window.handle
 
         # No match — build candidate suggestions (BUG-070)


### PR DESCRIPTION
## Problem
`naturo see --app Calculator` matches `CalculatorApp.exe` (inner UWP window) which has an empty element tree. The actual UI tree lives under `ApplicationFrameHost.exe` with the same title.

## Root Cause
UWP/WinUI3 apps have a split window architecture:
- **Inner process** (e.g. CalculatorApp.exe): owns the content but exposes a sparse/empty UIA tree
- **ApplicationFrameHost.exe**: the frame host that contains the complete, automatable element tree

`_resolve_hwnd` matched CalculatorApp.exe with score 3 (process name substring) and never looked at ApplicationFrameHost.

## Fix
After finding the best match, check if it's NOT ApplicationFrameHost. If so, scan for an ApplicationFrameHost.exe window with the same title and prefer it. This is safe because:
1. Only triggers when there's an exact title match between inner and frame host windows
2. ApplicationFrameHost always has the richer tree for UWP apps
3. No impact on non-UWP apps (they don't have ApplicationFrameHost windows)

## Impact
Fixes `see --app`, `click --app`, `type --app`, etc. for ALL UWP/WinUI3 apps: Calculator, Settings, Photos, Mail, Calendar, Store, etc.

## Testing
- 1441 tests pass, 475 skipped (platform-specific)
- Needs QA verification on compile machine with Calculator and other UWP apps

Fixes #185