### PR TITLE
fix: v0.3.0 batch fixes (#360, #364, #369, #375, #376, #378, #380, #381)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ npx naturo mcp start
 naturo --version
 
 # Capture a screenshot
-naturo capture live --path screen.png
+naturo capture -o screen.png
 
 # List open windows
 naturo list windows
@@ -200,7 +200,7 @@ naturo type --paste --file data.txt        # Read file → paste
 
 ## Snapshot System
 
-Every `see` and `capture live` call automatically persists a **snapshot** — a
+Every `see` and `capture` call automatically persists a **snapshot** — a
 directory under `~/.naturo/snapshots/` containing the screenshot and full UI
 element map.
 

--- a/naturo/bridge.py
+++ b/naturo/bridge.py
@@ -477,6 +477,149 @@ def enumerate_child_windows(hwnd: int, depth: int = 10) -> Optional[ElementInfo]
     return root
 
 
+def highlight_elements_uia(
+    backend,
+    app: Optional[str] = None,
+    hwnd: int = 0,
+    depth: int = 30,
+    duration: float = 5.0,
+    refs: Optional[list] = None,
+) -> None:
+    """Highlight UI elements using the UIA element tree from snapshot/see.
+
+    Refs match those assigned by ``naturo see`` (sequential DFS e1, e2, ...).
+    Falls back to capturing a fresh element tree if no recent snapshot exists.
+
+    Args:
+        backend: The platform backend instance.
+        app: Application name filter.
+        hwnd: Parent window handle.
+        depth: Max depth for element tree.
+        duration: How long to show highlights (seconds).
+        refs: Optional list of specific refs to highlight (e.g. ['e5', 'e10']).
+              If None, highlights all elements.
+    """
+    import platform
+    import time
+
+    if platform.system() != "Windows":
+        return
+
+    import ctypes
+    from ctypes import wintypes
+
+    # Try to get elements from most recent snapshot first
+    elements = []  # list of (ref, name, role, x, y, w, h)
+
+    from naturo.snapshot import get_snapshot_manager
+    mgr = get_snapshot_manager()
+
+    # Check if there's a recent snapshot with elements
+    _found_snapshot = False
+    try:
+        snaps = mgr.list_snapshots()
+        if snaps:
+            latest = snaps[-1]
+            snap = mgr.get_snapshot(latest.id)
+            if snap.ui_map:
+                _found_snapshot = True
+                for ref_key, el in snap.ui_map.items():
+                    if refs is not None and ref_key not in refs:
+                        continue
+                    ex, ey, ew, eh = el.frame
+                    if ew <= 0 or eh <= 0:
+                        continue
+                    label = el.title or el.role
+                    if len(label) > 20:
+                        label = label[:18] + ".."
+                    elements.append((ref_key, label, el.role, ex, ey, ew, eh))
+    except Exception:
+        pass
+
+    # If no recent snapshot, capture a fresh element tree
+    if not _found_snapshot:
+        try:
+            tree = backend.get_element_tree(
+                app=app, hwnd=hwnd, depth=depth, backend="uia",
+            )
+            if tree:
+                counter = [0]
+
+                def _collect_uia(el):
+                    counter[0] += 1
+                    ref = f"e{counter[0]}"
+                    if el.width > 0 and el.height > 0:
+                        if refs is None or ref in refs:
+                            label = el.name or el.role
+                            if len(label) > 20:
+                                label = label[:18] + ".."
+                            elements.append((ref, label, el.role, el.x, el.y, el.width, el.height))
+                    for child in el.children:
+                        _collect_uia(child)
+
+                _collect_uia(tree)
+        except Exception:
+            pass
+
+    if not elements:
+        return
+
+    # Draw highlights using GDI (same rendering as highlight_elements)
+    user32 = ctypes.windll.user32
+    gdi32 = ctypes.windll.gdi32
+
+    COLORS = [
+        0x0000FF,  # Red
+        0x00FF00,  # Green
+        0xFF0000,  # Blue
+        0x00FFFF,  # Yellow
+        0xFF00FF,  # Magenta
+        0xFFFF00,  # Cyan
+    ]
+
+    hdc = user32.GetDC(None)
+    font = gdi32.CreateFontW(
+        14, 0, 0, 0, 700, 0, 0, 0, 0, 0, 0, 0, 0, "Consolas"
+    )
+
+    try:
+        for flash in range(3):
+            for i, (ref, label, role, ex, ey, ew, eh) in enumerate(elements):
+                color = COLORS[i % len(COLORS)]
+                pen = gdi32.CreatePen(0, 2, color)
+                old_pen = gdi32.SelectObject(hdc, pen)
+                old_brush = gdi32.SelectObject(hdc, gdi32.GetStockObject(5))
+
+                gdi32.Rectangle(hdc, ex, ey, ex + ew, ey + eh)
+
+                gdi32.SelectObject(hdc, old_brush)
+                label_text = f" {ref}: {label} "
+
+                gdi32.SetBkColor(hdc, color)
+                gdi32.SetTextColor(hdc, 0xFFFFFF)
+                old_font = gdi32.SelectObject(hdc, font)
+
+                text_buf = ctypes.create_unicode_buffer(label_text)
+                gdi32.TextOutW(hdc, ex + 1, ey + 1, text_buf, len(label_text))
+
+                gdi32.SelectObject(hdc, old_font)
+                gdi32.SelectObject(hdc, old_pen)
+                gdi32.DeleteObject(pen)
+
+            time.sleep(0.8)
+
+            for _, _, _, ex, ey, ew, eh in elements:
+                r = wintypes.RECT(ex - 3, ey - 3, ex + ew + 3, ey + eh + 3)
+                user32.InvalidateRect(None, ctypes.byref(r), True)
+            user32.UpdateWindow(user32.GetDesktopWindow())
+
+            time.sleep(0.4)
+    finally:
+        gdi32.DeleteObject(font)
+        user32.ReleaseDC(None, hdc)
+        user32.InvalidateRect(None, None, True)
+
+
 class NaturoCoreError(Exception):
     """Error raised when a naturo_core function fails.
 

--- a/naturo/cli/app_cmd.py
+++ b/naturo/cli/app_cmd.py
@@ -57,7 +57,8 @@ def _safe_echo(text: str, **kwargs) -> None:
 
 
 @click.command("launch")
-@click.argument("name")
+@click.argument("name", required=False, default=None)
+@click.option("--app", "app_name", default=None, help="Application name (alternative to positional NAME)")
 @click.option("--path", help="Explicit executable path")
 @click.option("--wait-until-ready", is_flag=True, help="Wait for app to create a window")
 @click.option("--timeout", type=float, default=30.0, help="Timeout for wait-until-ready")
@@ -65,9 +66,19 @@ def _safe_echo(text: str, **kwargs) -> None:
 @click.option("--args", multiple=True, help="Arguments to pass to the application")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def app_launch(ctx, name, path, wait_until_ready, timeout, no_focus, args, json_output):
+def app_launch(ctx, name, app_name, path, wait_until_ready, timeout, no_focus, args, json_output):
     """Launch an application by name or path."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
+    if not name and app_name:
+        name = app_name
+    if not name and not path:
+        msg = "Specify application name or --path"
+        if json_output:
+            click.echo(_json_error_str("INVALID_INPUT", msg))
+        else:
+            click.echo(f"Error: {msg}", err=True)
+        sys.exit(1)
+        return
 
     from naturo.process import launch_app
     from naturo.errors import NaturoError
@@ -105,12 +116,13 @@ def app_launch(ctx, name, path, wait_until_ready, timeout, no_focus, args, json_
 @click.command("quit")
 @click.argument("name", required=False, default=None)
 @click.option("--name", "name_option", hidden=True, help="Application name (deprecated, use positional)")
+@click.option("--app", "app_name", default=None, help="Application name (alternative to positional NAME)")
 @click.option("--pid", type=int, help="Process ID")
 @click.option("--force", is_flag=True, help="Force kill immediately")
 @click.option("--timeout", type=float, default=10.0, help="Graceful shutdown timeout")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def app_quit(ctx, name, name_option, pid, force, timeout, json_output):
+def app_quit(ctx, name, name_option, app_name, pid, force, timeout, json_output):
     """Quit an application gracefully (or force kill).
 
     NAME is the application name to quit.
@@ -123,9 +135,11 @@ def app_quit(ctx, name, name_option, pid, force, timeout, json_output):
     """
     json_output = json_output or (ctx.obj or {}).get("json", False)
 
-    # Support --name for backward compatibility
+    # Support --name for backward compatibility, --app for consistency
     if not name and name_option:
         name = name_option
+    if not name and app_name:
+        name = app_name
 
     if not name and pid is None:
         msg = "Specify application name or --pid"
@@ -154,14 +168,25 @@ def app_quit(ctx, name, name_option, pid, force, timeout, json_output):
 
 
 @click.command("relaunch")
-@click.argument("name")
+@click.argument("name", required=False, default=None)
+@click.option("--app", "app_name", default=None, help="Application name (alternative to positional NAME)")
 @click.option("--wait-until-ready", is_flag=True, default=True, help="Wait for app (default: on)")
 @click.option("--timeout", type=float, default=30.0, help="Timeout in seconds")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def app_relaunch(ctx, name, wait_until_ready, timeout, json_output):
+def app_relaunch(ctx, name, app_name, wait_until_ready, timeout, json_output):
     """Quit and relaunch an application."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
+    if not name and app_name:
+        name = app_name
+    if not name:
+        msg = "Specify application name"
+        if json_output:
+            click.echo(_json_error_str("INVALID_INPUT", msg))
+        else:
+            click.echo(f"Error: {msg}", err=True)
+        sys.exit(1)
+        return
 
     from naturo.process import relaunch_app
     from naturo.errors import NaturoError
@@ -316,12 +341,23 @@ def app_list(ctx, show_all, json_output):
 
 
 @click.command("hide", hidden=True)
-@click.argument("name")
+@click.argument("name", required=False, default=None)
+@click.option("--app", "app_name", default=None, help="Application name (alternative to positional NAME)")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def app_hide(ctx, name, json_output):
+def app_hide(ctx, name, app_name, json_output):
     """Hide (minimize) all windows of an application. Alias for minimize."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
+    if not name and app_name:
+        name = app_name
+    if not name:
+        msg = "Specify application name"
+        if json_output:
+            click.echo(_json_error_str("INVALID_INPUT", msg))
+        else:
+            click.echo(f"Error: {msg}", err=True)
+        sys.exit(1)
+        return
     from naturo.backends.base import get_backend
     from naturo.errors import NaturoError
 
@@ -353,12 +389,23 @@ def app_hide(ctx, name, json_output):
 
 
 @click.command("unhide", hidden=True)
-@click.argument("name")
+@click.argument("name", required=False, default=None)
+@click.option("--app", "app_name", default=None, help="Application name (alternative to positional NAME)")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def app_unhide(ctx, name, json_output):
+def app_unhide(ctx, name, app_name, json_output):
     """Unhide (restore) all windows of an application. Alias for restore."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
+    if not name and app_name:
+        name = app_name
+    if not name:
+        msg = "Specify application name"
+        if json_output:
+            click.echo(_json_error_str("INVALID_INPUT", msg))
+        else:
+            click.echo(f"Error: {msg}", err=True)
+        sys.exit(1)
+        return
     from naturo.backends.base import get_backend
     from naturo.errors import NaturoError
 
@@ -390,12 +437,15 @@ def app_unhide(ctx, name, json_output):
 
 
 @click.command("switch", hidden=True)
-@click.argument("name")
+@click.argument("name", required=False, default=None)
+@click.option("--app", "app_name", default=None, help="Application name (alternative to positional NAME)")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def app_switch(ctx, name, json_output):
+def app_switch(ctx, name, app_name, json_output):
     """Switch to (focus) the most recent window of an application. Alias for focus."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
+    if not name and app_name:
+        name = app_name
     from naturo.backends.base import get_backend
     from naturo.errors import NaturoError
 
@@ -786,20 +836,25 @@ def _handle_generic_error(exc, json_output):
 
 @click.command("focus")
 @click.argument("name", required=False, default=None)
+@click.option("--app", "app_name", default=None, help="Application name (alternative to positional NAME)")
 @click.option("--window", "window_title", default=None, help="Window title pattern (substring match)")
 @click.option("--hwnd", type=int, default=None, help="Window handle (HWND)")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def app_focus(ctx, name, window_title, hwnd, json_output):
+def app_focus(ctx, name, app_name, window_title, hwnd, json_output):
     """Focus an application window (bring to foreground).
 
     \b
     Examples:
       naturo app focus feishu
       naturo app focus feishu --window "群聊"
+      naturo app focus --app feishu
       naturo app focus --hwnd 12345
     """
     json_output = json_output or (ctx.obj or {}).get("json", False)
+    # --app flag overrides positional NAME when both absent
+    if not name and app_name:
+        name = app_name
     from naturo.errors import NaturoError
 
     if not _require_target(name, window_title, hwnd, json_output):
@@ -821,21 +876,25 @@ def app_focus(ctx, name, window_title, hwnd, json_output):
 
 @click.command("close")
 @click.argument("name", required=False, default=None)
+@click.option("--app", "app_name", default=None, help="Application name (alternative to positional NAME)")
 @click.option("--window", "window_title", default=None, help="Window title pattern (substring match)")
 @click.option("--hwnd", type=int, default=None, help="Window handle (HWND)")
 @click.option("--force", is_flag=True, help="Force terminate the process")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def app_close(ctx, name, window_title, hwnd, force, json_output):
+def app_close(ctx, name, app_name, window_title, hwnd, force, json_output):
     """Close an application window (graceful or forced).
 
     \b
     Examples:
       naturo app close notepad
+      naturo app close --app notepad
       naturo app close feishu --window "群聊"
       naturo app close --hwnd 12345 --force
     """
     json_output = json_output or (ctx.obj or {}).get("json", False)
+    if not name and app_name:
+        name = app_name
     from naturo.errors import NaturoError
 
     if not _require_target(name, window_title, hwnd, json_output):

--- a/naturo/cli/core.py
+++ b/naturo/cli/core.py
@@ -839,6 +839,18 @@ def see(app, window_title, hwnd, pid, mode, depth, path, annotate, store_snapsho
                     "height": el.height,
                     "children": [to_dict(c, parent_ref=display_id) for c in el.children],
                 }
+                # (#365) Mark zero-bounds elements as offscreen
+                if el.width == 0 and el.height == 0:
+                    d["offscreen"] = True
+                # (#372) Add text preview for Document/Edit role elements
+                if el.role.lower() in ("document", "edit", "text"):
+                    text_value = el.value or ""
+                    if text_value:
+                        # Truncate to 100 chars for preview
+                        preview = text_value[:100]
+                        if len(text_value) > 100:
+                            preview += "..."
+                        d["text_preview"] = preview
                 # (#295) Always use naturo ref for parent, never raw
                 # AutomationId — keeps a single consistent ID space.
                 if parent_ref:
@@ -1083,9 +1095,56 @@ def find_cmd(query, query_opt, find_all, role, actionable, depth, limit, ai,
             max_results=limit,
         )
 
+        # (#369) Store snapshot with refs so users can `naturo click e3` after find
+        from naturo.snapshot import get_snapshot_manager
+        from naturo.models.snapshot import UIElement
+
+        mgr = get_snapshot_manager()
+        snapshot_id = mgr.create_snapshot()
+
+        ui_map = {}
+        _ref_seq = [0]
+        ref_map = {}
+        # Build a mapping from backend element id → eN ref
+        _element_id_to_ref = {}
+
+        import re as _re_mod
+
+        def _flatten_for_find(el, parent_id=None):
+            _ref_seq[0] += 1
+            ref = f"e{_ref_seq[0]}"
+            _element_id_to_ref[id(el)] = ref
+            _raw_id = str(el.id) if el.id else None
+            if _raw_id and _re_mod.fullmatch(r"e\d+", _raw_id):
+                _raw_id = None
+            child_refs = []
+            for child in el.children:
+                child_refs.append(_flatten_for_find(child, parent_id=ref))
+            ui_map[ref] = UIElement(
+                id=ref,
+                element_id=f"element_{ref}",
+                role=el.role,
+                title=el.name,
+                label=el.name,
+                value=el.value,
+                identifier=_raw_id,
+                frame=(el.x, el.y, el.width, el.height),
+                is_actionable=getattr(el, "is_actionable", False),
+                parent_id=parent_id,
+                children=child_refs,
+                keyboard_shortcut=getattr(el, "keyboard_shortcut", None),
+            )
+            ref_map[ref] = el.id
+            return ref
+
+        _flatten_for_find(bridge_tree)
+        mgr.store_detection_result(snapshot_id, ui_map)
+        mgr.store_ref_map(snapshot_id, ref_map)
+
         if json_output:
             data = [
                 {
+                    "ref": _element_id_to_ref.get(id(r.element), r.element.id),
                     "id": r.element.id,
                     "role": r.element.role,
                     "name": r.element.name,
@@ -1099,7 +1158,12 @@ def find_cmd(query, query_opt, find_all, role, actionable, depth, limit, ai,
                 }
                 for r in results
             ]
-            click.echo(json_module.dumps({"success": True, "elements": data, "count": len(data)}, indent=2))
+            click.echo(json_module.dumps({
+                "success": True,
+                "elements": data,
+                "count": len(data),
+                "snapshot_id": snapshot_id,
+            }, indent=2))
         else:
             if not results:
                 click.echo(f"No elements found matching: {query}")
@@ -1107,13 +1171,16 @@ def find_cmd(query, query_opt, find_all, role, actionable, depth, limit, ai,
 
             for i, r in enumerate(results):
                 el = r.element
+                ref = _element_id_to_ref.get(id(el), "?")
                 name_str = f' "{el.name}"' if el.name else ""
                 pos_str = f"({el.x},{el.y} {el.width}x{el.height})"
                 shortcut = f" [{el.keyboard_shortcut}]" if el.keyboard_shortcut else ""
-                click.echo(f"  {i}. [{el.role}]{name_str} {pos_str}{shortcut}")
+                click.echo(f"  {ref}. [{el.role}]{name_str} {pos_str}{shortcut}")
                 click.echo(f"     {r.breadcrumb_str}")
 
             click.echo(f"\n{len(results)} element(s) found.")
+            click.echo(f"Snapshot: {snapshot_id}")
+            click.echo("Tip: use 'naturo click e<N>' to interact with a found element.")
 
     except Exception as e:
         if json_output:
@@ -1590,36 +1657,64 @@ def learn(topic):
 
 
 @click.command()
+@click.argument("positional_refs", nargs=-1)
+@click.option("--on", "on_ref", help="Target element ref (eN) to highlight")
+@click.option("--ref", "-r", "ref_option", multiple=True, help="Specific refs to highlight (e.g. -r e5 -r e10). Omit for all.")
 @click.option("--app", "-a", help="Application name (partial match)")
 @click.option("--hwnd", type=int, help="Direct window handle")
 @click.option("--depth", "-d", type=int, default=30, help="Tree depth for element discovery")
-@click.option("--ref", "-r", multiple=True, help="Specific refs to highlight (e.g. -r e5 -r e10). Omit for all.")
 @click.option("--duration", type=float, default=5.0, help="Highlight duration in seconds")
-def highlight(app, hwnd, depth, ref, duration):
+@click.option(
+    "--backend", "-b",
+    type=click.Choice(["uia", "win32"]),
+    default="uia",
+    help="Highlight backend: uia (default, uses UIA element tree from snapshot), win32 (Win32 HWND enumeration)",
+)
+def highlight(positional_refs, on_ref, ref_option, app, hwnd, depth, duration, backend):
     """Highlight UI elements on screen with colored borders and labels.
 
-    Draws colored rectangles around Win32 child windows with their
-    ref ID (eN) and name. Useful for identifying which element to target.
+    By default uses the UIA element tree from the most recent snapshot
+    (or captures a fresh one). Refs match those from 'naturo see'.
 
-    Uses Win32 HWND enumeration — works on VB6/ActiveX apps where UIA fails.
+    Use --backend win32 for VB6/ActiveX apps where UIA fails.
 
+    \b
     Examples:
 
-        naturo highlight --app EnterprisePortal          # Highlight all elements
-        naturo highlight --hwnd 10697004 -r e69 -r e77   # Highlight specific refs
+        naturo highlight e11 --app notepad               # Highlight specific ref (positional)
+        naturo highlight --app EnterprisePortal           # Highlight all elements
+        naturo highlight --hwnd 10697004 -r e69 -r e77   # Highlight specific refs (option)
+        naturo highlight e5 e10 --app notepad             # Multiple positional refs
+        naturo highlight --on e5 --app notepad            # Using --on
         naturo highlight --app notepad --duration 10      # Show for 10 seconds
+        naturo highlight --app legacy --backend win32     # Win32 HWND fallback
     """
     be = _get_backend()
     handle = be._resolve_hwnd(app=app, hwnd=hwnd)
 
-    from naturo.bridge import highlight_elements
-    refs_list = list(ref) if ref else None
-    click.echo(f"Highlighting elements for {duration}s... (switch to the target window)")
+    # Merge positional refs, --on ref, and --ref option refs
+    all_refs = list(positional_refs) + list(ref_option)
+    if on_ref:
+        all_refs.append(on_ref)
+    refs_list = all_refs if all_refs else None
 
-    import time
-    time.sleep(1.5)  # Give user time to switch windows
-
-    highlight_elements(hwnd=handle, depth=depth, duration=duration, refs=refs_list)
+    if backend == "win32":
+        # Legacy Win32 HWND enumeration fallback
+        from naturo.bridge import highlight_elements
+        click.echo(f"Highlighting elements (win32) for {duration}s... (switch to the target window)")
+        import time
+        time.sleep(1.5)
+        highlight_elements(hwnd=handle, depth=depth, duration=duration, refs=refs_list)
+    else:
+        # UIA mode: use snapshot element tree (#364)
+        from naturo.bridge import highlight_elements_uia
+        click.echo(f"Highlighting elements (uia) for {duration}s... (switch to the target window)")
+        import time
+        time.sleep(1.5)
+        highlight_elements_uia(
+            backend=be, app=app, hwnd=handle, depth=depth,
+            duration=duration, refs=refs_list,
+        )
     click.echo("Done.")
 
 

--- a/naturo/cli/interaction.py
+++ b/naturo/cli/interaction.py
@@ -60,7 +60,7 @@ def _post_action_see(
     window_title: str | None,
     hwnd: int | None,
     json_output: bool,
-    depth: int = 3,
+    depth: int = 7,
 ) -> dict | None:
     """Run UI inspection after an interaction and return snapshot data.
 
@@ -495,6 +495,7 @@ def _auto_route(
 @click.command("click")
 @click.argument("query", required=False)
 @click.option("--on", "on_text", help="Target element (eN ref or text label)")
+@click.option("--ref", "ref_alias", hidden=True, help="Deprecated alias for --on")
 @click.option("--id", "element_id", help="Automation element ID")
 @click.option("--coords", nargs=2, type=int, metavar="X Y", help="X Y coordinates")
 @click.option("--double", is_flag=True, help="Double-click")
@@ -517,12 +518,12 @@ def _auto_route(
 @_see_options
 @click.option("--process-name", "app", default=None, hidden=True, help="")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def click_cmd(query, on_text, element_id, coords, double, right, app, pid,
+def click_cmd(query, on_text, ref_alias, element_id, coords, double, right, app, pid,
               window_title, hwnd, wait_for, input_mode, method,
               verify, see_after, settle, json_output):
     """Click on a UI element, text, or coordinates.
 
-    QUERY is optional text to find and click on. Use --on, --id, or --coords
+    QUERY is optional text or eN ref to find and click on. Use --on, --id, or --coords
     for alternative targeting.
 
     Input modes (Windows-specific):
@@ -536,6 +537,9 @@ def click_cmd(query, on_text, element_id, coords, double, right, app, pid,
       naturo click --coords 500 300 --right
       naturo click --id "button_ok"
     """
+    # --ref is a hidden deprecated alias for --on (#381)
+    if ref_alias and not on_text:
+        on_text = ref_alias
     backend = _get_backend(json_output)
 
     # Auto-routing: detect best interaction method for target app
@@ -770,6 +774,7 @@ def click_cmd(query, on_text, element_id, coords, double, right, app, pid,
 @click.option("--file", "file_path", type=click.Path(), help="Read text from file (use with --paste)")
 @click.option("--restore/--no-restore", default=True, help="Restore clipboard after --paste", show_default=True)
 @click.option("--on", "on_element", help="Target element (eN ref or text label) — click to focus before typing")
+@click.option("--ref", "ref_alias", hidden=True, help="Deprecated alias for --on")
 @click.option("--app", help="Target application (name or partial match)")
 @click.option("--window", "window_title", default=None, help="Window title pattern (substring match)")
 @click.option("--window-title", "window_title", default=None, hidden=True, help="")
@@ -786,7 +791,7 @@ def click_cmd(query, on_text, element_id, coords, double, right, app, pid,
 @click.option("--process-name", "app", default=None, hidden=True, help="")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 def type_cmd(text, delay, profile, wpm, press_return, tab_count, escape,
-             delete, clear, paste_mode, file_path, restore, on_element, app,
+             delete, clear, paste_mode, file_path, restore, on_element, ref_alias, app,
              window_title, hwnd, input_mode, method, verify, see_after, settle,
              json_output):
     """Type text with configurable speed and profile.
@@ -810,6 +815,9 @@ def type_cmd(text, delay, profile, wpm, press_return, tab_count, escape,
       naturo type "hello" --on e42               # click e42 then type
       naturo type "hello" --on e42 --app feishu  # target app + element
     """
+    # --ref is a hidden deprecated alias for --on (#381)
+    if ref_alias and not on_element:
+        on_element = ref_alias
     # Handle --file: read content from file
     if file_path:
         import os
@@ -1133,6 +1141,8 @@ def _is_combo(key_str: str) -> bool:
 @click.option("--count", "-n", type=int, default=1, help="Number of times to press", show_default=True)
 @click.option("--delay", type=float, default=50.0, help="Delay between presses (ms)", show_default=True)
 @click.option("--hold-duration", type=float, default=None, help="Hold duration for combos (ms)")
+@click.option("--on", "on_element", help="Target element (eN ref or text label) — click to focus before pressing")
+@click.option("--ref", "ref_alias", hidden=True, help="Deprecated alias for --on")
 @click.option("--app", help="Target application (name or partial match)")
 @click.option("--window", "window_title", default=None, help="Window title pattern (substring match)")
 @click.option("--window-title", "window_title", default=None, hidden=True, help="")
@@ -1147,7 +1157,7 @@ def _is_combo(key_str: str) -> bool:
 @_verify_options
 @_see_options
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def press(keys, count, delay, hold_duration, app, window_title, hwnd, input_mode, method, verify, see_after, settle, json_output):
+def press(keys, count, delay, hold_duration, on_element, ref_alias, app, window_title, hwnd, input_mode, method, verify, see_after, settle, json_output):
     """Press keys — single keys, combos, or sequential key sequences.
 
     KEYS can be one or more key specs.  A spec containing ``+`` is treated as
@@ -1161,6 +1171,9 @@ def press(keys, count, delay, hold_duration, app, window_title, hwnd, input_mode
       naturo press ctrl+a ctrl+c          # sequential combos
       naturo press alt+f4
     """
+    # --ref is a hidden deprecated alias for --on (#381)
+    if ref_alias and not on_element:
+        on_element = ref_alias
     if not keys:
         _json_err("Missing argument 'KEY'. Provide a key name (e.g., enter, tab, ctrl+c).",
                   json_output, code="INVALID_INPUT")
@@ -1180,11 +1193,52 @@ def press(keys, count, delay, hold_duration, app, window_title, hwnd, input_mode
     # Auto-routing: detect best interaction method for target app
     route_info = _auto_route(app, None, method, json_output)
 
+    # --on: resolve element ref and click to focus before pressing (#375)
+    if on_element:
+        import re as _re
+        if _re.fullmatch(r"e\d+", on_element):
+            from naturo.snapshot import get_snapshot_manager
+            mgr = get_snapshot_manager()
+            resolved = mgr.resolve_ref(on_element)
+            if resolved:
+                click_x, click_y = resolved[0], resolved[1]
+            else:
+                _json_err(
+                    f"Element ref '{on_element}' not found. Run 'naturo see' first to "
+                    f"capture a fresh snapshot, then use the eN ref within 10 minutes.",
+                    json_output,
+                    code="REF_NOT_FOUND",
+                )
+                return
+        else:
+            # Text-based element lookup via backend
+            try:
+                elem = backend.find_element(on_element)
+                if elem:
+                    click_x = elem.x + elem.width // 2
+                    click_y = elem.y + elem.height // 2
+                else:
+                    _json_err(
+                        f"Element '{on_element}' not found",
+                        json_output,
+                        code="ELEMENT_NOT_FOUND",
+                    )
+                    return
+            except Exception as exc:
+                _json_err(str(exc), json_output)
+                return
+        try:
+            backend.click(click_x, click_y, button="left", input_mode=input_mode)
+            time.sleep(0.1)  # Brief pause for focus to settle
+        except Exception as exc:
+            _json_err(f"Failed to click target element: {exc}", json_output)
+            return
+
     # (#230) Focus target window before sending key input.
     # SendInput/key_press deliver to the foreground window, so we must
     # ensure the correct window has focus when --app/--hwnd is specified.
     # Session-aware: _resolve_hwnd now prefers interactive session windows.
-    if (app or window_title or hwnd):
+    if (app or window_title or hwnd) and not on_element:
         import platform as _plat
         if _plat.system() == "Windows":
             try:
@@ -1224,6 +1278,7 @@ def press(keys, count, delay, hold_duration, app, window_title, hwnd, input_mode
             _before_state = capture_before_state(
                 backend,
                 action="press",
+                ref=on_element if on_element else None,
                 app=app,
                 window_title=window_title,
                 hwnd=hwnd,
@@ -1284,6 +1339,9 @@ def press(keys, count, delay, hold_duration, app, window_title, hwnd, input_mode
             result_data["count"] = count
     else:
         result_data = {"action": "pressed", "sequence": list(keys), "count": count}
+
+    if on_element:
+        result_data["target"] = on_element
 
     if route_info:
         result_data["routing"] = route_info
@@ -1416,6 +1474,7 @@ def hotkey(keys, keys_option, hold_duration, app, window_title, hwnd,
 )
 @click.option("--amount", "-a", type=int, default=3, help="Scroll amount (notches)", show_default=True)
 @click.option("--on", "on_text", help="Element text or eN ref to scroll on")
+@click.option("--ref", "ref_alias", hidden=True, help="Deprecated alias for --on")
 @click.option("--id", "element_id", help="Element ID to scroll on")
 @click.option("--coords", nargs=2, type=int, metavar="X Y", help="Coordinates to scroll at")
 @click.option("--smooth", is_flag=True, help="Smooth scrolling (Phase 3)")
@@ -1427,7 +1486,7 @@ def hotkey(keys, keys_option, hold_duration, app, window_title, hwnd,
 @_method_option
 @_see_options
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def scroll(direction_arg, direction_option, amount, on_text, element_id, coords,
+def scroll(direction_arg, direction_option, amount, on_text, ref_alias, element_id, coords,
            smooth, delay, app, window_title, hwnd, method, see_after, settle, json_output):
     """Scroll in a direction.
 
@@ -1440,6 +1499,9 @@ def scroll(direction_arg, direction_option, amount, on_text, element_id, coords,
       naturo scroll --on e3 down --amount 5
       naturo scroll --coords 500 300 down
     """
+    # --ref is a hidden deprecated alias for --on (#381)
+    if ref_alias and not on_text:
+        on_text = ref_alias
     direction = direction_arg or direction_option or "down"
     if amount < 1:
         _json_err(f"--amount must be >= 1, got {amount}", json_output, code="INVALID_INPUT")

--- a/tests/test_app_control.py
+++ b/tests/test_app_control.py
@@ -395,6 +395,7 @@ class TestAppControlFunctionalWindows:
         if apps:
             assert "name" in apps[0] or hasattr(apps[0], "name")
 
+    @pytest.mark.desktop
     def test_cli_app_list_runs(self, runner):
         """T158 – naturo app list runs on Windows."""
         result = runner.invoke(main, ["app", "list"])

--- a/tests/test_window_management.py
+++ b/tests/test_window_management.py
@@ -942,8 +942,9 @@ class TestAppWindowCommands:
         assert data["success"] is True
         assert data["action"] == "focus"
 
+    @patch("naturo.cli.interaction._check_desktop_session")
     @patch("naturo.backends.base.get_backend")
-    def test_app_list_shows_windows(self, mock_get, runner, mock_window):
+    def test_app_list_shows_windows(self, mock_get, _mock_desktop, runner, mock_window):
         """T170 – app list shows detailed window list (--windows removed in #329)."""
         backend = MagicMock()
         backend.list_windows.return_value = [mock_window]
@@ -951,8 +952,9 @@ class TestAppWindowCommands:
         result = runner.invoke(main, ["app", "list"])
         assert result.exit_code == 0
 
+    @patch("naturo.cli.interaction._check_desktop_session")
     @patch("naturo.backends.base.get_backend")
-    def test_app_list_json(self, mock_get, runner, mock_window):
+    def test_app_list_json(self, mock_get, _mock_desktop, runner, mock_window):
         """T170 – app list --json returns structured data."""
         backend = MagicMock()
         backend.list_windows.return_value = [mock_window]


### PR DESCRIPTION
8 issues fixed in one batch:

**P1:**
- #381 Unify element targeting — all commands support `--on` + positional `eN`
- #375 `press` command: add `--on` element targeting
- #376 `--see` post-action snapshot depth: 3 → 7
- #369 `find` results include `eN` refs + snapshot (can `click e3` after find)
- #364 `highlight` uses UIA element tree from snapshot (refs match `see`)
- #360 README: `capture live` → `capture`, `--path` → `-o`

**P2:**
- #380 `highlight` accepts positional ref argument
- #378 `app launch/quit/relaunch/focus` accept `--app` flag