### PR TITLE
fix: accept --app flag on app inspect for UX consistency (fixes #289)

### DIFF
--- a/naturo/cli/app_cmd.py
+++ b/naturo/cli/app_cmd.py
@@ -460,12 +460,13 @@ def app_find(ctx, name, pid, json_output):
 
 @click.command("inspect")
 @click.argument("name", required=False, default=None)
+@click.option("--app", "app_name", default=None, help="Application name (alternative to positional NAME)")
 @click.option("--pid", type=int, help="Inspect by process ID")
 @click.option("--all", "scan_all", is_flag=True, help="Scan all visible windows")
 @click.option("--quick", is_flag=True, help="Fast probe — stop at first available method")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def app_inspect(ctx, name, pid, scan_all, quick, json_output):
+def app_inspect(ctx, name, app_name, pid, scan_all, quick, json_output):
     """Probe an application and report available interaction methods.
 
     Detects which UI framework the app uses (Electron, WPF, Qt, etc.)
@@ -474,11 +475,16 @@ def app_inspect(ctx, name, pid, scan_all, quick, json_output):
     \b
     Examples:
       naturo app inspect notepad
+      naturo app inspect --app notepad
       naturo app inspect --pid 12345
       naturo app inspect --all
       naturo app inspect chrome --quick --json
     """
     json_output = json_output or (ctx.obj or {}).get("json", False)
+
+    # Accept --app as alias for positional NAME (#289)
+    if not name and app_name:
+        name = app_name
 
     from naturo.detect import detect, DetectionResult
     from naturo.detect.models import ProbeStatus

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -542,6 +542,52 @@ class TestAppInspectPidValidation:
         assert "PROCESS_NOT_FOUND" in result.output or "No process found" in result.output
 
 
+class TestAppInspectAppFlag:
+    """Tests for --app flag on app inspect (#289)."""
+
+    def test_app_flag_accepted(self):
+        """--app should be accepted as alias for positional NAME."""
+        from click.testing import CliRunner
+        from naturo.cli.app_cmd import app_inspect
+        from unittest.mock import patch, MagicMock
+
+        runner = CliRunner()
+        mock_proc = MagicMock(pid=1234, name="notepad.exe", path="C:\\notepad.exe")
+
+        mock_result = DetectionResult(
+            pid=1234, exe="notepad.exe", app_name="notepad",
+            frameworks=[], methods=[],
+        )
+
+        with patch("naturo.process.find_process", return_value=mock_proc):
+            with patch("naturo.detect.detect", return_value=mock_result):
+                result = runner.invoke(app_inspect, ["--app", "notepad", "--json"])
+
+        assert result.exit_code == 0
+        assert "1234" in result.output
+
+    def test_positional_still_works(self):
+        """Positional NAME should still work as before."""
+        from click.testing import CliRunner
+        from naturo.cli.app_cmd import app_inspect
+        from unittest.mock import patch, MagicMock
+
+        runner = CliRunner()
+        mock_proc = MagicMock(pid=5678, name="calc.exe", path="C:\\calc.exe")
+
+        mock_result = DetectionResult(
+            pid=5678, exe="calc.exe", app_name="calc",
+            frameworks=[], methods=[],
+        )
+
+        with patch("naturo.process.find_process", return_value=mock_proc):
+            with patch("naturo.detect.detect", return_value=mock_result):
+                result = runner.invoke(app_inspect, ["calc", "--json"])
+
+        assert result.exit_code == 0
+        assert "5678" in result.output
+
+
 class TestUwpFrameworkDetection:
     """Tests for UWP app framework detection fallback (fixes #257).
 


### PR DESCRIPTION
## Problem
`app inspect` accepts only a positional NAME argument, while all other commands (see, click, type, find) use `--app`. Users who learned the `--app` pattern try `app inspect --app notepad` and get an error.

## Fix
Added `--app` as an option alias for the positional NAME argument. Both forms now work:
```
naturo app inspect notepad         # positional (existing)
naturo app inspect --app notepad   # --app flag (new)
```

## Tests
Added 2 tests in `TestAppInspectAppFlag`:
- `test_app_flag_accepted` — `--app` flag resolves correctly
- `test_positional_still_works` — positional NAME still works