### PR TITLE
fix: use WTS API for desktop detection in tests (fixes #348)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,18 +14,63 @@ def pytest_configure(config):
 def _has_desktop_session() -> bool:
     """Check if an interactive desktop session is available.
 
-    On Windows, calls GetDesktopWindow() via user32. Returns False when
-    running headless (e.g. via SSH without an attached console session).
+    On Windows, queries the WTS (Windows Terminal Services) API to determine
+    whether the current process runs in an active Console or RDP session.
+    This correctly returns False for SSH sessions, unlike the old
+    ``GetDesktopWindow()`` approach which returned True for any session type.
+
+    Uses the same detection logic as ``naturo.cli.interaction._is_current_session_interactive()``.
+
     Always returns False on non-Windows platforms.
     """
     if platform.system() != "Windows":
         return False
     try:
         import ctypes
+        import ctypes.wintypes
 
-        user32 = ctypes.WinDLL("user32", use_last_error=True)
-        desktop = user32.GetDesktopWindow()
-        return desktop != 0
+        # Get the session ID for the current process.
+        pid = ctypes.windll.kernel32.GetCurrentProcessId()
+        session_id = ctypes.wintypes.DWORD(0)
+        ok = ctypes.windll.kernel32.ProcessIdToSessionId(
+            pid, ctypes.byref(session_id),
+        )
+        if not ok:
+            return False
+        sid = session_id.value
+
+        # Session 0 is always the non-interactive services session.
+        if sid == 0:
+            return False
+
+        # Query WTS connect state via pure ctypes.
+        WTS_CURRENT_SERVER_HANDLE = 0
+        WTSConnectState = 8  # WTS_INFO_CLASS enum value
+        WTSActive = 0
+        WTSConnected = 1
+
+        wtsapi32 = ctypes.windll.wtsapi32
+        buf = ctypes.wintypes.LPWSTR()
+        bytes_returned = ctypes.wintypes.DWORD(0)
+
+        ok = wtsapi32.WTSQuerySessionInformationW(
+            WTS_CURRENT_SERVER_HANDLE,
+            sid,
+            WTSConnectState,
+            ctypes.byref(buf),
+            ctypes.byref(bytes_returned),
+        )
+        if not ok:
+            return False
+
+        try:
+            state = ctypes.cast(
+                buf, ctypes.POINTER(ctypes.wintypes.DWORD),
+            ).contents.value
+        finally:
+            wtsapi32.WTSFreeMemory(buf)
+
+        return state in (WTSActive, WTSConnected)
     except Exception:
         return False
 


### PR DESCRIPTION
## Problem
`_has_desktop_session()` in `tests/conftest.py` used `GetDesktopWindow()` to detect desktop availability. This function returns a non-zero handle even in SSH sessions, causing 89 `@pytest.mark.desktop` tests to fail with COM/assertion errors instead of being skipped.

## Fix
Replace `GetDesktopWindow()` with `WTSQuerySessionInformationW` — the same WTS API approach already proven in `naturo/cli/interaction.py`. This queries the actual session connect state (Active/Connected vs Disconnected/Listen), correctly identifying SSH sessions as non-interactive.

## Testing
- All 1774 tests pass, 504 skipped on macOS (desktop tests correctly skip on non-Windows)
- The WTS detection will correctly skip desktop tests when run via SSH on the compile machine

Fixes #348