### PR TITLE
fix: assert HWND uniqueness instead of PID in multi-window test (fixes #427)

### DIFF
--- a/tests/test_e2e_notepad.py
+++ b/tests/test_e2e_notepad.py
@@ -88,16 +88,17 @@ class TestMultiWindowChaos:
             )
 
             # Each should have valid fields
-            pids = set()
+            hwnds = set()
             for w in notepad_windows:
                 assert w.pid > 0
                 assert w.hwnd > 0
                 assert isinstance(w.title, str)
                 assert "notepad" in w.process_name.lower()
-                pids.add(w.pid)
+                hwnds.add(w.hwnd)
 
-            # Should have distinct PIDs for each process
-            assert len(pids) >= 3
+            # Each window must have a distinct HWND (even if PIDs are shared
+            # due to Windows 11 Notepad tabbed single-process architecture)
+            assert len(hwnds) >= 3
         finally:
             for p in procs:
                 _kill_process(p)


### PR DESCRIPTION
## Changes\n- Changed `test_multi_window_list_all` to assert distinct HWNDs instead of distinct PIDs\n- Windows 11 Notepad uses tabbed single-process architecture — 3 instances share 1 PID but have 3 distinct HWNDs\n\n## Root Cause\nThe test assumed each `notepad.exe` launch creates a separate process with a unique PID. On Windows 11, new Notepad opens tabs in a single process, so `len(pids) >= 3` fails with `assert 1 >= 3`.\n\n## Fix\nAssert `len(hwnds) >= 3` instead — each window still has a unique HWND regardless of process architecture. This correctly tests that `list_windows()` enumerates all windows.\n\n## Testing\n- Test file parses and imports correctly\n- Logic verified: HWND uniqueness is the correct invariant for window enumeration\n\n**[Dev-Sirius]**