### PR TITLE
fix: store HWND in ElementInfo for Win32 hybrid mode (fixes #316)

### DIFF
--- a/naturo/bridge.py
+++ b/naturo/bridge.py
@@ -73,6 +73,7 @@ class ElementInfo:
         children: Child elements.
         parent_id: Parent element's id (filled by Python-layer traversal).
         keyboard_shortcut: Keyboard shortcut string (e.g., "Ctrl+S").
+        hwnd: Win32 window handle (Windows only, for hybrid mode and direct messaging).
     """
     id: str
     role: str
@@ -85,6 +86,7 @@ class ElementInfo:
     children: list["ElementInfo"] = field(default_factory=list)
     parent_id: Optional[str] = None
     keyboard_shortcut: Optional[str] = None
+    hwnd: Optional[int] = None
 
 
 def _parse_element(data: dict) -> ElementInfo:
@@ -393,6 +395,7 @@ def enumerate_child_windows(hwnd: int, depth: int = 10) -> Optional[ElementInfo]
             width=rect.right - rect.left,
             height=rect.bottom - rect.top,
             children=[],
+            hwnd=h,
         )
         counter[0] += 1
 

--- a/tests/test_elementinfo_hwnd.py
+++ b/tests/test_elementinfo_hwnd.py
@@ -1,0 +1,70 @@
+"""Tests for ElementInfo hwnd field (Issue #316)."""
+import pytest
+from naturo.bridge import ElementInfo
+
+
+class TestElementInfoHwnd:
+    """Verify ElementInfo stores hwnd for Win32 hybrid mode."""
+
+    def test_hwnd_field_exists(self):
+        """ElementInfo should have optional hwnd attribute."""
+        elem = ElementInfo(
+            id="e0",
+            role="Button",
+            name="OK",
+            value=None,
+            x=10,
+            y=20,
+            width=80,
+            height=30,
+            hwnd=12345,
+        )
+        assert elem.hwnd == 12345
+
+    def test_hwnd_optional(self):
+        """hwnd should be optional (None for non-Win32 backends)."""
+        elem = ElementInfo(
+            id="e1",
+            role="Edit",
+            name="Input",
+            value="text",
+            x=0,
+            y=0,
+            width=100,
+            height=20,
+        )
+        assert elem.hwnd is None
+
+    def test_hwnd_serializes_to_dict(self):
+        """When converting to dict, hwnd should be included."""
+        from dataclasses import asdict
+        elem = ElementInfo(
+            id="e2",
+            role="Window",
+            name="Main",
+            value=None,
+            x=0,
+            y=0,
+            width=800,
+            height=600,
+            hwnd=0x1234ABCD,
+        )
+        d = asdict(elem)
+        assert "hwnd" in d
+        assert d["hwnd"] == 0x1234ABCD
+
+    def test_hwnd_none_serializes_as_none(self):
+        """hwnd=None should serialize as null in JSON."""
+        from dataclasses import asdict
+        elem = ElementInfo(
+            id="e3",
+            role="Text",
+            name="Label",
+            value="Hello",
+            x=10,
+            y=10,
+            width=50,
+            height=15,
+        )
+        d = asdict(elem)
+        assert d["hwnd"] is None


### PR DESCRIPTION
Win32-enumerated elements now include their window handle to enable:
1. **Hybrid mode UIA traversal** — refine win32 results with detailed UIA child element inspection
2. **Direct message-based interaction** — send WM_SETTEXT, BM_CLICK, etc. to specific controls
3. **`naturo click --hwnd <hwnd>`** — target win32-discovered child controls directly

**Root cause:** Issue #316 — win32 backend enumerates elements but discards HWND, blocking hybrid mode and direct messaging.

**Solution:**
- Added `hwnd: Optional[int]` field to `ElementInfo` dataclass
- `enumerate_child_windows()` now stores HWND for each enumerated element
- Serializes to JSON snapshot for persistent handle reference

**Tests:** 4 new unit tests verifying hwnd field exists, is optional, and serializes correctly.

Fixes #316