### PR TITLE
fix: add highlight to desktop skip set and fix notepad_app UWP PID resolution (fixes #345, fixes #346)

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -93,18 +93,28 @@ def notepad_app(has_desktop) -> Generator[int, None, None]:
     if proc is None:
         pytest.skip("Could not launch Notepad")
 
-    pid = proc.pid
-    yield pid
+    # Windows 11 UWP Notepad: launcher PID differs from the actual Notepad process.
+    # Look up the real process the same way calculator_app handles UWP apps.
+    time.sleep(1)
+    actual_pid = _find_process_by_name("Notepad.exe")
+    if actual_pid is None:
+        actual_pid = proc.pid
 
-    # Teardown: kill Notepad
+    yield actual_pid
+
+    # Teardown: kill Notepad (by image name for UWP, fallback to proc handle)
+    try:
+        subprocess.run(
+            ["taskkill", "/F", "/IM", "Notepad.exe"],
+            capture_output=True,
+            timeout=5,
+        )
+    except Exception:
+        pass
     try:
         proc.terminate()
-        proc.wait(timeout=5)
     except Exception:
-        try:
-            proc.kill()
-        except Exception:
-            pass
+        pass
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_cli_consistency.py
+++ b/tests/test_cli_consistency.py
@@ -40,6 +40,7 @@ _DESKTOP_REQUIRED_COMMANDS = {
     ("taskbar",),
     ("menu-inspect",),
     ("dialog",),
+    ("highlight",),
     ("list", "apps"),
     ("list", "screens"),
 }


### PR DESCRIPTION
## Changes

### #345 — highlight GDI blocking timeout
- Added `("highlight",)` to `_DESKTOP_REQUIRED_COMMANDS` in `test_cli_consistency.py`
- The `highlight` command calls `gdi32.Rectangle` which blocks indefinitely in non-interactive desktop sessions
- This was causing `test_no_visible_command_prints_not_implemented` to time out at 30s

### #346 — notepad_app fixture returns wrong PID
- Windows 11 UWP Notepad: the launcher PID is a stub, not the actual Notepad process
- Fixed `notepad_app` fixture to use `_find_process_by_name('Notepad.exe')` after launch (same pattern as `calculator_app`)
- Updated teardown to use `taskkill /F /IM Notepad.exe` for reliable UWP cleanup

### CI note
The latest CI run (23574514462) had Windows DLL tests cancelled — likely the standard GitHub Actions desktop session flake, not related to these changes. All other platforms passed.