### PR TITLE
fix: apply consistent test marker filtering on Ubuntu/macOS CI (fixes #410)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -259,8 +259,8 @@ jobs:
       - name: Install package
         run: pip install -e ".[dev]"
 
-      - name: Run tests (skip DLL tests)
-        run: pytest -v
+      - name: Run tests (skip Windows/desktop tests)
+        run: pytest -v -m "not ui and not integration and not desktop and not windows"
 
   test-python-macos:
     name: Python Tests (macOS)
@@ -276,8 +276,8 @@ jobs:
       - name: Install package
         run: pip install -e ".[dev]"
 
-      - name: Run tests
-        run: pytest -v -m "not ui"
+      - name: Run tests (skip Windows/desktop tests)
+        run: pytest -v -m "not ui and not integration and not desktop and not windows"
 
   notify:
     name: Feishu Notification


### PR DESCRIPTION
## Changes
- Ubuntu CI: changed from bare `pytest -v` to `pytest -v -m "not ui and not integration and not desktop and not windows"`
- macOS CI: changed from `pytest -v -m "not ui"` to same full exclusion
- Both now match the Windows CI marker filter

## Problem
Ubuntu ran ALL tests including Windows-only markers (`ui`, `integration`, `desktop`, `windows`), causing failures or hangs. macOS only excluded `ui`, missing other platform-specific markers.

## Testing
- CI will verify this works on the PR itself (Ubuntu + macOS jobs should pass cleanly)

**[Dev-Sirius]**