### PR TITLE
fix: type --verify false negative — use UI text diff fallback (fixes #398)

### DIFF
--- a/naturo/cli/interaction.py
+++ b/naturo/cli/interaction.py
@@ -1068,6 +1068,7 @@ def type_cmd(text, delay, profile, wpm, press_return, tab_count, escape,
         try:
             from naturo.verify import verify_type, skip_result
             _before_value = _before_state.get("value") if _before_state else None
+            _before_ui_texts = _before_state.get("ui_texts") if _before_state else None
             _verification = verify_type(
                 backend,
                 text=text,
@@ -1076,6 +1077,7 @@ def type_cmd(text, delay, profile, wpm, press_return, tab_count, escape,
                 window_title=window_title,
                 hwnd=hwnd,
                 before_value=_before_value,
+                before_ui_texts=_before_ui_texts,
                 paste_mode=paste_mode,
             )
         except Exception as exc:

--- a/naturo/verify.py
+++ b/naturo/verify.py
@@ -111,6 +111,7 @@ def verify_type(
     window_title: Optional[str] = None,
     hwnd: Optional[int] = None,
     before_value: Optional[str] = None,
+    before_ui_texts: Optional[dict[str, str]] = None,
     paste_mode: bool = False,
     settle_ms: int = 150,
 ) -> VerificationResult:
@@ -130,6 +131,10 @@ def verify_type(
         window_title: Window title filter.
         hwnd: Window handle filter.
         before_value: Element value captured before the action.
+        before_ui_texts: Mapping of element identifiers to their text/value
+            captured before the action. Used as fallback when ValuePattern
+            comparison fails (e.g., WinUI 3 apps where ValuePattern doesn't
+            reflect typed text). See ``_capture_ui_texts``.
         paste_mode: Whether paste mode was used.
         settle_ms: Milliseconds to wait for UI to settle before verification.
 
@@ -211,14 +216,44 @@ def verify_type(
                     elapsed_ms=elapsed,
                 )
         else:
-            # Value unchanged → silent failure detected!
+            # Value unchanged via ValuePattern — try UI text diff fallback
+            # (#398) Some apps (Win11 Notepad WinUI 3, RichEditTextBlock)
+            # don't expose typed text through UIA ValuePattern, causing
+            # false negatives. Fall back to comparing child window texts
+            # and UIA element names (same approach as verify_click #263).
+            if before_ui_texts is not None:
+                try:
+                    after_ui_texts = _capture_ui_texts(
+                        backend, app=app, window_title=window_title, hwnd=hwnd,
+                    )
+                    if after_ui_texts and after_ui_texts != before_ui_texts:
+                        elapsed = (time.monotonic() - start) * 1000
+                        return VerificationResult(
+                            status=VerifyStatus.VERIFIED,
+                            detail=(
+                                "UI text changed after typing "
+                                "(ValuePattern unchanged but window text updated)"
+                            ),
+                            method="ui_text_diff",
+                            before=before_ui_texts,
+                            after=after_ui_texts,
+                            elapsed_ms=elapsed,
+                        )
+                except Exception as exc:
+                    logger.debug("Type UI text fallback failed: %s", exc)
+
+            # (#398) If even the UI text fallback shows no change, report
+            # UNKNOWN instead of FAILED. The ValuePattern may not work for
+            # certain app frameworks, so a "no change detected" is not
+            # definitive evidence of failure — it's inconclusive.
+            elapsed = (time.monotonic() - start) * 1000
             return VerificationResult(
-                status=VerifyStatus.FAILED,
+                status=VerifyStatus.UNKNOWN,
                 detail=(
                     f"Element value unchanged after type operation. "
-                    f"Text '{text[:50]}' was not typed into the target element. "
-                    f"Possible causes: wrong window focused, element not editable, "
-                    f"or running in a non-interactive session."
+                    f"Text '{text[:50]}' may not have been typed, or the app "
+                    f"framework does not expose typed text via UIA ValuePattern. "
+                    f"Consider using screenshot verification for confirmation."
                 ),
                 method="value_compare",
                 before=before_value,
@@ -803,16 +838,17 @@ def capture_before_state(
         logger.debug("Pre-action focus capture failed: %s", exc)
         state["focus"] = None
 
-    # (#263) For click actions, also capture UI texts for fallback verification.
-    # This enables detecting display changes that don't involve focus shifts
-    # (e.g., UWP Calculator buttons update the display without focus change).
-    if action == "click":
+    # (#263, #398) For click and type actions, capture UI texts for fallback
+    # verification. For clicks, this detects display changes without focus
+    # shifts. For type, this catches apps where ValuePattern doesn't reflect
+    # typed text (e.g., Win11 Notepad WinUI 3 RichEditTextBlock).
+    if action in ("click", "type"):
         try:
             state["ui_texts"] = _capture_ui_texts(
                 backend, app=app, window_title=window_title, hwnd=hwnd,
             )
         except Exception as exc:
-            logger.debug("Pre-click UI text capture failed: %s", exc)
+            logger.debug("Pre-%s UI text capture failed: %s", action, exc)
             state["ui_texts"] = None
 
     return state

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -95,8 +95,13 @@ class TestVerifyType:
         assert result.status == VerifyStatus.VERIFIED
         assert result.verified is True
 
-    def test_failed_when_value_unchanged(self):
-        """Value unchanged after typing → FAILED (silent failure)."""
+    def test_unknown_when_value_unchanged(self):
+        """Value unchanged after typing → UNKNOWN (inconclusive, not FAILED).
+
+        (#398) Changed from FAILED to UNKNOWN because some app frameworks
+        (Win11 Notepad WinUI 3) don't expose typed text via ValuePattern.
+        Reporting FAILED would be a false negative.
+        """
         backend = MagicMock()
         backend.get_element_value.return_value = {"value": "original"}
 
@@ -106,8 +111,8 @@ class TestVerifyType:
             before_value="original",
             settle_ms=0,
         )
-        assert result.status == VerifyStatus.FAILED
-        assert result.verified is False
+        assert result.status == VerifyStatus.UNKNOWN
+        assert result.verified is None
         assert "unchanged" in result.detail.lower()
 
     def test_verified_when_value_changed_but_text_not_found(self):
@@ -210,6 +215,48 @@ class TestVerifyType:
             settle_ms=0,
         )
         assert result.elapsed_ms >= 0
+
+
+    def test_verified_via_ui_text_fallback_when_value_unchanged(self):
+        """(#398) Value unchanged but UI text changed → VERIFIED via fallback.
+
+        Win11 Notepad WinUI 3 doesn't expose typed text via ValuePattern.
+        The UI text diff fallback detects the change via GetWindowText/UIA names.
+        """
+        backend = MagicMock()
+        backend.get_element_value.return_value = {"value": "original"}
+
+        before_ui_texts = {"child:12345": ""}
+        after_ui_texts = {"child:12345": "Hello"}
+
+        with patch("naturo.verify._capture_ui_texts", return_value=after_ui_texts):
+            result = verify_type(
+                backend,
+                text="Hello",
+                before_value="original",
+                before_ui_texts=before_ui_texts,
+                settle_ms=0,
+            )
+        assert result.status == VerifyStatus.VERIFIED
+        assert result.method == "ui_text_diff"
+
+    def test_unknown_when_value_and_ui_texts_both_unchanged(self):
+        """(#398) Value AND UI text both unchanged → UNKNOWN (not FAILED)."""
+        backend = MagicMock()
+        backend.get_element_value.return_value = {"value": "original"}
+
+        same_texts = {"child:12345": "original"}
+
+        with patch("naturo.verify._capture_ui_texts", return_value=same_texts):
+            result = verify_type(
+                backend,
+                text="Hello",
+                before_value="original",
+                before_ui_texts=same_texts,
+                settle_ms=0,
+            )
+        assert result.status == VerifyStatus.UNKNOWN
+        assert result.verified is None
 
 
 class TestVerifyClick:
@@ -448,15 +495,15 @@ class TestCaptureBeforeStateUiTexts:
         assert state["focus"] == focus_data
         assert state["ui_texts"] == ui_texts
 
-    def test_type_does_not_capture_ui_texts(self):
-        """Before-state for type should NOT capture UI texts."""
+    def test_type_captures_ui_texts_for_fallback(self):
+        """(#398) Before-state for type now captures UI texts for fallback verification."""
         backend = MagicMock()
         backend.get_element_value.return_value = {"value": "text"}
 
         with patch("naturo.verify._capture_focus_state", return_value={}):
             state = capture_before_state(backend, action="type")
 
-        assert "ui_texts" not in state
+        assert "ui_texts" in state
 
     def test_click_handles_ui_texts_error(self):
         """UI text capture failure → ui_texts=None, still works."""
@@ -609,8 +656,13 @@ class TestVerificationIntegration:
         )
         assert result.verified is True
 
-    def test_full_type_verify_failure_flow(self):
-        """Simulate silent failure: value stays the same → FAILED."""
+    def test_full_type_verify_inconclusive_flow(self):
+        """Value unchanged after typing → UNKNOWN (inconclusive).
+
+        (#398) Changed from FAILED to UNKNOWN. When ValuePattern reports
+        no change, it could be a real silent failure OR the app framework
+        doesn't expose typed text. We report UNKNOWN to avoid false negatives.
+        """
         backend = MagicMock()
         backend.get_element_value.return_value = {"value": "unchanged"}
 
@@ -623,7 +675,8 @@ class TestVerificationIntegration:
             before_value=before.get("value"),
             settle_ms=0,
         )
-        assert result.verified is False
+        assert result.verified is None
+        assert result.status == VerifyStatus.UNKNOWN
 
     def test_to_dict_includes_all_fields_for_json_output(self):
         """Verified result should serialize cleanly for JSON output."""


### PR DESCRIPTION
## Problem
`naturo type --verify` reports VERIFICATION_FAILED on Win11 Notepad even when text was successfully typed. The UIA ValuePattern doesn't reflect typed text in WinUI 3's RichEditTextBlock, causing the before/after value comparison to see no change.

## Root Cause
`verify_type()` relied solely on ValuePattern comparison. When before_value == after_value, it immediately reported FAILED. But some app frameworks (WinUI 3) don't expose typed text through ValuePattern.

## Fix
Three-part fix:
1. **UI text diff fallback**: When ValuePattern shows no change, compare child window texts + UIA element names (same approach already used by `verify_click` for #263). If UI text changed → VERIFIED.
2. **FAILED → UNKNOWN**: When even the fallback shows no change, report UNKNOWN (inconclusive) instead of FAILED. This avoids false negatives for apps where verification infrastructure can't read values.
3. **capture_before_state**: Now captures `ui_texts` for type actions (previously only for click).

## Behavior Change
| Scenario | Before | After |
|----------|--------|-------|
| ValuePattern shows change | VERIFIED (exit 0) | VERIFIED (exit 0) |
| ValuePattern unchanged, UI text changed | FAILED (exit 1) ❌ | VERIFIED (exit 0) ✅ |
| ValuePattern unchanged, UI text unchanged | FAILED (exit 1) | UNKNOWN (exit 2) |

## Tests
- 2 new tests for UI text fallback paths
- 2 existing tests updated (FAILED → UNKNOWN)
- All 1791 tests pass, 504 skipped

Fixes #398