### PR TITLE
fix: add per-probe timeout to prevent app inspect hanging indefinitely (fixes #288)

### DIFF
--- a/naturo/detect/chain.py
+++ b/naturo/detect/chain.py
@@ -40,6 +40,64 @@ _DEFAULT_PROBES: List[ProbeFunc] = [
     probe_vision,
 ]
 
+# Per-probe timeout in seconds.  CDP and UIA probes can hang on certain
+# applications (e.g. UWP Notepad without --quick), so each probe is
+# executed with a hard timeout to guarantee the chain always completes.
+_PROBE_TIMEOUT_SECONDS = 10
+
+
+def _run_probe_with_timeout(
+    probe_fn: ProbeFunc,
+    pid: int,
+    exe: str,
+    hwnd: Optional[int],
+) -> Optional["InteractionMethod"]:
+    """Execute a single probe function with a timeout guard.
+
+    Runs the probe in a daemon thread so that a hung probe (e.g. CDP wmic
+    call, UIA COM deadlock) cannot block the detection chain forever.
+    The thread is abandoned (not joined) on timeout — daemon threads are
+    reaped automatically when the process exits.
+
+    Args:
+        probe_fn: Probe function to execute.
+        pid: Process ID.
+        exe: Executable path.
+        hwnd: Window handle.
+
+    Returns:
+        InteractionMethod from the probe, or None on timeout / error.
+    """
+    import threading
+
+    result_holder: list = []
+    error_holder: list = []
+
+    def _target() -> None:
+        try:
+            r = probe_fn(pid, exe, hwnd)
+            result_holder.append(r)
+        except Exception as exc:
+            error_holder.append(exc)
+
+    t = threading.Thread(target=_target, daemon=True)
+    t.start()
+    t.join(timeout=_PROBE_TIMEOUT_SECONDS)
+
+    if t.is_alive():
+        logger.warning(
+            "Probe %s timed out after %ds for PID %d",
+            probe_fn.__name__,
+            _PROBE_TIMEOUT_SECONDS,
+            pid,
+        )
+        return None
+
+    if error_holder:
+        raise error_holder[0]
+
+    return result_holder[0] if result_holder else None
+
 
 def detect(
     pid: int,
@@ -81,11 +139,12 @@ def detect(
     # Phase 1: Detect frameworks from DLL signatures
     frameworks = detect_frameworks_from_dlls(pid, exe)
 
-    # Phase 2: Run probes to discover available interaction methods
+    # Phase 2: Run probes to discover available interaction methods.
+    # Each probe runs with a timeout to prevent indefinite hangs (#288).
     methods: List[InteractionMethod] = []
     for probe_fn in _DEFAULT_PROBES:
         try:
-            result = probe_fn(pid, exe, hwnd)
+            result = _run_probe_with_timeout(probe_fn, pid, exe, hwnd)
             if result is not None:
                 methods.append(result)
                 # In quick mode, stop at first available method

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -19,7 +19,7 @@ from naturo.detect.models import (
     ProbeStatus,
 )
 from naturo.detect.cache import DetectionCache
-from naturo.detect.chain import detect
+from naturo.detect.chain import detect, _run_probe_with_timeout, _PROBE_TIMEOUT_SECONDS
 
 
 # ── Models ──────────────────────────────────────────────────────────
@@ -618,3 +618,61 @@ class TestUwpFrameworkDetection:
 
         assert len(frameworks) >= 1
         assert frameworks[0].framework_type == FrameworkType.UWP
+
+
+# ── Probe Timeout ──────────────────────────────────────────────────
+
+
+class TestProbeTimeout:
+    """Tests for the per-probe timeout guard (#288)."""
+
+    def test_fast_probe_returns_result(self):
+        """A probe that completes quickly should return its result."""
+        def fast_probe(pid, exe, hwnd):
+            return InteractionMethod(
+                method=InteractionMethodType.UIA,
+                priority=METHOD_PRIORITY[InteractionMethodType.UIA],
+                status=ProbeStatus.AVAILABLE,
+                capabilities=["click"],
+                confidence=0.9,
+            )
+
+        result = _run_probe_with_timeout(fast_probe, pid=123, exe="", hwnd=None)
+        assert result is not None
+        assert result.method == InteractionMethodType.UIA
+
+    def test_hanging_probe_returns_none(self):
+        """A probe that exceeds the timeout should return None, not hang."""
+        import time
+        import naturo.detect.chain as chain_mod
+        orig = chain_mod._PROBE_TIMEOUT_SECONDS
+
+        def hanging_probe(pid, exe, hwnd):
+            time.sleep(60)  # Simulate indefinite hang
+            return InteractionMethod(
+                method=InteractionMethodType.CDP,
+                priority=METHOD_PRIORITY[InteractionMethodType.CDP],
+                status=ProbeStatus.AVAILABLE,
+                capabilities=["dom"],
+                confidence=0.9,
+            )
+
+        # Use a short timeout for the test
+        try:
+            chain_mod._PROBE_TIMEOUT_SECONDS = 0.5
+            start = time.monotonic()
+            result = _run_probe_with_timeout(hanging_probe, pid=123, exe="", hwnd=None)
+            elapsed = time.monotonic() - start
+        finally:
+            chain_mod._PROBE_TIMEOUT_SECONDS = orig
+
+        assert result is None, "Hanging probe should return None after timeout"
+        assert elapsed < 5, f"Timeout took too long: {elapsed:.1f}s"
+
+    def test_probe_exception_propagates(self):
+        """A probe that raises an exception should propagate the error."""
+        def broken_probe(pid, exe, hwnd):
+            raise RuntimeError("probe internal error")
+
+        with pytest.raises(RuntimeError, match="probe internal error"):
+            _run_probe_with_timeout(broken_probe, pid=123, exe="", hwnd=None)


### PR DESCRIPTION
## Problem
`naturo app inspect notepad` (without `--quick`) hangs indefinitely on non-browser apps like Notepad. The detection chain probes (CDP, UIA, MSAA, etc.) can block forever due to COM deadlocks or subprocess hangs.

## Root Cause
Probes run synchronously with no timeout. If any probe hangs (e.g., `wmic` subprocess on Windows 11, UIA COM call deadlock), the entire chain blocks.

## Fix
Each probe now runs in a daemon thread with a 10-second timeout (`_PROBE_TIMEOUT_SECONDS`). If a probe exceeds the timeout, it is abandoned (daemon thread is reaped at process exit) and the chain continues with the remaining probes.

## Tests
Added 3 tests in `TestProbeTimeout`:
- `test_fast_probe_returns_result` — normal probes return correctly
- `test_hanging_probe_returns_none` — hung probes return None after timeout
- `test_probe_exception_propagates` — exceptions propagate correctly

All 1690 tests pass.