### PR TITLE
fix: enumerate all AFH child windows for UWP/WinUI 3 element tree fallback (fixes #191)

### DIFF
--- a/naturo/backends/windows.py
+++ b/naturo/backends/windows.py
@@ -882,39 +882,87 @@ class WindowsBackend(Backend):
         raise WindowNotFoundError(search, suggested_action=hint)
 
     @staticmethod
-    def _find_uwp_core_hwnd(parent_hwnd: int) -> int:
-        """Find the UWP CoreWindow child HWND inside an ApplicationFrameHost window.
+    def _find_uwp_content_hwnd(parent_hwnd: int) -> list:
+        """Find content child HWNDs inside an ApplicationFrameHost window.
 
-        UWP apps wrap their actual UI inside a ``Windows.UI.Core.CoreWindow``
-        child window.  ``ElementFromHandle`` on the outer frame often returns
-        an empty element tree because the ControlViewWalker does not cross
-        the process boundary.  Targeting the CoreWindow directly fixes this.
+        UWP and WinUI 3 apps host their actual UI inside child windows of the
+        ApplicationFrameHost top-level window.  Classic UWP uses
+        ``Windows.UI.Core.CoreWindow``; WinUI 3 (Windows App SDK) may use
+        other window classes.  This method enumerates all child windows so
+        the caller can try each one for a non-empty UIA element tree.
+
+        The children are returned in priority order: known UWP/WinUI classes
+        first (CoreWindow, DesktopWindowXamlSource), then any remaining
+        visible children.
 
         Args:
             parent_hwnd: Handle of the ApplicationFrameHost top-level window.
 
         Returns:
-            CoreWindow child HWND if found, otherwise 0.
+            List of child HWNDs to try, ordered by priority (best first).
         """
         import sys
         if sys.platform != "win32":
-            return 0
+            return []
         try:
             import ctypes
+            from ctypes import wintypes
+
             user32 = ctypes.windll.user32
-            FindWindowExW = user32.FindWindowExW
-            FindWindowExW.restype = ctypes.c_void_p
-            FindWindowExW.argtypes = [
-                ctypes.c_void_p,  # hWndParent
-                ctypes.c_void_p,  # hWndChildAfter
-                ctypes.c_wchar_p,  # lpszClass
-                ctypes.c_void_p,  # lpszWindow (NULL = any)
-            ]
-            core_hwnd = FindWindowExW(parent_hwnd, None,
-                                      "Windows.UI.Core.CoreWindow", None)
-            return int(core_hwnd) if core_hwnd else 0
+
+            # Enumerate all child windows
+            children = []
+            WNDENUMPROC = ctypes.WINFUNCTYPE(
+                wintypes.BOOL, wintypes.HWND, wintypes.LPARAM,
+            )
+
+            def _enum_cb(hwnd, _lparam):
+                children.append(int(hwnd))
+                return True
+
+            user32.EnumChildWindows(
+                wintypes.HWND(parent_hwnd), WNDENUMPROC(_enum_cb), 0,
+            )
+
+            if not children:
+                return []
+
+            # Classify by window class name for priority ordering
+            GetClassNameW = user32.GetClassNameW
+            GetClassNameW.argtypes = [wintypes.HWND, ctypes.c_wchar_p, ctypes.c_int]
+            GetClassNameW.restype = ctypes.c_int
+
+            PRIORITY_CLASSES = {
+                "windows.ui.core.corewindow": 0,   # Classic UWP
+                "desktopwindowxamlsource": 1,       # WinUI 3
+            }
+
+            prioritized = []
+            rest = []
+            for hwnd in children:
+                cls_buf = ctypes.create_unicode_buffer(256)
+                GetClassNameW(wintypes.HWND(hwnd), cls_buf, 256)
+                cls_name = cls_buf.value.lower()
+                prio = PRIORITY_CLASSES.get(cls_name)
+                if prio is not None:
+                    prioritized.append((prio, hwnd, cls_buf.value))
+                else:
+                    rest.append(hwnd)
+
+            prioritized.sort(key=lambda t: t[0])
+            result = [h for _, h, _ in prioritized] + rest
+
+            if prioritized:
+                logger.debug(
+                    "UWP child windows for AFH %s: priority=%s, other=%d",
+                    parent_hwnd,
+                    [(cls, h) for _, h, cls in prioritized],
+                    len(rest),
+                )
+
+            return result
         except Exception:
-            return 0
+            return []
 
     def _is_afh_window(self, handle: int) -> bool:
         """Check if a window handle belongs to ApplicationFrameHost.exe.
@@ -943,11 +991,13 @@ class WindowsBackend(Backend):
         Fills parent_id, children IDs, and keyboard_shortcut for all elements
         via Python-layer post-processing (the C++ DLL does not emit these).
 
-        For UWP apps (Calculator, Settings, etc.) the UI tree lives inside a
-        ``Windows.UI.Core.CoreWindow`` child of the ``ApplicationFrameHost``
-        top-level window.  When the initial traversal returns an empty tree
-        from an AFH window, this method automatically retries with the
-        CoreWindow child HWND.
+        For UWP/WinUI apps (Calculator, Settings, etc.) the UI tree lives
+        inside child windows of the ``ApplicationFrameHost`` top-level window.
+        Classic UWP uses ``Windows.UI.Core.CoreWindow``; WinUI 3 apps use
+        other classes like ``DesktopWindowXamlSource``.  When the initial
+        traversal returns an empty tree from an AFH window, this method
+        enumerates all child windows and retries with each until a non-empty
+        tree is found.
 
         Args:
             window_title: Window title pattern (partial match, case-insensitive).
@@ -964,20 +1014,38 @@ class WindowsBackend(Backend):
         core = self._ensure_core()
         handle = self._resolve_hwnd(app=app, window_title=window_title, hwnd=hwnd)
 
-        def _try_uwp_core(current_result):
-            """If handle is an AFH window with empty tree, retry with CoreWindow child."""
+        def _try_uwp_children(current_result, get_tree_fn):
+            """If handle is an AFH window with empty tree, try child windows.
+
+            Enumerates all child HWNDs of the ApplicationFrameHost window
+            and returns the first one that yields a non-empty element tree.
+
+            Args:
+                current_result: The element tree from the AFH window itself.
+                get_tree_fn: Callable(hwnd, depth) -> element tree result.
+
+            Returns:
+                A non-empty element tree from a child HWND, or current_result
+                if no child yields a better result.
+            """
             if (current_result is not None
                     and not current_result.children
                     and handle
                     and self._is_afh_window(handle)):
-                core_hwnd = self._find_uwp_core_hwnd(handle)
-                if core_hwnd:
+                child_hwnds = self._find_uwp_content_hwnd(handle)
+                for child_hwnd in child_hwnds:
                     logger.debug(
-                        "UWP fallback: retrying element tree with CoreWindow "
-                        "HWND %s (parent AFH %s)", core_hwnd, handle,
+                        "UWP fallback: trying child HWND %s "
+                        "(parent AFH %s)", child_hwnd, handle,
                     )
-                    return core_hwnd
-            return 0
+                    child_result = get_tree_fn(child_hwnd, depth)
+                    if child_result is not None and child_result.children:
+                        logger.info(
+                            "UWP fallback: found %d children via child "
+                            "HWND %s", len(child_result.children), child_hwnd,
+                        )
+                        return child_result
+            return current_result
 
         if backend == "jab":
             result = core.jab_get_element_tree(hwnd=handle, depth=depth)
@@ -987,12 +1055,11 @@ class WindowsBackend(Backend):
             result = core.msaa_get_element_tree(hwnd=handle, depth=depth)
         elif backend == "auto":
             result = core.get_element_tree(hwnd=handle, depth=depth)
-            # UWP fallback: ApplicationFrameHost → CoreWindow child
-            uwp_hwnd = _try_uwp_core(result)
-            if uwp_hwnd:
-                uwp_result = core.get_element_tree(hwnd=uwp_hwnd, depth=depth)
-                if uwp_result is not None and uwp_result.children:
-                    result = uwp_result
+            # UWP/WinUI fallback: try child windows of AFH
+            result = _try_uwp_children(
+                result,
+                lambda h, d: core.get_element_tree(hwnd=h, depth=d),
+            )
             if result is None or (not result.children and not result.name):
                 # Try IA2 first (Firefox/Thunderbird/LibreOffice), then MSAA
                 ia2_result = core.ia2_get_element_tree(hwnd=handle, depth=depth)
@@ -1009,12 +1076,11 @@ class WindowsBackend(Backend):
                             result = msaa_result
         else:
             result = core.get_element_tree(hwnd=handle, depth=depth)
-            # UWP fallback for explicit "uia" backend too
-            uwp_hwnd = _try_uwp_core(result)
-            if uwp_hwnd:
-                uwp_result = core.get_element_tree(hwnd=uwp_hwnd, depth=depth)
-                if uwp_result is not None and uwp_result.children:
-                    result = uwp_result
+            # UWP/WinUI fallback for explicit "uia" backend too
+            result = _try_uwp_children(
+                result,
+                lambda h, d: core.get_element_tree(hwnd=h, depth=d),
+            )
 
         if result is None:
             return None

--- a/tests/test_uwp_fallback.py
+++ b/tests/test_uwp_fallback.py
@@ -1,7 +1,11 @@
-"""Tests for UWP ApplicationFrameHost → CoreWindow element tree fallback.
+"""Tests for UWP/WinUI ApplicationFrameHost child window element tree fallback.
 
 These tests use mocking and run on all platforms to verify the fallback
-logic in WindowsBackend.get_element_tree for UWP apps.
+logic in WindowsBackend.get_element_tree for UWP and WinUI 3 apps.
+
+The fallback enumerates child HWNDs of the ApplicationFrameHost window
+and tries each one until a non-empty UIA element tree is found.  This
+handles both classic UWP (CoreWindow) and WinUI 3 (DesktopWindowXamlSource).
 """
 
 from __future__ import annotations
@@ -74,40 +78,40 @@ class TestIsAfhWindow:
         assert backend._is_afh_window(999) is False
 
 
-class TestFindUwpCoreHwnd:
-    """Tests for _find_uwp_core_hwnd static method."""
+class TestFindUwpContentHwnd:
+    """Tests for _find_uwp_content_hwnd static method."""
 
-    def test_returns_zero_on_non_windows(self):
-        """Should return 0 on non-Windows platforms."""
+    def test_returns_empty_on_non_windows(self):
+        """Should return empty list on non-Windows platforms."""
         from naturo.backends.windows import WindowsBackend
 
         import sys
         if sys.platform == "win32":
             pytest.skip("Test only applicable on non-Windows")
 
-        assert WindowsBackend._find_uwp_core_hwnd(12345) == 0
+        assert WindowsBackend._find_uwp_content_hwnd(12345) == []
 
 
 class TestUwpElementTreeFallback:
-    """Tests for UWP CoreWindow fallback in get_element_tree."""
+    """Tests for UWP/WinUI child window fallback in get_element_tree."""
 
-    def test_uwp_fallback_retries_with_core_hwnd(self, backend):
-        """When AFH returns empty tree, should retry with CoreWindow HWND."""
+    def test_uwp_fallback_retries_with_child_hwnds(self, backend):
+        """When AFH returns empty tree, should try child HWNDs."""
         empty_root = _make_element(role="Pane", name="", children=[])
         rich_root = _make_element(
             role="Window", name="Calculator",
             children=[_make_element(role="Button", name="1")],
         )
 
-        # First call returns empty tree, second with CoreWindow returns rich
+        # First call returns empty tree, second with child HWND returns rich
         backend._core.get_element_tree = MagicMock(
             side_effect=[empty_root, rich_root],
         )
         backend._resolve_hwnd = MagicMock(return_value=100)
         backend._is_afh_window = MagicMock(return_value=True)
 
-        with patch.object(type(backend), "_find_uwp_core_hwnd",
-                          return_value=200):
+        with patch.object(type(backend), "_find_uwp_content_hwnd",
+                          return_value=[200]):
             with patch("naturo.backends.windows.populate_hierarchy"):
                 result = backend.get_element_tree(app="calc", backend="uia")
 
@@ -115,6 +119,33 @@ class TestUwpElementTreeFallback:
         assert result.role == "Window"
         assert len(result.children) == 1
         assert result.children[0].role == "Button"
+
+    def test_uwp_fallback_tries_multiple_children(self, backend):
+        """Should try multiple child HWNDs until one has content."""
+        empty_root = _make_element(role="Pane", name="", children=[])
+        also_empty = _make_element(role="Pane", name="", children=[])
+        rich_root = _make_element(
+            role="Window", name="Settings",
+            children=[_make_element(role="List", name="Categories")],
+        )
+
+        # First call: AFH empty; child 200: empty; child 300: rich
+        backend._core.get_element_tree = MagicMock(
+            side_effect=[empty_root, also_empty, rich_root],
+        )
+        backend._resolve_hwnd = MagicMock(return_value=100)
+        backend._is_afh_window = MagicMock(return_value=True)
+
+        with patch.object(type(backend), "_find_uwp_content_hwnd",
+                          return_value=[200, 300]):
+            with patch("naturo.backends.windows.populate_hierarchy"):
+                result = backend.get_element_tree(app="settings", backend="uia")
+
+        assert result is not None
+        assert result.role == "Window"
+        assert len(result.children) == 1
+        # Should have tried 3 times: AFH + child 200 + child 300
+        assert backend._core.get_element_tree.call_count == 3
 
     def test_no_fallback_when_tree_has_children(self, backend):
         """Should not attempt fallback when tree already has children."""
@@ -162,8 +193,8 @@ class TestUwpElementTreeFallback:
         backend._resolve_hwnd = MagicMock(return_value=100)
         backend._is_afh_window = MagicMock(return_value=True)
 
-        with patch.object(type(backend), "_find_uwp_core_hwnd",
-                          return_value=300):
+        with patch.object(type(backend), "_find_uwp_content_hwnd",
+                          return_value=[300]):
             with patch("naturo.backends.windows.populate_hierarchy"):
                 result = backend.get_element_tree(app="settings",
                                                   backend="auto")
@@ -171,3 +202,68 @@ class TestUwpElementTreeFallback:
         assert result is not None
         assert result.role == "Window"
         assert len(result.children) == 1
+
+    def test_fallback_returns_original_when_no_children_found(self, backend):
+        """When all child HWNDs also return empty, keep original result."""
+        empty_root = _make_element(role="Pane", name="", children=[])
+        child_empty = _make_element(role="Pane", name="", children=[])
+
+        backend._core.get_element_tree = MagicMock(
+            side_effect=[empty_root, child_empty],
+        )
+        backend._resolve_hwnd = MagicMock(return_value=100)
+        backend._is_afh_window = MagicMock(return_value=True)
+
+        with patch.object(type(backend), "_find_uwp_content_hwnd",
+                          return_value=[200]):
+            with patch("naturo.backends.windows.populate_hierarchy"):
+                result = backend.get_element_tree(app="calc", backend="uia")
+
+        # Should return original empty result (post-processed)
+        assert result is not None
+        assert result.children == []
+
+    def test_fallback_with_no_child_windows(self, backend):
+        """When AFH has no child windows at all, return original result."""
+        empty_root = _make_element(role="Pane", name="", children=[])
+
+        backend._core.get_element_tree = MagicMock(return_value=empty_root)
+        backend._resolve_hwnd = MagicMock(return_value=100)
+        backend._is_afh_window = MagicMock(return_value=True)
+
+        with patch.object(type(backend), "_find_uwp_content_hwnd",
+                          return_value=[]):
+            with patch("naturo.backends.windows.populate_hierarchy"):
+                result = backend.get_element_tree(app="calc", backend="uia")
+
+        assert result is not None
+        assert backend._core.get_element_tree.call_count == 1
+
+    def test_winui3_desktop_window_xaml_source(self, backend):
+        """Should find WinUI 3 apps that use DesktopWindowXamlSource."""
+        empty_root = _make_element(role="Pane", name="", children=[])
+        # First child (CoreWindow) also empty, second (DesktopWindowXamlSource) has content
+        also_empty = _make_element(role="Pane", name="", children=[])
+        rich_root = _make_element(
+            role="Window", name="Calculator",
+            children=[
+                _make_element(role="Group", name="Number pad"),
+                _make_element(role="Button", name="7"),
+            ],
+        )
+
+        backend._core.get_element_tree = MagicMock(
+            side_effect=[empty_root, also_empty, rich_root],
+        )
+        backend._resolve_hwnd = MagicMock(return_value=100)
+        backend._is_afh_window = MagicMock(return_value=True)
+
+        # Simulate: CoreWindow(200) → empty, DesktopWindowXamlSource(300) → rich
+        with patch.object(type(backend), "_find_uwp_content_hwnd",
+                          return_value=[200, 300]):
+            with patch("naturo.backends.windows.populate_hierarchy"):
+                result = backend.get_element_tree(app="calc", backend="uia")
+
+        assert result is not None
+        assert result.role == "Window"
+        assert len(result.children) == 2


### PR DESCRIPTION
## Problem
`see` returns empty children for UWP apps (Calculator, Settings) on Windows 11 24H2. The previous CoreWindow-only lookup (`_find_uwp_core_hwnd`) searched only for `Windows.UI.Core.CoreWindow` child class, which doesn't exist in WinUI 3 apps that use `DesktopWindowXamlSource` instead.

QA verified the fix from PR #193 failed twice on real hardware (naturo 0.2.1 and 0.2.5).

## Root Cause
Windows 11 24H2 Calculator (and other modern apps) have been rewritten as WinUI 3 / Windows App SDK apps. Their UI lives in `DesktopWindowXamlSource` child windows, not `CoreWindow`.

## Fix
Replace `_find_uwp_core_hwnd` (single class lookup) with `_find_uwp_content_hwnd` (enumerate all children):
- Enumerates ALL child windows of the ApplicationFrameHost parent
- Prioritizes known UWP/WinUI classes (CoreWindow, DesktopWindowXamlSource)
- Tries each child HWND with `get_element_tree` until a non-empty tree is found
- Falls back gracefully if no child yields content

## Tests
- 12 updated UWP fallback tests including WinUI 3 scenario
- All 1613 tests passing, 0 failures
- **Needs QA verification on compile machine** with `naturo see --app Calculator --json`