### PR TITLE
fix: click/press/type return exit 0 for inconclusive verification (fixes #426)

### DIFF
--- a/naturo/cli/interaction.py
+++ b/naturo/cli/interaction.py
@@ -738,17 +738,9 @@ def click_cmd(query, on_text, ref_alias, element_id, coords, double, right, app,
         if snapshot_data and json_output:
             result_data["snapshot"] = snapshot_data
 
-    # (#242) Exit code 2 for inconclusive click verification
-    if _verification and _verification.verified is None and _verification.status.value == "unknown":
-        if json_output:
-            click.echo(json.dumps({"success": True, "data": result_data}))
-        else:
-            for k, v in result_data.items():
-                if k in _VERIFICATION_KEYS:
-                    continue
-                click.echo(f"{k}: {v}")
-        sys.exit(2)
-
+    # (#426) Inconclusive verification (verified=null) no longer causes
+    # exit code 2.  The action was performed — we just can't confirm the
+    # UI effect.  Callers can inspect ``verified`` in JSON output.
     _json_ok(result_data, json_output)
 
 
@@ -1115,19 +1107,9 @@ def type_cmd(text, delay, profile, wpm, press_return, tab_count, escape,
                 click.echo(f"{k}: {v}")
             sys.exit(1)
 
-    # (#242) Exit code 2 (warning) when verification is inconclusive:
-    # success=true but verified=null means we can't confirm the action worked.
-    # Callers can distinguish 0 (confirmed), 1 (failed), 2 (inconclusive).
-    if _verification and _verification.verified is None and _verification.status.value == "unknown":
-        if json_output:
-            click.echo(json.dumps({"success": True, "data": result_data}))
-        else:
-            for k, v in result_data.items():
-                if k in _VERIFICATION_KEYS:
-                    continue
-                click.echo(f"{k}: {v}")
-        sys.exit(2)
-
+    # (#426) Inconclusive verification (verified=null) no longer causes
+    # exit code 2.  The action was performed — we just can't confirm the
+    # UI effect.  Callers can inspect ``verified`` in JSON output.
     _json_ok(result_data, json_output)
 
 
@@ -1384,17 +1366,9 @@ def press(keys, count, delay, hold_duration, on_element, ref_alias, app, window_
         if snapshot_data and json_output:
             result_data["snapshot"] = snapshot_data
 
-    # (#242) Exit code 2 for inconclusive press verification
-    if _verification and _verification.verified is None and _verification.status.value == "unknown":
-        if json_output:
-            click.echo(json.dumps({"success": True, "data": result_data}))
-        else:
-            for k, v in result_data.items():
-                if k in _VERIFICATION_KEYS:
-                    continue
-                click.echo(f"{k}: {v}")
-        sys.exit(2)
-
+    # (#426) Inconclusive verification (verified=null) no longer causes
+    # exit code 2.  The action was performed — we just can't confirm the
+    # UI effect.  Callers can inspect ``verified`` in JSON output.
     _json_ok(result_data, json_output)
 
 

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -874,8 +874,8 @@ class TestGetElementValueProbing:
                 backend.get_element_value()
 
 
-class TestExitCodeWarning:
-    """Test #242: exit code 2 for inconclusive verification."""
+class TestVerificationStatusProperties:
+    """Test verification status properties (#242 / #426)."""
 
     def test_unknown_status_properties(self):
         """Unknown status should have verified=None and status=unknown."""
@@ -885,8 +885,87 @@ class TestExitCodeWarning:
         assert result.status.value == "unknown"
 
     def test_skipped_not_treated_as_unknown(self):
-        """Skipped results should not trigger exit code 2."""
+        """Skipped and unknown are distinct statuses."""
         result = skip_result("not applicable")
         assert result.verified is None
         assert result.status != VerifyStatus.UNKNOWN
         assert result.status.value == "skipped"
+
+
+class TestInconclusiveExitCode:
+    """Test #426: click/press/type must exit 0 even when verification is inconclusive.
+
+    When the action was performed but verification cannot confirm the effect
+    (UNKNOWN status), the exit code must be 0.  The ``verified: null`` field
+    in the output lets callers distinguish confirmed from inconclusive.
+    """
+
+    def _run_click_with_unknown_verification(self):
+        """Invoke click_cmd with mocked backend that yields UNKNOWN verification."""
+        from click.testing import CliRunner
+        from naturo.cli.interaction import click_cmd
+
+        mock_backend = MagicMock()
+        mock_backend.click.return_value = None
+        mock_backend.get_element_tree.return_value = {"elements": []}
+
+        unknown = VerificationResult(
+            status=VerifyStatus.UNKNOWN,
+            detail="No focus change detected after click.",
+            method="focus_check",
+        )
+
+        runner = CliRunner()
+        with patch("naturo.cli.interaction._get_backend", return_value=mock_backend), \
+             patch("naturo.cli.interaction._auto_route", return_value=None), \
+             patch("naturo.verify.capture_before_state", return_value=None), \
+             patch("naturo.verify.verify_click", return_value=unknown):
+            result = runner.invoke(click_cmd, ["--coords", "500", "300", "--json"])
+        return result
+
+    def test_click_inconclusive_exits_zero(self):
+        """click must exit 0 when verification is inconclusive (#426)."""
+        result = self._run_click_with_unknown_verification()
+        assert result.exit_code == 0, (
+            f"Expected exit code 0 for inconclusive click, got {result.exit_code}.\n"
+            f"Output: {result.output}"
+        )
+
+    def test_click_inconclusive_json_has_verified_null(self):
+        """click JSON output must include verified=null for inconclusive."""
+        import json as json_mod
+
+        result = self._run_click_with_unknown_verification()
+        parsed = json_mod.loads(result.output)
+        assert parsed["success"] is True
+        assert parsed["data"]["verified"] is None
+
+    def _run_press_with_unknown_verification(self):
+        """Invoke press with mocked backend that yields UNKNOWN verification."""
+        from click.testing import CliRunner
+        from naturo.cli.interaction import press
+
+        mock_backend = MagicMock()
+        mock_backend.press_key.return_value = None
+
+        unknown = VerificationResult(
+            status=VerifyStatus.UNKNOWN,
+            detail="No UI state change after navigation key(s) enter.",
+            method="focus_check",
+        )
+
+        runner = CliRunner()
+        with patch("naturo.cli.interaction._get_backend", return_value=mock_backend), \
+             patch("naturo.cli.interaction._auto_route", return_value=None), \
+             patch("naturo.verify.capture_before_state", return_value=None), \
+             patch("naturo.verify.verify_press", return_value=unknown):
+            result = runner.invoke(press, ["enter", "--json"])
+        return result
+
+    def test_press_inconclusive_exits_zero(self):
+        """press must exit 0 when verification is inconclusive (#426)."""
+        result = self._run_press_with_unknown_verification()
+        assert result.exit_code == 0, (
+            f"Expected exit code 0 for inconclusive press, got {result.exit_code}.\n"
+            f"Output: {result.output}"
+        )


### PR DESCRIPTION
## Changes
- Removed `sys.exit(2)` for inconclusive verification (`verified=null`, `status=unknown`) from `click`, `press`, and `type` commands
- Inconclusive verification now falls through to `_json_ok()` — exit code 0 with verification data in output
- Added 3 tests in `TestInconclusiveExitCode` covering click and press exit codes + JSON output

## Root Cause
Post-action verification (#242) introduced exit code 2 for "inconclusive" results. In practice, `verify_click` and `verify_press` return UNKNOWN for most successful operations (no detectable focus/text change), making exit code 2 the common case. This broke `set -e` scripts, `&&` chaining, and CI pipelines.

## Exit Code Semantics (after fix)
| Code | Meaning |
|------|---------|
| 0 | Action performed (verification confirmed or inconclusive) |
| 1 | Verification detected silent failure |

Callers who need to distinguish confirmed from inconclusive can inspect the `verified` field in JSON output (`true` vs `null`).

## Testing
- 3 new tests: `test_click_inconclusive_exits_zero`, `test_click_inconclusive_json_has_verified_null`, `test_press_inconclusive_exits_zero`
- Full suite: 1767 passed, 362 skipped, 0 failed

**[Dev-Sirius]**