### PR TITLE
fix: add desktop skip guard to 162 desktop-dependent tests (fixes #341)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,57 @@
-import pytest
+from __future__ import annotations
+
 import platform
+from typing import Optional
+
+import pytest
 
 
 def pytest_configure(config):
     """Register custom markers."""
     pass  # markers defined in pyproject.toml
+
+
+def _has_desktop_session() -> bool:
+    """Check if an interactive desktop session is available.
+
+    On Windows, calls GetDesktopWindow() via user32. Returns False when
+    running headless (e.g. via SSH without an attached console session).
+    Always returns False on non-Windows platforms.
+    """
+    if platform.system() != "Windows":
+        return False
+    try:
+        import ctypes
+
+        user32 = ctypes.WinDLL("user32", use_last_error=True)
+        desktop = user32.GetDesktopWindow()
+        return desktop != 0
+    except Exception:
+        return False
+
+
+# Cache the result once per session to avoid repeated FFI calls.
+_DESKTOP_AVAILABLE: Optional[bool] = None
+
+
+def _check_desktop() -> bool:
+    """Return cached desktop session availability."""
+    global _DESKTOP_AVAILABLE
+    if _DESKTOP_AVAILABLE is None:
+        _DESKTOP_AVAILABLE = _has_desktop_session()
+    return _DESKTOP_AVAILABLE
+
+
+@pytest.fixture(autouse=True)
+def _skip_desktop_tests(request: pytest.FixtureRequest):
+    """Auto-skip tests marked ``@pytest.mark.desktop`` when no desktop session.
+
+    This covers the gap where tests guard on ``platform.system() == 'Windows'``
+    but still fail when run via SSH (Windows, but no interactive desktop).
+    """
+    if request.node.get_closest_marker("desktop") is not None:
+        if not _check_desktop():
+            pytest.skip("No interactive desktop session available")
 
 
 def cli_stdout(result):

--- a/tests/test_cli_phase2.py
+++ b/tests/test_cli_phase2.py
@@ -406,6 +406,7 @@ class TestKeyHotkeyParsing:
 
 
 @pytest.mark.ui
+@pytest.mark.desktop
 @pytest.mark.skipif(
     platform.system() != "Windows",
     reason="Functional input tests require Windows with desktop session",
@@ -502,6 +503,7 @@ class TestPhase2FunctionalWindows:
 
 @pytest.mark.ui
 @pytest.mark.e2e
+@pytest.mark.desktop
 @pytest.mark.skipif(
     platform.system() != "Windows",
     reason="E2E tests require Windows with desktop session",

--- a/tests/test_e2e_notepad.py
+++ b/tests/test_e2e_notepad.py
@@ -18,6 +18,7 @@ import pytest
 pytestmark = [
     pytest.mark.ui,
     pytest.mark.e2e,
+    pytest.mark.desktop,
     pytest.mark.skipif(
         platform.system() != "Windows",
         reason="End-to-end tests require Windows with desktop session",

--- a/tests/test_input_keyboard.py
+++ b/tests/test_input_keyboard.py
@@ -334,6 +334,7 @@ class TestHotkeyParsing:
 
 
 @pytest.mark.ui
+@pytest.mark.desktop
 @pytest.mark.skipif(
     platform.system() != "Windows",
     reason="Keyboard functional tests require Windows with desktop session",

--- a/tests/test_input_mouse.py
+++ b/tests/test_input_mouse.py
@@ -411,6 +411,7 @@ class TestClickButtonMapping:
 
 
 @pytest.mark.ui
+@pytest.mark.desktop
 @pytest.mark.skipif(
     platform.system() != "Windows",
     reason="Mouse functional tests require Windows with desktop session",

--- a/tests/test_phase2_comprehensive.py
+++ b/tests/test_phase2_comprehensive.py
@@ -596,6 +596,7 @@ class TestProductUX:
 
 
 @pytest.mark.ui
+@pytest.mark.desktop
 @pytest.mark.skipif(
     platform.system() != "Windows",
     reason="Functional input tests require Windows with desktop session",
@@ -649,6 +650,7 @@ class TestMouseInputFunctional:
 
 
 @pytest.mark.ui
+@pytest.mark.desktop
 @pytest.mark.skipif(
     platform.system() != "Windows",
     reason="Functional input tests require Windows with desktop session",
@@ -713,6 +715,7 @@ class TestKeyboardInputFunctional:
 
 
 @pytest.mark.ui
+@pytest.mark.desktop
 @pytest.mark.skipif(
     platform.system() != "Windows",
     reason="Performance tests require Windows with desktop session",
@@ -752,11 +755,11 @@ class TestPerformanceFunctional:
 
 @pytest.mark.ui
 @pytest.mark.e2e
+@pytest.mark.desktop
 @pytest.mark.skipif(
     platform.system() != "Windows",
     reason="E2E tests require Windows with desktop session",
 )
-@pytest.mark.ui
 class TestE2EWorkflows:
     """Windows-only E2E workflow tests (R-PD-005, R-PD-006).
 
@@ -827,6 +830,7 @@ class TestElementInspectionMethods:
 
 
 @pytest.mark.ui
+@pytest.mark.desktop
 @pytest.mark.skipif(
     platform.system() != "Windows",
     reason="Element inspection tests require Windows",

--- a/tests/test_phys_input.py
+++ b/tests/test_phys_input.py
@@ -419,6 +419,7 @@ class TestScanCodeCoverage:
 
 
 @pytest.mark.ui
+@pytest.mark.desktop
 @pytest.mark.skipif(not IS_WINDOWS, reason="Windows-only integration test")
 class TestPhysIntegrationWindows:
     """Integration tests that require Windows + naturo_core.dll."""


### PR DESCRIPTION
## Summary
Add `@pytest.mark.desktop` marker and autouse skip fixture for tests that require an interactive desktop session.

## Problem
162 tests fail when run via SSH on the compile machine because they need a desktop session (mouse/keyboard/phys input) but only guard on `platform.system() == 'Windows'`. SSH connections are Windows but headless.

## Solution
1. **`tests/conftest.py`**: Add `_has_desktop_session()` check (uses `GetDesktopWindow()` via ctypes) and autouse fixture that auto-skips `desktop`-marked tests when no desktop is detected.
2. **10 test classes + 1 module**: Add `@pytest.mark.desktop` marker to all desktop-dependent test classes across 6 test files.

## Files Changed
- `tests/conftest.py` — new autouse fixture
- `tests/test_input_mouse.py` — TestMouseFunctionalWindows
- `tests/test_input_keyboard.py` — TestKeyboardFunctionalWindows
- `tests/test_phase2_comprehensive.py` — 5 classes
- `tests/test_phys_input.py` — TestPhysIntegrationWindows
- `tests/test_cli_phase2.py` — 2 classes
- `tests/test_e2e_notepad.py` — module-level pytestmark

## Testing
- `pytest tests/ -x -q`: 1774 passed, 482 skipped ✅
- CI unaffected (already excludes `desktop` marker)
- Desktop-marked tests correctly skip when no desktop available

Fixes #341