### PR TITLE
fix: restore internal focus to editor after menu close (fixes #441)

### DIFF
--- a/naturo/backends/windows.py
+++ b/naturo/backends/windows.py
@@ -2252,6 +2252,22 @@ class WindowsBackend(Backend):
         try:
             elem = self._find_uia_element(uia, mod, hwnd=hwnd, name=name,
                                           automation_id=automation_id, role=role)
+
+            # (#441) When called with only hwnd (no name/role/automationId),
+            # _find_uia_element returns None because there are no conditions.
+            # Fall back to finding the first Edit or Document control in the
+            # window — this restores keyboard focus to the main content area
+            # after menu interactions or other focus-stealing events.
+            if elem is None and hwnd and not name and not automation_id and not role:
+                root = uia.ElementFromHandle(hwnd)
+                for ctl_type_id in (50004, 50030):  # Edit, Document
+                    cond = uia.CreatePropertyCondition(
+                        mod.UIA_ControlTypePropertyId, ctl_type_id
+                    )
+                    elem = root.FindFirst(mod.TreeScope_Descendants, cond)
+                    if elem is not None:
+                        break
+
             if elem is None:
                 logger.debug("UIA SetFocus: element not found (name=%r, role=%r)", name, role)
                 return False

--- a/naturo/cli/interaction.py
+++ b/naturo/cli/interaction.py
@@ -871,6 +871,13 @@ def type_cmd(text, delay, profile, wpm, press_return, tab_count, escape,
                     if route_info and _focused_pid.value:
                         route_info["focused_pid"] = _focused_pid.value
                         route_info["focused_hwnd"] = _target_hwnd
+                    # (#441) Also use UIA SetFocus to restore internal widget
+                    # focus (e.g. after menu open/close leaves focus on menu bar)
+                    if hasattr(backend, "focus_element_uia"):
+                        try:
+                            backend.focus_element_uia(hwnd=_target_hwnd)
+                        except Exception:
+                            pass
                     import time
                     time.sleep(0.15)  # Allow focus to settle
             except Exception as exc:

--- a/tests/test_uia_input.py
+++ b/tests/test_uia_input.py
@@ -191,6 +191,60 @@ class TestFocusElementUia:
             )
             assert result is False
 
+    def test_hwnd_only_falls_back_to_edit_control(self, windows_backend):
+        """(#441) focus_element_uia with only hwnd finds first Edit control."""
+        mock_mod = MagicMock()
+        mock_mod.UIA_ControlTypePropertyId = 30003
+        mock_mod.TreeScope_Descendants = 4
+        mock_uia = MagicMock()
+        mock_edit_elem = MagicMock()
+        mock_root = MagicMock()
+        mock_uia.ElementFromHandle.return_value = mock_root
+        # FindFirst returns an Edit element for ctl_type_id 50004
+        mock_root.FindFirst.return_value = mock_edit_elem
+
+        with patch.object(windows_backend, "_init_comtypes_uia",
+                          return_value=(mock_uia, mock_mod)), \
+             patch.object(windows_backend, "_find_uia_element",
+                          return_value=None):
+            result = windows_backend.focus_element_uia(hwnd=12345)
+            assert result is True
+            mock_edit_elem.SetFocus.assert_called_once()
+            mock_uia.ElementFromHandle.assert_called_once_with(12345)
+
+    def test_hwnd_only_no_edit_returns_false(self, windows_backend):
+        """(#441) focus_element_uia with only hwnd returns False if no Edit/Document found."""
+        mock_mod = MagicMock()
+        mock_mod.UIA_ControlTypePropertyId = 30003
+        mock_mod.TreeScope_Descendants = 4
+        mock_uia = MagicMock()
+        mock_root = MagicMock()
+        mock_uia.ElementFromHandle.return_value = mock_root
+        mock_root.FindFirst.return_value = None  # No Edit or Document found
+
+        with patch.object(windows_backend, "_init_comtypes_uia",
+                          return_value=(mock_uia, mock_mod)), \
+             patch.object(windows_backend, "_find_uia_element",
+                          return_value=None):
+            result = windows_backend.focus_element_uia(hwnd=12345)
+            assert result is False
+
+    def test_hwnd_only_not_triggered_with_name(self, windows_backend):
+        """(#441) Edit fallback does NOT trigger when name is provided."""
+        mock_mod = MagicMock()
+        mock_uia = MagicMock()
+
+        with patch.object(windows_backend, "_init_comtypes_uia",
+                          return_value=(mock_uia, mock_mod)), \
+             patch.object(windows_backend, "_find_uia_element",
+                          return_value=None):
+            result = windows_backend.focus_element_uia(
+                hwnd=12345, name="nonexistent"
+            )
+            assert result is False
+            # Should NOT have tried ElementFromHandle fallback
+            mock_uia.ElementFromHandle.assert_not_called()
+
 
 class TestFindUiaElement:
     """Tests for _find_uia_element helper."""


### PR DESCRIPTION
## Changes
- `focus_element_uia`: When called with only `hwnd` (no name/role/automationId), falls back to finding the first Edit or Document control in the window and calling `SetFocus()` on it
- `type_cmd`: Added UIA focus call after `SetForegroundWindow` (matching what `press` already had)
- 3 new tests in `TestFocusElementUia`

## Root Cause
After opening and closing a menu (Alt+F → Escape), `SetForegroundWindow` makes Notepad the foreground window but internal widget focus stays on the menu bar. `focus_element_uia(hwnd=target)` was called with only `hwnd` and no search criteria — `_find_uia_element` returned `None` (empty conditions), making the UIA focus call a no-op. SendInput keystrokes reached the window but were routed to the menu bar, not the text editor.

## Fix
When `focus_element_uia` receives only `hwnd`, it now searches the window's UIA tree for the first Edit (ctl_type 50004) or Document (ctl_type 50030) control and calls `SetFocus()` on it. This restores keyboard focus to the main content area after menu interactions.

Also added the missing `focus_element_uia` call to `type_cmd` — `press` already had it but `type` was missing it.

## Testing
- 3 new tests: hwnd-only fallback finds Edit, returns False if no Edit/Document, doesn't trigger when name is provided
- Full suite: 1770 passed, 365 skipped, 0 failed

**[Dev-Sirius]**