### PR TITLE
fix: add desktop skip guard to 5 residual tests (fixes #343)

### DIFF
--- a/tests/test_app_control.py
+++ b/tests/test_app_control.py
@@ -420,6 +420,7 @@ def _window_management_implemented():
     platform.system() != "Windows" or not _window_management_implemented(),
     reason="E2E app control tests require Windows with implemented window management methods",
 )
+@pytest.mark.desktop
 @pytest.mark.skipif(
     os.environ.get("CI") == "true" or os.environ.get("GITHUB_ACTIONS") == "true",
     reason="Requires interactive desktop session (not available in CI)",

--- a/tests/test_cli_phase1.py
+++ b/tests/test_cli_phase1.py
@@ -55,6 +55,7 @@ def test_see_has_depth_option(runner):
 
 
 @pytest.mark.ui
+@pytest.mark.desktop
 @pytest.mark.skipif(
     platform.system() != "Windows",
     reason="Functional CLI tests require Windows",


### PR DESCRIPTION
## Summary
Adds `@pytest.mark.desktop` to two test classes that were missed in #341:

- `TestCLIFunctionalWindows` in `test_cli_phase1.py` — had `@pytest.mark.ui` but not `desktop`
- `TestAppLifecycleE2EWindows` in `test_app_control.py` — relied on CI env vars instead of conftest auto-skip

These 5 tests fail in SSH sessions without an interactive desktop. The `desktop` marker ensures conftest handles the skip consistently.

Fixes #343