### PR TITLE
fix: window positional arg + deprecation warnings for window/hotkey (fixes #277, fixes #278)

### DIFF
--- a/naturo/cli/interaction.py
+++ b/naturo/cli/interaction.py
@@ -1335,6 +1335,12 @@ def hotkey(keys, keys_option, hold_duration, app, window_title, hwnd,
     Deprecated: use 'naturo press ctrl+c' instead of 'naturo hotkey ctrl+c'.
     This command is kept for backward compatibility.
     """
+    if not json_output:
+        click.echo(
+            "Warning: 'naturo hotkey' is deprecated and will be removed in v0.4.0. "
+            "Use 'naturo press' instead.",
+            err=True,
+        )
     # Build a single combo string from positional or --keys options
     if keys:
         combo = keys

--- a/naturo/cli/window_cmd.py
+++ b/naturo/cli/window_cmd.py
@@ -57,6 +57,23 @@ def _resolve_target(app: Optional[str], title: Optional[str], hwnd: Optional[int
     return {"title": effective_title, "hwnd": hwnd}
 
 
+_DEPRECATION_MSG = (
+    "Warning: 'naturo window' is deprecated and will be removed in v0.4.0. "
+    "Use 'naturo app' instead."
+)
+
+
+def _emit_deprecation(json_output: bool) -> None:
+    """Print a deprecation warning to stderr unless in JSON mode.
+
+    Args:
+        json_output: When ``True`` the warning is suppressed (JSON consumers
+            should check the ``deprecated`` key in the response instead).
+    """
+    if not json_output:
+        click.echo(_DEPRECATION_MSG, err=True)
+
+
 @click.group(cls=FuzzyGroup, hidden=True)
 def window():
     """Manage windows (deprecated — use 'naturo app' instead)."""
@@ -64,14 +81,19 @@ def window():
 
 
 @window.command()
+@click.argument("name", required=False, default=None)
 @click.option("--app", help="Application/process name (partial match)")
 @click.option("--title", help="Window title pattern (partial match)")
 @click.option("--hwnd", type=int, help="Window handle")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def focus(ctx, app, title, hwnd, json_output):
+def focus(ctx, name, app, title, hwnd, json_output):
     """Focus a window (bring to foreground)."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
+    _emit_deprecation(json_output)
+    # Support positional NAME for backward compat: naturo window focus "Notepad"
+    if name and not app:
+        app = name
     from naturo.errors import NaturoError
 
     if not app and not title and not hwnd:
@@ -105,15 +127,19 @@ def focus(ctx, app, title, hwnd, json_output):
 
 
 @window.command()
+@click.argument("name", required=False, default=None)
 @click.option("--app", help="Application/process name (partial match)")
 @click.option("--title", help="Window title pattern (partial match)")
 @click.option("--hwnd", type=int, help="Window handle")
 @click.option("--force", is_flag=True, help="Force terminate the process")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def close(ctx, app, title, hwnd, force, json_output):
+def close(ctx, name, app, title, hwnd, force, json_output):
     """Close a window (graceful or forced)."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
+    _emit_deprecation(json_output)
+    if name and not app:
+        app = name
     from naturo.errors import NaturoError
 
     if not app and not title and not hwnd:
@@ -149,14 +175,18 @@ def close(ctx, app, title, hwnd, force, json_output):
 
 
 @window.command()
+@click.argument("name", required=False, default=None)
 @click.option("--app", help="Application/process name (partial match)")
 @click.option("--title", help="Window title pattern (partial match)")
 @click.option("--hwnd", type=int, help="Window handle")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def minimize(ctx, app, title, hwnd, json_output):
+def minimize(ctx, name, app, title, hwnd, json_output):
     """Minimize a window."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
+    _emit_deprecation(json_output)
+    if name and not app:
+        app = name
     from naturo.errors import NaturoError
 
     if not app and not title and not hwnd:
@@ -190,14 +220,18 @@ def minimize(ctx, app, title, hwnd, json_output):
 
 
 @window.command()
+@click.argument("name", required=False, default=None)
 @click.option("--app", help="Application/process name (partial match)")
 @click.option("--title", help="Window title pattern (partial match)")
 @click.option("--hwnd", type=int, help="Window handle")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def maximize(ctx, app, title, hwnd, json_output):
+def maximize(ctx, name, app, title, hwnd, json_output):
     """Maximize a window."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
+    _emit_deprecation(json_output)
+    if name and not app:
+        app = name
     from naturo.errors import NaturoError
 
     if not app and not title and not hwnd:
@@ -231,14 +265,18 @@ def maximize(ctx, app, title, hwnd, json_output):
 
 
 @window.command()
+@click.argument("name", required=False, default=None)
 @click.option("--app", help="Application/process name (partial match)")
 @click.option("--title", help="Window title pattern (partial match)")
 @click.option("--hwnd", type=int, help="Window handle")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def restore(ctx, app, title, hwnd, json_output):
+def restore(ctx, name, app, title, hwnd, json_output):
     """Restore a minimized or maximized window to normal state."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
+    _emit_deprecation(json_output)
+    if name and not app:
+        app = name
     from naturo.errors import NaturoError
 
     if not app and not title and not hwnd:
@@ -282,6 +320,7 @@ def restore(ctx, app, title, hwnd, json_output):
 def window_move(ctx, app, title, hwnd, x, y, json_output):
     """Move a window to a position (keeps current size)."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
+    _emit_deprecation(json_output)
     from naturo.errors import NaturoError
 
     if x is None or y is None:
@@ -334,6 +373,7 @@ def window_move(ctx, app, title, hwnd, x, y, json_output):
 def resize(ctx, app, title, hwnd, width, height, json_output):
     """Resize a window (keeps current position)."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
+    _emit_deprecation(json_output)
     from naturo.errors import NaturoError, InvalidInputError
 
     if width is None or height is None:
@@ -397,6 +437,7 @@ def resize(ctx, app, title, hwnd, width, height, json_output):
 def set_bounds(ctx, app, title, hwnd, x, y, width, height, json_output):
     """Set window position and size at once."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
+    _emit_deprecation(json_output)
     from naturo.errors import NaturoError
 
     missing = []
@@ -465,6 +506,7 @@ def set_bounds(ctx, app, title, hwnd, x, y, width, height, json_output):
 def window_list(ctx, app, pid, json_output):
     """List open windows."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
+    _emit_deprecation(json_output)
     from naturo.errors import NaturoError
 
     try:

--- a/tests/test_window_backward_compat.py
+++ b/tests/test_window_backward_compat.py
@@ -1,0 +1,115 @@
+"""Tests for window command backward compatibility (fixes #277, #278).
+
+Verifies:
+- ``naturo window focus "Name"`` positional argument works
+- All window subcommands emit deprecation warnings
+- ``naturo hotkey`` emits deprecation warning
+"""
+from __future__ import annotations
+
+import unittest.mock as mock
+
+import pytest
+from click.testing import CliRunner
+
+from naturo.cli import main
+
+
+@pytest.fixture
+def runner():
+    """Click CLI test runner."""
+    return CliRunner()
+
+
+# ── #277: Positional argument on window subcommands ──────────────────────
+
+
+class TestWindowPositionalArg:
+    """``naturo window focus "Notepad"`` should work (backward compat)."""
+
+    @mock.patch("naturo.cli.window_cmd._get_backend")
+    def test_focus_positional(self, mock_backend, runner):
+        """Positional NAME maps to --app."""
+        result = runner.invoke(main, ["window", "focus", "Notepad"])
+        assert result.exit_code == 0
+        assert "Focused window" in result.output
+
+    @mock.patch("naturo.cli.window_cmd._get_backend")
+    def test_close_positional(self, mock_backend, runner):
+        result = runner.invoke(main, ["window", "close", "Notepad"])
+        assert result.exit_code == 0
+        assert "Closed window" in result.output
+
+    @mock.patch("naturo.cli.window_cmd._get_backend")
+    def test_minimize_positional(self, mock_backend, runner):
+        result = runner.invoke(main, ["window", "minimize", "Notepad"])
+        assert result.exit_code == 0
+        assert "Minimized window" in result.output
+
+    @mock.patch("naturo.cli.window_cmd._get_backend")
+    def test_maximize_positional(self, mock_backend, runner):
+        result = runner.invoke(main, ["window", "maximize", "Notepad"])
+        assert result.exit_code == 0
+        assert "Maximized window" in result.output
+
+    @mock.patch("naturo.cli.window_cmd._get_backend")
+    def test_restore_positional(self, mock_backend, runner):
+        result = runner.invoke(main, ["window", "restore", "Notepad"])
+        assert result.exit_code == 0
+        assert "Restored window" in result.output
+
+    @mock.patch("naturo.cli.window_cmd._get_backend")
+    def test_focus_app_option_still_works(self, mock_backend, runner):
+        """--app flag should still work."""
+        result = runner.invoke(main, ["window", "focus", "--app", "Notepad"])
+        assert result.exit_code == 0
+        assert "Focused window" in result.output
+
+
+# ── #278: Deprecation warnings ───────────────────────────────────────────
+
+
+class TestWindowDeprecationWarning:
+    """All window subcommands should emit deprecation warning to stderr."""
+
+    @mock.patch("naturo.cli.window_cmd._get_backend")
+    def test_focus_deprecation(self, mock_backend, runner):
+        result = runner.invoke(main, ["window", "focus", "--app", "X"])
+        assert "deprecated" in result.stderr.lower()
+        assert "naturo app" in result.stderr
+
+    @mock.patch("naturo.cli.window_cmd._get_backend")
+    def test_close_deprecation(self, mock_backend, runner):
+        result = runner.invoke(main, ["window", "close", "--app", "X"])
+        assert "deprecated" in result.stderr.lower()
+
+    @mock.patch("naturo.cli.window_cmd._get_backend")
+    def test_minimize_deprecation(self, mock_backend, runner):
+        result = runner.invoke(main, ["window", "minimize", "--app", "X"])
+        assert "deprecated" in result.stderr.lower()
+
+    @mock.patch("naturo.cli.window_cmd._get_backend")
+    def test_list_deprecation(self, mock_backend, runner):
+        mock_backend.return_value.list_windows.return_value = []
+        result = runner.invoke(main, ["window", "list"])
+        assert "deprecated" in result.stderr.lower()
+
+    @mock.patch("naturo.cli.window_cmd._get_backend")
+    def test_no_deprecation_in_json_mode(self, mock_backend, runner):
+        """JSON mode should suppress stderr deprecation."""
+        result = runner.invoke(main, ["window", "focus", "--app", "X", "--json"])
+        # In JSON mode, no deprecation warning to stderr
+        assert "deprecated" not in result.stderr.lower()
+
+
+class TestHotkeyDeprecationWarning:
+    """``naturo hotkey`` should emit deprecation warning."""
+
+    @mock.patch("naturo.cli.interaction._get_backend")
+    def test_hotkey_deprecation(self, mock_backend, runner):
+        mock_be = mock.MagicMock()
+        mock_be.press_key.return_value = None
+        mock_backend.return_value = mock_be
+        result = runner.invoke(main, ["hotkey", "ctrl+a"])
+        assert "deprecated" in result.stderr.lower()
+        assert "naturo press" in result.stderr


### PR DESCRIPTION
## Changes

### #277 — window backward compat: positional arg not accepted
- Added positional `NAME` argument to `window focus/close/minimize/maximize/restore` subcommands
- `naturo window focus "Notepad"` now works (v0.2.1 syntax)
- `--app` flag still works as primary mechanism

### #278 — hotkey/window backward compat: missing deprecation warning  
- All `window` subcommands now emit deprecation warning to stderr:
  `Warning: 'naturo window' is deprecated and will be removed in v0.4.0. Use 'naturo app' instead.`
- `hotkey` command now emits:
  `Warning: 'naturo hotkey' is deprecated and will be removed in v0.4.0. Use 'naturo press' instead.`
- Warnings suppressed in JSON output mode

### Tests
- 12 new tests covering positional args, deprecation warnings, and JSON mode behavior
- Full suite: 1704 passed, 494 skipped