### PR TITLE
fix: deduplicate UWP apps with same PID and title in app list (fixes #244)

### DIFF
--- a/naturo/backends/windows.py
+++ b/naturo/backends/windows.py
@@ -1946,6 +1946,7 @@ class WindowsBackend(Backend):
 
         windows = self.list_windows()
         seen_pids: set[int] = set()
+        seen_uwp: set[tuple[int, str]] = set()
         apps: list[dict] = []
         for w in windows:
             if not w.is_visible or w.is_minimized or w.pid in seen_pids:
@@ -1960,7 +1961,13 @@ class WindowsBackend(Backend):
             # with the window title as the app name (since the process name
             # is generic and unhelpful).  Don't add to seen_pids — multiple
             # UWP apps may share one AFH process but each has its own window.
+            # Deduplicate by (pid, title) to avoid listing the same UWP app
+            # multiple times when it has multiple top-level windows.
             if basename == self._UWP_HOST_PROCESS:
+                key = (w.pid, w.title)
+                if key in seen_uwp:
+                    continue
+                seen_uwp.add(key)
                 apps.append({
                     "name": w.title,
                     "pid": w.pid,

--- a/tests/test_app_control.py
+++ b/tests/test_app_control.py
@@ -319,6 +319,56 @@ class TestWindowCLIOptions:
         assert "--height" in result.output
 
 
+# ── UWP deduplication unit test (all platforms, mocked) ───────────────────────
+
+
+class TestUwpAppListDedup:
+    """Regression test for #244 — UWP app list deduplication."""
+
+    def test_uwp_duplicate_pid_title_deduplicated(self):
+        """list_apps should not list the same UWP app twice when it has
+        multiple top-level windows with identical PID and title (#244)."""
+        from unittest.mock import patch, PropertyMock
+        from naturo.backends.windows import WindowsBackend
+        from naturo.backends.base import WindowInfo as BaseWindowInfo
+
+        # Two Calculator windows with same PID and title (UWP duplicate)
+        # Plus one 设置 window with same PID but different title (should keep)
+        # Use ntpath-style basename via patch so os.path.basename works
+        # cross-platform in the test.
+        afh = "ApplicationFrameHost.exe"
+        fake_windows = [
+            BaseWindowInfo(
+                handle=0x1001, title="计算器",
+                process_name=afh,
+                pid=9984, x=0, y=0, width=400, height=500,
+                is_visible=True, is_minimized=False,
+            ),
+            BaseWindowInfo(
+                handle=0x1002, title="计算器",
+                process_name=afh,
+                pid=9984, x=0, y=0, width=400, height=500,
+                is_visible=True, is_minimized=False,
+            ),
+            BaseWindowInfo(
+                handle=0x1003, title="设置",
+                process_name=afh,
+                pid=9984, x=0, y=0, width=600, height=700,
+                is_visible=True, is_minimized=False,
+            ),
+        ]
+
+        backend = WindowsBackend.__new__(WindowsBackend)
+        with patch.object(backend, "list_windows", return_value=fake_windows):
+            apps = backend.list_apps()
+
+        uwp_names = [a["name"] for a in apps]
+        assert uwp_names.count("计算器") == 1, (
+            f"Calculator should appear once, got {uwp_names.count('计算器')}"
+        )
+        assert "设置" in uwp_names, "设置 should still appear"
+
+
 # ── Windows-only functional tests ─────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Problem
`naturo app list` shows Calculator (计算器) twice with the same PID 9984. ApplicationFrameHost.exe hosts multiple UWP apps, and Calculator happens to have multiple top-level windows with identical titles.

## Root Cause
The UWP branch in `list_apps()` intentionally skips `seen_pids` to allow multiple UWP apps sharing one AFH process. But it had no deduplication for windows with the same (PID, title) pair, causing duplicates when a UWP app has multiple top-level windows.

## Fix
Added a `seen_uwp: set[tuple[int, str]]` to deduplicate UWP entries by (pid, title). Different UWP apps sharing the same AFH process (e.g., Calculator vs 设置) still appear individually.

## Tests
- Added `TestUwpAppListDedup` with mocked windows verifying dedup behavior
- All 1674 tests pass

Fixes #244