### PR TITLE
fix: distinguish tree-assigned IDs from real AutomationIds in snapshots (fixes #229)

### DIFF
--- a/naturo/backends/windows.py
+++ b/naturo/backends/windows.py
@@ -1202,6 +1202,30 @@ class WindowsBackend(Backend):
             role=resolved_role,
             name=resolved_name,
         )
+
+        # (#229) Fallback: if UIA lookup returned None but we have snapshot
+        # data from the ref, return the snapshot metadata so the caller gets
+        # at least role/name/bounds instead of ELEMENT_NOT_FOUND.
+        if result is None and ref:
+            from naturo.snapshot import get_snapshot_manager as _gsm
+            _mgr = _gsm()
+            _el_result = _mgr.resolve_ref_element(ref)
+            if _el_result:
+                _elem, _snap = _el_result
+                ex, ey, ew, eh = _elem.frame
+                result = {
+                    "role": _elem.role,
+                    "name": _elem.title or _elem.label,
+                    "value": _elem.value,
+                    "pattern": None,
+                    "automation_id": _elem.identifier,
+                    "x": ex,
+                    "y": ey,
+                    "width": ew,
+                    "height": eh,
+                    "source": "snapshot",
+                }
+
         return result
 
     # === Phase 2: Input ===

--- a/naturo/cli/core.py
+++ b/naturo/cli/core.py
@@ -731,11 +731,20 @@ def see(app, window_title, hwnd, pid, mode, depth, path, annotate, store_snapsho
             _ref_seq = [0]
             ref_map = {}  # "e1" → element_id (backend id)
 
+            import re as _re_mod
+
             def _flatten(el, parent_id=None):
                 _ref_seq[0] += 1
                 ref = f"e{_ref_seq[0]}"
                 child_ids = [c.id for c in el.children]
                 props = getattr(el, "properties", {})
+                # (#229) Only store identifier if it's a real UIA AutomationId,
+                # not a tree-assigned sequential ID like "e1", "e2", etc.
+                # populate_hierarchy assigns "eN" to elements with empty ids,
+                # so we must filter those out to avoid false AutomationId lookups.
+                _raw_id = el.id if el.id else None
+                if _raw_id and _re_mod.fullmatch(r"e\d+", _raw_id):
+                    _raw_id = None  # Tree-assigned, not a real AutomationId
                 ui_map[el.id] = UIElement(
                     id=el.id,
                     element_id=f"element_{el.id}",
@@ -743,7 +752,7 @@ def see(app, window_title, hwnd, pid, mode, depth, path, annotate, store_snapsho
                     title=el.name,
                     label=el.name,
                     value=el.value,
-                    identifier=el.id if el.id else None,
+                    identifier=_raw_id,
                     frame=(el.x, el.y, el.width, el.height),
                     is_actionable=getattr(el, "is_actionable", False),
                     parent_id=props.get("parent_id", parent_id),


### PR DESCRIPTION
## Problem
`naturo get e1 --app notepad --json` returns ELEMENT_NOT_FOUND after a successful `naturo see`, even though snapshots ARE persisted to disk with refs.json.

### Root Cause
`_flatten()` in the `see` command stores `identifier=el.id` for every element. But `populate_hierarchy()` assigns sequential IDs like "e1", "e2", etc. to elements with empty UIA AutomationIds. When `get_element_value()` later resolves the ref:
1. Finds element in snapshot → `identifier = "e1"` 
2. Uses "e1" as UIA AutomationId → `core.get_element_value(automation_id="e1")`
3. UIA finds no element with AutomationId "e1" → returns None → ELEMENT_NOT_FOUND

Elements with REAL AutomationIds (e.g. "MenuBar", "num1Button") work fine. Only tree-assigned sequential IDs fail.

## Fix
1. **`_flatten()`**: Detect tree-assigned IDs (`/^e\d+$/` pattern) and set `identifier=None` instead — only real UIA AutomationIds are stored
2. **`get_element_value()`**: Add snapshot fallback — if UIA lookup returns None but we have snapshot data from the ref, return the snapshot metadata (role/name/bounds) with `source: "snapshot"`

## Testing
- 1623 tests pass, 495 skipped (cross-platform)
- Verified on compile machine: snapshot refs.json is correctly persisted, issue is purely in identifier resolution

Fixes #229
Fixes #222