### PR TITLE
fix: use WTS API for desktop detection in integration conftest (fixes #392)

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -21,14 +21,67 @@ pytestmark = pytest.mark.skipif(
 
 
 def _has_desktop_session() -> bool:
-    """Check if a desktop session is available (not headless)."""
+    """Check if an interactive desktop session is available.
+
+    On Windows, queries the WTS (Windows Terminal Services) API to determine
+    whether the current process runs in an active Console or RDP session.
+    This correctly returns False for non-interactive SSH sessions, unlike the
+    old ``GetDesktopWindow()`` approach which returned True for any session type.
+
+    Uses the same detection logic as ``tests/conftest.py::_has_desktop_session()``.
+    See GitHub issue #392 for details.
+
+    Returns:
+        True if running in an interactive desktop session, False otherwise.
+    """
     if platform.system() != "Windows":
         return False
     try:
         import ctypes
-        user32 = ctypes.WinDLL("user32", use_last_error=True)
-        desktop = user32.GetDesktopWindow()
-        return desktop != 0
+        import ctypes.wintypes
+
+        # Get the session ID for the current process.
+        pid = ctypes.windll.kernel32.GetCurrentProcessId()
+        session_id = ctypes.wintypes.DWORD(0)
+        ok = ctypes.windll.kernel32.ProcessIdToSessionId(
+            pid, ctypes.byref(session_id),
+        )
+        if not ok:
+            return False
+        sid = session_id.value
+
+        # Session 0 is always the non-interactive services session.
+        if sid == 0:
+            return False
+
+        # Query WTS connect state via pure ctypes.
+        WTS_CURRENT_SERVER_HANDLE = 0
+        WTSConnectState = 8  # WTS_INFO_CLASS enum value
+        WTSActive = 0
+        WTSConnected = 1
+
+        wtsapi32 = ctypes.windll.wtsapi32
+        buf = ctypes.wintypes.LPWSTR()
+        bytes_returned = ctypes.wintypes.DWORD(0)
+
+        ok = wtsapi32.WTSQuerySessionInformationW(
+            WTS_CURRENT_SERVER_HANDLE,
+            sid,
+            WTSConnectState,
+            ctypes.byref(buf),
+            ctypes.byref(bytes_returned),
+        )
+        if not ok:
+            return False
+
+        try:
+            state = ctypes.cast(
+                buf, ctypes.POINTER(ctypes.wintypes.DWORD),
+            ).contents.value
+        finally:
+            wtsapi32.WTSFreeMemory(buf)
+
+        return state in (WTSActive, WTSConnected)
     except Exception:
         return False
 


### PR DESCRIPTION
## Summary
Replace `GetDesktopWindow()` with WTS session query in `tests/integration/conftest.py`.

## Problem
`GetDesktopWindow()` always returns non-zero even in SSH sessions, causing integration tests to run and fail instead of being skipped. This is a partial regression of #348.

## Fix
Use the same WTS API approach as `tests/conftest.py`:
1. Get current process session ID via `ProcessIdToSessionId`
2. Reject Session 0 (non-interactive services session)
3. Query connect state via `WTSQuerySessionInformationW`
4. Only return True for `WTSActive` or `WTSConnected` states

This correctly returns False for SSH sessions where no interactive desktop is available.

## Testing
- Integration tests will now properly skip when run via SSH
- Tests still run correctly in interactive sessions (Console/RDP)
- No functional change to other test files (they already use the correct approach)

Fixes #392