### PR TITLE
fix: show interactive desktop warning in see/find/capture (fixes #255)

### DIFF
--- a/naturo/cli/core.py
+++ b/naturo/cli/core.py
@@ -15,16 +15,31 @@ from naturo.errors import WindowNotFoundError
 from naturo.cli.fuzzy_group import FuzzyGroup
 
 
-def _get_backend():
+def _get_backend(json_output: bool = False):
     """Get the platform-appropriate backend.
+
+    Performs a pre-flight check for an interactive desktop session on Windows
+    so that see/find/capture give the same clear error as click/type/press
+    instead of a vague 'No window found' message.
+
+    Args:
+        json_output: When True, emit JSON-formatted error and sys.exit
+            instead of raising an exception for NoDesktopSessionError.
 
     Returns:
         A Backend instance for the current platform.
 
     Raises:
-        RuntimeError: If no backend is available (unsupported platform or
-            missing dependencies like Peekaboo on macOS).
+        click.UsageError: If no interactive desktop session or no backend.
     """
+    from naturo.cli.interaction import _check_desktop_session
+    try:
+        _check_desktop_session()
+    except Exception as exc:
+        if json_output:
+            click.echo(_json_error_str("NO_DESKTOP_SESSION", str(exc)))
+            raise SystemExit(1)
+        raise click.UsageError(str(exc))
     from naturo.backends.base import get_backend
     return get_backend()
 
@@ -201,7 +216,7 @@ def live(app, window_title, hwnd, screen, path, fmt, store_snapshot, session,
         path = f"naturo-{app_label}-{timestamp}.{fmt}"
 
     try:
-        backend = _get_backend()
+        backend = _get_backend(json_output)
         if hwnd or app or window_title:
             # Resolve app/window_title to hwnd if needed
             target_hwnd = hwnd
@@ -475,7 +490,7 @@ def windows(app, pid, json_output):
         raise SystemExit(1)
 
     try:
-        backend = _get_backend()
+        backend = _get_backend(json_output)
         win_list = backend.list_windows()
 
         # Apply filters
@@ -542,7 +557,7 @@ def screens(json_output):
     whether the monitor is the primary display.
     """
     try:
-        backend = _get_backend()
+        backend = _get_backend(json_output)
         monitors = backend.list_monitors()
 
         if json_output:
@@ -682,7 +697,7 @@ def see(app, window_title, hwnd, pid, mode, depth, path, annotate, store_snapsho
         raise SystemExit(1)
 
     try:
-        be = _get_backend()
+        be = _get_backend(json_output)
 
         # ── Cascade mode: progressive multi-provider recognition (issue #140) ──
         cascade_stats = None
@@ -1024,7 +1039,7 @@ def find_cmd(query, query_opt, find_all, role, actionable, depth, limit, ai,
         raise SystemExit(1)
 
     try:
-        be = _get_backend()
+        be = _get_backend(json_output)
         tree = be.get_element_tree(app=app, depth=depth, backend=backend)
         if tree is None:
             msg = "No window found or UI tree is empty."
@@ -1233,7 +1248,7 @@ def menu_inspect(app, flat, json_output):
         raise SystemExit(1)
 
     try:
-        backend = _get_backend()
+        backend = _get_backend(json_output)
 
         # BUG-026: Check if app exists before inspecting menus
         if app:

--- a/tests/test_desktop_session.py
+++ b/tests/test_desktop_session.py
@@ -149,3 +149,44 @@ class TestIsCurrentSessionInteractive:
         """On Windows, the function should return a boolean."""
         result = _is_current_session_interactive()
         assert isinstance(result, bool)
+
+
+class TestCoreGetBackendDesktopCheck:
+    """Tests that core.py _get_backend checks for interactive desktop (fixes #255).
+
+    Previously, see/find/capture gave vague 'No window found' errors when
+    running without an interactive desktop. Now they show the same clear
+    NoDesktopSessionError that click/type/press already show.
+    """
+
+    def test_raises_usage_error_on_no_desktop(self):
+        """core._get_backend() should raise UsageError when no desktop session."""
+        import click
+        from naturo.cli.core import _get_backend
+
+        with patch("naturo.cli.interaction._check_desktop_session",
+                   side_effect=NoDesktopSessionError()):
+            with pytest.raises(click.UsageError, match="interactive desktop"):
+                _get_backend()
+
+    def test_json_output_exits_on_no_desktop(self):
+        """core._get_backend(json_output=True) should sys.exit with JSON error."""
+        from naturo.cli.core import _get_backend
+
+        with patch("naturo.cli.interaction._check_desktop_session",
+                   side_effect=NoDesktopSessionError()):
+            with pytest.raises(SystemExit):
+                _get_backend(json_output=True)
+
+    def test_passes_when_desktop_available(self):
+        """core._get_backend() should work normally when desktop is available."""
+        from naturo.cli.core import _get_backend
+
+        with patch("naturo.cli.interaction._check_desktop_session"):
+            # On non-Windows (macOS CI), get_backend may raise for other
+            # reasons — we only care that the desktop check passed.
+            try:
+                _get_backend()
+            except Exception as exc:
+                # Any error EXCEPT NoDesktopSessionError is fine
+                assert "interactive desktop" not in str(exc).lower()


### PR DESCRIPTION
## Problem
`see`, `find`, `capture`, and other core commands gave a vague 'No window found' error when running without an interactive desktop session (e.g., via SSH). Meanwhile, `click`/`type`/`press` already showed a clear `NoDesktopSessionError` with actionable guidance.

## Root Cause
`core.py::_get_backend()` didn't call `_check_desktop_session()`, while `interaction.py::_get_backend()` did.

## Fix
- Added `_check_desktop_session()` call to `core.py::_get_backend()`
- Supports both plain text and JSON error output modes
- All 6 call sites now pass `json_output` for proper error formatting

## Tests
- 3 new tests in `test_desktop_session.py` verifying the integration
- All 1688 existing tests pass

Fixes #255