### PR TITLE
fix: add deprecation warnings to hotkey and window commands (fixes #278)

### DIFF
--- a/naturo/cli/interaction.py
+++ b/naturo/cli/interaction.py
@@ -1357,6 +1357,14 @@ def hotkey(keys, keys_option, hold_duration, app, window_title, hwnd,
     Deprecated: use 'naturo press ctrl+c' instead of 'naturo hotkey ctrl+c'.
     This command is kept for backward compatibility.
     """
+    # Emit deprecation warning (goes to stderr, does not affect JSON output on stdout)
+    if not json_output:
+        click.echo(
+            "Warning: 'naturo hotkey' is deprecated and will be removed in a future version. "
+            "Use 'naturo press' instead.",
+            err=True,
+        )
+
     # Build a single combo string from positional or --keys options
     if keys:
         combo = keys

--- a/naturo/cli/window_cmd.py
+++ b/naturo/cli/window_cmd.py
@@ -57,6 +57,23 @@ def _resolve_target(app: Optional[str], title: Optional[str], hwnd: Optional[int
     return {"title": effective_title, "hwnd": hwnd}
 
 
+_WINDOW_DEPRECATION_MSG = (
+    "Warning: 'naturo window' is deprecated and will be removed in a future version. "
+    "Use 'naturo app' instead."
+)
+
+
+def _emit_window_deprecation(json_output: bool) -> None:
+    """Emit deprecation warning for window commands.
+
+    Args:
+        json_output: If True, skip text warning (caller should include
+            ``deprecated`` field in JSON response instead).
+    """
+    if not json_output:
+        click.echo(_WINDOW_DEPRECATION_MSG, err=True)
+
+
 @click.group(cls=FuzzyGroup, hidden=True)
 def window():
     """Manage windows (deprecated — use 'naturo app' instead)."""
@@ -72,6 +89,7 @@ def window():
 def focus(ctx, app, title, hwnd, json_output):
     """Focus a window (bring to foreground)."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
+    _emit_window_deprecation(json_output)
     from naturo.errors import NaturoError
 
     if not app and not title and not hwnd:
@@ -114,6 +132,7 @@ def focus(ctx, app, title, hwnd, json_output):
 def close(ctx, app, title, hwnd, force, json_output):
     """Close a window (graceful or forced)."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
+    _emit_window_deprecation(json_output)
     from naturo.errors import NaturoError
 
     if not app and not title and not hwnd:
@@ -157,6 +176,7 @@ def close(ctx, app, title, hwnd, force, json_output):
 def minimize(ctx, app, title, hwnd, json_output):
     """Minimize a window."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
+    _emit_window_deprecation(json_output)
     from naturo.errors import NaturoError
 
     if not app and not title and not hwnd:
@@ -198,6 +218,7 @@ def minimize(ctx, app, title, hwnd, json_output):
 def maximize(ctx, app, title, hwnd, json_output):
     """Maximize a window."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
+    _emit_window_deprecation(json_output)
     from naturo.errors import NaturoError
 
     if not app and not title and not hwnd:
@@ -239,6 +260,7 @@ def maximize(ctx, app, title, hwnd, json_output):
 def restore(ctx, app, title, hwnd, json_output):
     """Restore a minimized or maximized window to normal state."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
+    _emit_window_deprecation(json_output)
     from naturo.errors import NaturoError
 
     if not app and not title and not hwnd:
@@ -282,6 +304,7 @@ def restore(ctx, app, title, hwnd, json_output):
 def window_move(ctx, app, title, hwnd, x, y, json_output):
     """Move a window to a position (keeps current size)."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
+    _emit_window_deprecation(json_output)
     from naturo.errors import NaturoError
 
     if x is None or y is None:
@@ -334,6 +357,7 @@ def window_move(ctx, app, title, hwnd, x, y, json_output):
 def resize(ctx, app, title, hwnd, width, height, json_output):
     """Resize a window (keeps current position)."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
+    _emit_window_deprecation(json_output)
     from naturo.errors import NaturoError, InvalidInputError
 
     if width is None or height is None:
@@ -397,6 +421,7 @@ def resize(ctx, app, title, hwnd, width, height, json_output):
 def set_bounds(ctx, app, title, hwnd, x, y, width, height, json_output):
     """Set window position and size at once."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
+    _emit_window_deprecation(json_output)
     from naturo.errors import NaturoError
 
     missing = []
@@ -465,6 +490,7 @@ def set_bounds(ctx, app, title, hwnd, x, y, width, height, json_output):
 def window_list(ctx, app, pid, json_output):
     """List open windows."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
+    _emit_window_deprecation(json_output)
     from naturo.errors import NaturoError
 
     try:

--- a/tests/test_deprecation_warnings.py
+++ b/tests/test_deprecation_warnings.py
@@ -1,0 +1,65 @@
+"""Tests for deprecation warnings on legacy commands (hotkey, window).
+
+Verifies that deprecated commands emit warnings without breaking
+JSON output on stdout.
+
+Fixes #278.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from naturo.cli import main
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+class TestHotkeyDeprecationWarning:
+    """Tests for 'naturo hotkey' deprecation warning."""
+
+    def test_hotkey_text_mode_shows_warning(self, runner):
+        """hotkey in text mode emits deprecation warning."""
+        result = runner.invoke(main, ["hotkey", "ctrl+a"])
+        assert "deprecated" in result.output.lower()
+        assert "naturo press" in result.output
+
+    def test_hotkey_json_mode_clean_json(self, runner):
+        """hotkey --json must produce valid JSON without warning text on stdout."""
+        # In JSON mode, the deprecation warning is suppressed entirely
+        result = runner.invoke(main, ["hotkey", "ctrl+a", "--json"])
+        # The entire output should be valid JSON (no warning prefix)
+        lines = [ln for ln in result.output.strip().splitlines() if ln.strip()]
+        for line in lines:
+            # Each line should be parseable JSON
+            data = json.loads(line)
+            assert isinstance(data, dict)
+
+
+class TestWindowDeprecationWarning:
+    """Tests for 'naturo window' subcommand deprecation warnings."""
+
+    def test_window_focus_text_mode_shows_warning(self, runner):
+        """window focus in text mode emits deprecation warning."""
+        result = runner.invoke(main, ["window", "focus", "--app", "Nonexistent"])
+        assert "deprecated" in result.output.lower()
+        assert "naturo app" in result.output
+
+    def test_window_list_text_mode_shows_warning(self, runner):
+        """window list in text mode emits deprecation warning."""
+        result = runner.invoke(main, ["window", "list"])
+        assert "deprecated" in result.output.lower()
+        assert "naturo app" in result.output
+
+    def test_window_focus_json_mode_clean_json(self, runner):
+        """window focus --json must produce valid JSON without warning text."""
+        result = runner.invoke(main, ["window", "focus", "--app", "Nonexistent", "--json"])
+        lines = [ln for ln in result.output.strip().splitlines() if ln.strip()]
+        for line in lines:
+            data = json.loads(line)
+            assert isinstance(data, dict)


### PR DESCRIPTION
## Summary

Add runtime deprecation warnings when users invoke `naturo hotkey` or `naturo window` commands.

### Changes

- **`naturo hotkey`**: Emits "Warning: 'naturo hotkey' is deprecated... Use 'naturo press' instead." to stderr in text mode. Suppressed in JSON mode to keep stdout clean.
- **`naturo window *`**: All 9 subcommands (focus, close, minimize, maximize, restore, move, resize, set-bounds, list) emit "Warning: 'naturo window' is deprecated... Use 'naturo app' instead." Same text/JSON behavior.

### Design decisions

- Warnings go to stderr via `click.echo(err=True)` in text mode
- In JSON mode (`--json`), warnings are suppressed entirely to avoid polluting parseable output
- Each subcommand emits the warning independently (not the group callback) so it works correctly with Click's CliRunner in tests

### Tests

- Added `tests/test_deprecation_warnings.py` with 5 tests covering both text and JSON modes for hotkey and window commands
- Full suite: 1704 passed, 494 skipped

Fixes #278