### PR TITLE
fix: see --app now shows ALL windows of the application (fixes #304)

### DIFF
--- a/naturo/backends/windows.py
+++ b/naturo/backends/windows.py
@@ -1017,6 +1017,137 @@ class WindowsBackend(Backend):
 
         raise WindowNotFoundError(search, suggested_action=hint)
 
+    def _resolve_hwnds(self, app: Optional[str] = None,
+                       window_title: Optional[str] = None) -> list[int]:
+        """Resolve ALL window handles matching app name or window title.
+
+        Same matching logic as _resolve_hwnd, but returns ALL windows that
+        match (score > 0), sorted by score descending.
+
+        Used by `see --app` to enumerate all windows of an application (#304).
+
+        Args:
+            app: Application/process name (case-insensitive, partial match).
+            window_title: Window title pattern (case-insensitive, partial match).
+
+        Returns:
+            List of window handles (HWNDs), sorted by match quality (best first).
+            Empty list if no matches found.
+
+        Note:
+            Does NOT accept `hwnd` parameter (use [hwnd] if you have a handle).
+            Skips foreground window fallback (returns [] if no search term).
+        """
+        search = app or window_title
+        if not search:
+            return []
+
+        search_lower = search.lower()
+        windows = self.list_windows()
+        console_session = self._get_console_session_id()
+        match_process = app is not None
+
+        # Collect all matching windows with their scores
+        matches = []  # [(score, in_console, title_len, WindowInfo), ...]
+
+        for w in windows:
+            score = 0
+            proc_stem = w.process_name.lower()
+            if proc_stem.endswith(".exe"):
+                proc_stem = proc_stem[:-4]
+            title_lower = w.title.lower()
+
+            if match_process:
+                # Process-name matching
+                if search_lower == proc_stem:
+                    score = 4
+                elif search_lower in proc_stem:
+                    score = 3
+                # Title fallback
+                elif search_lower == title_lower:
+                    score = 2
+                elif search_lower in title_lower:
+                    score = 1
+                # Alias matching
+                if score == 0:
+                    aliases = self._APP_ALIASES.get(search_lower, set())
+                    for alias in aliases:
+                        if alias == proc_stem or alias == title_lower:
+                            score = 2
+                            break
+                        if alias in proc_stem or alias in title_lower:
+                            score = 1
+                            break
+            else:
+                # --window-title: only match window title
+                if search_lower == title_lower:
+                    score = 4
+                elif search_lower in title_lower:
+                    score = 1
+
+            if score == 0:
+                continue
+
+            # Session-aware ranking
+            in_console = False
+            if console_session >= 0:
+                w_session = self._get_process_session_id(w.pid)
+                in_console = (w_session == console_session)
+
+            matches.append((score, in_console, len(w.title), w))
+
+        # Sort by: score desc, console first, shorter title first
+        # (in_console: True > False, so negate for descending)
+        matches.sort(key=lambda x: (x[0], x[1], -x[2]), reverse=True)
+
+        # Extract HWNDs
+        hwnds = [m[3].handle for m in matches]
+
+        # UWP/ApplicationFrameHost fixup: prefer frame windows when available
+        # (same logic as _resolve_hwnd, but applied to all matches)
+        fixed_hwnds = []
+        for hwnd in hwnds:
+            # Find the WindowInfo for this hwnd
+            w_info = next((m[3] for m in matches if m[3].handle == hwnd), None)
+            if not w_info:
+                fixed_hwnds.append(hwnd)
+                continue
+
+            proc = w_info.process_name.lower()
+            if proc.endswith(".exe"):
+                proc = proc[:-4]
+
+            if proc != "applicationframehost":
+                # Check if there's a frame window with same title
+                frame_hwnd = None
+                for m in matches:
+                    frame_proc = m[3].process_name.lower()
+                    if frame_proc.endswith(".exe"):
+                        frame_proc = frame_proc[:-4]
+                    if (
+                        frame_proc == "applicationframehost"
+                        and m[3].title == w_info.title
+                        and m[3].handle != hwnd
+                    ):
+                        frame_hwnd = m[3].handle
+                        break
+                if frame_hwnd:
+                    fixed_hwnds.append(frame_hwnd)
+                else:
+                    fixed_hwnds.append(hwnd)
+            else:
+                fixed_hwnds.append(hwnd)
+
+        # Deduplicate (in case of frame window replacements)
+        seen = set()
+        result = []
+        for h in fixed_hwnds:
+            if h not in seen:
+                seen.add(h)
+                result.append(h)
+
+        return result
+
     @staticmethod
     def _find_uwp_content_hwnd(parent_hwnd: int) -> list:
         """Find content child HWNDs inside an ApplicationFrameHost window.

--- a/naturo/cli/core.py
+++ b/naturo/cli/core.py
@@ -651,10 +651,66 @@ def see(app, window_title, hwnd, pid, mode, depth, path, annotate, store_snapsho
             tree = cascade_result.tree
             cascade_stats = cascade_result.stats
         else:
-            tree = be.get_element_tree(
-                app=app, window_title=window_title, hwnd=hwnd, depth=depth,
-                backend=backend,
-            )
+            # (#304) When --app is used without --hwnd, enumerate ALL windows
+            # of the application and merge their UI trees.
+            if app and not hwnd and hasattr(be, "_resolve_hwnds"):
+                hwnds = be._resolve_hwnds(app=app)
+                if not hwnds:
+                    msg = f"No windows found for app '{app}'."
+                    if json_output:
+                        click.echo(_json_error_str("WINDOW_NOT_FOUND", msg))
+                    else:
+                        click.echo(msg)
+                    raise SystemExit(1)
+
+                # Get element tree for each window
+                from naturo.backends.base import ElementInfo as BaseElementInfo
+                window_trees = []
+                for h in hwnds:
+                    subtree = be.get_element_tree(
+                        hwnd=h, depth=depth, backend=backend,
+                    )
+                    if subtree:
+                        window_trees.append((h, subtree))
+
+                if not window_trees:
+                    msg = "All windows have empty UI trees."
+                    if json_output:
+                        click.echo(_json_error_str("WINDOW_NOT_FOUND", msg))
+                    else:
+                        click.echo(msg)
+                    raise SystemExit(1)
+
+                # Merge into a single root: create a virtual root node
+                # with each window's tree as a child
+                tree = BaseElementInfo(
+                    id="app_root",
+                    role="Application",
+                    name=app,
+                    value=None,
+                    x=0, y=0, width=0, height=0,
+                    children=[],
+                )
+                for h, subtree in window_trees:
+                    # Wrap each window tree with a "Window" group node
+                    # to preserve window identity in output
+                    window_node = BaseElementInfo(
+                        id=f"window_{h}",
+                        role="WindowGroup",
+                        name=f"{subtree.name} (HWND:{h})",
+                        value=None,
+                        x=subtree.x,
+                        y=subtree.y,
+                        width=subtree.width,
+                        height=subtree.height,
+                        children=[subtree],
+                    )
+                    tree.children.append(window_node)
+            else:
+                tree = be.get_element_tree(
+                    app=app, window_title=window_title, hwnd=hwnd, depth=depth,
+                    backend=backend,
+                )
 
         if tree is None:
             msg = "No window found or UI tree is empty."

--- a/tests/test_resolve_all_windows.py
+++ b/tests/test_resolve_all_windows.py
@@ -1,0 +1,173 @@
+"""Tests for _resolve_hwnds (Issue #304)."""
+import pytest
+from naturo.backends.windows import WindowsBackend
+from naturo.backends.base import WindowInfo
+
+
+class TestResolveAllWindows:
+    """Verify _resolve_hwnds returns all matching windows."""
+
+    def test_resolve_all_matching_process_windows(self, monkeypatch):
+        """_resolve_hwnds should return all windows for a given process."""
+        backend = WindowsBackend()
+
+        def mock_list_windows():
+            return [
+                WindowInfo(
+                    handle=1000,
+                    title="Feishu - Main",
+                    process_name="Lark.exe",
+                    pid=100,
+                    x=0, y=0, width=1920, height=1080,
+                    is_visible=True,
+                    is_minimized=False,
+                ),
+                WindowInfo(
+                    handle=2000,
+                    title="Feishu - Video Call",
+                    process_name="Lark.exe",
+                    pid=100,
+                    x=200, y=100, width=800, height=600,
+                    is_visible=True,
+                    is_minimized=False,
+                ),
+                WindowInfo(
+                    handle=3000,
+                    title="Feishu - Image Preview",
+                    process_name="Lark.exe",
+                    pid=100,
+                    x=400, y=300, width=1024, height=768,
+                    is_visible=True,
+                    is_minimized=False,
+                ),
+                WindowInfo(
+                    handle=4000,
+                    title="Notepad",
+                    process_name="notepad.exe",
+                    pid=200,
+                    x=100, y=100, width=640, height=480,
+                    is_visible=True,
+                    is_minimized=False,
+                ),
+            ]
+
+        def mock_console_session():
+            return 1
+
+        def mock_process_session(pid):
+            return 1
+
+        monkeypatch.setattr(backend, "list_windows", mock_list_windows)
+        monkeypatch.setattr(backend, "_get_console_session_id", mock_console_session)
+        monkeypatch.setattr(backend, "_get_process_session_id", mock_process_session)
+
+        # --app "Lark" should return all 3 Feishu windows
+        result = backend._resolve_hwnds(app="Lark")
+        assert len(result) == 3
+        assert set(result) == {1000, 2000, 3000}
+
+    def test_resolve_hwnds_empty_when_no_match(self, monkeypatch):
+        """_resolve_hwnds should return empty list when nothing matches."""
+        backend = WindowsBackend()
+
+        def mock_list_windows():
+            return [
+                WindowInfo(
+                    handle=1000,
+                    title="Notepad",
+                    process_name="notepad.exe",
+                    pid=100,
+                    x=0, y=0, width=640, height=480,
+                    is_visible=True,
+                    is_minimized=False,
+                ),
+            ]
+
+        def mock_console_session():
+            return 1
+
+        def mock_process_session(pid):
+            return 1
+
+        monkeypatch.setattr(backend, "list_windows", mock_list_windows)
+        monkeypatch.setattr(backend, "_get_console_session_id", mock_console_session)
+        monkeypatch.setattr(backend, "_get_process_session_id", mock_process_session)
+
+        result = backend._resolve_hwnds(app="Feishu")
+        assert result == []
+
+    def test_resolve_hwnds_sorted_by_score(self, monkeypatch):
+        """_resolve_hwnds should sort results by match quality."""
+        backend = WindowsBackend()
+
+        def mock_list_windows():
+            return [
+                WindowInfo(
+                    handle=1000,
+                    title="My App - Window 1",
+                    process_name="otherapp.exe",
+                    pid=100,
+                    x=0, y=0, width=800, height=600,
+                    is_visible=True,
+                    is_minimized=False,
+                ),
+                WindowInfo(
+                    handle=2000,
+                    title="MyApp",
+                    process_name="myapp.exe",
+                    pid=200,
+                    x=0, y=0, width=800, height=600,
+                    is_visible=True,
+                    is_minimized=False,
+                ),
+                WindowInfo(
+                    handle=3000,
+                    title="MyApp - Settings",
+                    process_name="myapp.exe",
+                    pid=200,
+                    x=100, y=100, width=400, height=300,
+                    is_visible=True,
+                    is_minimized=False,
+                ),
+            ]
+
+        def mock_console_session():
+            return 1
+
+        def mock_process_session(pid):
+            return 1
+
+        monkeypatch.setattr(backend, "list_windows", mock_list_windows)
+        monkeypatch.setattr(backend, "_get_console_session_id", mock_console_session)
+        monkeypatch.setattr(backend, "_get_process_session_id", mock_process_session)
+
+        result = backend._resolve_hwnds(app="myapp")
+        # Exact process name match (score 4) should come first
+        # Both myapp.exe windows should be included
+        assert len(result) == 2
+        assert result[0] in (2000, 3000)  # Both have score 4
+        assert result[1] in (2000, 3000)
+        # Title substring match (1000) should NOT be included (different process)
+
+    def test_resolve_hwnds_no_search_term_returns_empty(self, monkeypatch):
+        """_resolve_hwnds should return [] when no search term provided."""
+        backend = WindowsBackend()
+
+        def mock_list_windows():
+            return [
+                WindowInfo(
+                    handle=1000,
+                    title="Notepad",
+                    process_name="notepad.exe",
+                    pid=100,
+                    x=0, y=0, width=640, height=480,
+                    is_visible=True,
+                    is_minimized=False,
+                ),
+            ]
+
+        monkeypatch.setattr(backend, "list_windows", mock_list_windows)
+
+        # No app or window_title → empty list
+        result = backend._resolve_hwnds()
+        assert result == []


### PR DESCRIPTION
Previously, `naturo see --app feishu` only inspected one window. When an app has multiple windows (chat + video call + preview), it would pick one arbitrarily and ignore the rest.

**Root cause:** Issue #304 — _resolve_hwnd returns a single HWND. All --app commands operate on one window only.

**Solution:**
- Added `_resolve_hwnds()` backend method — returns ALL windows matching an app (sorted by match quality)
- `see --app` (without `--hwnd`) now enumerates all app windows and merges their UI trees
- Each window's tree is wrapped in a WindowGroup node with HWND annotation
- Element refs (eN) are globally unique across all windows

**Output format:**
```
[Application] "feishu"
  [WindowGroup] "飞书 - Main (HWND:1234)" window_1234
    [Pane] "ChatList" e1
    ...
  [WindowGroup] "飞书 - Video Call (HWND:5678)" window_5678
    [Pane] "CallControls" e50
    ...
```

**Tests:** 4 new unit tests for _resolve_hwnds (all-window enumeration, sorting, empty cases).

**Limitations:**
- Cascade mode not yet updated (still single-window) — future work
- Single-target commands (click/type) still use best-match window (future work)

Fixes #304