### PR TITLE
feat: fuzzy command matching suggests closest command on typo (fixes #149)

### DIFF
--- a/naturo/cli/__init__.py
+++ b/naturo/cli/__init__.py
@@ -20,6 +20,7 @@ if sys.platform == "win32" and not os.environ.get("PYTHONUTF8"):
 
 import click
 from naturo.version import __version__
+from naturo.cli.fuzzy_group import FuzzyGroup
 
 from naturo.cli.core import capture, list_cmd, see, find_cmd, menu_inspect
 from naturo.cli.get_cmd import get_cmd
@@ -77,7 +78,7 @@ def _patch_all_commands(group: click.BaseCommand) -> None:
     _patch_json_flag(group)
 
 
-@click.group()
+@click.group(cls=FuzzyGroup)
 @click.version_option(__version__, prog_name="naturo")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.option("--verbose", "-v", is_flag=True, help="Verbose logging")

--- a/naturo/cli/ai.py
+++ b/naturo/cli/ai.py
@@ -2,12 +2,13 @@
 import click
 import json
 import sys
+from naturo.cli.fuzzy_group import FuzzyGroup
 
 
 # ── mcp ─────────────────────────────────────────
 
 
-@click.group()
+@click.group(cls=FuzzyGroup)
 def mcp():
     """MCP (Model Context Protocol) server for AI agent integration."""
     pass

--- a/naturo/cli/core.py
+++ b/naturo/cli/core.py
@@ -11,6 +11,7 @@ import click
 
 from naturo.cli.error_helpers import json_error as _json_error_str
 from naturo.errors import WindowNotFoundError
+from naturo.cli.fuzzy_group import FuzzyGroup
 
 
 def _get_backend():
@@ -65,7 +66,7 @@ def _platform_error_msg(feature: str) -> str:
 # ── capture ─────────────────────────────────────
 
 
-@click.group()
+@click.group(cls=FuzzyGroup)
 def capture():
     """Capture screenshots, video, or watch for changes."""
     pass
@@ -219,7 +220,7 @@ def watch(app, window_title, hwnd, interval, timeout, path, json_output):
 # ── list ────────────────────────────────────────
 
 
-@click.group("list")
+@click.group("list", cls=FuzzyGroup)
 def list_cmd():
     """List apps, windows, screens, or permissions."""
     pass

--- a/naturo/cli/dialog_cmd.py
+++ b/naturo/cli/dialog_cmd.py
@@ -23,9 +23,10 @@ import sys
 import click
 
 from naturo.cli.error_helpers import emit_error, emit_exception_error
+from naturo.cli.fuzzy_group import FuzzyGroup
 
 
-@click.group()
+@click.group(cls=FuzzyGroup)
 def dialog():
     """Detect and interact with system dialogs.
 

--- a/naturo/cli/electron_cmd.py
+++ b/naturo/cli/electron_cmd.py
@@ -14,6 +14,7 @@ import sys
 from typing import Optional
 
 import click
+from naturo.cli.fuzzy_group import FuzzyGroup
 
 
 def _json_out(data: dict) -> None:
@@ -30,7 +31,7 @@ def _json_err(message: str, code: str = "ERROR") -> None:
 # ── electron group ───────────────────────────────────────────────────────────
 
 
-@click.group("electron")
+@click.group("electron", cls=FuzzyGroup)
 def electron() -> None:
     """Detect and automate Electron/CEF applications via CDP.
 
@@ -232,7 +233,7 @@ def electron_launch(app_path: str, port: int, json_output: bool) -> None:
 # ── chrome group ─────────────────────────────────────────────────────────────
 
 
-@click.group("chrome")
+@click.group("chrome", cls=FuzzyGroup)
 def chrome() -> None:
     """Chrome DevTools Protocol commands.
 

--- a/naturo/cli/extensions.py
+++ b/naturo/cli/extensions.py
@@ -3,6 +3,7 @@ import json as json_module
 import sys
 
 import click
+from naturo.cli.fuzzy_group import FuzzyGroup
 
 
 def _not_implemented(name: str, phase: str, json_output: bool) -> None:
@@ -27,7 +28,7 @@ def _not_implemented(name: str, phase: str, json_output: bool) -> None:
 # ── excel ───────────────────────────────────────
 
 
-@click.group(hidden=True)
+@click.group(hidden=True, cls=FuzzyGroup)
 def excel():
     """Excel COM automation (Windows-specific).
 
@@ -263,7 +264,7 @@ def excel_info(path, sheet, json_output):
 # ── java ────────────────────────────────────────
 
 
-@click.group()
+@click.group(cls=FuzzyGroup)
 def java():
     """Java application automation via Java Access Bridge (Windows-specific).
 
@@ -302,7 +303,7 @@ def java_click(query, pid, title, json_output):
 # ── sap ─────────────────────────────────────────
 
 
-@click.group()
+@click.group(cls=FuzzyGroup)
 def sap():
     """SAP GUI Scripting automation (Windows-specific).
 

--- a/naturo/cli/fuzzy_group.py
+++ b/naturo/cli/fuzzy_group.py
@@ -1,0 +1,42 @@
+"""FuzzyGroup — Click Group with typo-correcting command suggestions."""
+
+import difflib
+
+import click
+
+
+class FuzzyGroup(click.Group):
+    """Click Group subclass that suggests the closest command on typos.
+
+    When a user types an unrecognized subcommand, this group uses
+    ``difflib.get_close_matches`` to find and suggest the most similar
+    command name, improving the error message from a bare "No such command"
+    to "No such command 'X'. Did you mean 'Y'?".
+    """
+
+    def resolve_command(self, ctx: click.Context, args: list[str]):
+        """Override to inject typo-correction suggestions.
+
+        Args:
+            ctx: Click context.
+            args: Remaining CLI arguments (args[0] is the subcommand name).
+
+        Returns:
+            Tuple of (command_name, command, remaining_args) from the parent
+            implementation.
+
+        Raises:
+            click.UsageError: When the command is not found and a close match
+                exists, includes "Did you mean 'X'?" in the error.
+        """
+        cmd_name = click.utils.make_str(args[0])
+        cmd = self.get_command(ctx, cmd_name)
+        if cmd is None:
+            matches = difflib.get_close_matches(
+                cmd_name, self.list_commands(ctx), n=1, cutoff=0.6
+            )
+            if matches:
+                ctx.fail(
+                    f"No such command '{cmd_name}'. Did you mean '{matches[0]}'?"
+                )
+        return super().resolve_command(ctx, args)

--- a/naturo/cli/snapshot.py
+++ b/naturo/cli/snapshot.py
@@ -16,13 +16,14 @@ import json as json_module
 import click
 
 from naturo.snapshot import SnapshotManager
+from naturo.cli.fuzzy_group import FuzzyGroup
 
 
 def _get_manager() -> SnapshotManager:
     return SnapshotManager()
 
 
-@click.group()
+@click.group(cls=FuzzyGroup)
 def snapshot() -> None:
     """Manage UI automation snapshots."""
     pass

--- a/naturo/cli/system.py
+++ b/naturo/cli/system.py
@@ -4,11 +4,12 @@ Note: dialog commands moved to naturo/cli/dialog_cmd.py (Phase 4.5).
 Note: clipboard and open commands removed — handled by AI agent directly.
 """
 import click
+from naturo.cli.fuzzy_group import FuzzyGroup
 
 # ── app ─────────────────────────────────────────
 
 
-@click.group()
+@click.group(cls=FuzzyGroup)
 def app():
     """Manage applications: launch, quit, switch, and more."""
     pass
@@ -52,7 +53,7 @@ def app_list(json_output):
 # ── menu ────────────────────────────────────────
 
 
-@click.group()
+@click.group(cls=FuzzyGroup)
 def menu():
     """Interact with application menu bars."""
     pass
@@ -85,7 +86,7 @@ def menu_list(app, window_title, hwnd, depth, json_output):
 # ── taskbar (Windows-specific, maps to Peekaboo dock) ──
 
 
-@click.group()
+@click.group(cls=FuzzyGroup)
 def taskbar():
     """Windows taskbar management (pin, unpin, list).
 
@@ -120,7 +121,7 @@ def taskbar_list(json_output):
 # ── tray (Windows-specific, maps to Peekaboo menubar) ──
 
 
-@click.group()
+@click.group(cls=FuzzyGroup)
 def tray():
     """System tray icon interaction.
 

--- a/naturo/cli/window_cmd.py
+++ b/naturo/cli/window_cmd.py
@@ -12,6 +12,7 @@ from typing import Optional
 import click
 
 from naturo.cli.error_helpers import emit_error, emit_exception_error, json_error, json_error_from_exception
+from naturo.cli.fuzzy_group import FuzzyGroup
 
 
 def _safe_echo(text: str, **kwargs) -> None:
@@ -56,7 +57,7 @@ def _resolve_target(app: Optional[str], title: Optional[str], hwnd: Optional[int
     return {"title": effective_title, "hwnd": hwnd}
 
 
-@click.group()
+@click.group(cls=FuzzyGroup)
 def window():
     """Manage windows: focus, close, minimize, maximize, restore, move, resize."""
     pass

--- a/tests/test_fuzzy_command.py
+++ b/tests/test_fuzzy_command.py
@@ -1,0 +1,46 @@
+"""Tests for fuzzy command matching — typo correction suggestions."""
+
+import pytest
+from click.testing import CliRunner
+from naturo.cli import main
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+class TestFuzzyTopLevel:
+    """Fuzzy matching on top-level naturo commands."""
+
+    @pytest.mark.parametrize("typo,expected", [
+        ("captur", "capture"),
+        ("clck", "click"),
+        ("tpye", "type"),
+        ("widnow", "window"),
+        ("snapshto", "snapshot"),
+        ("appp", "app"),
+    ])
+    def test_suggests_close_match(self, runner, typo, expected):
+        result = runner.invoke(main, [typo])
+        assert result.exit_code != 0
+        assert f"Did you mean '{expected}'?" in result.output
+
+    def test_no_suggestion_for_gibberish(self, runner):
+        result = runner.invoke(main, ["xyzzyplugh"])
+        assert result.exit_code != 0
+        assert "Did you mean" not in result.output
+
+
+class TestFuzzySubgroup:
+    """Fuzzy matching on subgroup commands (e.g. app inspect)."""
+
+    def test_app_subcommand_typo(self, runner):
+        result = runner.invoke(main, ["app", "inspact"])
+        assert result.exit_code != 0
+        assert "Did you mean 'inspect'?" in result.output
+
+    def test_app_subcommand_typo_lanch(self, runner):
+        result = runner.invoke(main, ["app", "lanch"])
+        assert result.exit_code != 0
+        assert "Did you mean 'launch'?" in result.output


### PR DESCRIPTION
## Feature
When a user types an unrecognized subcommand, naturo now suggests the closest match:
```
C:\> naturo captur
Error: No such command 'captur'. Did you mean 'capture'?

C:\> naturo app inspact feishu
Error: No such command 'inspact'. Did you mean 'inspect'?
```

## Changes
- Added `FuzzyGroup` in `naturo/cli/fuzzy_group.py` — custom `click.Group` subclass
- Overrides `resolve_command` to use `difflib.get_close_matches(cutoff=0.6)`
- Applied to all 14 command groups (top-level + all subgroups)
- No new dependencies (difflib is stdlib)

## Testing
- 9 new tests in `tests/test_fuzzy_command.py`
- All 1469 tests pass locally

Fixes #149