### PR TITLE
fix: UWP/WinUI empty UIA tree in cascade and see command (fixes #394)

### DIFF
--- a/naturo/backends/windows.py
+++ b/naturo/backends/windows.py
@@ -1475,14 +1475,45 @@ class WindowsBackend(Backend):
                             "HWND %s", len(child_result.children), child_hwnd,
                         )
                         return child_result
+
+                # (#394) WinUI 3 apps may need deeper traversal.
+                # Retry child HWNDs with increased depth if original
+                # depth was low and yielded nothing.
+                if depth < 15:
+                    deeper = min(depth * 2, 20)
+                    logger.debug(
+                        "UWP fallback: retrying children with depth=%d "
+                        "(was %d)", deeper, depth,
+                    )
+                    for child_hwnd in child_hwnds:
+                        child_result = get_tree_fn(child_hwnd, deeper)
+                        if child_result is not None and child_result.children:
+                            logger.info(
+                                "UWP fallback (depth=%d): found %d children "
+                                "via child HWND %s",
+                                deeper, len(child_result.children), child_hwnd,
+                            )
+                            return child_result
             return current_result
 
         if backend == "jab":
             result = core.jab_get_element_tree(hwnd=handle, depth=depth)
+            result = _try_uwp_children(
+                result,
+                lambda h, d: core.jab_get_element_tree(hwnd=h, depth=d),
+            )
         elif backend == "ia2":
             result = core.ia2_get_element_tree(hwnd=handle, depth=depth)
+            result = _try_uwp_children(
+                result,
+                lambda h, d: core.ia2_get_element_tree(hwnd=h, depth=d),
+            )
         elif backend == "msaa":
             result = core.msaa_get_element_tree(hwnd=handle, depth=depth)
+            result = _try_uwp_children(
+                result,
+                lambda h, d: core.msaa_get_element_tree(hwnd=h, depth=d),
+            )
         elif backend == "win32":
             # Pure Win32 HWND enumeration (VB6/ActiveX fallback)
             from naturo.bridge import enumerate_child_windows

