### PR TITLE
fix: capture element crop accounts for window-relative coordinates (fixes #220)

### DIFF
--- a/.work/qa-round18-report.md
+++ b/.work/qa-round18-report.md
@@ -1,0 +1,106 @@
+# QA Round 18 Report — 2026-03-24 14:07
+
+**QA-Mariana** | Version: 0.2.5 (main @ 0e2ebc4) | Machine: Robot-Compile (Win11, 1920×1080, 96DPI)
+
+## 1. Verification Status
+
+### #208 — UIA probe falls back to vision for Win32 apps
+- **Status**: ⏳ Cannot verify — PR #214 not yet merged to main
+- **Dev comment**: Fix adds `_get_native_core()` with COM init before UIA probe
+- **Action**: Waiting for merge; will verify next round
+
+### #142 — Global --provider, --model, --api-key flags
+- **Status**: ⚠️ Partially implemented — flags exist only on `find` command, not globally
+- **Issue**: Title says "Global flags for all AI-capable commands" but implementation adds flags only to `naturo find --ai`. `naturo --provider` returns "No such option"
+- **Action**: Will comment on issue
+
+### #143 — Anthropic subscription/OAuth token auth
+- **Status**: ✅ Code merged (PR #207), `naturo config show` shows ANTHROPIC_AUTH_TOKEN field
+- **Note**: Cannot verify runtime auth without actual Anthropic token on test machine
+
+### #138 — Auto-detect Electron apps in see
+- **Status**: ✅ Code merged (PR #213), `naturo electron list` correctly detects Electron apps (Clash, Edge, etc.)
+- **Note**: Lists `naturo.exe` itself as Electron — possible false positive worth investigating
+
+### #173 — Snapshot session isolation
+- **Status**: ✅ Code merged (PR #209), 274 new tests
+
+## 2. Proactive Testing Results
+
+### L0 — Smoke Tests ✅
+| Command | Result | Notes |
+|---------|--------|-------|
+| `naturo --version` | ✅ 0.2.5 | |
+| `naturo --help` | ✅ | All 22 commands listed |
+| `naturo --json app list` | ✅ | Global --json works |
+| `naturo app list --json` | ✅ | Consistent with global |
+| `naturo list screens --json` | ✅ | 1 monitor, 1920×1080, 96 DPI |
+| `naturo list windows --json` | ✅ | 15 windows found (via schtasks /it /i) |
+| `naturo config show --json` | ✅ | Clean JSON, credential redaction |
+| `naturo electron list --json` | ✅ | 4 Electron apps detected |
+
+### L1 — Error Handling ✅
+| Scenario | Result | Notes |
+|----------|--------|-------|
+| `see --depth 0` | ✅ INVALID_INPUT | Clear error message |
+| `see --depth 11` | ✅ INVALID_INPUT | Boundary enforced |
+| `see --app nonexistent` | ✅ WINDOW_NOT_FOUND | Suggests `naturo list windows` |
+| `app launch notepad2` | ✅ APP_NOT_FOUND | Clear error |
+| `click --json` (no desktop) | ✅ NO_DESKTOP_SESSION | Explains situation + suggests RDP |
+| `click` (no desktop, no json) | ✅ | Same error, text format, exit code 2 |
+
+### L1 — UWP App Traversal ❌ (Known #191)
+| App | Elements Found | Expected | Status |
+|-----|---------------|----------|--------|
+| Notepad (Win11 UWP) | 2 (Window + TitleBar) | ~15+ (menu, tabs, edit area, status bar) | ❌ |
+| Calculator (UWP) | 1 (Pane, 0 children) | ~50+ (buttons, display) | ❌ |
+
+This is the known issue #191 — UWP/ApplicationFrameHost traversal is broken.
+
+### Mouse Operations — COM Error (schtasks context)
+| Command | Result | Notes |
+|---------|--------|-------|
+| `click --coords 400 300` | ❌ "mouse_move: System/COM error" | Via schtasks /it /i |
+| `click e2 --app notepad` | ❌ Same COM error | |
+| `move --coords 500 500` | ❌ Same COM error | |
+| `type QAtest` | ✅ | Keyboard works fine |
+| `press enter` | ✅ | Keyboard works fine |
+
+**Analysis**: All mouse operations (click, move, drag) fail with COM error code -2 when run via schtasks, even with `/it /i` flags. Keyboard operations (type, press) work fine. This is likely a Win32 `SendInput` permission issue in the schtasks execution context — the mouse API requires a specific desktop interaction level that schtasks doesn't provide. **This is a test environment limitation, not a naturo bug.** However, it means we cannot verify mouse-dependent commands without an actual RDP session or OpenClaw node connection.
+
+### Repo Hygiene Issue ⚠️
+- **60+ screenshot .png files** committed to the repo root (`naturo-screen-*.png`)
+- Total ~20MB of binary files in git history
+- Branch `fix/cleanup-screenshots` exists, suggesting Dev is aware
+- Recommendation: Add `*.png` to `.gitignore` (except intentional ones), remove from history with `git filter-branch` or BFG
+
+## 3. Product Quality Assessment
+
+### Current State: 6/10 — "Works for specific scenarios, but major gaps"
+
+**Strengths:**
+- Error handling is excellent — clear messages with suggested actions
+- JSON output is consistent and well-structured
+- Command structure is clean and intuitive (`naturo --help` is good)
+- New features (config, electron detect) are solid additions
+- DPI reporting is accurate (96 DPI confirmed)
+
+**Weaknesses:**
+- UWP app traversal (#191) is a showstopper for Win11 — Notepad and Calculator are THE default test apps
+- Auto-routing (#208) regression still unfixed (PR pending)
+- `click --coords` is the most basic use case and it works in principle, but testing is blocked
+
+### Top 3 Improvement Priorities
+1. **Fix UWP traversal (#191)** — Without this, naturo is unusable on Win11 defaults (Notepad, Calculator, Settings are all UWP)
+2. **Merge #208 fix** — Auto-routing falling back to vision defeats the purpose
+3. **Repo cleanup** — 60+ screenshots in git is unprofessional for an open-source project
+
+### Risk Warnings
+1. **Win11 compatibility**: If users try naturo on Win11 with default apps, they'll see empty/minimal UI trees and assume the tool is broken
+2. **#142 incomplete**: Issue closed but only partially implemented — users reading changelog will expect global flags
+3. **Test coverage gap**: No way to verify mouse operations without RDP — could be hiding real bugs
+
+## 4. Cleanup Performed
+- ✅ Quit notepad, calc via `naturo app quit`
+- ✅ Deleted schtasks NaturoQA, NaturoQA2, NaturoQATest
+- ⚠️ 3 zombie Notepad.exe processes in session 0 (can't kill from SSH, harmless)

--- a/naturo/cli/core.py
+++ b/naturo/cli/core.py
@@ -233,10 +233,13 @@ def live(app, window_title, hwnd, screen, path, fmt, store_snapshot, session,
         # ── Element / region crop (issue #160) ───────────────────────────────
         crop_box = None  # (left, top, right, bottom) in image coordinates
 
+        # Track whether the capture is window-relative (for element crop offset)
+        _is_window_capture = bool(hwnd or app or window_title)
+
         if element_ref:
             # Resolve eN ref → bounds from most recent snapshot
-            from naturo.snapshot import SnapshotManager
-            _mgr = SnapshotManager()
+            from naturo.snapshot import get_snapshot_manager
+            _mgr = get_snapshot_manager(session=session)
             resolved = _mgr.resolve_ref(element_ref)
             if resolved is None:
                 msg = (
@@ -251,13 +254,45 @@ def live(app, window_title, hwnd, screen, path, fmt, store_snapshot, session,
             cx, cy, _snap_id = resolved
             el_result = _mgr.resolve_ref_element(element_ref)
             if el_result:
-                element, _ = el_result
+                element, snap_id = el_result
                 ex, ey, ew, eh = element.frame
+
+                # When capturing a specific window (--app/--hwnd), the
+                # screenshot is window-relative (origin 0,0) but element
+                # coords from the snapshot are screen-absolute.  Subtract
+                # the window origin so the crop aligns with the image.
+                win_offset_x, win_offset_y = 0, 0
+                if _is_window_capture:
+                    # Try 1: query current window rect via Win32 API
+                    try:
+                        import platform as _plat
+                        _cap_hwnd = target_hwnd if target_hwnd else 0
+                        if _cap_hwnd and _plat.system() == "Windows":
+                            import ctypes
+                            import ctypes.wintypes as wt
+                            rect = wt.RECT()
+                            if ctypes.windll.user32.GetWindowRect(
+                                _cap_hwnd, ctypes.byref(rect)
+                            ):
+                                win_offset_x = rect.left
+                                win_offset_y = rect.top
+                    except Exception:
+                        pass
+                    # Try 2: fall back to snapshot window_bounds
+                    if win_offset_x == 0 and win_offset_y == 0:
+                        try:
+                            snap_data = _mgr.get_snapshot(snap_id)
+                            if snap_data.window_bounds:
+                                win_offset_x = snap_data.window_bounds[0]
+                                win_offset_y = snap_data.window_bounds[1]
+                        except Exception:
+                            pass  # Best-effort; absolute coords as last resort
+
                 crop_box = (
-                    max(0, ex - padding),
-                    max(0, ey - padding),
-                    ex + ew + padding,
-                    ey + eh + padding,
+                    max(0, ex - win_offset_x - padding),
+                    max(0, ey - win_offset_y - padding),
+                    ex - win_offset_x + ew + padding,
+                    ey - win_offset_y + eh + padding,
                 )
         elif region:
             # Parse X,Y,W,H
@@ -723,6 +758,21 @@ def see(app, window_title, hwnd, pid, mode, depth, path, annotate, store_snapsho
             # Persist ref mapping so click/type can resolve e<N> refs
             mgr.store_ref_map(snapshot_id, ref_map)
 
+            # Store window bounds in the snapshot metadata for coordinate
+            # offset calculations (e.g. capture --element crop).
+            _win_bounds = None
+            if tree:
+                _win_bounds = (tree.x, tree.y, tree.width, tree.height)
+            snap_obj = mgr.get_snapshot(snapshot_id)
+            snap_obj.window_bounds = _win_bounds
+            snap_obj.window_handle = hwnd
+            snap_obj.application_name = app
+            snap_obj.window_title = window_title
+            mgr._write_json_atomic(
+                mgr._snap_dir(snapshot_id) / "snapshot.json",
+                snap_obj.to_dict(),
+            )
+
             # Optionally capture screenshot into snapshot
             if path:
                 result = backend.capture_screen(output_path=path)
@@ -730,6 +780,7 @@ def see(app, window_title, hwnd, pid, mode, depth, path, annotate, store_snapsho
                     "window_handle": hwnd,
                     "application_name": app,
                     "window_title": window_title,
+                    "window_bounds": _win_bounds,
                 }
                 mgr.store_screenshot(snapshot_id, result.path, metadata)
 


### PR DESCRIPTION
## Problem
`capture live --app notepad --element e14` fails with 'Crop region has zero size' for title bar buttons. The element's screen-absolute coordinates (x=1614) exceed the window-relative image width (1536), causing `right < left`.

## Root Cause
When `--app` is used, `capture_window()` produces a window-relative image (origin 0,0), but the crop code uses screen-absolute element coordinates from the snapshot without subtracting the window origin.

## Fix
1. Detect window captures (`--app`/`--hwnd`/`--window`)
2. Query the window's screen position via Win32 `GetWindowRect` (primary)
3. Fall back to `snapshot.window_bounds` metadata (secondary)
4. Subtract window origin from element coordinates before cropping

Also:
- Use `get_snapshot_manager(session=)` for session-aware snapshot lookup
- Store `window_bounds` in `see` command snapshots for downstream use

## Testing
All 1623 tests pass (481 skipped — platform-specific)