### PR TITLE
fix: find command fuzzy search now matches role, name, and value (fixes #281)

### DIFF
--- a/naturo/search.py
+++ b/naturo/search.py
@@ -167,11 +167,25 @@ def _search_recursive(
     current_path = path + [(el.role, el.name)]
 
     # Check match
-    role_match = _matches_role(el.role, role_filter) if role_filter else True
-    name_match = _matches_name(el.name, name_filter) if name_filter else True
+    # Issue #281: when role_filter is not specified but name_filter is,
+    # match against BOTH role and name (fuzzy search).
+    if role_filter:
+        role_match = _matches_role(el.role, role_filter)
+        name_match = _matches_name(el.name, name_filter) if name_filter else True
+        match_any = role_match and name_match
+    elif name_filter:
+        # Fuzzy all-fields search: match if name OR role OR value contains pattern
+        role_match_fuzzy = _matches_name(el.role, name_filter)
+        name_match_fuzzy = _matches_name(el.name, name_filter)
+        value_match_fuzzy = _matches_name(el.value, name_filter) if el.value else False
+        # At least one must match
+        match_any = role_match_fuzzy or name_match_fuzzy or value_match_fuzzy
+    else:
+        match_any = True
+
     actionable_match = (not actionable_only) or _is_actionable(el)
 
-    if role_match and name_match and actionable_match:
+    if match_any and actionable_match:
         # For "match all" queries (no filters), skip if both name and role empty
         if role_filter or name_filter or (el.name or el.role):
             results.append(SearchResult(element=el, breadcrumb=current_path))

--- a/tests/test_search_fuzzy_all_fields.py
+++ b/tests/test_search_fuzzy_all_fields.py
@@ -1,0 +1,163 @@
+"""Tests for fuzzy all-fields search (Issue #281)."""
+import pytest
+from naturo.search import search_elements
+from naturo.bridge import ElementInfo
+
+
+class TestFuzzyAllFieldsSearch:
+    """Verify that simple queries match role, name, and value."""
+
+    def test_simple_query_matches_role(self):
+        """Simple query should match elements by role (e.g., 'Button' finds Buttons)."""
+        tree = ElementInfo(
+            id="root",
+            role="Window",
+            name="Main",
+            value=None,
+            x=0, y=0, width=800, height=600,
+            children=[
+                ElementInfo(
+                    id="b1",
+                    role="Button",
+                    name="OK",
+                    value=None,
+                    x=10, y=10, width=80, height=30,
+                ),
+                ElementInfo(
+                    id="e1",
+                    role="Edit",
+                    name="Input",
+                    value="",
+                    x=10, y=50, width=200, height=25,
+                ),
+            ],
+        )
+
+        results = search_elements(tree, "Button")
+        assert len(results) == 1
+        assert results[0].element.id == "b1"
+
+    def test_simple_query_matches_name(self):
+        """Simple query should match elements by name."""
+        tree = ElementInfo(
+            id="root",
+            role="Window",
+            name="Main",
+            value=None,
+            x=0, y=0, width=800, height=600,
+            children=[
+                ElementInfo(
+                    id="b1",
+                    role="Button",
+                    name="Save",
+                    value=None,
+                    x=10, y=10, width=80, height=30,
+                ),
+                ElementInfo(
+                    id="b2",
+                    role="Button",
+                    name="Cancel",
+                    value=None,
+                    x=100, y=10, width=80, height=30,
+                ),
+            ],
+        )
+
+        results = search_elements(tree, "Save")
+        assert len(results) == 1
+        assert results[0].element.id == "b1"
+
+    def test_simple_query_matches_value(self):
+        """Simple query should match elements by value."""
+        tree = ElementInfo(
+            id="root",
+            role="Window",
+            name="Main",
+            value=None,
+            x=0, y=0, width=800, height=600,
+            children=[
+                ElementInfo(
+                    id="e1",
+                    role="Edit",
+                    name="Input",
+                    value="Hello World",
+                    x=10, y=10, width=200, height=25,
+                ),
+                ElementInfo(
+                    id="e2",
+                    role="Edit",
+                    name="Other",
+                    value="Foo Bar",
+                    x=10, y=40, width=200, height=25,
+                ),
+            ],
+        )
+
+        results = search_elements(tree, "Hello")
+        assert len(results) == 1
+        assert results[0].element.id == "e1"
+
+    def test_simple_query_matches_chinese_name(self):
+        """Simple query with Chinese characters should match names."""
+        tree = ElementInfo(
+            id="root",
+            role="Window",
+            name="主窗口",
+            value=None,
+            x=0, y=0, width=800, height=600,
+            children=[
+                ElementInfo(
+                    id="m1",
+                    role="MenuItem",
+                    name="编辑",
+                    value=None,
+                    x=10, y=10, width=60, height=20,
+                ),
+                ElementInfo(
+                    id="m2",
+                    role="MenuItem",
+                    name="文件",
+                    value=None,
+                    x=80, y=10, width=60, height=20,
+                ),
+            ],
+        )
+
+        results = search_elements(tree, "编辑")
+        assert len(results) == 1
+        assert results[0].element.id == "m1"
+
+    def test_role_prefix_overrides_fuzzy_search(self):
+        """role: prefix should only match role, not name/value."""
+        tree = ElementInfo(
+            id="root",
+            role="Window",
+            name="Main",
+            value=None,
+            x=0, y=0, width=800, height=600,
+            children=[
+                ElementInfo(
+                    id="b1",
+                    role="Button",
+                    name="Edit",  # "Edit" in name
+                    value=None,
+                    x=10, y=10, width=80, height=30,
+                ),
+                ElementInfo(
+                    id="e1",
+                    role="Edit",  # "Edit" is role
+                    name="Input",
+                    value="",
+                    x=10, y=50, width=200, height=25,
+                ),
+            ],
+        )
+
+        # Simple "Edit" should find both (fuzzy search)
+        results = search_elements(tree, "Edit")
+        assert len(results) == 2
+
+        # "role:Edit" should only find the Edit role element
+        results = search_elements(tree, "role:Edit")
+        assert len(results) == 1
+        assert results[0].element.id == "e1"


### PR DESCRIPTION
Previously, simple queries like `naturo find 'Button'` only searched element names, missing elements where 'Button' is the role (not the name). This was confusing for users, especially in non-English locales where role names differ from UI text.

**Root cause:** Issue #281 — find without --ai returns no results. Simple queries were name-only, ignoring role matches.

**Solution:**
- When no explicit `role:` prefix is used, fuzzy search now matches **any of**: role, name, value
- `naturo find 'Edit'` will find elements with role=Edit OR name containing 'Edit' OR value containing 'Edit'
- Explicit filters (`role:`, `name:`) still work as before (exact field match)

**Examples:**
- `naturo find 'Button'` → finds all Button role elements + any element with 'Button' in name/value
- `naturo find '编辑'` → finds Chinese MenuItem named '编辑'
- `naturo find 'role:Button'` → only finds Button role elements (strict)

**Tests:** 5 new tests for fuzzy all-fields search, Chinese locale, and explicit role filtering.

Fixes #281