### PR TITLE
fix: add UWP CoreWindow fallback for empty element trees (fixes #191)

### DIFF
--- a/naturo/backends/windows.py
+++ b/naturo/backends/windows.py
@@ -881,6 +881,58 @@ class WindowsBackend(Backend):
 
         raise WindowNotFoundError(search, suggested_action=hint)
 
+    @staticmethod
+    def _find_uwp_core_hwnd(parent_hwnd: int) -> int:
+        """Find the UWP CoreWindow child HWND inside an ApplicationFrameHost window.
+
+        UWP apps wrap their actual UI inside a ``Windows.UI.Core.CoreWindow``
+        child window.  ``ElementFromHandle`` on the outer frame often returns
+        an empty element tree because the ControlViewWalker does not cross
+        the process boundary.  Targeting the CoreWindow directly fixes this.
+
+        Args:
+            parent_hwnd: Handle of the ApplicationFrameHost top-level window.
+
+        Returns:
+            CoreWindow child HWND if found, otherwise 0.
+        """
+        import sys
+        if sys.platform != "win32":
+            return 0
+        try:
+            import ctypes
+            user32 = ctypes.windll.user32
+            FindWindowExW = user32.FindWindowExW
+            FindWindowExW.restype = ctypes.c_void_p
+            FindWindowExW.argtypes = [
+                ctypes.c_void_p,  # hWndParent
+                ctypes.c_void_p,  # hWndChildAfter
+                ctypes.c_wchar_p,  # lpszClass
+                ctypes.c_void_p,  # lpszWindow (NULL = any)
+            ]
+            core_hwnd = FindWindowExW(parent_hwnd, None,
+                                      "Windows.UI.Core.CoreWindow", None)
+            return int(core_hwnd) if core_hwnd else 0
+        except Exception:
+            return 0
+
+    def _is_afh_window(self, handle: int) -> bool:
+        """Check if a window handle belongs to ApplicationFrameHost.exe.
+
+        Args:
+            handle: Window handle to check.
+
+        Returns:
+            True if the window process is ApplicationFrameHost.exe.
+        """
+        for w in self.list_windows():
+            if w.handle == handle:
+                proc = w.process_name.lower()
+                if proc.endswith(".exe"):
+                    proc = proc[:-4]
+                return proc == "applicationframehost"
+        return False
+
     def get_element_tree(self, window_title: Optional[str] = None,
                          depth: int = 3,
                          app: Optional[str] = None,
@@ -890,6 +942,12 @@ class WindowsBackend(Backend):
 
         Fills parent_id, children IDs, and keyboard_shortcut for all elements
         via Python-layer post-processing (the C++ DLL does not emit these).
+
+        For UWP apps (Calculator, Settings, etc.) the UI tree lives inside a
+        ``Windows.UI.Core.CoreWindow`` child of the ``ApplicationFrameHost``
+        top-level window.  When the initial traversal returns an empty tree
+        from an AFH window, this method automatically retries with the
+        CoreWindow child HWND.
 
         Args:
             window_title: Window title pattern (partial match, case-insensitive).
@@ -906,6 +964,21 @@ class WindowsBackend(Backend):
         core = self._ensure_core()
         handle = self._resolve_hwnd(app=app, window_title=window_title, hwnd=hwnd)
 
+        def _try_uwp_core(current_result):
+            """If handle is an AFH window with empty tree, retry with CoreWindow child."""
+            if (current_result is not None
+                    and not current_result.children
+                    and handle
+                    and self._is_afh_window(handle)):
+                core_hwnd = self._find_uwp_core_hwnd(handle)
+                if core_hwnd:
+                    logger.debug(
+                        "UWP fallback: retrying element tree with CoreWindow "
+                        "HWND %s (parent AFH %s)", core_hwnd, handle,
+                    )
+                    return core_hwnd
+            return 0
+
         if backend == "jab":
             result = core.jab_get_element_tree(hwnd=handle, depth=depth)
         elif backend == "ia2":
@@ -914,6 +987,12 @@ class WindowsBackend(Backend):
             result = core.msaa_get_element_tree(hwnd=handle, depth=depth)
         elif backend == "auto":
             result = core.get_element_tree(hwnd=handle, depth=depth)
+            # UWP fallback: ApplicationFrameHost → CoreWindow child
+            uwp_hwnd = _try_uwp_core(result)
+            if uwp_hwnd:
+                uwp_result = core.get_element_tree(hwnd=uwp_hwnd, depth=depth)
+                if uwp_result is not None and uwp_result.children:
+                    result = uwp_result
             if result is None or (not result.children and not result.name):
                 # Try IA2 first (Firefox/Thunderbird/LibreOffice), then MSAA
                 ia2_result = core.ia2_get_element_tree(hwnd=handle, depth=depth)
@@ -930,6 +1009,12 @@ class WindowsBackend(Backend):
                             result = msaa_result
         else:
             result = core.get_element_tree(hwnd=handle, depth=depth)
+            # UWP fallback for explicit "uia" backend too
+            uwp_hwnd = _try_uwp_core(result)
+            if uwp_hwnd:
+                uwp_result = core.get_element_tree(hwnd=uwp_hwnd, depth=depth)
+                if uwp_result is not None and uwp_result.children:
+                    result = uwp_result
 
         if result is None:
             return None

--- a/tests/test_uwp_fallback.py
+++ b/tests/test_uwp_fallback.py
@@ -1,0 +1,173 @@
+"""Tests for UWP ApplicationFrameHost → CoreWindow element tree fallback.
+
+These tests use mocking and run on all platforms to verify the fallback
+logic in WindowsBackend.get_element_tree for UWP apps.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def backend():
+    """Create a WindowsBackend with mocked core initialization."""
+    with patch("naturo.backends.windows.WindowsBackend._ensure_core"):
+        from naturo.backends.windows import WindowsBackend
+
+        b = WindowsBackend()
+        b._core = MagicMock()
+        return b
+
+
+def _make_element(role="Pane", name="", children=None):
+    """Create a mock ElementInfo-like object."""
+    el = SimpleNamespace(
+        id="e0",
+        role=role,
+        name=name,
+        value=None,
+        x=0, y=0, width=100, height=100,
+        children=children or [],
+        parent_id=None,
+        keyboard_shortcut=None,
+    )
+    return el
+
+
+def _make_window(handle, title, process_name, pid=100):
+    """Create a mock WindowInfo."""
+    return SimpleNamespace(
+        handle=handle,
+        title=title,
+        process_name=process_name,
+        pid=pid,
+        x=0, y=0, width=800, height=600,
+        is_visible=True,
+        is_minimized=False,
+    )
+
+
+class TestIsAfhWindow:
+    """Tests for _is_afh_window helper."""
+
+    def test_detects_afh_window(self, backend):
+        """Should return True for ApplicationFrameHost.exe windows."""
+        backend.list_windows = MagicMock(return_value=[
+            _make_window(123, "Calculator", "ApplicationFrameHost.exe"),
+        ])
+        assert backend._is_afh_window(123) is True
+
+    def test_rejects_non_afh_window(self, backend):
+        """Should return False for regular windows."""
+        backend.list_windows = MagicMock(return_value=[
+            _make_window(456, "Notepad", "notepad.exe"),
+        ])
+        assert backend._is_afh_window(456) is False
+
+    def test_unknown_handle(self, backend):
+        """Should return False for unknown handles."""
+        backend.list_windows = MagicMock(return_value=[])
+        assert backend._is_afh_window(999) is False
+
+
+class TestFindUwpCoreHwnd:
+    """Tests for _find_uwp_core_hwnd static method."""
+
+    def test_returns_zero_on_non_windows(self):
+        """Should return 0 on non-Windows platforms."""
+        from naturo.backends.windows import WindowsBackend
+
+        import sys
+        if sys.platform == "win32":
+            pytest.skip("Test only applicable on non-Windows")
+
+        assert WindowsBackend._find_uwp_core_hwnd(12345) == 0
+
+
+class TestUwpElementTreeFallback:
+    """Tests for UWP CoreWindow fallback in get_element_tree."""
+
+    def test_uwp_fallback_retries_with_core_hwnd(self, backend):
+        """When AFH returns empty tree, should retry with CoreWindow HWND."""
+        empty_root = _make_element(role="Pane", name="", children=[])
+        rich_root = _make_element(
+            role="Window", name="Calculator",
+            children=[_make_element(role="Button", name="1")],
+        )
+
+        # First call returns empty tree, second with CoreWindow returns rich
+        backend._core.get_element_tree = MagicMock(
+            side_effect=[empty_root, rich_root],
+        )
+        backend._resolve_hwnd = MagicMock(return_value=100)
+        backend._is_afh_window = MagicMock(return_value=True)
+
+        with patch.object(type(backend), "_find_uwp_core_hwnd",
+                          return_value=200):
+            with patch("naturo.backends.windows.populate_hierarchy"):
+                result = backend.get_element_tree(app="calc", backend="uia")
+
+        assert result is not None
+        assert result.role == "Window"
+        assert len(result.children) == 1
+        assert result.children[0].role == "Button"
+
+    def test_no_fallback_when_tree_has_children(self, backend):
+        """Should not attempt fallback when tree already has children."""
+        rich_root = _make_element(
+            role="Pane", name="Notepad",
+            children=[_make_element(role="Edit", name="Text")],
+        )
+
+        backend._core.get_element_tree = MagicMock(return_value=rich_root)
+        backend._resolve_hwnd = MagicMock(return_value=100)
+        backend._is_afh_window = MagicMock()
+
+        with patch("naturo.backends.windows.populate_hierarchy"):
+            result = backend.get_element_tree(app="notepad", backend="uia")
+
+        # _is_afh_window should not be called since tree has children
+        backend._is_afh_window.assert_not_called()
+        assert len(result.children) == 1
+
+    def test_fallback_skipped_for_non_afh(self, backend):
+        """Should not retry for non-AFH windows even with empty tree."""
+        empty_root = _make_element(role="Pane", name="", children=[])
+
+        backend._core.get_element_tree = MagicMock(return_value=empty_root)
+        backend._resolve_hwnd = MagicMock(return_value=100)
+        backend._is_afh_window = MagicMock(return_value=False)
+
+        with patch("naturo.backends.windows.populate_hierarchy"):
+            result = backend.get_element_tree(app="notepad", backend="uia")
+
+        # Only one call — no retry
+        assert backend._core.get_element_tree.call_count == 1
+
+    def test_auto_backend_uses_uwp_fallback(self, backend):
+        """UWP fallback should also work with backend='auto'."""
+        empty_root = _make_element(role="Pane", name="", children=[])
+        rich_root = _make_element(
+            role="Window", name="Settings",
+            children=[_make_element(role="List", name="Categories")],
+        )
+
+        backend._core.get_element_tree = MagicMock(
+            side_effect=[empty_root, rich_root],
+        )
+        backend._resolve_hwnd = MagicMock(return_value=100)
+        backend._is_afh_window = MagicMock(return_value=True)
+
+        with patch.object(type(backend), "_find_uwp_core_hwnd",
+                          return_value=300):
+            with patch("naturo.backends.windows.populate_hierarchy"):
+                result = backend.get_element_tree(app="settings",
+                                                  backend="auto")
+
+        assert result is not None
+        assert result.role == "Window"
+        assert len(result.children) == 1


### PR DESCRIPTION
## Problem
UWP apps (Calculator, Settings, Store, etc.) run inside `ApplicationFrameHost.exe`. When `naturo see --app calc` targets the AFH window, `ElementFromHandle` + `ControlViewWalker` returns only a root Pane with 0 children — the walker doesn't cross the process boundary into the actual UWP content.

This makes `see → click` completely non-functional for ALL UWP apps on Windows 11.

## Root Cause
The UIA element tree traversal stops at the ApplicationFrameHost frame boundary. The actual UI lives inside a `Windows.UI.Core.CoreWindow` child window hosted by the UWP content process.

## Fix
1. **`_find_uwp_core_hwnd(parent_hwnd)`**: Uses `FindWindowExW` to locate the `Windows.UI.Core.CoreWindow` child HWND inside an AFH window
2. **`_is_afh_window(handle)`**: Checks if a window belongs to `ApplicationFrameHost.exe`
3. **`get_element_tree` fallback**: When the initial traversal returns an empty tree from an AFH window, automatically retries with the CoreWindow child HWND
4. Works for both explicit `uia` and `auto` backends

## Testing
- 8 new mock-based unit tests covering all fallback paths
- All 1451 tests pass (475 skipped, platform-gated)
- Real-device verification needed on Windows compile machine

Fixes #191