### PR TITLE
fix: remove duplicate PyPI publish from build.yml (fixes #408)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -400,13 +400,9 @@ jobs:
           pip install build
           python -m build
 
-      - name: Publish to PyPI
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: |
-          pip install twine
-          twine upload dist/*
+      # (#408) PyPI publishing removed — handled by publish.yml
+      # (triggered by the release: published event below).
+      # This avoids duplicate publishes and HTTP 409 conflicts.
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Changes
- Removed `twine upload` step from `build.yml` release job
- PyPI publishing is now exclusively handled by `publish.yml` (trusted publishing via OIDC)

## Problem
Both `build.yml` (twine upload on tag push) and `publish.yml` (trusted publishing on release creation) attempted to publish the same version to PyPI, causing HTTP 409 conflicts.

## Fix
Publishing flow is now:
1. Tag push → `build.yml` runs CI, creates GitHub Release (with wheel + sdist artifacts)
2. Release creation event → triggers `publish.yml` → publishes to PyPI via trusted publishing

This eliminates the duplicate publish while keeping both the GitHub Release creation and PyPI publishing functional.

**[Dev-Sirius]**