### PR TITLE
fix: add missing logger import to windows backend (fixes #190)

### DIFF
--- a/naturo/backends/windows.py
+++ b/naturo/backends/windows.py
@@ -6,6 +6,8 @@ and UI element tree inspection. Later phases will add input and interaction.
 
 from __future__ import annotations
 
+import logging
+
 from naturo.backends.base import (
     Backend,
     WindowInfo as BaseWindowInfo,
@@ -17,6 +19,8 @@ from naturo.bridge import NaturoCore, NaturoCoreError, populate_hierarchy
 from naturo.errors import NaturoError
 from naturo.models.menu import MenuItem
 from typing import List, Optional
+
+logger = logging.getLogger(__name__)
 
 
 class WindowsBackend(Backend):


### PR DESCRIPTION
## Problem
`naturo/backends/windows.py` references `logger` at lines 71, 1105, 1128, 1134, 1140, 1144, 1147 but never imports `logging` or defines `logger`. Any code path hitting these lines crashes with `NameError: name 'logger' is not defined`.

Affected paths:
- Zero-bounds element detection (line 71)
- Invoke fallback for click (lines 1105-1147)

## Fix
Add `import logging` and `logger = logging.getLogger(__name__)` at module level.

## Testing
All 1443 tests pass, 475 skipped (platform-gated).

Fixes #190