### PR TITLE
fix: add role alias fallback for get command (fixes #352)

### DIFF
--- a/naturo/backends/windows.py
+++ b/naturo/backends/windows.py
@@ -1685,6 +1685,29 @@ class WindowsBackend(Backend):
             name=resolved_name,
         )
 
+        # (#352) Role alias fallback: when an explicit role search fails,
+        # try common aliases.  Win11 Notepad uses "Document" for its text
+        # editor, but users naturally try "Edit".  This maps between roles
+        # that serve similar purposes in different app frameworks.
+        if result is None and resolved_role and not resolved_aid:
+            _ROLE_ALIASES: dict[str, list[str]] = {
+                "Edit": ["Document", "RichEdit20W"],
+                "Document": ["Edit", "RichEdit20W"],
+                "RichEdit20W": ["Edit", "Document"],
+                "Text": ["StaticText"],
+                "StaticText": ["Text"],
+            }
+            aliases = _ROLE_ALIASES.get(resolved_role, [])
+            for alias_role in aliases:
+                result = core.get_element_value(
+                    hwnd=target_hwnd,
+                    automation_id=resolved_aid,
+                    role=alias_role,
+                    name=resolved_name,
+                )
+                if result is not None:
+                    break
+
         # (#229) Fallback: if UIA lookup returned None but we have snapshot
         # data from the ref, return the snapshot metadata so the caller gets
         # at least role/name/bounds instead of ELEMENT_NOT_FOUND.

--- a/naturo/cli/get_cmd.py
+++ b/naturo/cli/get_cmd.py
@@ -122,10 +122,19 @@ def get_cmd(ctx, target, ref, automation_id, role, name, prop, app,
                 msg += f" (ref={ref})"
             if automation_id:
                 msg += f" (automation_id={automation_id})"
+            if role:
+                msg += f" (role={role})"
+            suggested = (
+                "Run 'naturo see' to inspect available elements and their "
+                "actual roles.  Note: some apps use different role names "
+                "than expected (e.g. Notepad uses 'Document' instead of "
+                "'Edit' for its text area)."
+            )
             emit_error(
                 "ELEMENT_NOT_FOUND",
                 msg,
                 json_output,
+                suggested_action=suggested,
             )
 
         if json_output:

--- a/tests/test_get_cmd.py
+++ b/tests/test_get_cmd.py
@@ -435,3 +435,80 @@ class TestGetElementValueBridge:
 
         with pytest.raises(NaturoCoreError):
             core.get_element_value(hwnd=0, automation_id="test")
+
+
+class TestRoleAliasFallback:
+    """Tests for role alias fallback in get_element_value (#352)."""
+
+    def test_edit_falls_back_to_document(self):
+        """When role='Edit' fails, should try 'Document' as alias (#352).
+
+        Win11 Notepad's text editor uses role 'Document', not 'Edit'.
+        """
+        from unittest.mock import patch, MagicMock, call
+
+        mock_core = MagicMock()
+        # First call with role='Edit' returns None (not found)
+        # Second call with role='Document' returns a result
+        mock_core.get_element_value.side_effect = [
+            None,  # role='Edit' → not found
+            {"value": "Hello", "role": "Document", "name": "Text Editor",
+             "pattern": "TextPattern", "automation_id": "", "x": 0, "y": 0,
+             "width": 800, "height": 600},  # role='Document' → found
+        ]
+
+        from naturo.backends.windows import WindowsBackend
+        backend = WindowsBackend.__new__(WindowsBackend)
+        backend._core = mock_core
+
+        with patch.object(backend, '_ensure_core', return_value=mock_core):
+            result = backend.get_element_value(role="Edit", hwnd=12345)
+
+        assert result is not None
+        assert result["role"] == "Document"
+        assert result["value"] == "Hello"
+        # Should have been called twice: once with Edit, once with Document
+        assert mock_core.get_element_value.call_count == 2
+
+    def test_no_fallback_when_first_role_succeeds(self):
+        """When the initial role lookup succeeds, no alias fallback needed."""
+        from unittest.mock import patch, MagicMock
+
+        mock_core = MagicMock()
+        mock_core.get_element_value.return_value = {
+            "value": "Hello", "role": "Edit", "name": "Search",
+            "pattern": "ValuePattern", "automation_id": "txtSearch",
+            "x": 0, "y": 0, "width": 200, "height": 30,
+        }
+
+        from naturo.backends.windows import WindowsBackend
+        backend = WindowsBackend.__new__(WindowsBackend)
+        backend._core = mock_core
+
+        with patch.object(backend, '_ensure_core', return_value=mock_core):
+            result = backend.get_element_value(role="Edit", hwnd=12345)
+
+        assert result is not None
+        assert result["role"] == "Edit"
+        # Only called once — no fallback needed
+        assert mock_core.get_element_value.call_count == 1
+
+    def test_no_alias_fallback_with_automation_id(self):
+        """Role alias fallback should not trigger when automation_id is set."""
+        from unittest.mock import patch, MagicMock
+
+        mock_core = MagicMock()
+        mock_core.get_element_value.return_value = None  # Not found
+
+        from naturo.backends.windows import WindowsBackend
+        backend = WindowsBackend.__new__(WindowsBackend)
+        backend._core = mock_core
+
+        with patch.object(backend, '_ensure_core', return_value=mock_core):
+            result = backend.get_element_value(
+                role="Edit", automation_id="txtMissing", hwnd=12345,
+            )
+
+        assert result is None
+        # Only one call — no alias fallback because automation_id is set
+        assert mock_core.get_element_value.call_count == 1


### PR DESCRIPTION
## Summary

Fixes #352 — `get --role Edit` now works for Win11 Notepad even though its text area uses the `Document` UIA role.

### Changes

**Role alias fallback** in `WindowsBackend.get_element_value()`:
- When an explicit role search fails and no automation_id is set, tries common role aliases before returning None
- Alias mappings: Edit ↔ Document ↔ RichEdit20W (text editors), Text ↔ StaticText (labels)

**Improved error message** in `get` CLI:
- ELEMENT_NOT_FOUND now includes the role in the message
- Suggests running `naturo see` to inspect actual element roles
- Notes that some apps use different role names than expected

### Tests
- 3 new tests for role alias fallback behavior
- All 1777 tests passing