### PR TITLE
fix: increase default tree depth from 3 to 5 for see/snapshot commands (fixes #228)

### DIFF
--- a/naturo/cli/core.py
+++ b/naturo/cli/core.py
@@ -618,7 +618,7 @@ def permissions(json_output):
     default="full",
     help="Analysis mode: full (all elements), interactive (clickable only), fast (quick scan)",
 )
-@click.option("--depth", "-d", type=int, default=3, help="Maximum tree depth (1-10)")
+@click.option("--depth", "-d", type=int, default=5, help="Maximum tree depth (1-10)")
 @click.option("--path", "-p", help="Save screenshot to path")
 @click.option("--annotate", is_flag=True, help="Annotate screenshot with element labels")
 @click.option("--snapshot/--no-snapshot", "store_snapshot", default=True, help="Store result in snapshot (default: on)")

--- a/naturo/mcp_server.py
+++ b/naturo/mcp_server.py
@@ -520,7 +520,7 @@ def create_server(host: str = "localhost", port: int = 3100) -> FastMCP:
     @_safe_tool
     def see_ui_tree(
         window_title: Optional[str] = None,
-        depth: int = 3,
+        depth: int = 5,
         accessibility_backend: str = "uia",
     ) -> dict:
         """Inspect the UI accessibility tree of a window.
@@ -1083,7 +1083,7 @@ def create_server(host: str = "localhost", port: int = 3100) -> FastMCP:
     @_safe_tool
     def create_snapshot(
         window_title: Optional[str] = None,
-        depth: int = 3,
+        depth: int = 5,
     ) -> dict:
         """Create a snapshot of the current UI state (screenshot + element tree).
 
@@ -1093,7 +1093,7 @@ def create_server(host: str = "localhost", port: int = 3100) -> FastMCP:
 
         Args:
             window_title: Target window (partial match). None = foreground window.
-            depth: How deep to traverse the UI tree (1-10, default 3).
+            depth: How deep to traverse the UI tree (1-10, default 5).
 
         Returns:
             Dict with snapshot_id, screenshot_path (base64), and element tree summary.


### PR DESCRIPTION
## Problem
UWP apps like Calculator have deeply nested UI trees. The `see` command defaulted to `--depth 3`, which only returned 10 elements (title bar + containers). Interactive elements like number pad buttons live at depth 4-5 and were missed entirely.

Meanwhile, `find --role Button` (default depth 5) could discover these buttons — inconsistent behavior that confused users.

## Fix
Increase default depth from 3 to 5 across:
- CLI `see` command
- MCP `see_ui_tree` tool  
- MCP `create_snapshot` tool

This aligns all inspection commands to depth 5, matching `find`.

## Testing
- All 1623 tests pass (495 skipped for platform)
- No tests relied on the default value — they all pass depth explicitly

Fixes #228