### PR TITLE
fix: UWP app resolution picks stale AFH window without CoreWindow child (fixes #394)

### DIFF
--- a/naturo/backends/windows.py
+++ b/naturo/backends/windows.py
@@ -986,6 +986,12 @@ class WindowsBackend(Backend):
             if best_proc.endswith(".exe"):
                 best_proc = best_proc[:-4]
             if best_proc != "applicationframehost":
+                # (#394) Collect ALL AFH windows with matching title, then
+                # prefer one that actually has a CoreWindow child (live UI).
+                # Stale AFH windows (e.g., from schtasks-launched instances)
+                # may linger without a CoreWindow child, producing empty
+                # UIA trees.
+                afh_candidates = []
                 for w in windows:
                     frame_proc = w.process_name.lower()
                     if frame_proc.endswith(".exe"):
@@ -995,8 +1001,30 @@ class WindowsBackend(Backend):
                         and w.title == best_window.title
                         and w.handle != best_window.handle
                     ):
-                        best_window = w
-                        break
+                        afh_candidates.append(w)
+
+                if afh_candidates:
+                    # Prefer AFH window with a CoreWindow child
+                    chosen_afh = None
+                    for afh_w in afh_candidates:
+                        children = self._find_uwp_content_hwnd(afh_w.handle)
+                        if children:
+                            chosen_afh = afh_w
+                            logger.debug(
+                                "UWP fixup: AFH hwnd=%s has %d content "
+                                "children, selecting it",
+                                afh_w.handle, len(children),
+                            )
+                            break
+                    if chosen_afh is None:
+                        # No AFH has content children — fall back to first
+                        chosen_afh = afh_candidates[0]
+                        logger.debug(
+                            "UWP fixup: no AFH has content children, "
+                            "falling back to first AFH hwnd=%s",
+                            chosen_afh.handle,
+                        )
+                    best_window = chosen_afh
 
             return best_window.handle
 


### PR DESCRIPTION
## Problem
`naturo see --app calculator` returns empty UIA tree (0 children) for UWP Calculator despite the app being visible and running.

## Root Cause (found via compile machine debugging)
Multiple Calculator instances left stale ApplicationFrameHost windows. The stale AFH (hwnd=69168) had NO CoreWindow child — only title bar and input sink windows. The newer AFH windows (hwnd=1575522 etc.) had proper CoreWindow children with full UI trees (56 elements).

`_resolve_hwnd`'s UWP fixup picked the **first** AFH with matching title, which happened to be the stale one. The cascade engine then correctly rejected empty trees from all backends but had no valid tree to fall back to.

## Fix
When the UWP fixup in `_resolve_hwnd` finds AFH candidates with matching title:
1. Check each AFH for content children via `_find_uwp_content_hwnd()`
2. Prefer the AFH that has a CoreWindow or DesktopWindowXamlSource child
3. Fall back to first AFH only if none have content children

## Evidence
- AFH hwnd=69168 (stale): 3 children — ApplicationFrameTitleBarWindow×2 + ApplicationFrameInputSinkWindow. NO CoreWindow. → empty UIA tree
- AFH hwnd=1575522 (live): 4 children — including `Windows.UI.Core.CoreWindow` (pid=24216). → 56 UIA elements ✅

## Tests
All 1791 pass, 504 skipped. Integration test requires real UWP app — QA verification needed.

Fixes #394