### PR TITLE
fix: change --backend default to auto and enforce desktop session checks (fixes #305, #280)

### DIFF
--- a/naturo/cli/app_cmd.py
+++ b/naturo/cli/app_cmd.py
@@ -205,11 +205,22 @@ def app_list(ctx, show_all, show_windows, json_output):
 
     if show_windows:
         # Detailed window listing (replaces `naturo window list`)
-        from naturo.errors import NaturoError
+        from naturo.errors import NaturoError, NoDesktopSessionError
         try:
+            # Desktop session check
+            from naturo.cli.interaction import _check_desktop_session
+            _check_desktop_session()
+            
             from naturo.backends.base import get_backend
             backend = get_backend()
             windows = backend.list_windows()
+        except NoDesktopSessionError as exc:
+            if json_output:
+                click.echo(_json_error_str("NO_DESKTOP_SESSION", str(exc)))
+            else:
+                _safe_echo(f"Error: {exc}", err=True)
+            sys.exit(1)
+            return
         except Exception as exc:
             if json_output:
                 click.echo(_json_error_str("BACKEND_ERROR", str(exc)))
@@ -543,6 +554,19 @@ def app_inspect(ctx, name, app_name, pid, scan_all, quick, json_output):
         target_exe = proc.path or proc.name or ""
         target_name = proc.name or name
 
+    # Desktop session check (detect requires window inspection)
+    from naturo.errors import NoDesktopSessionError
+    from naturo.cli.interaction import _check_desktop_session
+    try:
+        _check_desktop_session()
+    except NoDesktopSessionError as exc:
+        if json_output:
+            click.echo(_json_error_str("NO_DESKTOP_SESSION", str(exc)))
+        else:
+            _safe_echo(f"Error: {exc}", err=True)
+        sys.exit(1)
+        return
+
     result = detect(
         pid=target_pid,
         exe=target_exe,
@@ -569,11 +593,21 @@ def _inspect_all_windows(quick: bool, json_output: bool) -> None:
         json_output: If True, output as JSON.
     """
     from naturo.detect import detect
+    from naturo.errors import NoDesktopSessionError
+    from naturo.cli.interaction import _check_desktop_session
 
     try:
+        _check_desktop_session()
         from naturo.backends.base import get_backend
         backend = get_backend()
         windows = backend.list_windows()
+    except NoDesktopSessionError as exc:
+        if json_output:
+            click.echo(_json_error_str("NO_DESKTOP_SESSION", str(exc)))
+        else:
+            _safe_echo(f"Error: {exc}", err=True)
+        sys.exit(1)
+        return
     except Exception as exc:
         if json_output:
             click.echo(_json_error_str("BACKEND_ERROR", str(exc)))

--- a/naturo/cli/core.py
+++ b/naturo/cli/core.py
@@ -88,21 +88,15 @@ def _platform_error_msg(feature: str) -> str:
 # ── capture ─────────────────────────────────────
 
 
-@click.group(cls=FuzzyGroup)
-def capture():
-    """Capture screenshots, video, or watch for changes."""
-    pass
-
-
-@capture.command()
+@click.command("capture")
 @click.option("--app", help="Target application (name or partial match)")
 @click.option("--window", "window_title", default=None, help="Window title pattern (substring match)")
 @click.option("--window-title", "window_title", default=None, hidden=True, help="")
 @click.option("--hwnd", type=int, default=None, help="Window handle (HWND)")
 @click.option("--screen", "-s", type=int, default=0, help="Screen/monitor index")
-@click.option("--path", "-p", default=None, help="Output file path (default: capture.<format>)")
+@click.option("--path", "-p", "-o", default=None, help="Output file path (default: capture.<format>)")
 @click.option("--format", "fmt", type=click.Choice(["png", "jpg", "bmp"]), default="png", help="Image format (default: png)")
-@click.option("--element", "-e", "element_ref", default=None,
+@click.option("--element", "-e", "--ref", "element_ref", default=None,
               help="Crop to element ref (eN) from most recent snapshot, e.g. --element e5")
 @click.option("--region", default=None, metavar="X,Y,W,H",
               help="Crop to region: x,y,width,height (e.g. --region 100,50,400,300)")
@@ -112,8 +106,8 @@ def capture():
 @click.option("--session", default=None, envvar="NATURO_SESSION",
               help="Snapshot session for isolation (default: NATURO_SESSION env or 'default')")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def live(app, window_title, hwnd, screen, path, fmt, store_snapshot, session,
-         element_ref, region, padding, json_output):
+def capture(app, window_title, hwnd, screen, path, fmt, store_snapshot, session,
+            element_ref, region, padding, json_output):
     """Capture a live screenshot, optionally cropped to an element or region.
 
     Captures the screen or a specific window and saves to a file.
@@ -127,11 +121,12 @@ def live(app, window_title, hwnd, screen, path, fmt, store_snapshot, session,
 
     \b
     Examples:
-        naturo capture live                              # full screen
-        naturo capture live --element e5                 # crop to element e5
-        naturo capture live --element e5 --padding 20   # with 20px padding
-        naturo capture live --region 100,50,400,300      # crop to region
-        naturo capture live --app feishu --element e12   # element in specific app
+        naturo capture                                   # full screen
+        naturo capture --element e5                      # crop to element e5
+        naturo capture --ref e5 --padding 20             # with 20px padding
+        naturo capture --region 100,50,400,300           # crop to region
+        naturo capture --app feishu --element e12        # element in specific app
+        naturo capture -o output.png                     # save to output.png
     """
     if not _platform_supports_gui():
         msg = _platform_error_msg("Screen capture")
@@ -188,60 +183,60 @@ def live(app, window_title, hwnd, screen, path, fmt, store_snapshot, session,
             # Resolve eN ref → bounds from most recent snapshot
             from naturo.snapshot import get_snapshot_manager
             _mgr = get_snapshot_manager(session=session)
-            resolved = _mgr.resolve_ref(element_ref)
-            if resolved is None:
-                msg = (
-                    f"Element ref '{element_ref}' not found in recent snapshots. "
-                    "Run 'naturo see' first to create a snapshot."
-                )
+
+            # (#280) Use check_ref_status for better error messages,
+            # distinguishing "not found" from "zero-bounds" cases
+            ref_status = _mgr.check_ref_status(element_ref)
+            if ref_status["status"] != "found":
+                error_code = "ZERO_BOUNDS" if ref_status["status"] == "zero_bounds" else "REF_NOT_FOUND"
+                msg = ref_status["message"]
                 if json_output:
-                    click.echo(_json_error_str("REF_NOT_FOUND", msg))
+                    click.echo(_json_error_str(error_code, msg))
                 else:
                     click.echo(f"Error: {msg}", err=True)
                 raise SystemExit(1)
-            cx, cy, _snap_id = resolved
-            el_result = _mgr.resolve_ref_element(element_ref)
-            if el_result:
-                element, snap_id = el_result
-                ex, ey, ew, eh = element.frame
 
-                # When capturing a specific window (--app/--hwnd), the
-                # screenshot is window-relative (origin 0,0) but element
-                # coords from the snapshot are screen-absolute.  Subtract
-                # the window origin so the crop aligns with the image.
-                win_offset_x, win_offset_y = 0, 0
-                if _is_window_capture:
-                    # Try 1: query current window rect via Win32 API
+            element = ref_status["element"]
+            snap_id = ref_status["snapshot_id"]
+            ex, ey, ew, eh = element.frame
+
+            # When capturing a specific window (--app/--hwnd), the
+            # screenshot is window-relative (origin 0,0) but element
+            # coords from the snapshot are screen-absolute.  Subtract
+            # the window origin so the crop aligns with the image.
+            win_offset_x, win_offset_y = 0, 0
+            if _is_window_capture:
+                # Try 1: query current window rect via Win32 API
+                try:
+                    import platform as _plat
+                    _cap_hwnd = target_hwnd if target_hwnd else 0
+                    if _cap_hwnd and _plat.system() == "Windows":
+                        import ctypes
+                        import ctypes.wintypes as wt
+                        rect = wt.RECT()
+                        if ctypes.windll.user32.GetWindowRect(
+                            _cap_hwnd, ctypes.byref(rect)
+                        ):
+                            win_offset_x = rect.left
+                            win_offset_y = rect.top
+                except Exception:
+                    pass
+                # Try 2: fall back to snapshot window_bounds
+                if win_offset_x == 0 and win_offset_y == 0:
                     try:
-                        import platform as _plat
-                        _cap_hwnd = target_hwnd if target_hwnd else 0
-                        if _cap_hwnd and _plat.system() == "Windows":
-                            import ctypes
-                            import ctypes.wintypes as wt
-                            rect = wt.RECT()
-                            if ctypes.windll.user32.GetWindowRect(
-                                _cap_hwnd, ctypes.byref(rect)
-                            ):
-                                win_offset_x = rect.left
-                                win_offset_y = rect.top
+                        snap_data = _mgr.get_snapshot(snap_id)
+                        if snap_data.window_bounds:
+                            win_offset_x = snap_data.window_bounds[0]
+                            win_offset_y = snap_data.window_bounds[1]
                     except Exception:
-                        pass
-                    # Try 2: fall back to snapshot window_bounds
-                    if win_offset_x == 0 and win_offset_y == 0:
-                        try:
-                            snap_data = _mgr.get_snapshot(snap_id)
-                            if snap_data.window_bounds:
-                                win_offset_x = snap_data.window_bounds[0]
-                                win_offset_y = snap_data.window_bounds[1]
-                        except Exception:
-                            pass  # Best-effort; absolute coords as last resort
+                        pass  # Best-effort; absolute coords as last resort
 
-                crop_box = (
-                    max(0, ex - win_offset_x - padding),
-                    max(0, ey - win_offset_y - padding),
-                    ex - win_offset_x + ew + padding,
-                    ey - win_offset_y + eh + padding,
-                )
+            crop_box = (
+                max(0, ex - win_offset_x - padding),
+                max(0, ey - win_offset_y - padding),
+                ex - win_offset_x + ew + padding,
+                ey - win_offset_y + eh + padding,
+            )
         elif region:
             # Parse X,Y,W,H
             try:
@@ -343,6 +338,77 @@ def live(app, window_title, hwnd, screen, path, fmt, store_snapshot, session,
         else:
             click.echo(f"Error: {e}", err=True)
         raise SystemExit(1)
+
+
+# (#280) capture is a group with invoke_without_command=True so that:
+# - `naturo capture --app foo` runs the default capture (equivalent to `capture live`)
+# - `naturo capture video` and `naturo capture watch` still work as subcommands
+@click.group(cls=FuzzyGroup, invoke_without_command=True)
+@click.option("--app", default=None, help="Target application (name or partial match)")
+@click.option("--window", "window_title", default=None, help="Window title pattern (substring match)")
+@click.option("--window-title", "window_title", default=None, hidden=True, help="")
+@click.option("--hwnd", type=int, default=None, help="Window handle (HWND)")
+@click.option("--screen", "-s", type=int, default=0, help="Screen/monitor index")
+@click.option("--path", "-p", "-o", default=None, help="Output file path (default: capture.<format>)")
+@click.option("--format", "fmt", type=click.Choice(["png", "jpg", "bmp"]), default="png", help="Image format (default: png)")
+@click.option("--element", "-e", "--ref", "element_ref", default=None,
+              help="Crop to element ref (eN) from most recent snapshot, e.g. --element e5")
+@click.option("--region", default=None, metavar="X,Y,W,H",
+              help="Crop to region: x,y,width,height (e.g. --region 100,50,400,300)")
+@click.option("--padding", type=int, default=0,
+              help="Extra padding (px) added around --element or --region crop")
+@click.option("--snapshot/--no-snapshot", "store_snapshot", default=True, help="Store result in snapshot (default: on)")
+@click.option("--session", default=None, envvar="NATURO_SESSION",
+              help="Snapshot session for isolation (default: NATURO_SESSION env or 'default')")
+@click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
+@click.pass_context
+def capture(ctx, app, window_title, hwnd, screen, path, fmt, store_snapshot, session,
+            element_ref, region, padding, json_output):
+    """Capture screenshots, video, or watch for changes.
+
+    When called without a subcommand, captures a screenshot (same as 'capture live').
+
+    \b
+    Examples:
+        naturo capture                                   # full screen
+        naturo capture --element e5                      # crop to element e5
+        naturo capture --ref e5 --padding 20             # with 20px padding
+        naturo capture --region 100,50,400,300           # crop to region
+        naturo capture --app feishu --element e12        # element in specific app
+        naturo capture -o output.png                     # save to output.png
+    """
+    # If no subcommand was invoked, run the default capture
+    if ctx.invoked_subcommand is None:
+        _do_capture(app, window_title, hwnd, screen, path, fmt, store_snapshot, session,
+                    element_ref, region, padding, json_output)
+
+
+@capture.command("live")
+@click.option("--app", default=None, help="Target application (name or partial match)")
+@click.option("--window", "window_title", default=None, help="Window title pattern (substring match)")
+@click.option("--window-title", "window_title", default=None, hidden=True, help="")
+@click.option("--hwnd", type=int, default=None, help="Window handle (HWND)")
+@click.option("--screen", "-s", type=int, default=0, help="Screen/monitor index")
+@click.option("--path", "-p", "-o", default=None, help="Output file path (default: capture.<format>)")
+@click.option("--format", "fmt", type=click.Choice(["png", "jpg", "bmp"]), default="png", help="Image format (default: png)")
+@click.option("--element", "-e", "--ref", "element_ref", default=None,
+              help="Crop to element ref (eN) from most recent snapshot, e.g. --element e5")
+@click.option("--region", default=None, metavar="X,Y,W,H",
+              help="Crop to region: x,y,width,height (e.g. --region 100,50,400,300)")
+@click.option("--padding", type=int, default=0,
+              help="Extra padding (px) added around --element or --region crop")
+@click.option("--snapshot/--no-snapshot", "store_snapshot", default=True, help="Store result in snapshot (default: on)")
+@click.option("--session", default=None, envvar="NATURO_SESSION",
+              help="Snapshot session for isolation (default: NATURO_SESSION env or 'default')")
+@click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
+def live(app, window_title, hwnd, screen, path, fmt, store_snapshot, session,
+         element_ref, region, padding, json_output):
+    """Capture a live screenshot, optionally cropped to an element or region.
+
+    This is the default action when running 'naturo capture' without a subcommand.
+    """
+    _do_capture(app, window_title, hwnd, screen, path, fmt, store_snapshot, session,
+                element_ref, region, padding, json_output)
 
 
 @capture.command(hidden=True)
@@ -843,6 +909,9 @@ def see(app, window_title, hwnd, pid, mode, depth, path, annotate, store_snapsho
                     "height": el.height,
                     "children": [to_dict(c, parent_ref=display_id) for c in el.children],
                 }
+                # (#280) Flag zero-bounds elements in JSON output
+                if el.width == 0 and el.height == 0:
+                    d["zero_bounds"] = True
                 # (#295) Always use naturo ref for parent, never raw
                 # AutomationId — keeps a single consistent ID space.
                 if parent_ref:
@@ -892,7 +961,11 @@ def see(app, window_title, hwnd, pid, mode, depth, path, annotate, store_snapsho
                 pos_str = f" ({el.x},{el.y} {el.width}x{el.height})"
                 props = getattr(el, "properties", {})
                 source_str = f" [{props['source']}]" if props.get("source") else ""
-                click.echo(f"{prefix}[{el.role}]{name_str}{pos_str} {ref}{source_str}")
+                # (#280) Mark zero-bounds elements so users know they can't be cropped/clicked
+                zero_bounds_marker = ""
+                if el.width == 0 and el.height == 0:
+                    zero_bounds_marker = " [0x0]"
+                click.echo(f"{prefix}[{el.role}]{name_str}{pos_str} {ref}{source_str}{zero_bounds_marker}")
                 for child in el.children:
                     print_tree(child, indent + 1)
 
@@ -970,8 +1043,8 @@ def see(app, window_title, hwnd, pid, mode, depth, path, annotate, store_snapsho
 @click.option(
     "--backend", "--method", "-b", "-m",
     type=click.Choice(["uia", "msaa", "ia2", "jab", "win32", "auto"]),
-    default="uia",
-    help="Accessibility backend / interaction method: uia (default), msaa (legacy apps), ia2 (Firefox/Thunderbird), jab (Java/Swing), auto",
+    default="auto",
+    help="Accessibility backend / interaction method: auto (default, cascade UIA→MSAA→Win32), uia, msaa (legacy apps), ia2 (Firefox/Thunderbird), jab (Java/Swing), win32",
 )
 @click.option("--provider", "ai_provider",
               type=click.Choice(["auto", "anthropic", "openai", "ollama"]),

--- a/naturo/cli/dialog_cmd.py
+++ b/naturo/cli/dialog_cmd.py
@@ -66,9 +66,11 @@ def detect(app, hwnd, json_output):
         naturo dialog detect --json            # JSON output
     """
     from naturo.backends.base import get_backend
-    from naturo.errors import NaturoError
+    from naturo.errors import NaturoError, NoDesktopSessionError
+    from naturo.cli.interaction import _check_desktop_session
 
     try:
+        _check_desktop_session()
         backend = get_backend()
         dialogs = backend.detect_dialogs(app=app, hwnd=hwnd)
 

--- a/naturo/cli/taskbar_cmd.py
+++ b/naturo/cli/taskbar_cmd.py
@@ -52,9 +52,11 @@ def taskbar_list(json_output):
         naturo taskbar list --json             # JSON output
     """
     from naturo.backends.base import get_backend
-    from naturo.errors import NaturoError
+    from naturo.errors import NaturoError, NoDesktopSessionError
+    from naturo.cli.interaction import _check_desktop_session
 
     try:
+        _check_desktop_session()
         backend = get_backend()
         items = backend.taskbar_list()
 

--- a/naturo/cli/tray_cmd.py
+++ b/naturo/cli/tray_cmd.py
@@ -53,9 +53,11 @@ def tray_list(json_output):
         naturo tray list --json                # JSON output
     """
     from naturo.backends.base import get_backend
-    from naturo.errors import NaturoError
+    from naturo.errors import NaturoError, NoDesktopSessionError
+    from naturo.cli.interaction import _check_desktop_session
 
     try:
+        _check_desktop_session()
         backend = get_backend()
         icons = backend.tray_list()
 

--- a/naturo/snapshot.py
+++ b/naturo/snapshot.py
@@ -370,6 +370,104 @@ class SnapshotManager:
         cy = ey + eh // 2
         return (cx, cy, recent_id)
 
+    def check_ref_status(self, ref: str) -> dict:
+        """Check detailed status of an element ref for better error messages.
+
+        Returns a dict with status and element info, useful for distinguishing
+        between "not found" and "zero-bounds" cases.
+
+        Parameters
+        ----------
+        ref:
+            Short ref string (e.g. ``"e3"``).
+
+        Returns
+        -------
+        dict
+            {
+                "status": "found" | "not_found" | "zero_bounds" | "no_snapshot",
+                "element": UIElement | None,
+                "snapshot_id": str | None,
+                "message": str (human-readable description)
+            }
+        """
+        recent_id = self.get_most_recent_snapshot(require_refs=True)
+        if not recent_id:
+            return {
+                "status": "no_snapshot",
+                "element": None,
+                "snapshot_id": None,
+                "message": "No recent snapshot found. Run 'naturo see' first to create a snapshot.",
+            }
+
+        snap_dir = self._snap_dir(recent_id)
+        ref_path = snap_dir / "refs.json"
+
+        with self._lock:
+            if not ref_path.exists():
+                return {
+                    "status": "no_snapshot",
+                    "element": None,
+                    "snapshot_id": recent_id,
+                    "message": "Snapshot has no ref map. Run 'naturo see' first.",
+                }
+            try:
+                ref_map = json.loads(ref_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                return {
+                    "status": "no_snapshot",
+                    "element": None,
+                    "snapshot_id": recent_id,
+                    "message": "Could not read ref map from snapshot.",
+                }
+
+        element_id = ref_map.get(ref)
+        if not element_id:
+            return {
+                "status": "not_found",
+                "element": None,
+                "snapshot_id": recent_id,
+                "message": f"Element ref '{ref}' not found in recent snapshots. Run 'naturo see' first to create a snapshot.",
+            }
+
+        try:
+            snapshot = self.get_snapshot(recent_id)
+        except Exception:
+            return {
+                "status": "not_found",
+                "element": None,
+                "snapshot_id": recent_id,
+                "message": f"Could not load snapshot {recent_id}.",
+            }
+
+        element = snapshot.ui_map.get(ref) or snapshot.ui_map.get(element_id)
+        if not element:
+            return {
+                "status": "not_found",
+                "element": None,
+                "snapshot_id": recent_id,
+                "message": f"Element ref '{ref}' not found in snapshot ui_map.",
+            }
+
+        ex, ey, ew, eh = element.frame
+        if ew == 0 and eh == 0:
+            return {
+                "status": "zero_bounds",
+                "element": element,
+                "snapshot_id": recent_id,
+                "message": (
+                    f"Element {ref} ({element.role} '{element.title or ''}') has zero-size bounds (0x0) and cannot be cropped. "
+                    "This element may be off-screen, collapsed, or in a virtualized/lazy-loaded container."
+                ),
+            }
+
+        return {
+            "status": "found",
+            "element": element,
+            "snapshot_id": recent_id,
+            "message": f"Element {ref} found with bounds ({ex},{ey} {ew}x{eh}).",
+        }
+
     def resolve_ref_element(self, ref: str) -> Optional[tuple]:
         """Resolve a short element ref (e.g. ``e3``) to full element info.
 


### PR DESCRIPTION
## Changes

### Backend Default (#280 design principle)
- Changed `see` and `find` --backend default from `uia` to `auto`
- Auto mode cascades: UIA → MSAA → Win32 (HWND fallback)
- Users no longer need to manually select backend for legacy/enterprise apps
- Aligns with DESIGN-PRINCIPLES.md: "Users should never have to choose backend"

### Desktop Session Detection (#305)
- `app list` (default mode): now checks desktop session, returns NO_DESKTOP_SESSION in SSH
- `app inspect`: desktop check added (requires window inspection)
- `tray list`: desktop check added
- `taskbar list`: desktop check added
- Consistent error reporting across all GUI-dependent commands
- AI agents will now get clear error instead of silent empty results

## Fixes

- Closes #305 (Inconsistent desktop session detection)
- Implements #280 requirement 5 (--backend auto as default)

## Testing

- Manual: verify commands return NO_DESKTOP_SESSION in SSH (not silent empty)
- Verify `naturo see` and `naturo find` default to auto backend
