### PR TITLE
feat: add code coverage reporting with Codecov (fixes #409)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -221,11 +221,22 @@ jobs:
             --timeout=30 --timeout-method=thread \
             -x --tb=short \
             --junit-xml=pytest-results.xml \
+            --cov=naturo --cov-report=xml --cov-report=term-missing \
             -p no:cacheprovider \
             2>&1 | tee pytest-output.txt
           echo "EXIT_CODE=$?" >> pytest-output.txt
         env:
           PYTEST_TIMEOUT: "30"
+
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.xml
+          flags: windows
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload test artifacts
         if: always()
@@ -235,6 +246,7 @@ jobs:
           path: |
             pytest-output.txt
             pytest-results.xml
+            coverage.xml
           retention-days: 7
           if-no-files-found: ignore
 
@@ -260,7 +272,17 @@ jobs:
         run: pip install -e ".[dev]"
 
       - name: Run tests (skip Windows/desktop tests)
-        run: pytest -v -m "not ui and not integration and not desktop and not windows"
+        run: pytest -v -m "not ui and not integration and not desktop and not windows" --cov=naturo --cov-report=xml --cov-report=term-missing
+
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.xml
+          flags: ubuntu
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   test-python-macos:
     name: Python Tests (macOS)
@@ -277,7 +299,17 @@ jobs:
         run: pip install -e ".[dev]"
 
       - name: Run tests (skip Windows/desktop tests)
-        run: pytest -v -m "not ui and not integration and not desktop and not windows"
+        run: pytest -v -m "not ui and not integration and not desktop and not windows" --cov=naturo --cov-report=xml --cov-report=term-missing
+
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.xml
+          flags: macos
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   notify:
     name: Feishu Notification

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 > See, click, type, capture. Desktop automation core only.
 
 [![Build & Test](https://github.com/AcePeak/naturo/actions/workflows/build.yml/badge.svg)](https://github.com/AcePeak/naturo/actions/workflows/build.yml)
+[![codecov](https://codecov.io/gh/AcePeak/naturo/graph/badge.svg)](https://codecov.io/gh/AcePeak/naturo)
 [![PyPI version](https://img.shields.io/pypi/v/naturo)](https://pypi.org/project/naturo/)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)


### PR DESCRIPTION
## Changes\n- Added `--cov=naturo --cov-report=xml --cov-report=term-missing` to all 3 CI test jobs\n- Added Codecov upload step (codecov/codecov-action@v5) with per-platform flags (windows, ubuntu, macos)\n- Added Codecov badge to README\n- Included coverage.xml in test artifact uploads\n\n## Setup Required\n- Configure `CODECOV_TOKEN` secret in repo settings (get from codecov.io after enabling the repo)\n- Coverage upload is non-blocking (`fail_ci_if_error: false`) so CI won't break if token is missing\n\n## Testing\n- `pytest-cov` already in dev dependencies\n- CI will validate the workflow syntax on this PR\n\n**[Dev-Sirius]**