### PR TITLE
fix: get command resolves element refs and app targeting correctly (fixes #222)

### DIFF
--- a/naturo/backends/base.py
+++ b/naturo/backends/base.py
@@ -199,6 +199,7 @@ class Backend(ABC):
         automation_id: Optional[str] = None,
         role: Optional[str] = None,
         name: Optional[str] = None,
+        app: Optional[str] = None,
         window_title: Optional[str] = None,
         hwnd: Optional[int] = None,
     ) -> Optional[dict]:
@@ -212,6 +213,7 @@ class Backend(ABC):
             automation_id: UIA AutomationId.
             role: Element role (e.g. ``"Edit"``).
             name: Element name.
+            app: Application name (partial match) for window targeting.
             window_title: Window title for targeting.
             hwnd: Window handle.
 

--- a/naturo/backends/linux.py
+++ b/naturo/backends/linux.py
@@ -119,5 +119,5 @@ class LinuxBackend(Backend):
         raise NotImplementedError("Linux backend coming in Phase 7")
 
     def get_element_value(self, ref=None, automation_id=None, role=None,
-                          name=None, window_title=None, hwnd=None) -> Optional[dict]:
+                          name=None, app=None, window_title=None, hwnd=None) -> Optional[dict]:
         raise NotImplementedError("Linux backend coming in Phase 7")

--- a/naturo/backends/macos.py
+++ b/naturo/backends/macos.py
@@ -540,6 +540,7 @@ class MacOSBackend(Backend):
         automation_id: Optional[str] = None,
         role: Optional[str] = None,
         name: Optional[str] = None,
+        app: Optional[str] = None,
         window_title: Optional[str] = None,
         hwnd: Optional[int] = None,
     ) -> Optional[dict]:

--- a/naturo/backends/windows.py
+++ b/naturo/backends/windows.py
@@ -1116,6 +1116,7 @@ class WindowsBackend(Backend):
         automation_id: Optional[str] = None,
         role: Optional[str] = None,
         name: Optional[str] = None,
+        app: Optional[str] = None,
         window_title: Optional[str] = None,
         hwnd: Optional[int] = None,
     ) -> Optional[dict]:
@@ -1130,6 +1131,7 @@ class WindowsBackend(Backend):
             automation_id: UIA AutomationId string.
             role: Element role (e.g. ``"Edit"``).
             name: Element name.
+            app: Application name (partial match) for window targeting.
             window_title: Window title for targeting.
             hwnd: Window handle.
 
@@ -1149,8 +1151,8 @@ class WindowsBackend(Backend):
         target_hwnd = hwnd or 0
 
         if ref and not resolved_aid:
-            from naturo.snapshot import SnapshotManager
-            mgr = SnapshotManager()
+            from naturo.snapshot import get_snapshot_manager
+            mgr = get_snapshot_manager()
             result = mgr.resolve_ref_element(ref)
             if result:
                 elem, _snap_id = result
@@ -1174,12 +1176,20 @@ class WindowsBackend(Backend):
                     f"Run 'naturo see' first to capture elements."
                 )
 
