### PR TITLE
fix: detect UWP Calculator and other UWP apps by exe name and path (fixes #257)

### DIFF
--- a/naturo/detect/probes.py
+++ b/naturo/detect/probes.py
@@ -61,6 +61,27 @@ _JAB_DLLS = {"windowsaccessbridge-64.dll", "windowsaccessbridge-32.dll", "window
 _GTK_DLLS = {"libgtk-3-0.dll", "libgtk-4-1.dll"}
 _UWP_DLLS = {"windows.ui.xaml.dll", "microsoft.ui.xaml.dll", "twinapi.appcore.dll"}
 _UWP_EXES = {"applicationframehost.exe"}
+# Known UWP app executables (lowercase) for fallback when DLL scan is unavailable
+_UWP_KNOWN_APPS = {
+    "calculatorapp.exe", "calculator.exe",
+    "windowsalarms.exe", "time.exe",
+    "mspaint.exe",  # New Paint is UWP
+    "notepad.exe",  # Windows 11 Notepad is UWP
+    "microsoft.photos.exe", "photos.exe",
+    "video.ui.exe",  # Movies & TV
+    "microsoft.media.player.exe",  # Media Player
+    "windowsterminal.exe", "wt.exe",
+    "windowscamera.exe",
+    "screenclippinghost.exe",
+    "gamebar.exe", "gamebarftserver.exe",
+    "feedbackhub.exe",
+    "getstarted.exe",  # Tips
+    "yourphone.exe", "phonelink.exe",
+    "textinputhost.exe",
+    "searchhost.exe",
+    "startmenuexperiencehost.exe",
+    "shellexperiencehost.exe",
+}
 
 
 def _get_process_dlls(pid: int) -> Set[str]:
@@ -153,6 +174,18 @@ def detect_frameworks_from_dlls(pid: int, exe: str) -> List[FrameworkInfo]:
                 framework_type=FrameworkType.JAVA_SWING,
                 dll_signatures=["(inferred from exe name)"],
             ))
+        # UWP detection: known app names or WindowsApps install path (#257)
+        exe_base = os.path.basename(exe_lower) if exe_lower else ""
+        if not frameworks and (
+            exe_base in _UWP_KNOWN_APPS
+            or exe_base in _UWP_EXES
+            or "\\windowsapps\\" in exe_lower
+            or "/windowsapps/" in exe_lower
+        ):
+            frameworks.append(FrameworkInfo(
+                framework_type=FrameworkType.UWP,
+                dll_signatures=[f"(inferred from {exe_base or 'WindowsApps path'})"],
+            ))
         # Fallback: if no exe-name heuristic matched but we're on Windows,
         # report Win32 so the field is never empty (#253)
         if not frameworks:
@@ -232,10 +265,11 @@ def detect_frameworks_from_dlls(pid: int, exe: str) -> List[FrameworkInfo]:
             dll_signatures=sorted(gtk_matches),
         ))
 
-    # UWP / XAML — detect from DLL signatures or exe name (#253)
+    # UWP / XAML — detect from DLL signatures, exe name, or install path (#253, #257)
     uwp_matches = dlls & _UWP_DLLS
     exe_base = os.path.basename(exe).lower()
