### PR TITLE
fix: resolve app aliases in launch_app for cross-locale names (fixes #246)

### DIFF
--- a/naturo/process.py
+++ b/naturo/process.py
@@ -197,6 +197,76 @@ def is_running(name: str) -> bool:
     return find_process(name=name) is not None
 
 
+# Launch aliases: map user-friendly names to executable names for launching.
+# These mirror _APP_ALIASES in WindowsBackend but only include entries
+# where the alias resolves to an actual executable basename (no CJK display
+# names since those aren't valid for ``where`` / ``start``).
+_LAUNCH_ALIASES: dict[str, list[str]] = {
+    "calculator": ["calc", "calculatorapp"],
+    "计算器": ["calc", "calculatorapp"],
+    "paint": ["mspaint"],
+    "画图": ["mspaint"],
+    "settings": ["systemsettings"],
+    "设置": ["systemsettings"],
+    "notepad": ["notepad"],
+    "记事本": ["notepad"],
+    "explorer": ["explorer"],
+    "file explorer": ["explorer"],
+    "文件资源管理器": ["explorer"],
+    "edge": ["msedge"],
+    "task manager": ["taskmgr"],
+    "任务管理器": ["taskmgr"],
+    "command prompt": ["cmd"],
+    "命令提示符": ["cmd"],
+    "terminal": ["windowsterminal"],
+    "终端": ["windowsterminal"],
+}
+
+
+def _resolve_launch_name(name: str) -> str:
+    """Resolve a user-friendly app name to a launchable executable name.
+
+    Checks if the given *name* is directly resolvable via ``where`` on
+    Windows.  If not, looks up ``_LAUNCH_ALIASES`` and returns the first
+    alias that ``where`` can find.  Falls back to the original *name*
+    when no alias resolves.
+
+    Args:
+        name: User-provided application name (e.g. "calculator").
+
+    Returns:
+        An executable name that the system can launch (e.g. "calc").
+    """
+    if platform.system() != "Windows":
+        return name
+
+    # If the name itself is directly resolvable, use it as-is.
+    try:
+        result = subprocess.run(
+            ["where", name], capture_output=True, text=True, timeout=5,
+        )
+        if result.returncode == 0:
+            return name
+    except (subprocess.TimeoutExpired, OSError):
+        pass
+
+    # Try aliases
+    aliases = _LAUNCH_ALIASES.get(name.lower(), [])
+    for alias in aliases:
+        try:
+            result = subprocess.run(
+                ["where", alias], capture_output=True, text=True, timeout=5,
+            )
+            if result.returncode == 0:
+                return alias
+        except (subprocess.TimeoutExpired, OSError):
+            continue
+
+    # Last resort: return first alias if available (let ``start`` try it),
+    # otherwise the original name.
+    return aliases[0] if aliases else name
+
+
 def launch_app(
     name: str | None = None,
     path: str | None = None,
@@ -237,10 +307,14 @@ def launch_app(
                     raise AppNotFoundError(launch_target, suggested_action="File does not exist")
                 proc = subprocess.Popen([path] + cmd_args)
             else:
+                # Resolve the launch name: try the original name first,
+                # then fall back to alias-resolved executable names.
+                resolved_name = _resolve_launch_name(name or "")
+
                 # Use 'where' to verify command exists, then 'start'
                 try:
                     where_result = subprocess.run(
-                        ["where", name or ""],
+                        ["where", resolved_name],
                         capture_output=True, text=True, timeout=5,
                     )
                 except (subprocess.TimeoutExpired, subprocess.CalledProcessError, OSError):
@@ -249,7 +323,7 @@ def launch_app(
                     # Also check if it's a known app via start — run synchronously to check
                     try:
                         result = subprocess.run(
-                            ["cmd", "/c", "start", "/wait", "", name or ""] + cmd_args,
+                            ["cmd", "/c", "start", "/wait", "", resolved_name] + cmd_args,
                             capture_output=True, text=True, timeout=10,
                         )
                     except subprocess.TimeoutExpired:
@@ -261,12 +335,14 @@ def launch_app(
                     if result.returncode != 0:
                         raise AppNotFoundError(launch_target)
                     # start /wait succeeded but we need to find the PID now
-                    found = find_process(name=name)
+                    found = find_process(name=resolved_name)
+                    if not found and resolved_name != (name or ""):
+                        found = find_process(name=name)
                     if found:
                         return found
                     # Launched but already exited — report success with a dummy PID
                     return ProcessInfo(pid=0, name=name or "", path="", is_running=False)
-                proc = subprocess.Popen(["cmd", "/c", "start", "", name or ""] + cmd_args)
+                proc = subprocess.Popen(["cmd", "/c", "start", "", resolved_name] + cmd_args)
         elif system == "Darwin":
             if path:
                 proc = subprocess.Popen([path] + cmd_args)

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -6,6 +6,7 @@ from naturo.process import (
     ProcessInfo, find_process, is_running, launch_app, quit_app,
     relaunch_app, list_apps, _list_processes,
     _get_console_session_id, _get_process_session_id,
+    _resolve_launch_name, _LAUNCH_ALIASES,
 )
 from naturo.errors import AppNotFoundError, TimeoutError
 
@@ -246,6 +247,93 @@ class TestLaunchApp:
 
         with pytest.raises(AppNotFoundError):
             launch_app(name="app", wait_until_ready=True, timeout=2.0)
+
+
+class TestResolveLaunchName:
+    """Tests for _resolve_launch_name alias resolution (#246)."""
+
+    def test_aliases_table_has_expected_entries(self):
+        """Smoke test: key aliases exist in the table."""
+        assert "calculator" in _LAUNCH_ALIASES
+        assert "paint" in _LAUNCH_ALIASES
+        assert "settings" in _LAUNCH_ALIASES
+
+    def test_calculator_aliases(self):
+        """calculator maps to calc and calculatorapp."""
+        aliases = _LAUNCH_ALIASES["calculator"]
+        assert "calc" in aliases
+        assert "calculatorapp" in aliases
+
+    def test_paint_aliases(self):
+        """paint maps to mspaint."""
+        assert "mspaint" in _LAUNCH_ALIASES["paint"]
+
+    @patch("naturo.process.platform.system", return_value="Darwin")
+    def test_non_windows_returns_original(self, _mock_sys):
+        """On non-Windows platforms, alias resolution is a no-op."""
+        assert _resolve_launch_name("calculator") == "calculator"
+
+    @patch("naturo.process.platform.system", return_value="Windows")
+    @patch("naturo.process.subprocess.run")
+    def test_direct_name_found(self, mock_run, _mock_sys):
+        """If the name itself is resolvable via 'where', return it unchanged."""
+        mock_run.return_value = MagicMock(returncode=0)
+        assert _resolve_launch_name("notepad") == "notepad"
+
+    @patch("naturo.process.platform.system", return_value="Windows")
+    @patch("naturo.process.subprocess.run")
+    def test_alias_resolution(self, mock_run, _mock_sys):
+        """'calculator' should resolve to 'calc' when 'where calculator' fails."""
+        def where_side_effect(args, **kwargs):
+            name = args[1] if len(args) > 1 else ""
+            if name == "calc":
+                return MagicMock(returncode=0)
+            return MagicMock(returncode=1)
+        mock_run.side_effect = where_side_effect
+        assert _resolve_launch_name("calculator") == "calc"
+
+    @patch("naturo.process.platform.system", return_value="Windows")
+    @patch("naturo.process.subprocess.run")
+    def test_paint_alias_resolution(self, mock_run, _mock_sys):
+        """'paint' should resolve to 'mspaint'."""
+        def where_side_effect(args, **kwargs):
+            name = args[1] if len(args) > 1 else ""
+            if name == "mspaint":
+                return MagicMock(returncode=0)
+            return MagicMock(returncode=1)
+        mock_run.side_effect = where_side_effect
+        assert _resolve_launch_name("paint") == "mspaint"
+
+    @patch("naturo.process.platform.system", return_value="Windows")
+    @patch("naturo.process.subprocess.run")
+    def test_unknown_name_returns_original(self, mock_run, _mock_sys):
+        """Unknown names with no aliases return the original name."""
+        mock_run.return_value = MagicMock(returncode=1)
+        assert _resolve_launch_name("some_random_app") == "some_random_app"
+
+    @patch("naturo.process.platform.system", return_value="Windows")
+    @patch("naturo.process.subprocess.run")
+    def test_case_insensitive_lookup(self, mock_run, _mock_sys):
+        """Alias lookup is case-insensitive."""
+        def where_side_effect(args, **kwargs):
+            name = args[1] if len(args) > 1 else ""
+            if name == "calc":
+                return MagicMock(returncode=0)
+            return MagicMock(returncode=1)
+        mock_run.side_effect = where_side_effect
+        assert _resolve_launch_name("Calculator") == "calc"
+
+    @patch("naturo.process.platform.system", return_value="Windows")
+    @patch("naturo.process.subprocess.run")
+    def test_cjk_alias_resolution(self, mock_run, _mock_sys):
+        """Chinese alias '计算器' should resolve to 'calc'."""
+        def where_side_effect(args, **kwargs):
+            name = args[1] if len(args) > 1 else ""
+            if name == "calc":
+                return MagicMock(returncode=0)
+            return MagicMock(returncode=1)
+        mock_run.side_effect = where_side_effect
+        assert _resolve_launch_name("计算器") == "calc"
 
 
 class TestQuitApp:


### PR DESCRIPTION
## Problem
`naturo app launch calculator` and `naturo app launch paint` fail with "Application not found" because `launch_app()` in `process.py` only uses `where` + `cmd /c start` to find executables — it doesn't consult the alias table that `--app` matching already uses.

## Fix
- Added `_LAUNCH_ALIASES` mapping table in `process.py` (mirrors `_APP_ALIASES` from `WindowsBackend`, filtered to only executable-resolvable names)
- Added `_resolve_launch_name()` helper that tries `where` on the original name first, then iterates aliases to find a resolvable executable
- Updated `launch_app()` Windows path to use resolved name for `where`, `start`, and `find_process`

## Tests
- 10 new tests in `TestResolveLaunchName`: alias table smoke tests, Windows/non-Windows behavior, case-insensitive lookup, CJK alias resolution
- All 1684 tests pass (495 skipped — Windows-only tests on macOS)

Fixes #246