### PR TITLE
fix: session-aware window/process resolution for schtasks contexts (fixes #230)

### DIFF
--- a/naturo/backends/windows.py
+++ b/naturo/backends/windows.py
@@ -775,6 +775,52 @@ class WindowsBackend(Backend):
         "终端": {"windowsterminal", "terminal"},
     }
 
+    @staticmethod
+    def _get_console_session_id() -> int:
+        """Get the active console (interactive desktop) session ID.
+
+        Uses WTSGetActiveConsoleSessionId to determine which Windows session
+        owns the physical console.  Returns -1 if the call fails.
+
+        Returns:
+            Active console session ID, or -1 on failure.
+        """
+        try:
+            import ctypes
+            session_id = ctypes.windll.kernel32.WTSGetActiveConsoleSessionId()
+            # WTSGetActiveConsoleSessionId returns 0xFFFFFFFF on failure
+            if session_id == 0xFFFFFFFF:
+                return -1
+            return session_id
+        except Exception:
+            return -1
+
+    @staticmethod
+    def _get_process_session_id(pid: int) -> int:
+        """Get the Windows session ID for a given process.
+
+        Uses ProcessIdToSessionId to determine which session a process
+        belongs to.  Session 0 is the non-interactive services session;
+        session 1+ are interactive user sessions.
+
+        Args:
+            pid: Process ID.
+
+        Returns:
+            Session ID, or -1 on failure.
+        """
+        try:
+            import ctypes
+            session_id = ctypes.wintypes.DWORD()
+            success = ctypes.windll.kernel32.ProcessIdToSessionId(
+                pid, ctypes.byref(session_id)
+            )
+            if success:
+                return session_id.value
+            return -1
+        except Exception:
+            return -1
+
     def _resolve_hwnd(self, app: Optional[str] = None,
                       window_title: Optional[str] = None,
                       hwnd: Optional[int] = None) -> int:
@@ -791,6 +837,11 @@ class WindowsBackend(Backend):
           3 — process-name substring    (e.g. ``expl`` in ``explorer.exe``)
           2 — exact title match         (e.g. ``notepad`` == ``Notepad``)
           1 — title substring           (e.g. ``note`` in ``Untitled - Notepad``)
