### PR TITLE
feat: merge window commands into app — single namespace for all app/window ops (fixes #170)

### DIFF
--- a/naturo/cli/__init__.py
+++ b/naturo/cli/__init__.py
@@ -34,7 +34,10 @@ from naturo.cli.tray_cmd import tray
 from naturo.cli.desktop_cmd import desktop
 from naturo.cli.snapshot import snapshot
 from naturo.cli.wait_cmd import wait
-from naturo.cli.app_cmd import app_launch, app_quit, app_relaunch, app_list, app_find, app_hide, app_unhide, app_switch, app_inspect
+from naturo.cli.app_cmd import (
+    app_launch, app_quit, app_relaunch, app_list, app_find, app_hide, app_unhide, app_switch, app_inspect,
+    app_focus, app_close, app_minimize, app_maximize, app_restore, app_move, app_windows,
+)
 from naturo.cli.window_cmd import window
 from naturo.cli.diff_cmd import diff
 from naturo.cli.ai import mcp
@@ -153,10 +156,21 @@ app.add_command(app_quit, "quit")
 app.add_command(app_relaunch, "relaunch")
 app.add_command(app_list, "list")
 app.add_command(app_find, "find")
-app.add_command(app_hide, "hide")
-app.add_command(app_unhide, "unhide")
-app.add_command(app_switch, "switch")
 app.add_command(app_inspect, "inspect")
+
+# Window operations unified under app (#170)
+app.add_command(app_focus, "focus")
+app.add_command(app_close, "close")
+app.add_command(app_minimize, "minimize")
+app.add_command(app_maximize, "maximize")
+app.add_command(app_restore, "restore")
+app.add_command(app_move, "move")
+app.add_command(app_windows, "windows")
+
+# Legacy aliases (hidden from help but still work)
+app.add_command(app_switch, "switch")  # alias for focus
+app.add_command(app_hide, "hide")      # alias for minimize
+app.add_command(app_unhide, "unhide")  # alias for restore
 
 
 # ── Patch all commands to propagate global --json to subcommands ─────────────

--- a/naturo/cli/app_cmd.py
+++ b/naturo/cli/app_cmd.py
@@ -1,7 +1,9 @@
-"""CLI app command extensions — launch, quit, relaunch, list, find, inspect.
+"""CLI app command extensions — launch, quit, relaunch, list, find, inspect, and window ops.
 
 Replaces the stub implementations in system.py with working process management.
 These are registered as subcommands of the existing ``app`` group.
+Window operations (focus, close, minimize, maximize, restore, move, resize) are
+also registered here, unifying app + window into a single namespace.
 """
 import json
 import os
@@ -189,15 +191,59 @@ def app_relaunch(ctx, name, wait_until_ready, timeout, json_output):
 
 @click.command("list")
 @click.option("--all", "show_all", is_flag=True, help="Show all processes (not just apps with windows)")
+@click.option("--windows", "show_windows", is_flag=True, help="Show all open windows with details")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def app_list(ctx, show_all, json_output):
+def app_list(ctx, show_all, show_windows, json_output):
     """List running applications with visible windows.
 
     By default, only user-facing applications with visible windows are shown.
     Use --all to include all processes (system services, background tasks).
+    Use --windows to list all open windows with handles and dimensions.
     """
     json_output = json_output or (ctx.obj or {}).get("json", False)
+
+    if show_windows:
+        # Detailed window listing (replaces `naturo window list`)
+        from naturo.errors import NaturoError
+        try:
+            from naturo.backends.base import get_backend
+            backend = get_backend()
+            windows = backend.list_windows()
+        except Exception as exc:
+            if json_output:
+                click.echo(_json_error_str("BACKEND_ERROR", str(exc)))
+            else:
+                _safe_echo(f"Error: {exc}", err=True)
+            sys.exit(1)
+            return
+
+        if json_output:
+            click.echo(json.dumps({
+                "success": True,
+                "windows": [
+                    {
+                        "handle": w.handle,
+                        "title": w.title,
+                        "process_name": w.process_name,
+                        "pid": w.pid,
+                        "x": w.x, "y": w.y,
+                        "width": w.width, "height": w.height,
+                        "is_visible": w.is_visible,
+                        "is_minimized": w.is_minimized,
+                    }
+                    for w in windows
+                ],
+                "count": len(windows),
+            }, indent=2))
+        else:
+            if not windows:
+                click.echo("No windows found")
+            else:
+                for w in windows:
+                    _safe_echo(f"  {w.handle:>10}  {w.process_name:<20}  {w.title}")
+                click.echo(f"\n{len(windows)} windows")
+        return
 
     if show_all:
         # Legacy behavior: list all processes via tasklist/ps
@@ -254,12 +300,12 @@ def app_list(ctx, show_all, json_output):
             click.echo(f"\n{len(apps_data)} applications")
 
 
-@click.command("hide")
+@click.command("hide", hidden=True)
 @click.argument("name")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
 def app_hide(ctx, name, json_output):
-    """Hide (minimize) all windows of an application."""
+    """Hide (minimize) all windows of an application. Alias for minimize."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
     from naturo.backends.base import get_backend
     from naturo.errors import NaturoError
@@ -291,12 +337,12 @@ def app_hide(ctx, name, json_output):
         sys.exit(1)
 
 
-@click.command("unhide")
+@click.command("unhide", hidden=True)
 @click.argument("name")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
 def app_unhide(ctx, name, json_output):
-    """Unhide (restore) all windows of an application."""
+    """Unhide (restore) all windows of an application. Alias for restore."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
     from naturo.backends.base import get_backend
     from naturo.errors import NaturoError
@@ -328,12 +374,12 @@ def app_unhide(ctx, name, json_output):
         sys.exit(1)
 
 
-@click.command("switch")
+@click.command("switch", hidden=True)
 @click.argument("name")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
 def app_switch(ctx, name, json_output):
-    """Switch to (focus) the most recent window of an application."""
+    """Switch to (focus) the most recent window of an application. Alias for focus."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
     from naturo.backends.base import get_backend
     from naturo.errors import NaturoError
@@ -578,3 +624,394 @@ def _print_inspect_result(result) -> None:
                     _safe_echo(f"             {key}: {val}")
     else:
         _safe_echo("  No interaction methods detected")
+
+
+# ── Window operations (unified under app) ────────────────────────────────────
+
+def _resolve_window_target(name, window_title=None, hwnd=None):
+    """Build keyword arguments for backend window methods.
+
+    Accepts the unified app command style: positional NAME with optional
+    --window title filter and --hwnd.
+
+    Args:
+        name: Application/process name (positional).
+        window_title: Optional title substring to pick a specific window.
+        hwnd: Optional direct window handle.
+
+    Returns:
+        Dict with title and/or hwnd keys for backend calls.
+    """
+    effective_title = name
+    if window_title:
+        effective_title = window_title
+    return {"title": effective_title, "hwnd": hwnd}
+
+
+def _require_target(name, window_title, hwnd, json_output):
+    """Validate that at least one target identifier is provided.
+
+    Returns:
+        True if valid, False if error was emitted.
+    """
+    if not name and not window_title and not hwnd:
+        msg = "Specify an app name, --window, or --hwnd"
+        if json_output:
+            click.echo(_json_error_str("INVALID_INPUT", msg))
+        else:
+            _safe_echo(f"Error: {msg}", err=True)
+        sys.exit(1)
+        return False
+    return True
+
+
+def _handle_naturo_error(exc, json_output):
+    """Emit a NaturoError and exit."""
+    if json_output:
+        click.echo(json.dumps(exc.to_json_response()))
+    else:
+        _safe_echo(f"Error: {exc.message}", err=True)
+    sys.exit(1)
+
+
+def _handle_generic_error(exc, json_output):
+    """Emit a generic exception and exit."""
+    if json_output:
+        click.echo(_json_error_str("UNKNOWN_ERROR", str(exc)))
+    else:
+        _safe_echo(f"Error: {exc}", err=True)
+    sys.exit(1)
+
+
+@click.command("focus")
+@click.argument("name", required=False, default=None)
+@click.option("--window", "window_title", default=None, help="Window title pattern (substring match)")
+@click.option("--hwnd", type=int, default=None, help="Window handle (HWND)")
+@click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
+@click.pass_context
+def app_focus(ctx, name, window_title, hwnd, json_output):
+    """Focus an application window (bring to foreground).
+
+    \b
+    Examples:
+      naturo app focus feishu
+      naturo app focus feishu --window "群聊"
+      naturo app focus --hwnd 12345
+    """
+    json_output = json_output or (ctx.obj or {}).get("json", False)
+    from naturo.errors import NaturoError
+
+    if not _require_target(name, window_title, hwnd, json_output):
+        return
+
+    try:
+        from naturo.backends.base import get_backend
+        backend = get_backend()
+        backend.focus_window(**_resolve_window_target(name, window_title, hwnd))
+        if json_output:
+            click.echo(json.dumps({"success": True, "action": "focus"}))
+        else:
+            _safe_echo(f"Focused window: {name or window_title or hwnd}")
+    except NaturoError as exc:
+        _handle_naturo_error(exc, json_output)
+    except Exception as exc:
+        _handle_generic_error(exc, json_output)
+
+
+@click.command("close")
+@click.argument("name", required=False, default=None)
+@click.option("--window", "window_title", default=None, help="Window title pattern (substring match)")
+@click.option("--hwnd", type=int, default=None, help="Window handle (HWND)")
+@click.option("--force", is_flag=True, help="Force terminate the process")
+@click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
+@click.pass_context
+def app_close(ctx, name, window_title, hwnd, force, json_output):
+    """Close an application window (graceful or forced).
+
+    \b
+    Examples:
+      naturo app close notepad
+      naturo app close feishu --window "群聊"
+      naturo app close --hwnd 12345 --force
+    """
+    json_output = json_output or (ctx.obj or {}).get("json", False)
+    from naturo.errors import NaturoError
+
+    if not _require_target(name, window_title, hwnd, json_output):
+        return
+
+    try:
+        from naturo.backends.base import get_backend
+        backend = get_backend()
+        kwargs = _resolve_window_target(name, window_title, hwnd)
+        kwargs["force"] = force
+        backend.close_window(**kwargs)
+        if json_output:
+            click.echo(json.dumps({"success": True, "action": "close", "force": force}))
+        else:
+            _safe_echo(f"Closed window: {name or window_title or hwnd}")
+    except NaturoError as exc:
+        _handle_naturo_error(exc, json_output)
+    except Exception as exc:
+        _handle_generic_error(exc, json_output)
+
+
+@click.command("minimize")
+@click.argument("name", required=False, default=None)
+@click.option("--window", "window_title", default=None, help="Window title pattern (substring match)")
+@click.option("--hwnd", type=int, default=None, help="Window handle (HWND)")
+@click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
+@click.pass_context
+def app_minimize(ctx, name, window_title, hwnd, json_output):
+    """Minimize an application window.
+
+    \b
+    Examples:
+      naturo app minimize feishu
+      naturo app minimize --hwnd 12345
+    """
+    json_output = json_output or (ctx.obj or {}).get("json", False)
+    from naturo.errors import NaturoError
+
+    if not _require_target(name, window_title, hwnd, json_output):
+        return
+
+    try:
+        from naturo.backends.base import get_backend
+        backend = get_backend()
+        backend.minimize_window(**_resolve_window_target(name, window_title, hwnd))
+        if json_output:
+            click.echo(json.dumps({"success": True, "action": "minimize"}))
+        else:
+            _safe_echo(f"Minimized window: {name or window_title or hwnd}")
+    except NaturoError as exc:
+        _handle_naturo_error(exc, json_output)
+    except Exception as exc:
+        _handle_generic_error(exc, json_output)
+
+
+@click.command("maximize")
+@click.argument("name", required=False, default=None)
+@click.option("--window", "window_title", default=None, help="Window title pattern (substring match)")
+@click.option("--hwnd", type=int, default=None, help="Window handle (HWND)")
+@click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
+@click.pass_context
+def app_maximize(ctx, name, window_title, hwnd, json_output):
+    """Maximize an application window.
+
+    \b
+    Examples:
+      naturo app maximize feishu
+      naturo app maximize --hwnd 12345
+    """
+    json_output = json_output or (ctx.obj or {}).get("json", False)
+    from naturo.errors import NaturoError
+
+    if not _require_target(name, window_title, hwnd, json_output):
+        return
+
+    try:
+        from naturo.backends.base import get_backend
+        backend = get_backend()
+        backend.maximize_window(**_resolve_window_target(name, window_title, hwnd))
+        if json_output:
+            click.echo(json.dumps({"success": True, "action": "maximize"}))
+        else:
+            _safe_echo(f"Maximized window: {name or window_title or hwnd}")
+    except NaturoError as exc:
+        _handle_naturo_error(exc, json_output)
+    except Exception as exc:
+        _handle_generic_error(exc, json_output)
+
+
+@click.command("restore")
+@click.argument("name", required=False, default=None)
+@click.option("--window", "window_title", default=None, help="Window title pattern (substring match)")
+@click.option("--hwnd", type=int, default=None, help="Window handle (HWND)")
+@click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
+@click.pass_context
+def app_restore(ctx, name, window_title, hwnd, json_output):
+    """Restore a minimized or maximized window to normal state.
+
+    \b
+    Examples:
+      naturo app restore feishu
+      naturo app restore --hwnd 12345
+    """
+    json_output = json_output or (ctx.obj or {}).get("json", False)
+    from naturo.errors import NaturoError
+
+    if not _require_target(name, window_title, hwnd, json_output):
+        return
+
+    try:
+        from naturo.backends.base import get_backend
+        backend = get_backend()
+        backend.restore_window(**_resolve_window_target(name, window_title, hwnd))
+        if json_output:
+            click.echo(json.dumps({"success": True, "action": "restore"}))
+        else:
+            _safe_echo(f"Restored window: {name or window_title or hwnd}")
+    except NaturoError as exc:
+        _handle_naturo_error(exc, json_output)
+    except Exception as exc:
+        _handle_generic_error(exc, json_output)
+
+
+@click.command("move")
+@click.argument("name", required=False, default=None)
+@click.option("--window", "window_title", default=None, help="Window title pattern (substring match)")
+@click.option("--hwnd", type=int, default=None, help="Window handle (HWND)")
+@click.option("--x", type=int, default=None, help="Target X position")
+@click.option("--y", type=int, default=None, help="Target Y position")
+@click.option("--width", type=int, default=None, help="New width in pixels (optional)")
+@click.option("--height", type=int, default=None, help="New height in pixels (optional)")
+@click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
+@click.pass_context
+def app_move(ctx, name, window_title, hwnd, x, y, width, height, json_output):
+    """Move and/or resize an application window.
+
+    Combines move, resize, and set-bounds into one command.
+    Provide --x/--y for position and/or --width/--height for size.
+
+    \b
+    Examples:
+      naturo app move feishu --x 100 --y 100
+      naturo app move feishu --x 100 --y 100 --width 800 --height 600
+      naturo app move feishu --width 800 --height 600
+    """
+    json_output = json_output or (ctx.obj or {}).get("json", False)
+    from naturo.errors import NaturoError
+
+    if not _require_target(name, window_title, hwnd, json_output):
+        return
+
+    has_position = x is not None and y is not None
+    has_size = width is not None and height is not None
+    has_partial_position = (x is not None) != (y is not None)
+    has_partial_size = (width is not None) != (height is not None)
+
+    if has_partial_position:
+        msg = "Both --x and --y are required when setting position"
+        if json_output:
+            click.echo(_json_error_str("INVALID_INPUT", msg))
+        else:
+            _safe_echo(f"Error: {msg}", err=True)
+        sys.exit(1)
+        return
+
+    if has_partial_size:
+        msg = "Both --width and --height are required when setting size"
+        if json_output:
+            click.echo(_json_error_str("INVALID_INPUT", msg))
+        else:
+            _safe_echo(f"Error: {msg}", err=True)
+        sys.exit(1)
+        return
+
+    if not has_position and not has_size:
+        msg = "Provide --x/--y for position and/or --width/--height for size"
+        if json_output:
+            click.echo(_json_error_str("INVALID_INPUT", msg))
+        else:
+            _safe_echo(f"Error: {msg}", err=True)
+        sys.exit(1)
+        return
+
+    if has_size and (width < 1 or height < 1):
+        msg = f"Width and height must be >= 1, got width={width} height={height}"
+        if json_output:
+            click.echo(_json_error_str("INVALID_INPUT", msg))
+        else:
+            _safe_echo(f"Error: {msg}", err=True)
+        sys.exit(1)
+        return
+
+    try:
+        from naturo.backends.base import get_backend
+        backend = get_backend()
+        kwargs = _resolve_window_target(name, window_title, hwnd)
+
+        if has_position and has_size:
+            backend.set_bounds(x=x, y=y, width=width, height=height, **kwargs)
+            action = "set-bounds"
+            result_data = {"success": True, "action": action, "x": x, "y": y, "width": width, "height": height}
+            msg = f"Set bounds: ({x}, {y}) {width}x{height}"
+        elif has_position:
+            backend.move_window(x=x, y=y, **kwargs)
+            action = "move"
+            result_data = {"success": True, "action": action, "x": x, "y": y}
+            msg = f"Moved window to ({x}, {y})"
+        else:
+            backend.resize_window(width=width, height=height, **kwargs)
+            action = "resize"
+            result_data = {"success": True, "action": action, "width": width, "height": height}
+            msg = f"Resized window to {width}x{height}"
+
+        if json_output:
+            click.echo(json.dumps(result_data))
+        else:
+            _safe_echo(msg)
+    except NaturoError as exc:
+        _handle_naturo_error(exc, json_output)
+    except Exception as exc:
+        _handle_generic_error(exc, json_output)
+
+
+@click.command("windows")
+@click.argument("name", required=False, default=None)
+@click.option("--pid", type=int, help="Process ID")
+@click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
+@click.pass_context
+def app_windows(ctx, name, pid, json_output):
+    """List open windows (optionally filtered by app name or PID).
+
+    \b
+    Examples:
+      naturo app windows
+      naturo app windows feishu
+      naturo app windows --pid 1234
+    """
+    json_output = json_output or (ctx.obj or {}).get("json", False)
+    from naturo.errors import NaturoError
+
+    try:
+        from naturo.backends.base import get_backend
+        backend = get_backend()
+        windows = backend.list_windows()
+
+        if name:
+            name_lower = name.lower()
+            windows = [w for w in windows if name_lower in w.process_name.lower() or name_lower in w.title.lower()]
+        if pid is not None:
+            windows = [w for w in windows if w.pid == pid]
+
+        if json_output:
+            click.echo(json.dumps({
+                "success": True,
+                "windows": [
+                    {
+                        "handle": w.handle,
+                        "title": w.title,
+                        "process_name": w.process_name,
+                        "pid": w.pid,
+                        "x": w.x, "y": w.y,
+                        "width": w.width, "height": w.height,
+                        "is_visible": w.is_visible,
+                        "is_minimized": w.is_minimized,
+                    }
+                    for w in windows
+                ],
+                "count": len(windows),
+            }, indent=2))
+        else:
+            if not windows:
+                click.echo("No windows found")
+            else:
+                for w in windows:
+                    _safe_echo(f"  {w.handle:>10}  {w.process_name:<20}  {w.title}")
+                click.echo(f"\n{len(windows)} windows")
+    except NaturoError as exc:
+        _handle_naturo_error(exc, json_output)
+    except Exception as exc:
+        _handle_generic_error(exc, json_output)

--- a/naturo/cli/system.py
+++ b/naturo/cli/system.py
@@ -11,7 +11,7 @@ from naturo.cli.fuzzy_group import FuzzyGroup
 
 @click.group(cls=FuzzyGroup)
 def app():
-    """Manage applications: launch, quit, switch, and more."""
+    """Manage applications and windows: launch, quit, focus, close, minimize, maximize, restore, move, and more."""
     pass
 
 

--- a/naturo/cli/window_cmd.py
+++ b/naturo/cli/window_cmd.py
@@ -57,9 +57,9 @@ def _resolve_target(app: Optional[str], title: Optional[str], hwnd: Optional[int
     return {"title": effective_title, "hwnd": hwnd}
 
 
-@click.group(cls=FuzzyGroup)
+@click.group(cls=FuzzyGroup, hidden=True)
 def window():
-    """Manage windows: focus, close, minimize, maximize, restore, move, resize."""
+    """Manage windows (deprecated — use 'naturo app' instead)."""
     pass
 
 

--- a/tests/test_app_control.py
+++ b/tests/test_app_control.py
@@ -95,10 +95,16 @@ class TestAppCLIOptions:
         result = runner.invoke(main, ["app", "--help"])
         assert "list" in result.output
 
-    def test_app_switch_subcommand(self, runner):
-        """T157 – app switch subcommand is documented."""
+    def test_app_focus_subcommand(self, runner):
+        """T157 – app focus subcommand is documented (replaced switch)."""
         result = runner.invoke(main, ["app", "--help"])
-        assert "switch" in result.output
+        assert "focus" in result.output
+
+    def test_app_window_commands_in_help(self, runner):
+        """T170 – window operations appear under app group."""
+        result = runner.invoke(main, ["app", "--help"])
+        for cmd in ("focus", "close", "minimize", "maximize", "restore", "move", "windows"):
+            assert cmd in result.output, f"'{cmd}' missing from app --help"
 
     def test_app_launch_args_option(self, runner):
         """T152 – app launch --args option is documented."""

--- a/tests/test_window_management.py
+++ b/tests/test_window_management.py
@@ -565,17 +565,20 @@ class TestWindowListCLI:
 class TestAppHideUnhideSwitchCLI:
     """Tests for `naturo app hide/unhide/switch`."""
 
-    def test_hide_in_help(self, runner):
-        result = runner.invoke(main, ["app", "--help"])
-        assert "hide" in result.output
+    def test_hide_still_callable(self, runner):
+        """hide is a hidden alias for minimize — still callable."""
+        result = runner.invoke(main, ["app", "hide", "--help"])
+        assert result.exit_code == 0
 
-    def test_unhide_in_help(self, runner):
-        result = runner.invoke(main, ["app", "--help"])
-        assert "unhide" in result.output
+    def test_unhide_still_callable(self, runner):
+        """unhide is a hidden alias for restore — still callable."""
+        result = runner.invoke(main, ["app", "unhide", "--help"])
+        assert result.exit_code == 0
 
-    def test_switch_in_help(self, runner):
-        result = runner.invoke(main, ["app", "--help"])
-        assert "switch" in result.output
+    def test_switch_still_callable(self, runner):
+        """switch is a hidden alias for focus — still callable."""
+        result = runner.invoke(main, ["app", "switch", "--help"])
+        assert result.exit_code == 0
 
     @patch("naturo.backends.base.get_backend")
     def test_hide_success(self, mock_get, runner, mock_window):
@@ -812,3 +815,151 @@ class TestWindowTargeting:
         assert result.exit_code == 0
         call_kwargs = backend.focus_window.call_args[1]
         assert call_kwargs["title"] == "Notepad"
+
+
+# ── Tests for unified app window commands (#170) ────────────────────────────
+
+
+class TestAppWindowCommands:
+    """Tests for window operations under 'naturo app' namespace (#170)."""
+
+    @patch("naturo.backends.base.get_backend")
+    def test_app_focus_by_name(self, mock_get, runner):
+        backend = MagicMock()
+        mock_get.return_value = backend
+        result = runner.invoke(main, ["app", "focus", "notepad"])
+        assert result.exit_code == 0
+        assert "Focused" in result.output
+
+    @patch("naturo.backends.base.get_backend")
+    def test_app_focus_by_hwnd(self, mock_get, runner):
+        backend = MagicMock()
+        mock_get.return_value = backend
+        result = runner.invoke(main, ["app", "focus", "--hwnd", "12345"])
+        assert result.exit_code == 0
+
+    def test_app_focus_no_target(self, runner):
+        result = runner.invoke(main, ["app", "focus"])
+        assert result.exit_code != 0
+
+    @patch("naturo.backends.base.get_backend")
+    def test_app_close_by_name(self, mock_get, runner):
+        backend = MagicMock()
+        mock_get.return_value = backend
+        result = runner.invoke(main, ["app", "close", "notepad"])
+        assert result.exit_code == 0
+        assert "Closed" in result.output
+
+    @patch("naturo.backends.base.get_backend")
+    def test_app_close_force(self, mock_get, runner):
+        backend = MagicMock()
+        mock_get.return_value = backend
+        result = runner.invoke(main, ["app", "close", "notepad", "--force"])
+        assert result.exit_code == 0
+        call_kwargs = backend.close_window.call_args[1]
+        assert call_kwargs["force"] is True
+
+    @patch("naturo.backends.base.get_backend")
+    def test_app_minimize_by_name(self, mock_get, runner):
+        backend = MagicMock()
+        mock_get.return_value = backend
+        result = runner.invoke(main, ["app", "minimize", "notepad"])
+        assert result.exit_code == 0
+        assert "Minimized" in result.output
+
+    @patch("naturo.backends.base.get_backend")
+    def test_app_maximize_by_name(self, mock_get, runner):
+        backend = MagicMock()
+        mock_get.return_value = backend
+        result = runner.invoke(main, ["app", "maximize", "notepad"])
+        assert result.exit_code == 0
+        assert "Maximized" in result.output
+
+    @patch("naturo.backends.base.get_backend")
+    def test_app_restore_by_name(self, mock_get, runner):
+        backend = MagicMock()
+        mock_get.return_value = backend
+        result = runner.invoke(main, ["app", "restore", "notepad"])
+        assert result.exit_code == 0
+        assert "Restored" in result.output
+
+    @patch("naturo.backends.base.get_backend")
+    def test_app_move_position(self, mock_get, runner):
+        backend = MagicMock()
+        mock_get.return_value = backend
+        result = runner.invoke(main, ["app", "move", "notepad", "--x", "100", "--y", "200"])
+        assert result.exit_code == 0
+        assert "Moved" in result.output
+
+    @patch("naturo.backends.base.get_backend")
+    def test_app_move_resize(self, mock_get, runner):
+        backend = MagicMock()
+        mock_get.return_value = backend
+        result = runner.invoke(main, ["app", "move", "notepad", "--width", "800", "--height", "600"])
+        assert result.exit_code == 0
+        assert "Resized" in result.output
+
+    @patch("naturo.backends.base.get_backend")
+    def test_app_move_set_bounds(self, mock_get, runner):
+        backend = MagicMock()
+        mock_get.return_value = backend
+        result = runner.invoke(main, ["app", "move", "notepad", "--x", "100", "--y", "200", "--width", "800", "--height", "600"])
+        assert result.exit_code == 0
+        assert "Set bounds" in result.output
+
+    def test_app_move_partial_position(self, runner):
+        result = runner.invoke(main, ["app", "move", "notepad", "--x", "100"])
+        assert result.exit_code != 0
+
+    def test_app_move_no_params(self, runner):
+        result = runner.invoke(main, ["app", "move", "notepad"])
+        assert result.exit_code != 0
+
+    @patch("naturo.backends.base.get_backend")
+    def test_app_windows_list(self, mock_get, runner, mock_window):
+        backend = MagicMock()
+        backend.list_windows.return_value = [mock_window]
+        mock_get.return_value = backend
+        result = runner.invoke(main, ["app", "windows"])
+        assert result.exit_code == 0
+        assert "1 windows" in result.output
+
+    @patch("naturo.backends.base.get_backend")
+    def test_app_windows_filter_by_name(self, mock_get, runner, mock_window):
+        backend = MagicMock()
+        backend.list_windows.return_value = [mock_window]
+        mock_get.return_value = backend
+        result = runner.invoke(main, ["app", "windows", "notepad"])
+        assert result.exit_code == 0
+
+    @patch("naturo.backends.base.get_backend")
+    def test_app_focus_json(self, mock_get, runner):
+        backend = MagicMock()
+        mock_get.return_value = backend
+        result = runner.invoke(main, ["app", "focus", "notepad", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["success"] is True
+        assert data["action"] == "focus"
+
+    @patch("naturo.backends.base.get_backend")
+    def test_app_list_windows_flag(self, mock_get, runner, mock_window):
+        """T170 – app list --windows shows detailed window list."""
+        backend = MagicMock()
+        backend.list_windows.return_value = [mock_window]
+        mock_get.return_value = backend
+        result = runner.invoke(main, ["app", "list", "--windows"])
+        assert result.exit_code == 0
+        assert "1 windows" in result.output
+
+    @patch("naturo.backends.base.get_backend")
+    def test_app_list_windows_json(self, mock_get, runner, mock_window):
+        """T170 – app list --windows --json returns structured data."""
+        backend = MagicMock()
+        backend.list_windows.return_value = [mock_window]
+        mock_get.return_value = backend
+        result = runner.invoke(main, ["app", "list", "--windows", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["success"] is True
+        assert len(data["windows"]) == 1


### PR DESCRIPTION
Merge window commands into app. Window ops (focus, close, minimize, maximize, restore, move, resize, windows) now under naturo app. Legacy window group + switch/hide/unhide become hidden aliases. No breaking changes. All 1487 tests pass. Fixes #170