### PR TITLE
fix: prefer larger window over popup menu in HWND resolution (fixes #440)

### DIFF
--- a/naturo/backends/windows.py
+++ b/naturo/backends/windows.py
@@ -871,9 +871,9 @@ class WindowsBackend(Backend):
         over windows in Session 0 (the non-interactive services session).
         This prevents schtasks/remote contexts from targeting ghost windows.
 
-        Case-insensitive throughout.  Among equal scores the window whose
-        title is shortest wins (heuristic: less noise in the title ⇒ more
-        likely the "main" window).
+        Case-insensitive throughout.  Among equal scores the window with
+        the largest area wins (#440: popup menus are tiny top-level windows
+        that should not beat the main application window).
 
         Args:
             app: Application/process name to search for (case-insensitive,
@@ -964,7 +964,8 @@ class WindowsBackend(Backend):
             # Decision: pick this window if it has a higher score, or if
             # scores are equal but this window is in the console session
             # while the current best is not, or if all else is equal,
-            # prefer the shorter title (more likely the "main" window).
+            # prefer the larger window area (#440: popup menus are tiny
+            # top-level windows that should not beat the main window).
             if score > best_score:
                 best_score = score
                 best_session_bonus = in_console
@@ -974,9 +975,11 @@ class WindowsBackend(Backend):
                     # Same score but this one is in the interactive session
                     best_session_bonus = in_console
                     best_window = w
-                elif in_console == best_session_bonus and len(w.title) < len(best_window.title):
-                    # Same score and same session status — prefer shorter title
-                    best_window = w
+                elif in_console == best_session_bonus:
+                    w_area = w.width * w.height
+                    best_area = best_window.width * best_window.height
+                    if w_area > best_area:
+                        best_window = w
 
         if best_window is not None:
             # UWP/WinUI apps: the real UI tree lives under

--- a/tests/test_resolve_hwnd_session.py
+++ b/tests/test_resolve_hwnd_session.py
@@ -67,7 +67,7 @@ class TestResolveHwndSessionAwareness:
         assert result == 2002
 
     def test_falls_back_when_session_unknown(self):
-        """When console session is unknown, use title-length heuristic."""
+        """When console session is unknown, prefer larger window area (#440)."""
         BackendClass = _make_backend()
         backend = MagicMock(spec=BackendClass)
 
@@ -81,7 +81,7 @@ class TestResolveHwndSessionAwareness:
             WindowInfo(
                 handle=2002, title="Notepad",
                 process_name="Notepad.exe", pid=200,
-                x=100, y=100, width=800, height=600,
+                x=100, y=100, width=1200, height=800,
                 is_visible=True, is_minimized=False,
             ),
         ]
@@ -92,8 +92,37 @@ class TestResolveHwndSessionAwareness:
         backend._APP_ALIASES = BackendClass._APP_ALIASES
 
         result = backend._resolve_hwnd(app="notepad")
-        # Both match equally on process name; PID 200 has shorter title
+        # Both match equally on process name; PID 200 has larger area
         assert result == 2002
+
+    def test_popup_menu_not_selected_over_main_window(self):
+        """(#440) Popup menu (tiny window) should not beat main window."""
+        BackendClass = _make_backend()
+        backend = MagicMock(spec=BackendClass)
+
+        windows = [
+            WindowInfo(
+                handle=3001, title="Untitled - Notepad",
+                process_name="Notepad.exe", pid=300,
+                x=100, y=100, width=1536, height=534,
+                is_visible=True, is_minimized=False,
+            ),
+            WindowInfo(
+                handle=3002, title="X",
+                process_name="Notepad.exe", pid=300,
+                x=500, y=200, width=38, height=46,
+                is_visible=True, is_minimized=False,
+            ),
+        ]
+        backend.list_windows = MagicMock(return_value=windows)
+        backend._resolve_hwnd = BackendClass._resolve_hwnd.__get__(backend)
+        backend._get_console_session_id = MagicMock(return_value=1)
+        backend._get_process_session_id = MagicMock(return_value=1)
+        backend._APP_ALIASES = BackendClass._APP_ALIASES
+
+        result = backend._resolve_hwnd(app="notepad")
+        # Main window (3001) has much larger area than popup (3002)
+        assert result == 3001
 
     def test_higher_score_wins_over_session(self):
         """A higher match score should win even if in Session 0."""


### PR DESCRIPTION
## Changes
- Changed `_resolve_hwnd` tie-breaking from "shorter title" to "larger window area"
- Updated existing test to use different window sizes instead of different title lengths
- Added new test: popup menu (38x46) should not beat main window (1536x534)

## Root Cause
When a popup menu is open (e.g., File menu via Alt+F in Notepad), it creates a top-level window under the same process (`notepad.exe`). Both windows get score 4 (exact process name match). The tie-breaker preferred shorter titles, so the tiny popup (38x46 with title "X") beat the main window (1536x534 with title "Untitled - Notepad").

## Fix
Changed the equal-score tie-breaker from `len(w.title) < len(best_window.title)` to `w.width * w.height > best_window.width * best_window.height`. This naturally selects the main application window over popups, tooltips, and other transient windows.

## Testing
- 4 tests in `test_resolve_hwnd_session.py` passed (including 1 new, 1 updated)
- Full suite: 1829 passed, 304 skipped, 0 failed

**[Dev-Sirius]**