### PR TITLE
fix: capture live no longer invalidates see snapshot element refs (fixes #283)

### DIFF
--- a/naturo/snapshot.py
+++ b/naturo/snapshot.py
@@ -322,7 +322,7 @@ class SnapshotManager:
             ``(x, y, snapshot_id)`` — center coordinates and the snapshot ID
             used; or ``None`` if no matching ref was found.
         """
-        recent_id = self.get_most_recent_snapshot()
+        recent_id = self.get_most_recent_snapshot(require_refs=True)
         if not recent_id:
             return None
 
@@ -386,7 +386,7 @@ class SnapshotManager:
         tuple | None
             ``(UIElement, snapshot_id)`` or ``None`` if not found.
         """
-        recent_id = self.get_most_recent_snapshot()
+        recent_id = self.get_most_recent_snapshot(require_refs=True)
         if not recent_id:
             return None
 
@@ -474,7 +474,11 @@ class SnapshotManager:
 
             return Snapshot.from_dict(data)
 
-    def get_most_recent_snapshot(self, app_name: Optional[str] = None) -> Optional[str]:
+    def get_most_recent_snapshot(
+        self,
+        app_name: Optional[str] = None,
+        require_refs: bool = False,
+    ) -> Optional[str]:
         """Return the ID of the most recent valid snapshot within the validity window.
 
         Parameters
@@ -482,6 +486,11 @@ class SnapshotManager:
         app_name:
             If provided, only consider snapshots whose ``application_name``
             matches (case-insensitive substring match).
+        require_refs:
+            If ``True``, only consider snapshots that have a ``refs.json``
+            file (i.e. snapshots produced by ``see`` that contain element
+            refs).  This prevents ``capture live`` screenshots from
+            shadowing ``see`` snapshots when resolving element refs (#283).
 
         Returns
         -------
@@ -500,6 +509,10 @@ class SnapshotManager:
                     continue
                 json_path = entry / "snapshot.json"
                 if not json_path.exists():
+                    continue
+
+                # Skip snapshots without refs when caller needs element refs
+                if require_refs and not (entry / "refs.json").exists():
                     continue
 
                 try:

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -339,6 +339,91 @@ class TestGetMostRecentSnapshot:
         assert mgr.get_most_recent_snapshot(app_name="notepad") == sid
         assert mgr.get_most_recent_snapshot(app_name="NOTE") == sid
 
+    def test_require_refs_skips_screenshot_only_snapshots(
+        self, mgr: SnapshotManager, png_file: Path, sample_ui_map: Dict[str, UIElement]
+    ) -> None:
+        """Snapshot without refs.json should be skipped when require_refs=True.
+
+        Regression test for #283: ``capture live`` creates a snapshot with
+        only a screenshot (no refs.json), which was shadowing ``see``
+        snapshots and breaking subsequent element ref resolution.
+        """
+        # 1. Create a "see" snapshot with refs
+        see_sid = mgr.create_snapshot()
+        mgr.store_screenshot(see_sid, str(png_file), {"application_name": "App"})
+        mgr.store_detection_result(see_sid, sample_ui_map)
+        mgr.store_ref_map(see_sid, {"e1": "element_0", "e2": "element_1"})
+        time.sleep(0.02)  # ensure different mtime
+
+        # 2. Create a "capture live" snapshot (screenshot only, no refs)
+        cap_sid = mgr.create_snapshot()
+        mgr.store_screenshot(cap_sid, str(png_file), {"application_name": "App"})
+
+        # Without require_refs, the capture snapshot is most recent
+        assert mgr.get_most_recent_snapshot() == cap_sid
+
+        # With require_refs, the see snapshot is returned
+        assert mgr.get_most_recent_snapshot(require_refs=True) == see_sid
+
+    def test_require_refs_returns_none_when_no_refs_exist(
+        self, mgr: SnapshotManager, png_file: Path
+    ) -> None:
+        """When no snapshot has refs.json, require_refs=True returns None."""
+        sid = mgr.create_snapshot()
+        mgr.store_screenshot(sid, str(png_file), {})
+        assert mgr.get_most_recent_snapshot(require_refs=True) is None
+
+
+# ── resolve_ref after capture live (#283) ─────────────────────────────────────
+
+
+class TestResolveRefAfterCaptureLive:
+    """Verify that capture live does not break element ref resolution (#283)."""
+
+    def test_resolve_ref_survives_capture_live_snapshot(
+        self, mgr: SnapshotManager, png_file: Path, sample_ui_map: Dict[str, UIElement]
+    ) -> None:
+        """Element refs remain resolvable after a capture-live snapshot is created."""
+        # Create a "see" snapshot with refs and ui_map
+        see_sid = mgr.create_snapshot()
+        mgr.store_screenshot(see_sid, str(png_file), {"application_name": "App"})
+        mgr.store_detection_result(see_sid, sample_ui_map)
+        mgr.store_ref_map(see_sid, {"e1": "element_0", "e2": "element_1"})
+        time.sleep(0.02)
+
+        # Create a newer "capture live" snapshot (no refs)
+        cap_sid = mgr.create_snapshot()
+        mgr.store_screenshot(cap_sid, str(png_file), {"application_name": "App"})
+
+        # resolve_ref should still find e1 from the see snapshot
+        result = mgr.resolve_ref("e1")
+        assert result is not None
+        cx, cy, snap_id = result
+        assert snap_id == see_sid
+        # e1 frame is (10, 20, 80, 30) → center (50, 35)
+        assert cx == 50
+        assert cy == 35
+
+    def test_resolve_ref_element_survives_capture_live_snapshot(
+        self, mgr: SnapshotManager, png_file: Path, sample_ui_map: Dict[str, UIElement]
+    ) -> None:
+        """resolve_ref_element still works after capture-live creates a new snapshot."""
+        see_sid = mgr.create_snapshot()
+        mgr.store_screenshot(see_sid, str(png_file), {"application_name": "App"})
+        mgr.store_detection_result(see_sid, sample_ui_map)
+        mgr.store_ref_map(see_sid, {"e1": "element_0", "e2": "element_1"})
+        time.sleep(0.02)
+
+        cap_sid = mgr.create_snapshot()
+        mgr.store_screenshot(cap_sid, str(png_file), {"application_name": "App"})
+
+        result = mgr.resolve_ref_element("e1")
+        assert result is not None
+        element, snap_id = result
+        assert snap_id == see_sid
+        assert element.role == "AXButton"
+        assert element.title == "Save"
+
 
 # ── list_snapshots ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Problem

`capture live` creates a screenshot-only snapshot (no refs.json) which became the 'most recent' snapshot, shadowing the `see` snapshot that has element refs. Subsequent `capture live --element eN` then fails because the newest snapshot has no refs.

## Root Cause

`get_most_recent_snapshot()` returns the most recent snapshot of **any** type. When `capture live` stores its screenshot, it creates a new snapshot without refs, which shadows the `see` snapshot.

## Fix

- Added `require_refs` parameter to `get_most_recent_snapshot()` — when `True`, only snapshots with `refs.json` are considered
- `resolve_ref()` and `resolve_ref_element()` now pass `require_refs=True`
- This ensures element ref resolution always finds the most recent `see` snapshot, not a bare `capture live` screenshot

## Tests

Added 4 regression tests:
- `test_require_refs_skips_screenshot_only_snapshots`
- `test_require_refs_returns_none_when_no_refs_exist`
- `test_resolve_ref_survives_capture_live_snapshot`
- `test_resolve_ref_element_survives_capture_live_snapshot`

All 1701 tests pass (494 skipped on macOS).