### PR TITLE
docs: fix release guide — use menu-inspect instead of menu (fixes #282)

### DIFF
--- a/.work/v0.3.0-release-guide.md
+++ b/.work/v0.3.0-release-guide.md
@@ -341,7 +341,7 @@ naturo tray list
 
 ### 2.14 Native Menu 枚举 (#158)
 ```bash
-naturo menu --app Notepad
+naturo menu-inspect --app Notepad
 # Expected: 正确显示 File/Edit/Format/View/Help 菜单结构
 ```
 
@@ -432,7 +432,7 @@ QA 必须在 Windows 桌面环境（有 GUI session）上逐项验证。
 - [ ] 2.11 desktop warning: (在非交互 session 中测试)
 - [ ] 2.12 PID 验证: `naturo app inspect --pid 0` 和 `--pid 99999`
 - [ ] 2.13 taskbar/tray: `naturo taskbar list` + `naturo tray list`
-- [ ] 2.14 menu: `naturo menu --app Notepad`
+- [ ] 2.14 menu: `naturo menu-inspect --app Notepad`
 - [ ] 2.15 zero-bounds fallback: (需特殊 app 触发)
 - [ ] 2.16 session-aware: (需 schtasks 场景)
 - [ ] 2.17 get ref: `naturo get e3 --app Notepad`


### PR DESCRIPTION
Release guide section 2.14 referenced `naturo menu`, but the actual command is `naturo menu-inspect` (`menu` was removed in command consolidation).

**Changes:**
- Updated line 344: `naturo menu --app` → `naturo menu-inspect --app`
- Updated line 435: checklist item now uses correct command

**Root cause:** Issue #282 — release guide was not updated after command rename.

Fixes #282