+
+        Session awareness (#230): When multiple windows match with equal
+        scores, windows in the active console session are strongly preferred
+        over windows in Session 0 (the non-interactive services session).
+        This prevents schtasks/remote contexts from targeting ghost windows.
 
         Case-insensitive throughout.  Among equal scores the window whose
         title is shortest wins (heuristic: less noise in the title ⇒ more
@@ -821,10 +872,14 @@ class WindowsBackend(Backend):
         search_lower = search.lower()
         windows = self.list_windows()
 
+        # Get console session for session-aware ranking (#230)
+        console_session = self._get_console_session_id()
+
         # --app → match process name first; --window-title → match title only
         match_process = app is not None
 
         best_score = 0
+        best_session_bonus = False  # True if best_window is in console session
         best_window = None
 
         for w in windows:
@@ -863,14 +918,34 @@ class WindowsBackend(Backend):
                 elif search_lower in title_lower:
                     score = 1  # substring in title
 
-            if score > best_score or (
-                score == best_score
-                and score > 0
-                and best_window is not None
-                and len(w.title) < len(best_window.title)
-            ):
+            if score == 0:
+                continue
+
+            # Session-aware ranking (#230): prefer windows in the active
+            # console session over windows in Session 0 (services session).
+            # This prevents schtasks-launched commands from targeting ghost
+            # processes that exist in the non-interactive session.
+            in_console = False
+            if console_session >= 0:
+                w_session = self._get_process_session_id(w.pid)
+                in_console = (w_session == console_session)
+
+            # Decision: pick this window if it has a higher score, or if
+            # scores are equal but this window is in the console session
+            # while the current best is not, or if all else is equal,
+            # prefer the shorter title (more likely the "main" window).
+            if score > best_score:
                 best_score = score
+                best_session_bonus = in_console
                 best_window = w
+            elif score == best_score and best_window is not None:
+                if in_console and not best_session_bonus:
+                    # Same score but this one is in the interactive session
+                    best_session_bonus = in_console
+                    best_window = w
+                elif in_console == best_session_bonus and len(w.title) < len(best_window.title):
+                    # Same score and same session status — prefer shorter title
+                    best_window = w
 
         if best_window is not None:
             # UWP/WinUI apps: the real UI tree lives under

--- a/naturo/cli/interaction.py
+++ b/naturo/cli/interaction.py
@@ -730,6 +730,8 @@ def type_cmd(text, delay, profile, wpm, press_return, tab_count, escape,
     # (#230) When --app/--hwnd/--window is specified, focus the target window
     # before typing. SendInput sends keystrokes to the foreground window, so
     # without focusing first, type silently sends to the wrong window.
+    # Session-aware: _resolve_hwnd now prefers interactive session windows.
+    _focused_hwnd = None
     if (app or window_title or hwnd) and not on_element:
         import platform as _plat
         if _plat.system() == "Windows":
@@ -738,11 +740,21 @@ def type_cmd(text, delay, profile, wpm, press_return, tab_count, escape,
                     app=app, window_title=window_title, hwnd=hwnd,
                 )
                 if _target_hwnd:
+                    _focused_hwnd = _target_hwnd
                     import ctypes
+                    import ctypes.wintypes
                     SW_RESTORE = 9
                     if backend._is_iconic(_target_hwnd):
                         ctypes.windll.user32.ShowWindow(_target_hwnd, SW_RESTORE)
                     ctypes.windll.user32.SetForegroundWindow(_target_hwnd)
+                    # Record the actual PID we focused for accurate routing info
+                    _focused_pid = ctypes.wintypes.DWORD()
+                    ctypes.windll.user32.GetWindowThreadProcessId(
+                        _target_hwnd, ctypes.byref(_focused_pid)
+                    )
+                    if route_info and _focused_pid.value:
+                        route_info["focused_pid"] = _focused_pid.value
+                        route_info["focused_hwnd"] = _target_hwnd
                     import time
                     time.sleep(0.15)  # Allow focus to settle
             except Exception as exc:
@@ -973,6 +985,7 @@ def press(keys, count, delay, hold_duration, app, window_title, hwnd, input_mode
     # (#230) Focus target window before sending key input.
     # SendInput/key_press deliver to the foreground window, so we must
     # ensure the correct window has focus when --app/--hwnd is specified.
+    # Session-aware: _resolve_hwnd now prefers interactive session windows.
     if (app or window_title or hwnd):
         import platform as _plat
         if _plat.system() == "Windows":
@@ -982,10 +995,19 @@ def press(keys, count, delay, hold_duration, app, window_title, hwnd, input_mode
                 )
                 if _target_hwnd:
                     import ctypes
+                    import ctypes.wintypes
                     SW_RESTORE = 9
                     if backend._is_iconic(_target_hwnd):
                         ctypes.windll.user32.ShowWindow(_target_hwnd, SW_RESTORE)
                     ctypes.windll.user32.SetForegroundWindow(_target_hwnd)
+                    # Record actual focused PID for routing accuracy
+                    _focused_pid = ctypes.wintypes.DWORD()
+                    ctypes.windll.user32.GetWindowThreadProcessId(
+                        _target_hwnd, ctypes.byref(_focused_pid)
+                    )
+                    if route_info and _focused_pid.value:
+                        route_info["focused_pid"] = _focused_pid.value
+                        route_info["focused_hwnd"] = _target_hwnd
                     # Also try UIA SetFocus for schtasks/remote contexts (#226)
                     if hasattr(backend, "focus_element_uia"):
                         try:

--- a/naturo/process.py
+++ b/naturo/process.py
@@ -90,11 +90,61 @@ def _list_processes() -> list[ProcessInfo]:
     return processes
 
 
+def _get_console_session_id() -> int:
+    """Get the active console (interactive desktop) session ID on Windows.
+
+    Uses WTSGetActiveConsoleSessionId to determine which Windows session
+    owns the physical console.
+
+    Returns:
+        Active console session ID, or -1 on failure or non-Windows.
+    """
+    if platform.system() != "Windows":
+        return -1
+    try:
+        import ctypes
+        session_id = ctypes.windll.kernel32.WTSGetActiveConsoleSessionId()
+        if session_id == 0xFFFFFFFF:
+            return -1
+        return session_id
+    except Exception:
+        return -1
+
+
+def _get_process_session_id(pid: int) -> int:
+    """Get the Windows session ID for a process.
+
+    Args:
+        pid: Process ID.
+
+    Returns:
+        Session ID, or -1 on failure or non-Windows.
+    """
+    if platform.system() != "Windows":
+        return -1
+    try:
+        import ctypes
+        import ctypes.wintypes
+        session_id = ctypes.wintypes.DWORD()
+        success = ctypes.windll.kernel32.ProcessIdToSessionId(
+            pid, ctypes.byref(session_id)
+        )
+        if success:
+            return session_id.value
+        return -1
+    except Exception:
+        return -1
+
+
 def find_process(
     name: str | None = None,
     pid: int | None = None,
 ) -> ProcessInfo | None:
     """Find a running process by name or PID.
+
+    When searching by name, prefers processes in the active console session
+    over those in Session 0 (non-interactive services session).  This
+    prevents schtasks/remote contexts from targeting ghost processes (#230).
 
     Args:
         name: Process name (case-insensitive substring match).
@@ -108,13 +158,31 @@ def find_process(
 
     processes = _list_processes()
 
-    for proc in processes:
-        if pid is not None and proc.pid == pid:
-            return proc
-        if name is not None and name.lower() in proc.name.lower():
-            return proc
+    # PID lookup is exact — no session preference needed
+    if pid is not None:
+        for proc in processes:
+            if proc.pid == pid:
+                return proc
+        return None
 
-    return None
+    # Name lookup: prefer interactive session processes (#230)
+    assert name is not None
+    name_lower = name.lower()
+    first_match: ProcessInfo | None = None
+    console_session = _get_console_session_id()
+
+    for proc in processes:
+        if name_lower not in proc.name.lower():
+            continue
+        if first_match is None:
+            first_match = proc
+        # If we can determine sessions, prefer the console session
+        if console_session >= 0:
+            proc_session = _get_process_session_id(proc.pid)
+            if proc_session == console_session:
+                return proc  # Found an interactive session match — use it
+
+    return first_match  # Fallback to first match if no console session match
 
 
 def is_running(name: str) -> bool:

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -5,6 +5,7 @@ from unittest.mock import patch, MagicMock
 from naturo.process import (
     ProcessInfo, find_process, is_running, launch_app, quit_app,
     relaunch_app, list_apps, _list_processes,
+    _get_console_session_id, _get_process_session_id,
 )
 from naturo.errors import AppNotFoundError, TimeoutError
 
@@ -58,6 +59,69 @@ class TestFindProcess:
         mock_list.return_value = [ProcessInfo(pid=1, name="Notepad.exe")]
         result = find_process(name="notepad")
         assert result is not None
+
+    @patch("naturo.process._get_process_session_id")
+    @patch("naturo.process._get_console_session_id")
+    @patch("naturo.process._list_processes")
+    def test_prefers_interactive_session_over_session_0(
+        self, mock_list, mock_console, mock_proc_session
+    ):
+        """When multiple processes match, prefer the one in the active
+        console session over the one in Session 0 (#230)."""
+        mock_list.return_value = [
+            ProcessInfo(pid=100, name="Notepad.exe"),  # Session 0 ghost
+            ProcessInfo(pid=200, name="Notepad.exe"),  # Interactive session
+        ]
+        mock_console.return_value = 1
+        # PID 100 → Session 0, PID 200 → Session 1 (console)
+        mock_proc_session.side_effect = lambda pid: 0 if pid == 100 else 1
+        result = find_process(name="notepad")
+        assert result is not None
+        assert result.pid == 200, "Should prefer interactive session (PID 200)"
+
+    @patch("naturo.process._get_process_session_id")
+    @patch("naturo.process._get_console_session_id")
+    @patch("naturo.process._list_processes")
+    def test_falls_back_to_first_match_when_no_console_session(
+        self, mock_list, mock_console, mock_proc_session
+    ):
+        """When console session ID is unavailable, fall back to first match."""
+        mock_list.return_value = [
+            ProcessInfo(pid=100, name="Notepad.exe"),
+            ProcessInfo(pid=200, name="Notepad.exe"),
+        ]
+        mock_console.return_value = -1  # Can't determine console session
+        result = find_process(name="notepad")
+        assert result is not None
+        assert result.pid == 100, "Should fall back to first match"
+
+    @patch("naturo.process._get_process_session_id")
+    @patch("naturo.process._get_console_session_id")
+    @patch("naturo.process._list_processes")
+    def test_session_aware_single_match(
+        self, mock_list, mock_console, mock_proc_session
+    ):
+        """When only one process matches, return it regardless of session."""
+        mock_list.return_value = [
+            ProcessInfo(pid=100, name="Notepad.exe"),
+        ]
+        mock_console.return_value = 1
+        mock_proc_session.return_value = 0  # Only in Session 0
+        result = find_process(name="notepad")
+        assert result is not None
+        assert result.pid == 100
+
+
+class TestSessionHelpers:
+    """Tests for session ID helper functions."""
+
+    @patch("platform.system", return_value="Darwin")
+    def test_console_session_non_windows(self, _mock):
+        assert _get_console_session_id() == -1
+
+    @patch("platform.system", return_value="Darwin")
+    def test_process_session_non_windows(self, _mock):
+        assert _get_process_session_id(1234) == -1
 
 
 class TestIsRunning:

--- a/tests/test_resolve_hwnd_session.py
+++ b/tests/test_resolve_hwnd_session.py
@@ -1,0 +1,130 @@
+"""Tests for session-aware window resolution in _resolve_hwnd (#230).
+
+These tests mock the Windows backend to verify that _resolve_hwnd prefers
+windows in the active console session over windows in Session 0 (the
+non-interactive services session).  This prevents schtasks/remote contexts
+from targeting ghost processes.
+"""
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import patch, MagicMock, PropertyMock
+
+from naturo.backends.base import WindowInfo
+
+
+def _make_backend():
+    """Create a WindowsBackend-like object for testing _resolve_hwnd.
+
+    Since we can't import WindowsBackend on non-Windows (it needs
+    naturo_core.dll), we test the logic via the actual class with mocked
+    internals.
+    """
+    try:
+        from naturo.backends.windows import WindowsBackend
+        return WindowsBackend
+    except Exception:
+        pytest.skip("WindowsBackend not available on this platform")
+
+
+class TestResolveHwndSessionAwareness:
+    """Verify _resolve_hwnd prefers interactive session windows."""
+
+    def _make_windows(self):
+        """Two Notepad windows: one in Session 0, one in Session 1."""
+        return [
+            WindowInfo(
+                handle=1001, title="Untitled - Notepad",
+                process_name="Notepad.exe", pid=100,
+                x=0, y=0, width=800, height=600,
+                is_visible=True, is_minimized=False,
+            ),
+            WindowInfo(
+                handle=2002, title="Untitled - Notepad",
+                process_name="Notepad.exe", pid=200,
+                x=100, y=100, width=800, height=600,
+                is_visible=True, is_minimized=False,
+            ),
+        ]
+
+    def test_prefers_console_session_window(self):
+        """When two windows match equally, prefer the one in console session."""
+        BackendClass = _make_backend()
+        backend = MagicMock(spec=BackendClass)
+        backend.list_windows = MagicMock(return_value=self._make_windows())
+
+        # Bind the real method to our mock
+        backend._resolve_hwnd = BackendClass._resolve_hwnd.__get__(backend)
+        backend._get_console_session_id = MagicMock(return_value=1)
+        backend._get_process_session_id = MagicMock(
+            side_effect=lambda pid: 0 if pid == 100 else 1
+        )
+        backend._APP_ALIASES = BackendClass._APP_ALIASES
+
+        result = backend._resolve_hwnd(app="notepad")
+        # Should pick handle 2002 (PID 200, Session 1) not 1001 (PID 100, Session 0)
+        assert result == 2002
+
+    def test_falls_back_when_session_unknown(self):
+        """When console session is unknown, use title-length heuristic."""
+        BackendClass = _make_backend()
+        backend = MagicMock(spec=BackendClass)
+
+        windows = [
+            WindowInfo(
+                handle=1001, title="Untitled - Notepad",
+                process_name="Notepad.exe", pid=100,
+                x=0, y=0, width=800, height=600,
+                is_visible=True, is_minimized=False,
+            ),
+            WindowInfo(
+                handle=2002, title="Notepad",
+                process_name="Notepad.exe", pid=200,
+                x=100, y=100, width=800, height=600,
+                is_visible=True, is_minimized=False,
+            ),
+        ]
+        backend.list_windows = MagicMock(return_value=windows)
+        backend._resolve_hwnd = BackendClass._resolve_hwnd.__get__(backend)
+        backend._get_console_session_id = MagicMock(return_value=-1)
+        backend._get_process_session_id = MagicMock(return_value=-1)
+        backend._APP_ALIASES = BackendClass._APP_ALIASES
+
+        result = backend._resolve_hwnd(app="notepad")
+        # Both match equally on process name; PID 200 has shorter title
+        assert result == 2002
+
+    def test_higher_score_wins_over_session(self):
+        """A higher match score should win even if in Session 0."""
+        BackendClass = _make_backend()
+        backend = MagicMock(spec=BackendClass)
+
+        windows = [
+            WindowInfo(
+                handle=1001, title="Some Notepad Thing",
+                process_name="other.exe", pid=100,
+                x=0, y=0, width=800, height=600,
+                is_visible=True, is_minimized=False,
+            ),
+            WindowInfo(
+                handle=2002, title="Untitled",
+                process_name="Notepad.exe", pid=200,
+                x=100, y=100, width=800, height=600,
+                is_visible=True, is_minimized=False,
+            ),
+        ]
+        backend.list_windows = MagicMock(return_value=windows)
+        backend._resolve_hwnd = BackendClass._resolve_hwnd.__get__(backend)
+        backend._get_console_session_id = MagicMock(return_value=1)
+        # PID 100 in console, PID 200 in Session 0
+        backend._get_process_session_id = MagicMock(
+            side_effect=lambda pid: 1 if pid == 100 else 0
+        )
+        backend._APP_ALIASES = BackendClass._APP_ALIASES
+
+        result = backend._resolve_hwnd(app="notepad")
+        # PID 200 has exact process name match (score 4),
+        # PID 100 only has title substring (score 1).
+        # Higher score wins regardless of session.
+        assert result == 2002


### PR DESCRIPTION
Fix session-aware window/process resolution to prevent schtasks ghost targeting. See issue #230 for details.