--- a/naturo/cascade.py
+++ b/naturo/cascade.py
@@ -393,6 +393,26 @@ def run_cascade(
                 tagged = _tag_source(tree, pname)
                 flat = _flatten(tagged)
                 elements_count = len(flat)
+
+                # (#394) A tree with only a root node and zero children is
+                # not useful — likely a UWP/WinUI app where the backend
+                # could not reach the real UI.  Record it but keep trying
+                # the next provider instead of accepting it immediately.
+                if not tree.children:
+                    logger.info(
+                        "Provider %s returned root-only tree (0 children), "
+                        "trying next provider...", pname,
+                    )
+                    stats.providers.append(ProviderStat(
+                        name=pname, elements=elements_count,
+                        elapsed_ms=elapsed, status="empty_tree",
+                    ))
+                    # Keep as fallback in case no provider does better
+                    if root_tree is None:
+                        root_tree = tagged
+                        window_area = _window_area(tree)
+                    continue
+
                 stats.providers.append(ProviderStat(
                     name=pname, elements=elements_count, elapsed_ms=elapsed, status="ok"
                 ))

--- a/tests/test_cascade.py
+++ b/tests/test_cascade.py
@@ -155,7 +155,10 @@ class TestRunCascade:
         assert result.tree.properties.get("source") == "uia"
 
     def test_stats_recorded(self):
-        tree = _make_el(id="root", w=1000, h=600)
+        tree = _make_el(
+            id="root", w=1000, h=600,
+            children=[_make_el(id="btn")],
+        )
         be = _make_backend(tree)
 
         result = run_cascade(be, backend_name="uia")
@@ -191,6 +194,51 @@ class TestRunCascade:
 
         assert result.tree is not None
         assert call_count[0] >= 2  # tried at least uia and msaa
+
+    def test_auto_skips_empty_tree_provider(self):
+        """When a provider returns root-only tree (0 children), cascade should
+        continue to next provider instead of stopping (#394)."""
+        empty_root = _make_el(id="root", role="Pane", name="", children=[])
+        rich_tree = _make_el(
+            id="root", role="Window", name="Calculator",
+            children=[_make_el(id="btn", role="Button", name="1")],
+        )
+
+        call_count = [0]
+
+        def get_tree(*args, **kwargs):
+            b = kwargs.get("backend", "uia")
+            call_count[0] += 1
+            if b == "uia":
+                return empty_root
+            if b == "msaa":
+                return rich_tree
+            return None
+
+        be = MagicMock()
+        be.get_element_tree.side_effect = get_tree
+
+        result = run_cascade(be, backend_name="auto")
+
+        assert result.tree is not None
+        assert len(result.tree.children) == 1
+        assert call_count[0] >= 2
+        # Check that UIA was recorded as empty_tree
+        uia_stat = next(p for p in result.stats.providers if p.name == "uia")
+        assert uia_stat.status == "empty_tree"
+
+    def test_empty_tree_kept_as_fallback_when_no_provider_works(self):
+        """When all providers return empty trees, keep the first one as fallback."""
+        empty_root = _make_el(id="root", role="Pane", name="", children=[])
+
+        be = MagicMock()
+        be.get_element_tree.return_value = empty_root
+
+        result = run_cascade(be, backend_name="auto")
+
+        # Should still return the root (as fallback), not None
+        assert result.tree is not None
+        assert result.tree.children == []
 
     def test_stats_to_dict(self):
         tree = _make_el(id="root", w=1000, h=600)

--- a/tests/test_uwp_fallback.py
+++ b/tests/test_uwp_fallback.py
@@ -204,12 +204,14 @@ class TestUwpElementTreeFallback:
         assert len(result.children) == 1
 
     def test_fallback_returns_original_when_no_children_found(self, backend):
-        """When all child HWNDs also return empty, keep original result."""
+        """When all child HWNDs also return empty (including deeper retry), keep original result."""
         empty_root = _make_element(role="Pane", name="", children=[])
         child_empty = _make_element(role="Pane", name="", children=[])
+        child_empty_deeper = _make_element(role="Pane", name="", children=[])
 
+        # 3 calls: AFH(depth=3), child@depth=3, child@depth=6 (deeper retry)
         backend._core.get_element_tree = MagicMock(
-            side_effect=[empty_root, child_empty],
+            side_effect=[empty_root, child_empty, child_empty_deeper],
         )
         backend._resolve_hwnd = MagicMock(return_value=100)
         backend._is_afh_window = MagicMock(return_value=True)
@@ -222,6 +224,8 @@ class TestUwpElementTreeFallback:
         # Should return original empty result (post-processed)
         assert result is not None
         assert result.children == []
+        # 3 calls: AFH + child@orig_depth + child@deeper_depth
+        assert backend._core.get_element_tree.call_count == 3
 
     def test_fallback_with_no_child_windows(self, backend):
         """When AFH has no child windows at all, return original result."""
@@ -238,6 +242,54 @@ class TestUwpElementTreeFallback:
 
         assert result is not None
         assert backend._core.get_element_tree.call_count == 1
+
+    def test_uwp_fallback_retries_deeper_depth(self, backend):
+        """When all child HWNDs return empty at original depth, retry with deeper depth (#394)."""
+        empty_root = _make_element(role="Pane", name="", children=[])
+        child_empty_shallow = _make_element(role="Pane", name="", children=[])
+        # Deeper traversal reveals content
+        rich_root = _make_element(
+            role="Window", name="Calculator",
+            children=[_make_element(role="Button", name="1")],
+        )
+
+        # Calls: AFH(depth=7) → empty, child(depth=7) → empty, child(depth=14) → rich
+        backend._core.get_element_tree = MagicMock(
+            side_effect=[empty_root, child_empty_shallow, rich_root],
+        )
+        backend._resolve_hwnd = MagicMock(return_value=100)
+        backend._is_afh_window = MagicMock(return_value=True)
+
+        with patch.object(type(backend), "_find_uwp_content_hwnd",
+                          return_value=[200]):
+            with patch("naturo.backends.windows.populate_hierarchy"):
+                result = backend.get_element_tree(app="calc", depth=7, backend="uia")
+
+        assert result is not None
+        assert result.role == "Window"
+        assert len(result.children) == 1
+        # 3 calls: AFH, child@depth=7, child@depth=14
+        assert backend._core.get_element_tree.call_count == 3
+
+    def test_uwp_fallback_no_deeper_retry_when_depth_already_high(self, backend):
+        """Should not retry deeper when depth is already >= 15."""
+        empty_root = _make_element(role="Pane", name="", children=[])
+        child_empty = _make_element(role="Pane", name="", children=[])
+
+        backend._core.get_element_tree = MagicMock(
+            side_effect=[empty_root, child_empty],
+        )
+        backend._resolve_hwnd = MagicMock(return_value=100)
+        backend._is_afh_window = MagicMock(return_value=True)
+
+        with patch.object(type(backend), "_find_uwp_content_hwnd",
+                          return_value=[200]):
+            with patch("naturo.backends.windows.populate_hierarchy"):
+                result = backend.get_element_tree(app="calc", depth=20, backend="uia")
+
+        # Only 2 calls: AFH + child (no deeper retry since depth=20 >= 15)
+        assert backend._core.get_element_tree.call_count == 2
+
 
 class TestClickElementUia:
     """Tests for click_element_uia UWP click fallback (#248)."""
@@ -259,6 +311,33 @@ class TestClickElementUia:
         with patch.object(backend, "_init_comtypes_uia", side_effect=ImportError("no comtypes")):
             result = backend.click_element_uia(x=100, y=200)
         assert result is False
+
+
+class TestMsaaUwpFallback:
+    """Tests for MSAA UWP child window fallback (#394)."""
+
+    def test_msaa_uwp_fallback_retries_with_child_hwnds(self, backend):
+        """MSAA backend should also try child HWNDs for AFH windows."""
+        empty_root = _make_element(role="Pane", name="", children=[])
+        rich_root = _make_element(
+            role="Window", name="Calculator",
+            children=[_make_element(role="Button", name="1")],
+        )
+
+        backend._core.msaa_get_element_tree = MagicMock(
+            side_effect=[empty_root, rich_root],
+        )
+        backend._resolve_hwnd = MagicMock(return_value=100)
+        backend._is_afh_window = MagicMock(return_value=True)
+
+        with patch.object(type(backend), "_find_uwp_content_hwnd",
+                          return_value=[200]):
+            with patch("naturo.backends.windows.populate_hierarchy"):
+                result = backend.get_element_tree(app="calc", backend="msaa")
+
+        assert result is not None
+        assert result.role == "Window"
+        assert len(result.children) == 1
 
 
 class TestWinui3DesktopWindowXamlSource:


### PR DESCRIPTION
## Problem
`naturo see --app calculator --json` returns only 1 root Pane element with 0 children for UWP/WinUI apps (Windows Calculator, Settings, etc.). The cascade engine accepts this empty tree as valid and stops trying other providers.

## Root Cause
Three gaps in UWP app handling:
1. **Cascade engine** accepts any non-None tree as valid, even if it has 0 children (just a root Pane)
2. **UWP depth issue**: WinUI 3 child HWNDs may need deeper traversal than the requested depth
3. **Backend coverage**: only UIA and auto backends try child HWNDs of ApplicationFrameHost; MSAA/IA2/JAB do not

## Fix
1. **Cascade**: skip root-only trees (0 children) and continue to next provider. Keep empty tree as fallback.
2. **Deeper retry**: when all child HWNDs return empty at original depth, retry with 2x depth (up to 20)
3. **All backends**: extend UWP child-HWND fallback to MSAA/IA2/JAB backends

## Tests
- New cascade tests for empty-tree skip and fallback behavior
- New UWP tests for deeper depth retry and MSAA fallback
- All 1789 tests pass