### PR TITLE
fix: validate PID in app inspect — reject invalid/non-existent PIDs (fixes #256)

### DIFF
--- a/naturo/cli/app_cmd.py
+++ b/naturo/cli/app_cmd.py
@@ -496,6 +496,27 @@ def app_inspect(ctx, name, pid, scan_all, quick, json_output):
         sys.exit(1)
         return
 
+    # Validate PID if provided directly
+    if pid is not None:
+        if pid <= 0:
+            msg = f"Invalid PID: {pid}. PID must be a positive integer."
+            if json_output:
+                click.echo(_json_error_str("INVALID_INPUT", msg))
+            else:
+                _safe_echo(f"Error: {msg}", err=True)
+            sys.exit(1)
+            return
+        # Check if process actually exists
+        from naturo.process import find_process as _find_proc
+        if _find_proc(pid=pid) is None:
+            msg = f"No process found with PID {pid}. The process may have exited."
+            if json_output:
+                click.echo(_json_error_str("PROCESS_NOT_FOUND", msg))
+            else:
+                _safe_echo(f"Error: {msg}", err=True)
+            sys.exit(1)
+            return
+
     # Resolve PID from name
     target_pid = pid
     target_exe = ""

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -499,3 +499,44 @@ class TestFindMainWindowUwp:
         desktop_hwnd = user32.GetDesktopWindow()
         result = _frame_hosts_pid(user32, desktop_hwnd, 0)
         assert isinstance(result, bool)
+
+
+class TestAppInspectPidValidation:
+    """Tests for app inspect --pid input validation (fixes #256).
+
+    Verifies that invalid PIDs (0, negative, non-existent) are rejected
+    with clear error messages instead of showing misleading 'Unknown' results.
+    """
+
+    def test_zero_pid_rejected(self):
+        """PID 0 should be rejected with INVALID_INPUT error."""
+        from click.testing import CliRunner
+        from naturo.cli.app_cmd import app_inspect
+
+        runner = CliRunner()
+        result = runner.invoke(app_inspect, ["--pid", "0", "--json"])
+        assert result.exit_code != 0
+        assert "INVALID_INPUT" in result.output or "Invalid PID" in result.output
+
+    def test_negative_pid_rejected(self):
+        """Negative PID should be rejected with INVALID_INPUT error."""
+        from click.testing import CliRunner
+        from naturo.cli.app_cmd import app_inspect
+
+        runner = CliRunner()
+        result = runner.invoke(app_inspect, ["--pid", "-1", "--json"])
+        assert result.exit_code != 0
+        assert "INVALID_INPUT" in result.output or "Invalid PID" in result.output
+
+    def test_nonexistent_pid_rejected(self):
+        """Non-existent PID should be rejected with PROCESS_NOT_FOUND error."""
+        from click.testing import CliRunner
+        from naturo.cli.app_cmd import app_inspect
+        from unittest.mock import patch
+
+        # Use a PID that almost certainly doesn't exist
+        runner = CliRunner()
+        with patch("naturo.process.find_process", return_value=None):
+            result = runner.invoke(app_inspect, ["--pid", "999999", "--json"])
+        assert result.exit_code != 0
+        assert "PROCESS_NOT_FOUND" in result.output or "No process found" in result.output


### PR DESCRIPTION
## Problem
`app inspect --pid 0` and `app inspect --pid 999999` silently returned misleading 'Unknown' results instead of clear errors.

## Fix
- Reject PID <= 0 with INVALID_INPUT error
- Check process existence via `find_process(pid=N)` before detection
- Non-existent PID returns PROCESS_NOT_FOUND error
- Both JSON and plain text error modes supported

## Tests
- 3 new tests: zero PID, negative PID, non-existent PID
- All 1691 tests pass

Fixes #256