### PR TITLE
fix: click verification returns verified:null for UWP apps (fixes #270)

### DIFF
--- a/naturo/verify.py
+++ b/naturo/verify.py
@@ -335,7 +335,7 @@ def verify_click(
     # Focus unchanged — try UI text comparison as fallback (#263).
     # This catches cases like UWP Calculator where button clicks update
     # a display element without changing focus.
-    if before_ui_texts:
+    if before_ui_texts is not None:
         try:
             after_ui_texts = _capture_ui_texts(
                 backend, app=app, window_title=window_title, hwnd=hwnd,
@@ -578,9 +578,13 @@ def _capture_uia_child_names(
 ) -> dict[str, str]:
     """Capture UIA element names for a window's direct children.
 
-    Lightweight alternative to full tree traversal — only walks depth=2
-    children and collects Name properties.  Used as fallback for UWP apps
-    where Win32 ``GetWindowTextW`` returns nothing on child windows.
+    Uses ``TreeScope_Descendants`` to walk all descendant elements and
+    collect their Name properties.  Used as fallback for UWP apps where
+    Win32 ``GetWindowTextW`` returns nothing on child windows.
+
+    Previous depth=2 approach missed UWP display elements (e.g.,
+    Calculator's CalculatorResults) that sit at depth 3+ under the
+    ApplicationFrameHost window (#270).
 
     The UIA scan runs in a daemon thread with a timeout to prevent hangs
     on headless CI runners or unresponsive UIA providers.
@@ -611,48 +615,24 @@ def _capture_uia_child_names(
                 result_holder["texts"] = texts
                 return
 
-            # TreeScope_Children = 2
+            # TreeScope_Descendants = 4 — walk all descendants to capture
+            # deeply-nested display elements in UWP/XAML apps (#270).
             true_cond = uia.CreateTrueCondition()
-            children = root.FindAll(2, true_cond)
-            if not children:
+            descendants = root.FindAll(4, true_cond)
+            if not descendants:
                 result_holder["texts"] = texts
                 return
 
-            count = min(children.Length, max_elements)
+            count = min(descendants.Length, max_elements)
             for i in range(count):
-                child = children.GetElement(i)
-                name = child.CurrentName or ""
+                elem = descendants.GetElement(i)
+                name = elem.CurrentName or ""
                 if not name:
                     continue
-                aid = child.CurrentAutomationId or ""
-                ctrl_type = child.CurrentControlType
+                aid = elem.CurrentAutomationId or ""
+                ctrl_type = elem.CurrentControlType
                 key = f"uia:{ctrl_type}:{aid}" if aid else f"uia:{ctrl_type}:{name}"
                 texts[key] = name
-
-                # Also scan one more level (grandchildren) for display elements
-                try:
-                    grandchildren = child.FindAll(2, true_cond)
-                    if grandchildren:
-                        gc_count = min(grandchildren.Length, max_elements - len(texts))
-                        for j in range(gc_count):
-                            gc = grandchildren.GetElement(j)
-                            gc_name = gc.CurrentName or ""
-                            if not gc_name:
-                                continue
-                            gc_aid = gc.CurrentAutomationId or ""
-                            gc_ctrl = gc.CurrentControlType
-                            gc_key = (
-                                f"uia:{gc_ctrl}:{gc_aid}" if gc_aid
-                                else f"uia:{gc_ctrl}:{gc_name}"
-                            )
-                            texts[gc_key] = gc_name
-                            if len(texts) >= max_elements:
-                                break
-                except Exception:
-                    pass
-
-                if len(texts) >= max_elements:
-                    break
 
         except Exception as exc:
             logger.debug("UIA child name capture failed: %s", exc)

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -338,6 +338,31 @@ class TestVerifyClickUiTextFallback:
 
         assert result.status == VerifyStatus.UNKNOWN
 
+    def test_empty_before_ui_texts_still_triggers_capture(self):
+        """Empty dict before_ui_texts should still trigger post-capture (#270).
+
+        Previously ``if before_ui_texts:`` treated ``{}`` as falsy and
+        skipped the fallback.  With the fix (``is not None``), an empty
+        pre-capture still runs post-capture and can detect new text.
+        """
+        backend = MagicMock(spec=[])
+        focus = {"foreground_hwnd": 100}
+
+        with patch("naturo.verify._capture_focus_state") as mock_focus, \
+             patch("naturo.verify._capture_ui_texts") as mock_texts:
+            mock_focus.return_value = focus.copy()
+            # Pre-capture was empty, but post-capture finds new text
+            mock_texts.return_value = {"uia:50004:CalculatorResults": "7"}
+            result = verify_click(
+                backend,
+                before_focus=focus,
+                before_ui_texts={},
+                settle_ms=0,
+            )
+
+        assert result.status == VerifyStatus.VERIFIED
+        assert result.method == "ui_text_diff"
+
     def test_ui_text_capture_error_handled_gracefully(self):
         """UI text capture fails → falls through to UNKNOWN, no crash."""
         backend = MagicMock(spec=[])


### PR DESCRIPTION
## Problem

Click verification always returns `verified: null` for UWP Calculator despite successful button clicks. The `ui_text_diff` fallback never triggers.

## Root Cause

Two issues in `verify.py`:

1. **Shallow UIA scan**: `_capture_uia_child_names()` only walked depth=2 (children + grandchildren). UWP Calculator's display element (`CalculatorResults`) sits at depth 3+ under ApplicationFrameHost, so it was never captured. Before/after `ui_texts` were identical → no diff → `verified: null`.

2. **Falsy guard**: `if before_ui_texts:` treated empty dict `{}` as falsy, skipping the UI text fallback entirely when Win32 `EnumChildWindows` returned no text (common for UWP apps).

## Fix

- Use `TreeScope_Descendants` (=4) instead of manual depth-2 walk in `_capture_uia_child_names`, capped by `max_elements` and thread timeout
- Change guard to `if before_ui_texts is not None:` so empty pre-capture still triggers post-capture comparison

## Tests

- Added `test_empty_before_ui_texts_still_triggers_capture` for the falsy guard fix
- All 1684 tests pass, 49 verify tests pass

Fixes #270