### PR TITLE
fix: Win32 backend WindowsForms class name role mapping (fixes #314)

### DIFF
--- a/naturo/bridge.py
+++ b/naturo/bridge.py
@@ -161,6 +161,46 @@ _WIN32_CLASS_ROLE_MAP = {
 }
 
 
+def _get_role_from_class_name(cls_name: str, is_top_level: bool = False) -> str:
+    """Map Win32 class name to UIA-style role.
+
+    Handles WindowsForms dynamic class names (e.g., WindowsForms10.EDIT.app.0.xxx).
+
+    Args:
+        cls_name: Win32 class name from GetClassName
+        is_top_level: If True, default to "Window" instead of "Pane"
+
+    Returns:
+        UIA role string (Button, Edit, Text, etc.)
+    """
+    # Direct match (e.g., "Button", "ThunderRT6CommandButton")
+    role = _WIN32_CLASS_ROLE_MAP.get(cls_name)
+    if role:
+        return role
+
+    # WindowsForms class name pattern: WindowsForms10.{TYPE}.app.{version}.{hash}
+    # Examples:
+    #   WindowsForms10.STATIC.app.0.xxx → TYPE=STATIC → Text
+    #   WindowsForms10.EDIT.app.0.xxx → TYPE=EDIT → Edit
+    #   WindowsForms10.Window.8.app.0.xxx → TYPE=Window → Pane (generic container)
+    if cls_name.startswith("WindowsForms10."):
+        parts = cls_name.split(".")
+        if len(parts) >= 3:
+            inner_type = parts[1]  # e.g., "EDIT", "STATIC", "Window", "SysTreeView32"
+            # Try exact match first (handles "SysTreeView32" embedded in WindowsForms)
+            role = _WIN32_CLASS_ROLE_MAP.get(inner_type)
+            if role:
+                return role
+            # Fallback: uppercase TYPE might be uppercase version of base class
+            # (STATIC → Static, EDIT → Edit)
+            if inner_type.isupper():
+                role = _WIN32_CLASS_ROLE_MAP.get(inner_type.capitalize())
+                if role:
+                    return role
+
+    return "Window" if is_top_level else "Pane"
+
+
 def highlight_elements(hwnd: int, depth: int = 10, duration: float = 5.0,
                        refs: Optional[list] = None) -> None:
     """Draw colored borders and labels on Win32 child windows for visual identification.
@@ -373,10 +413,8 @@ def enumerate_child_windows(hwnd: int, depth: int = 10) -> Optional[ElementInfo]
     def _build_tree(h, current_depth):
         """Recursively build ElementInfo tree from HWND hierarchy."""
         title, cls_name, rect = _get_window_info(h)
-        role = _WIN32_CLASS_ROLE_MAP.get(cls_name, "Pane")
-        # Use "Window" for top-level
-        if current_depth == 0:
-            role = _WIN32_CLASS_ROLE_MAP.get(cls_name, "Window")
+        is_top_level = (current_depth == 0)
+        role = _get_role_from_class_name(cls_name, is_top_level=is_top_level)
 
         # Include class name in display for debugging and identification
         display_name = title

--- a/tests/test_windowsforms_class_mapping.py
+++ b/tests/test_windowsforms_class_mapping.py
@@ -1,0 +1,65 @@
+"""Tests for WindowsForms class name role mapping (Issue #314)."""
+import pytest
+from naturo.bridge import _get_role_from_class_name
+
+
+class TestWindowsFormsClassMapping:
+    """Test WindowsForms10.{TYPE}.app.0.xxx class name parsing."""
+
+    def test_direct_match_takes_priority(self):
+        """Standard Win32 class names should match directly."""
+        assert _get_role_from_class_name("Button") == "Button"
+        assert _get_role_from_class_name("Edit") == "Edit"
+        assert _get_role_from_class_name("Static") == "Text"
+        assert _get_role_from_class_name("SysTreeView32") == "Tree"
+
+    def test_windowsforms_static(self):
+        """WindowsForms10.STATIC.app.0.xxx should map to Text."""
+        cls = "WindowsForms10.STATIC.app.0.37504c8_r29_ad1"
+        assert _get_role_from_class_name(cls) == "Text"
+
+    def test_windowsforms_edit(self):
+        """WindowsForms10.EDIT.app.0.xxx should map to Edit."""
+        cls = "WindowsForms10.EDIT.app.0.12345_r7_ae3"
+        assert _get_role_from_class_name(cls) == "Edit"
+
+    def test_windowsforms_systreev32(self):
+        """WindowsForms10.SysTreeView32.app.0.xxx should map to Tree."""
+        cls = "WindowsForms10.SysTreeView32.app.0.abc123"
+        assert _get_role_from_class_name(cls) == "Tree"
+
+    def test_windowsforms_window_generic_container(self):
+        """WindowsForms10.Window.8.app.0.xxx should map to Pane (generic container)."""
+        cls = "WindowsForms10.Window.8.app.0.37504c8_r29_ad1"
+        assert _get_role_from_class_name(cls) == "Pane"
+
+    def test_windowsforms_button(self):
+        """WindowsForms10.BUTTON.app.0.xxx should map to Button."""
+        cls = "WindowsForms10.BUTTON.app.0.xyz789"
+        assert _get_role_from_class_name(cls) == "Button"
+
+    def test_unknown_class_defaults_to_pane(self):
+        """Unknown class names should default to Pane."""
+        assert _get_role_from_class_name("SomeCustomClass") == "Pane"
+        assert _get_role_from_class_name("WindowsForms10.UNKNOWN.app.0.xxx") == "Pane"
+
+    def test_top_level_defaults_to_window(self):
+        """Top-level unknown classes should default to Window."""
+        assert _get_role_from_class_name("CustomMainWindow", is_top_level=True) == "Window"
+        assert _get_role_from_class_name("WindowsForms10.UNKNOWN.app.0.xxx", is_top_level=True) == "Window"
+
+    def test_thunderrt6_vb6_classes(self):
+        """VB6 ThunderRT6 class names should still work."""
+        assert _get_role_from_class_name("ThunderRT6FormDC") == "Window"
+        assert _get_role_from_class_name("ThunderRT6CommandButton") == "Button"
+        assert _get_role_from_class_name("ThunderRT6TextBox") == "Edit"
+        assert _get_role_from_class_name("ThunderRT6CheckBox") == "CheckBox"
+
+    def test_case_sensitivity(self):
+        """Uppercase TYPE should be handled (STATIC → Static)."""
+        # STATIC (uppercase) should match Static (capitalized) in map
+        cls = "WindowsForms10.STATIC.app.0.xxx"
+        assert _get_role_from_class_name(cls) == "Text"
+        # EDIT → Edit
+        cls = "WindowsForms10.EDIT.app.0.yyy"
+        assert _get_role_from_class_name(cls) == "Edit"


### PR DESCRIPTION
WindowsForms controls use dynamic class names like `WindowsForms10.EDIT.app.0.xxx`, which were not matched by _WIN32_CLASS_ROLE_MAP and defaulted to Pane.

**Root cause:** Issue #314 — U8 outputs all Pane because WindowsForms class names are not in the map.

**Solution:**
- Added `_get_role_from_class_name()` to parse WindowsForms dynamic class names
- Extracts TYPE from `WindowsForms10.{TYPE}.app.{version}.{hash}` pattern
- Remaps TYPE to UIA role (STATIC → Text, EDIT → Edit, etc.)
- Handles case variations and embedded types (SysTreeView32)

**Mappings:**
- `WindowsForms10.STATIC.app.0.xxx` → Text
- `WindowsForms10.EDIT.app.0.xxx` → Edit
- `WindowsForms10.SysTreeView32.app.0.xxx` → Tree
- `WindowsForms10.Window.8.app.0.xxx` → Pane (generic container)

**Tests:** 10 new unit tests covering WindowsForms parsing, VB6 compat, case handling.

Fixes #314