-    if uwp_matches or exe_base in _UWP_EXES:
+    _exe_lower = exe.lower()
+    if uwp_matches or exe_base in _UWP_EXES or exe_base in _UWP_KNOWN_APPS or "\\windowsapps\\" in _exe_lower:
         sigs = sorted(uwp_matches) if uwp_matches else [f"(inferred from {exe_base})"]
         frameworks.append(FrameworkInfo(
             framework_type=FrameworkType.UWP,

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -540,3 +540,63 @@ class TestAppInspectPidValidation:
             result = runner.invoke(app_inspect, ["--pid", "999999", "--json"])
         assert result.exit_code != 0
         assert "PROCESS_NOT_FOUND" in result.output or "No process found" in result.output
+
+
+class TestUwpFrameworkDetection:
+    """Tests for UWP app framework detection fallback (fixes #257).
+
+    When DLL scanning is unavailable (common for protected UWP processes),
+    framework detection should still identify UWP apps via exe name or path.
+    """
+
+    def test_calculator_detected_as_uwp_by_exe_name(self):
+        """CalculatorApp.exe should be detected as UWP even without DLL scan."""
+        from naturo.detect.probes import detect_frameworks_from_dlls
+        from naturo.detect.models import FrameworkType
+        from unittest.mock import patch
+
+        # Simulate DLL scan failure (returns empty set)
+        with patch("naturo.detect.probes._get_process_dlls", return_value=set()):
+            frameworks = detect_frameworks_from_dlls(
+                pid=12345, exe="C:\\Program Files\\WindowsApps\\Microsoft.WindowsCalculator\\CalculatorApp.exe"
+            )
+
+        assert len(frameworks) >= 1
+        assert frameworks[0].framework_type == FrameworkType.UWP
+
+    def test_windowsapps_path_detected_as_uwp(self):
+        """Any exe in WindowsApps directory should be detected as UWP."""
+        from naturo.detect.probes import detect_frameworks_from_dlls
+        from naturo.detect.models import FrameworkType
+        from unittest.mock import patch
+
+        with patch("naturo.detect.probes._get_process_dlls", return_value=set()):
+            frameworks = detect_frameworks_from_dlls(
+                pid=12345, exe="C:\\Program Files\\WindowsApps\\SomeApp\\unknown.exe"
+            )
+
+        assert len(frameworks) >= 1
+        assert frameworks[0].framework_type == FrameworkType.UWP
+
+    def test_known_uwp_apps_detected(self):
+        """All known UWP app exe names should be detected as UWP."""
+        from naturo.detect.probes import detect_frameworks_from_dlls, _UWP_KNOWN_APPS
+        from naturo.detect.models import FrameworkType
+        from unittest.mock import patch
+
+        for app_exe in ["calculatorapp.exe", "windowsterminal.exe", "windowscamera.exe"]:
+            with patch("naturo.detect.probes._get_process_dlls", return_value=set()):
+                frameworks = detect_frameworks_from_dlls(pid=12345, exe=app_exe)
+            assert frameworks[0].framework_type == FrameworkType.UWP, f"{app_exe} not detected as UWP"
+
+    def test_non_uwp_app_not_detected_as_uwp(self):
+        """Non-UWP apps should not be detected as UWP."""
+        from naturo.detect.probes import detect_frameworks_from_dlls
+        from naturo.detect.models import FrameworkType
+        from unittest.mock import patch
+
+        with patch("naturo.detect.probes._get_process_dlls", return_value=set()):
+            frameworks = detect_frameworks_from_dlls(pid=12345, exe="C:\\Windows\\system32\\cmd.exe")
+
+        # Should fallback to WIN32 on Windows or UNKNOWN on other platforms
+        assert frameworks[0].framework_type != FrameworkType.UWP


### PR DESCRIPTION
## Problem
`app inspect calculator` reported 'win32' framework with only vision fallback. Calculator is a UWP/XAML app — the DLL scan fails because UWP processes are protected.

## Root Cause
When DLL scanning fails, the fallback heuristics only checked for Electron/Chrome/Java exe names. UWP apps like CalculatorApp.exe fell through to the generic WIN32 default.

## Fix
- Added `_UWP_KNOWN_APPS` set with 20+ known UWP app executables (Calculator, Terminal, Camera, Paint, etc.)
- Added WindowsApps install path detection (`\\WindowsApps\\` in exe path)
- Both DLL-scan and no-DLL-scan branches now detect UWP via exe name/path

## Tests
- 4 new tests: Calculator exe name, WindowsApps path, known apps batch, non-UWP exclusion
- All 1692 tests pass

Fixes #257