### PR TITLE
fix: sync CMakeLists.txt version to 0.2.5

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(naturo_core VERSION 0.2.1 LANGUAGES CXX)
+project(naturo_core VERSION 0.2.5 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
Version bump to 0.2.5 missed updating core/CMakeLists.txt, causing test_version_matches_cmake to fail.

- Updated CMakeLists.txt project version from 0.2.1 to 0.2.5
- CI should go green after this