### PR TITLE
fix: fall back to proc.name when proc.path is empty for UWP detection (fixes #257)

### DIFF
--- a/naturo/cli/app_cmd.py
+++ b/naturo/cli/app_cmd.py
@@ -534,7 +534,7 @@ def app_inspect(ctx, name, pid, scan_all, quick, json_output):
             sys.exit(1)
             return
         target_pid = proc.pid
-        target_exe = proc.path or ""
+        target_exe = proc.path or proc.name or ""
         target_name = proc.name or name
 
     result = detect(

--- a/naturo/mcp_server.py
+++ b/naturo/mcp_server.py
@@ -493,7 +493,7 @@ def create_server(host: str = "localhost", port: int = 3100) -> FastMCP:
                     },
                 }
             target_pid = proc.pid
-            target_exe = proc.path or ""
+            target_exe = proc.path or proc.name or ""
             target_name = proc.name or name
 
         if target_pid is None:

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -600,3 +600,21 @@ class TestUwpFrameworkDetection:
 
         # Should fallback to WIN32 on Windows or UNKNOWN on other platforms
         assert frameworks[0].framework_type != FrameworkType.UWP
+
+    def test_uwp_detected_from_bare_proc_name(self):
+        """When proc.path is empty, proc.name (bare exe) should still detect UWP.
+
+        Regression test for #257: UWP protected processes return empty path
+        from find_process(). The fallback passes proc.name (e.g. 'CalculatorApp.exe')
+        as the exe argument, and framework detection must still match it.
+        """
+        from naturo.detect.probes import detect_frameworks_from_dlls
+        from naturo.detect.models import FrameworkType
+        from unittest.mock import patch
+
+        # Simulate what happens when proc.path="" and we fall back to proc.name
+        with patch("naturo.detect.probes._get_process_dlls", return_value=set()):
+            frameworks = detect_frameworks_from_dlls(pid=12345, exe="CalculatorApp.exe")
+
+        assert len(frameworks) >= 1
+        assert frameworks[0].framework_type == FrameworkType.UWP


### PR DESCRIPTION
## Problem
UWP protected processes (e.g. CalculatorApp.exe) return empty `path` from `find_process()`. The inspect command passed this empty string to the detection chain, so exe-name-based UWP detection never triggered — Calculator was incorrectly reported as `win32`.

## Root Cause
`proc.path` returns `''` for UWP protected processes. The code did `target_exe = proc.path or ''`, which kept `target_exe=''`. The detection function then could not match against `_UWP_KNOWN_APPS` because `os.path.basename('')` is `''`.

## Fix
Fall back to `proc.name` when `proc.path` is empty:
```python
target_exe = proc.path or proc.name or ''
```

Applied in both:
- `naturo/cli/app_cmd.py` (CLI path)
- `naturo/mcp_server.py` (MCP server path)

## Tests
- Added `test_uwp_detected_from_bare_proc_name` — verifies UWP detection works with bare exe name (no path)
- All 1699 tests pass, 496 skipped

## QA Verification
@QA please re-verify on compile machine:
```bash
naturo app inspect calculator --json
```
Expected: `framework.detected` shows `uwp`