-        if window_title and not target_hwnd:
-            wins = core.list_windows()
-            for w in wins:
-                if window_title.lower() in (w.title or "").lower():
-                    target_hwnd = w.hwnd
-                    break
+        # Resolve app/window_title to HWND for targeted lookup
+        if (app or window_title) and not target_hwnd:
+            try:
+                target_hwnd = self._resolve_hwnd(
+                    app=app, window_title=window_title
+                )
+            except Exception:
+                # Fall back to scanning windows manually
+                if window_title:
+                    wins = core.list_windows()
+                    for w in wins:
+                        if window_title.lower() in (w.title or "").lower():
+                            target_hwnd = w.hwnd
+                            break
 
         if not resolved_aid and not resolved_role and not resolved_name:
             raise NaturoError(

--- a/naturo/cli/core.py
+++ b/naturo/cli/core.py
@@ -743,6 +743,7 @@ def see(app, window_title, hwnd, pid, mode, depth, path, annotate, store_snapsho
                     title=el.name,
                     label=el.name,
                     value=el.value,
+                    identifier=el.id if el.id else None,
                     frame=(el.x, el.y, el.width, el.height),
                     is_actionable=getattr(el, "is_actionable", False),
                     parent_id=props.get("parent_id", parent_id),

--- a/naturo/cli/get_cmd.py
+++ b/naturo/cli/get_cmd.py
@@ -111,6 +111,7 @@ def get_cmd(ctx, target, ref, automation_id, role, name, prop, app,
             automation_id=automation_id,
             role=role,
             name=name,
+            app=app,
             window_title=window_title,
             hwnd=hwnd,
         )

--- a/naturo/cli/interaction.py
+++ b/naturo/cli/interaction.py
@@ -105,6 +105,7 @@ def _post_action_see(
             title=el.name,
             label=el.name,
             value=el.value,
+            identifier=el.id if el.id else None,
             frame=(el.x, el.y, el.width, el.height),
             is_actionable=getattr(el, "is_actionable", False),
             parent_id=props.get("parent_id", parent_id),

--- a/tests/test_get_cmd.py
+++ b/tests/test_get_cmd.py
@@ -99,6 +99,7 @@ class TestGetCLI:
             automation_id=None,
             role=None,
             name=None,
+            app=None,
             window_title=None,
             hwnd=None,
         )
@@ -132,6 +133,7 @@ class TestGetCLI:
             automation_id="txtSearch",
             role=None,
             name=None,
+            app=None,
             window_title=None,
             hwnd=None,
         )
@@ -150,6 +152,7 @@ class TestGetCLI:
             automation_id=None,
             role="Edit",
             name="Search",
+            app=None,
             window_title=None,
             hwnd=None,
         )
@@ -220,6 +223,7 @@ class TestGetCLI:
             automation_id=None,
             role=None,
             name=None,
+            app=None,
             window_title="Notepad",
             hwnd=None,
         )
@@ -240,6 +244,7 @@ class TestGetCLI:
             automation_id=None,
             role=None,
             name=None,
+            app=None,
             window_title=None,
             hwnd=12345,
         )
@@ -258,6 +263,7 @@ class TestGetCLI:
             automation_id="txtSearch",
             role=None,
             name=None,
+            app=None,
             window_title=None,
             hwnd=None,
         )
@@ -276,6 +282,7 @@ class TestGetCLI:
             automation_id=None,
             role=None,
             name=None,
+            app=None,
             window_title=None,
             hwnd=None,
         )


### PR DESCRIPTION
## Problem
`naturo get e3 --app notepad --json` fails with ELEMENT_NOT_FOUND even immediately after `naturo see --app notepad` returns e3. The see→get workflow is broken.

## Root Causes
1. **Wrong SnapshotManager**: `get_element_value()` used raw `SnapshotManager()` instead of `get_snapshot_manager()`, ignoring `NATURO_SESSION` env var
2. **app parameter not wired**: `get_cmd.py` accepted `--app` but never passed it to the backend, so HWND was always 0 (foreground window)
3. **identifier not stored**: AutomationId was never stored in UIElement during snapshot creation, forcing fallback to role+name matching

## Changes
- Use `get_snapshot_manager()` in Windows backend for session-aware snapshot lookup
- Add `app` parameter to `get_element_value()` across all backends (base, windows, macos, linux)
- Pass `--app` from CLI to backend, using `_resolve_hwnd()` for proper window targeting
- Store `identifier` (AutomationId) in UIElement during snapshot creation (both `see` and post-action snapshot paths)
- Update test assertions for new `app` parameter

## Testing
- All 1623 tests pass (481 skipped — platform-specific)
- test_get_cmd.py: 22/22 pass