### PR TITLE
fix: find default depth increased to 20 for exhaustive search (fixes #284)

### DIFF
--- a/naturo/cli/core.py
+++ b/naturo/cli/core.py
@@ -884,7 +884,7 @@ def see(app, window_title, hwnd, pid, mode, depth, path, annotate, store_snapsho
               help="Find all elements (equivalent to query \"*\"). Safe from shell glob expansion.")
 @click.option("--role", help="Filter by element role (e.g., Button, Edit)")
 @click.option("--actionable", is_flag=True, help="Only show actionable elements")
-@click.option("--depth", "-d", type=int, default=7, help="Maximum tree depth (1-10)")
+@click.option("--depth", "-d", type=int, default=20, help="Maximum tree depth (default 20; use lower values for performance)")
 @click.option("--limit", type=int, default=50, help="Maximum number of results")
 @click.option("--ai", is_flag=True, help="Use AI vision to find element by natural language")
 @click.option("--screenshot", type=click.Path(), default=None,
@@ -950,9 +950,9 @@ def find_cmd(query, query_opt, find_all, role, actionable, depth, limit, ai,
                       model=ai_model, api_key=ai_api_key)
         return
 
-    # BUG-028: Validate --depth range (before platform check — input validation first)
-    if depth < 1 or depth > 10:
-        msg = f"--depth must be between 1 and 10, got {depth}"
+    # Validate --depth range (find supports deeper traversal than see)
+    if depth < 1 or depth > 50:
+        msg = f"--depth must be between 1 and 50, got {depth}"
         if json_output:
             click.echo(_json_error_str("INVALID_INPUT", msg))
         else:

--- a/tests/test_bug_round_full.py
+++ b/tests/test_bug_round_full.py
@@ -176,7 +176,7 @@ class TestBUG028DepthValidation:
     def test_find_depth_zero(self, runner):
         result = runner.invoke(main, ["find", "Save", "--depth", "0"])
         assert result.exit_code != 0
-        assert "must be between 1 and 10" in result.output or "error" in result.output.lower()
+        assert "must be between 1 and 50" in result.output or "error" in result.output.lower()
 
     def test_find_depth_negative_json(self, runner):
         result = runner.invoke(main, ["find", "Save", "--depth", "-1", "--json"])
@@ -188,6 +188,19 @@ class TestBUG028DepthValidation:
     def test_see_depth_11(self, runner):
         result = runner.invoke(main, ["see", "--depth", "11"])
         assert result.exit_code != 0
+
+    def test_find_depth_20_accepted(self, runner):
+        """Issue #284: find should accept depth > 10 (default is 20)."""
+        # depth=20 should be accepted (not rejected as out-of-range)
+        result = runner.invoke(main, ["find", "Save", "--depth", "20"])
+        # Should not fail with INVALID_INPUT for depth
+        assert "must be between" not in (result.output or "")
+
+    def test_find_depth_51_rejected(self, runner):
+        """Issue #284: find depth max is 50."""
+        result = runner.invoke(main, ["find", "Save", "--depth", "51"])
+        assert result.exit_code != 0
+        assert "must be between 1 and 50" in result.output or "error" in result.output.lower()
 
 
 class TestBUG032TypeWpmValidation:


### PR DESCRIPTION
## Problem
`find` used the same default depth (7) as `see`, causing it to miss deeply nested elements. Users reported `naturo see` finding elements that `naturo find` couldn't locate.

## Root Cause
`find`'s purpose is exhaustive search — unlike `see` which needs readable output, there's no reason to limit search depth to 7.

## Fix
- `find` default depth: 7 → 20
- `find` max allowed depth: 10 → 50
- `see` keeps depth=7 default and 1-10 range (output readability concern)

## Tests
- Updated depth validation tests for new range
- Added tests for depth=20 accepted, depth=51 rejected
- All 1697 tests pass