### PR TITLE
fix: remove misleading SSH-safe claim from find help text (fixes #332)

### DIFF
--- a/naturo/cli/core.py
+++ b/naturo/cli/core.py
@@ -981,7 +981,7 @@ def find_cmd(query, query_opt, find_all, role, actionable, depth, limit, ai,
         naturo find "Save"                      # fuzzy name search
         naturo find "Button:Save"               # role + name
         naturo find "role:Edit"                  # by role only
-        naturo find --all --actionable           # all actionable elements (SSH-safe)
+        naturo find --all --actionable           # all actionable elements
         naturo find --all --role Button          # all buttons
         naturo find "the save button" --ai       # AI vision search
         naturo find "Save" --app "Notepad"              # search in specific app

--- a/tests/test_find_query_option.py
+++ b/tests/test_find_query_option.py
@@ -103,7 +103,7 @@ class TestFindAllFlag:
         mock_backend.get_element_tree.assert_called()
 
     def test_all_with_actionable(self, runner, mock_backend):
-        """--all --actionable finds all actionable elements (SSH-safe wildcard)."""
+        """--all --actionable finds all actionable elements (wildcard)."""
         result = runner.invoke(find_cmd, ["--all", "--actionable", "--json"])
         assert "Missing argument" not in (result.output or "")
         mock_backend.get_element_tree.assert_called()


### PR DESCRIPTION
## Problem
`naturo find --all --actionable` help text claims `(SSH-safe)` but the command requires a desktop session (UIA) and returns `NO_DESKTOP_SESSION` over SSH.

## Fix
Remove the misleading `(SSH-safe)` annotation from help text. The command requires a desktop session, so the claim was incorrect.

## Changes
- `naturo/cli/core.py`: Remove `(SSH-safe)` from find command help examples
- `tests/test_find_query_option.py`: Update test docstring accordingly

Fixes #332