### PR TITLE
fix: DLL version sync and test stderr isolation (fixes #217, fixes #218)

### DIFF
--- a/scripts/sync_dll.py
+++ b/scripts/sync_dll.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Download the latest naturo_core.dll from CI artifacts.
+
+Usage:
+    python scripts/sync_dll.py
+
+This downloads the DLL built by the latest successful CI run on main
+and places it into naturo/bin/ where the bridge module expects it.
+
+Requires: gh CLI authenticated.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def main() -> int:
+    """Download the latest CI-built DLL artifact to naturo/bin/."""
+    repo_root = Path(__file__).resolve().parent.parent
+    target_dir = repo_root / "naturo" / "bin"
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    print("Fetching latest successful CI run on main...")
+    result = subprocess.run(
+        [
+            "gh", "run", "list",
+            "--branch", "main",
+            "--status", "success",
+            "--limit", "1",
+            "--json", "databaseId",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root),
+    )
+    if result.returncode != 0:
+        print(f"Error listing runs: {result.stderr}", file=sys.stderr)
+        return 1
+
+    import json
+    runs = json.loads(result.stdout)
+    if not runs:
+        print("No successful CI runs found on main.", file=sys.stderr)
+        return 1
+
+    run_id = runs[0]["databaseId"]
+    print(f"Downloading DLL from run {run_id}...")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dl_result = subprocess.run(
+            [
+                "gh", "run", "download", str(run_id),
+                "--name", "naturo-core-dll",
+                "--dir", tmpdir,
+            ],
+            capture_output=True,
+            text=True,
+            cwd=str(repo_root),
+        )
+        if dl_result.returncode != 0:
+            print(f"Error downloading artifact: {dl_result.stderr}", file=sys.stderr)
+            return 1
+
+        # The artifact contains bin/Release/naturo_core.dll
+        dll_src = Path(tmpdir) / "bin" / "Release" / "naturo_core.dll"
+        if not dll_src.exists():
+            # Try flat layout
+            dll_src = Path(tmpdir) / "naturo_core.dll"
+
+        if not dll_src.exists():
+            print(f"DLL not found in artifact. Contents: {list(Path(tmpdir).rglob('*'))}", file=sys.stderr)
+            return 1
+
+        dll_dst = target_dir / "naturo_core.dll"
+        shutil.copy2(str(dll_src), str(dll_dst))
+        print(f"✅ DLL copied to {dll_dst}")
+
+        # Verify version
+        try:
+            import ctypes
+            dll = ctypes.CDLL(str(dll_dst))
+            dll.naturo_version.restype = ctypes.c_char_p
+            dll_ver = dll.naturo_version().decode()
+
+            from naturo.version import __version__
+            print(f"   DLL version:    {dll_ver}")
+            print(f"   Python version: {__version__}")
+            if dll_ver != __version__:
+                print(f"⚠️  Version mismatch! DLL={dll_ver} Python={__version__}", file=sys.stderr)
+                return 1
+            print("✅ Versions match!")
+        except Exception as exc:
+            print(f"⚠️  Could not verify version: {exc}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,16 @@ def pytest_configure(config):
     pass  # markers defined in pyproject.toml
 
 
+def cli_stdout(result):
+    """Extract stdout-only text from a Click CliRunner result.
+
+    Click 8.x's ``result.output`` mixes stderr and stdout. Use
+    ``result.stdout`` when available (Click ≥8.0) to avoid stderr
+    warnings contaminating JSON output assertions.
+    """
+    return getattr(result, "stdout", result.output)
+
+
 @pytest.fixture
 def is_windows():
     return platform.system() == "Windows"

--- a/tests/test_cli_phase1.py
+++ b/tests/test_cli_phase1.py
@@ -70,10 +70,11 @@ class TestCLIFunctionalWindows:
     def test_list_windows_json(self, runner):
         """'naturo list windows --json' should produce valid JSON."""
         import json
+        from tests.conftest import cli_stdout
 
         result = runner.invoke(main, ["list", "windows", "--json"])
         assert result.exit_code == 0
-        data = json.loads(result.output)
+        data = json.loads(cli_stdout(result))
         assert isinstance(data, dict)
         assert data["success"] is True
         assert isinstance(data["windows"], list)


### PR DESCRIPTION
## Changes

### #217 — DLL version out of sync
- **Root cause**: Compile machine had stale DLL (0.2.1) while Python package is 0.2.5. Source code was already correct.
- **Immediate fix**: SCP'd the latest DLL to compile machine — versions now match (0.2.5 = 0.2.5)
- **Preventive**: Added `scripts/sync_dll.py` — downloads the latest CI-built DLL artifact via `gh run download` and places it in `naturo/bin/`

### #218 — CliRunner mixes stderr with stdout
- **Root cause**: Click's `CliRunner().output` includes both stdout and stderr. Stderr warnings (e.g., 'no interactive desktop session') break JSON parsing.
- **Fix**: Added `cli_stdout()` helper in `conftest.py` that uses `result.stdout` (Click 8+) which isolates stdout from stderr. Applied to the specific failing test.
- **Note**: ~150 other `json.loads(result.output)` patterns exist — migration to `cli_stdout()` can be done incrementally.

## Testing
- All 1623 tests pass locally (34s)
- Compile machine DLL version verified: DLL=0.2.5, Python=0.2.5