### PR TITLE
feat: hide snapshot commands from top-level help (fixes #163)

### DIFF
--- a/naturo/cli/snapshot.py
+++ b/naturo/cli/snapshot.py
@@ -23,9 +23,9 @@ def _get_manager() -> SnapshotManager:
     return SnapshotManager()
 
 
-@click.group(cls=FuzzyGroup)
+@click.group(cls=FuzzyGroup, hidden=True)
 def snapshot() -> None:
-    """Manage UI automation snapshots."""
+    """Manage UI automation snapshots (internal/debug command)."""
     pass
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,8 +30,8 @@ def test_cli_help(runner):
         "click", "type", "press", "scroll", "drag", "move",
         # System
         "app",
-        # Snapshot & Phase 3
-        "snapshot", "wait", "diff",
+        # Phase 3
+        "wait", "diff",
     ]
     for cmd in expected:
         assert cmd in result.output, f"Missing command: {cmd}"


### PR DESCRIPTION
## Changes
- `snapshot` group set to `hidden=True` — still callable but not shown in `naturo --help`
- Keeps top-level commands focused on user-facing operations (see, click, type, app, etc.)
- `snapshot list/clean` remain accessible for debugging purposes

Fixes #163