### PR TITLE
fix: add missing properties arg to app_root merge node (fixes #338)

### DIFF
--- a/naturo/cli/core.py
+++ b/naturo/cli/core.py
@@ -677,6 +677,7 @@ def see(app, window_title, hwnd, pid, mode, depth, path, annotate, store_snapsho
                     value=None,
                     x=0, y=0, width=0, height=0,
                     children=[],
+                    properties={},
                 )
                 for h, subtree in window_trees:
                     # Wrap each window tree with a "Window" group node


### PR DESCRIPTION
## Problem
QA-Mariana reported that the previous fix (commit 2081820) for #338 was incomplete. The `window_node` got `properties={}` but the virtual root `tree` node at line 673 was still missing it, causing `see --app notepad --backend uia --json` to crash with `TypeError: ElementInfo.__init__() missing 1 required positional argument: 'properties'` when multiple windows exist.

## Fix
Add `properties={}` to the `app_root` BaseElementInfo constructor at line 673.

## Tests
All 1776 tests pass, 502 skipped.