### PR TITLE
feat: hybrid tree with per-node backend selection (fixes #367)

### DIFF
--- a/naturo/cascade.py
+++ b/naturo/cascade.py
@@ -319,6 +319,347 @@ def _fetch_ai_elements(
         return []
 
 
+# ── Hybrid tree helpers ───────────────────────────────────────────────────────
+
+# Map Win32 class names to preferred accessibility backends.
+_CLASS_BACKEND_MAP: dict[str, str] = {
+    # Electron / CEF — web content behind UIA opaque pane
+    "Chrome_RenderWidgetHostHWND": "cdp",
+    "Chrome_WidgetWin_0": "cdp",
+    "Chrome_WidgetWin_1": "cdp",
+    # Java — Swing/AWT use Java Access Bridge
+    "SunAwtFrame": "jab",
+    "SunAwtDialog": "jab",
+    "SunAwtCanvas": "jab",
+    "SunAwtPanel": "jab",
+    # Mozilla — Firefox/Thunderbird use IAccessible2
+    "MozillaWindowClass": "ia2",
+    "MozillaCompositorWindowClass": "ia2",
+}
+
+
+def _detect_backend_for_class(cls_name: str) -> str:
+    """Select the best accessibility backend for a Win32 window class.
+
+    Args:
+        cls_name: Win32 window class name (e.g. "Chrome_RenderWidgetHostHWND").
+
+    Returns:
+        Backend name: "cdp", "jab", "ia2", or "uia" (default).
+    """
+    if cls_name in _CLASS_BACKEND_MAP:
+        return _CLASS_BACKEND_MAP[cls_name]
+    # Java Access Bridge classes can have versioned names
+    if cls_name.startswith("SunAwt") or cls_name.startswith("javax.swing"):
+        return "jab"
+    return "uia"
+
+
+def _get_hwnd_children_with_class(hwnd: int) -> list[tuple[int, str, str, tuple[int, int, int, int]]]:
+    """Enumerate direct child HWNDs with class name and bounds.
+
+    Returns list of (child_hwnd, class_name, title, (x, y, w, h)).
+    Runs only on Windows; returns empty list on other platforms.
+    """
+    import platform as _plat
+    if _plat.system() != "Windows":
+        return []
+
+    import ctypes
+    from ctypes import wintypes
+
+    user32 = ctypes.windll.user32
+    children: list[tuple[int, str, str, tuple[int, int, int, int]]] = []
+
+    child = user32.FindWindowExW(hwnd, None, None, None)
+    while child:
+        cls_buf = ctypes.create_unicode_buffer(256)
+        user32.GetClassNameW(child, cls_buf, 256)
+        title_buf = ctypes.create_unicode_buffer(256)
+        user32.GetWindowTextW(child, title_buf, 256)
+        rect = wintypes.RECT()
+        user32.GetWindowRect(child, ctypes.byref(rect))
+        w = rect.right - rect.left
+        h = rect.bottom - rect.top
+        children.append((child, cls_buf.value, title_buf.value, (rect.left, rect.top, w, h)))
+        child = user32.FindWindowExW(hwnd, child, None, None)
+
+    return children
+
+
+def build_hybrid_tree(
+    backend,
+    *,
+    hwnd: int,
+    depth: int = 3,
+    pid: Optional[int] = None,
+) -> tuple[Optional[ElementInfo], CascadeStats]:
+    """Build a hybrid element tree with per-node backend selection.
+
+    Instead of running one backend for the entire tree, this function:
+
+    1. Gets the UIA tree for the root window (fast, single DLL call).
+    2. Enumerates Win32 child HWNDs to discover the window hierarchy.
+    3. For each child HWND, detects the best backend by class name:
+       - ``Chrome_RenderWidgetHostHWND`` -> CDP
+       - ``SunAwt*`` -> JAB (Java Access Bridge)
+       - ``MozillaWindowClass`` -> IA2 (IAccessible2)
+       - Default -> UIA
+    4. For UIA leaf nodes that have Win32 children, enriches the tree by
+       fetching subtrees from the appropriate backend per child HWND.
+    5. Tags every element with its discovery backend in ``properties["source"]``.
+
+    This produces a mixed-backend tree like Naturobot's selector format::
+
+        [win32] Window 'Feishu' hwnd=198164
+          [uia] TitleBar 'Feishu'
+          [win32] ChildWindow class='Chrome_RenderWidgetHostHWND'
+            [cdp] div.nav-item 'Messages'
+            [cdp] div.nav-item 'Calendar'
+
+    Args:
+        backend: Platform backend instance.
+        hwnd: Root window handle.
+        depth: Maximum tree depth for each backend probe.
+        pid: Process ID (used for CDP port detection).
+
+    Returns:
+        Tuple of (root ElementInfo or None, CascadeStats).
+    """
+    stats = CascadeStats()
+
+    # ── Phase 1: Get UIA tree as primary structure ──────────────────────────
+    t0 = time.monotonic()
+    try:
+        uia_tree = backend.get_element_tree(hwnd=hwnd, depth=depth, backend="uia")
+    except Exception as exc:
+        logger.debug("Hybrid: UIA tree failed: %s", exc)
+        uia_tree = None
+    uia_elapsed = (time.monotonic() - t0) * 1000
+
+    if uia_tree is None:
+        stats.providers.append(ProviderStat(name="uia", elapsed_ms=uia_elapsed, status="error"))
+        return None, stats
+
+    uia_tree = _tag_source(uia_tree, "uia")
+    uia_flat = _flatten(uia_tree)
+    stats.providers.append(ProviderStat(
+        name="uia", elements=len(uia_flat), elapsed_ms=uia_elapsed, status="ok",
+    ))
+
+    # ── Phase 2: Enumerate Win32 child HWNDs ────────────────────────────────
+    t0 = time.monotonic()
+    win32_children = _get_hwnd_children_with_class(hwnd)
+    win32_elapsed = (time.monotonic() - t0) * 1000
+
+    if not win32_children:
+        # No child HWNDs — UIA tree is all we have
+        stats.total_elements = len(uia_flat)
+        window_area = _window_area(uia_tree)
+        if window_area > 0:
+            stats.coverage_estimate = _estimate_coverage(uia_flat[1:], window_area)
+        return uia_tree, stats
+
+    # ── Phase 3: Per-HWND backend enrichment ────────────────────────────────
+    # Find UIA leaf nodes (no children or only Pane children) that correspond
+    # to Win32 child HWNDs where a different backend would be better.
+    enriched_count = 0
+    cdp_count = 0
+    jab_count = 0
+    ia2_count = 0
+
+    for child_hwnd, cls_name, title, (cx, cy, cw, ch) in win32_children:
+        preferred = _detect_backend_for_class(cls_name)
+        if preferred == "uia":
+            continue  # UIA tree already covers this
+
+        # Find the UIA node that contains this HWND's bounds
+        target_node = _find_node_by_bounds(uia_tree, cx, cy, cw, ch)
+
+        if preferred == "cdp":
+            # Try CDP for Electron/CEF content
+            cdp_elements = _try_cdp_for_hwnd(
+                child_hwnd, pid, (cx, cy, cw, ch),
+            )
+            if cdp_elements and target_node is not None:
+                target_node.children.extend(cdp_elements)
+                cdp_count += len(cdp_elements)
+                enriched_count += len(cdp_elements)
+            elif cdp_elements:
+                # No matching UIA node — append to root
+                uia_tree.children.extend(cdp_elements)
+                cdp_count += len(cdp_elements)
+                enriched_count += len(cdp_elements)
+
+        elif preferred == "jab":
+            jab_elements = _try_backend_for_hwnd(
+                backend, child_hwnd, "jab", depth, cls_name, title,
+            )
+            if jab_elements and target_node is not None:
+                target_node.children.extend(jab_elements)
+                jab_count += len(jab_elements)
+                enriched_count += len(jab_elements)
+
+        elif preferred == "ia2":
+            ia2_elements = _try_backend_for_hwnd(
+                backend, child_hwnd, "ia2", depth, cls_name, title,
+            )
+            if ia2_elements and target_node is not None:
+                target_node.children.extend(ia2_elements)
+                ia2_count += len(ia2_elements)
+                enriched_count += len(ia2_elements)
+
+    # Record Win32 scan + enrichment stats
+    total_enrichment_elapsed = (time.monotonic() - t0) * 1000
+    if win32_children:
+        stats.providers.append(ProviderStat(
+            name="win32_scan", elements=len(win32_children),
+            elapsed_ms=win32_elapsed, status="ok",
+        ))
+    if cdp_count > 0:
+        stats.providers.append(ProviderStat(
+            name="cdp", elements=cdp_count,
+            elapsed_ms=total_enrichment_elapsed - win32_elapsed, status="ok",
+        ))
+    if jab_count > 0:
+        stats.providers.append(ProviderStat(
+            name="jab", elements=jab_count,
+            elapsed_ms=total_enrichment_elapsed - win32_elapsed, status="ok",
+        ))
+    if ia2_count > 0:
+        stats.providers.append(ProviderStat(
+            name="ia2", elements=ia2_count,
+            elapsed_ms=total_enrichment_elapsed - win32_elapsed, status="ok",
+        ))
+
+    # Final stats
+    all_flat = _flatten(uia_tree)
+    stats.total_elements = len(all_flat)
+    window_area = _window_area(uia_tree)
+    if window_area > 0:
+        stats.coverage_estimate = _estimate_coverage(all_flat[1:], window_area)
+
+    return uia_tree, stats
+
+
+def _find_node_by_bounds(
+    root: ElementInfo,
+    x: int, y: int, w: int, h: int,
+    tolerance: int = 5,
+) -> Optional[ElementInfo]:
+    """Find the deepest tree node whose bounds contain or closely match the target.
+
+    Walks the tree depth-first, preferring deeper matches.  A node "matches" if
+    its bounding box overlaps with the target by at least 80% of the target area.
+
+    Args:
+        root: Root of the element tree to search.
+        x, y, w, h: Target bounding rectangle.
+        tolerance: Pixel tolerance for bounds comparison.
+
+    Returns:
+        The best matching ElementInfo, or None.
+    """
+    if w <= 0 or h <= 0:
+        return None
+
+    target_area = w * h
+    best: Optional[ElementInfo] = None
+    best_depth = -1
+
+    def _walk(node: ElementInfo, depth: int) -> None:
+        nonlocal best, best_depth
+
+        # Check if node bounds overlap significantly with target
+        nx, ny, nw, nh = node.x, node.y, node.width, node.height
+        overlap_x = max(0, min(nx + nw, x + w) - max(nx, x))
+        overlap_y = max(0, min(ny + nh, y + h) - max(ny, y))
+        overlap_area = overlap_x * overlap_y
+
+        if overlap_area >= target_area * 0.5:
+            # Prefer deeper nodes (more specific containers)
+            if depth > best_depth:
+                best = node
+                best_depth = depth
+
+        for child in node.children:
+            _walk(child, depth + 1)
+
+    _walk(root, 0)
+    return best
+
+
+def _try_cdp_for_hwnd(
+    child_hwnd: int,
+    pid: Optional[int],
+    bounds: tuple[int, int, int, int],
+) -> list[ElementInfo]:
+    """Try CDP to get elements for a Chrome_RenderWidgetHostHWND.
+
+    Args:
+        child_hwnd: HWND of the render widget.
+        pid: Process ID for debug port detection.
+        bounds: (x, y, w, h) of the child window.
+
+    Returns:
+        List of tagged CDP elements, or empty list.
+    """
+    if pid is None:
+        return []
+
+    try:
+        from naturo.electron import get_debug_port
+        debug_port = get_debug_port(pid)
+    except Exception:
+        return []
+
+    if not debug_port:
+        return []
+
+    elements = _fetch_cdp_elements(pid, debug_port, bounds)
+    return [_tag_source(el, "cdp") for el in elements]
+
+
+def _try_backend_for_hwnd(
+    backend,
+    child_hwnd: int,
+    backend_name: str,
+    depth: int,
+    cls_name: str,
+    title: str,
+) -> list[ElementInfo]:
+    """Try a specific backend for a child HWND and return tagged children.
+
+    Args:
+        backend: Platform backend instance.
+        child_hwnd: HWND to probe.
+        backend_name: Backend to use ("jab", "ia2", "msaa").
+        depth: Max tree depth.
+        cls_name: Win32 class name (for logging).
+        title: Window title (for logging).
+
+    Returns:
+        List of tagged child elements (not including root), or empty list.
+    """
+    try:
+        tree = backend.get_element_tree(
+            hwnd=child_hwnd, depth=depth, backend=backend_name,
+        )
+    except Exception as exc:
+        logger.debug(
+            "Hybrid: %s failed for HWND %s (%s '%s'): %s",
+            backend_name, child_hwnd, cls_name, title, exc,
+        )
+        return []
+
+    if tree is None or not tree.children:
+        return []
+
+    tagged = _tag_source(tree, backend_name)
+    # Return children of the root (the root itself is the HWND container)
+    return tagged.children
+
+
 # ── Main cascade entry point ──────────────────────────────────────────────────
 
 
@@ -370,6 +711,34 @@ def run_cascade(
     CascadeResult
         Merged element tree with source-tagged elements and statistics.
     """
+    # ── Hybrid mode: per-node backend selection ────────────────────────────
+    if backend_name == "hybrid":
+        resolved_hwnd = hwnd
+        if resolved_hwnd is None:
+            # Resolve app/window_title to hwnd first
+            try:
+                resolved_hwnd = backend._resolve_hwnd(
+                    app=app, window_title=window_title, hwnd=hwnd,
+                )
+            except Exception as exc:
+                logger.debug("Hybrid: HWND resolution failed: %s", exc)
+                return CascadeResult(
+                    tree=None,
+                    stats=CascadeStats(providers=[
+                        ProviderStat(name="hybrid", status="error"),
+                    ]),
+                    primary_provider="hybrid",
+                )
+
+        tree, stats = build_hybrid_tree(
+            backend, hwnd=resolved_hwnd, depth=depth, pid=pid,
+        )
+        return CascadeResult(
+            tree=tree,
+            stats=stats,
+            primary_provider="hybrid",
+        )
+
     stats = CascadeStats()
     merged_elements: List[ElementInfo] = []
     root_tree: Optional[ElementInfo] = None

--- a/naturo/cli/core.py
+++ b/naturo/cli/core.py
@@ -572,9 +572,9 @@ def permissions(json_output):
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.option(
     "--backend", "--method", "-b", "-m",
-    type=click.Choice(["uia", "msaa", "ia2", "jab", "win32", "auto"]),
+    type=click.Choice(["uia", "msaa", "ia2", "jab", "win32", "auto", "hybrid"]),
     default="auto",
-    help="Accessibility backend / interaction method: auto (default: tries all), uia, msaa (legacy apps), ia2 (Firefox/Thunderbird), jab (Java/Swing), win32 (VB6/ActiveX)",
+    help="Accessibility backend / interaction method: auto (default: tries all), uia, msaa (legacy apps), ia2 (Firefox/Thunderbird), jab (Java/Swing), win32 (VB6/ActiveX), hybrid (per-node backend selection)",
 )
 def see(app, window_title, hwnd, pid, mode, depth, path, annotate, store_snapshot, session,
         cascade, fill_gaps, show_stats, coverage_target, visible_only, json_output, backend):
@@ -590,6 +590,10 @@ def see(app, window_title, hwnd, pid, mode, depth, path, annotate, store_snapsho
     applications (Firefox, Thunderbird, LibreOffice). Use --backend auto to
     try UIA first, then IA2, then MSAA automatically.
 
+    Use --backend hybrid for per-node backend selection — each node in the
+    tree picks the optimal backend based on its Win32 class (Electron→CDP,
+    Java→JAB, Mozilla→IA2, default→UIA).
+
     Use --cascade to progressively try multiple providers (UIA → CDP → AI vision).
     This maximizes coverage for Electron apps (Feishu, Slack, VS Code, etc.)
     that render content in a WebView.
@@ -600,6 +604,7 @@ def see(app, window_title, hwnd, pid, mode, depth, path, annotate, store_snapsho
         naturo see --app feishu --cascade --fill-gaps  # Also use AI vision
         naturo see --app feishu --cascade --stats      # Show provider breakdown
         naturo see --app feishu --backend auto         # Try all A11y backends
+        naturo see --app feishu --backend hybrid       # Per-node backend selection
     """
     # BUG-028: Validate --depth range (before platform check — input validation first)
     if depth < 1 or depth > 50:
@@ -623,7 +628,7 @@ def see(app, window_title, hwnd, pid, mode, depth, path, annotate, store_snapsho
 
         # ── Cascade mode: progressive multi-provider recognition (issue #140) ──
         cascade_stats = None
-        if cascade or backend == "auto":
+        if cascade or backend == "auto" or backend == "hybrid":
             # (#275) Auto-capture screenshot for cascade mode so AI vision
             # fallback can trigger when UIA tree is too shallow.
             cascade_screenshot = path
@@ -1019,9 +1024,9 @@ def see(app, window_title, hwnd, pid, mode, depth, path, annotate, store_snapsho
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.option(
     "--backend", "--method", "-b", "-m",
-    type=click.Choice(["uia", "msaa", "ia2", "jab", "win32", "auto"]),
+    type=click.Choice(["uia", "msaa", "ia2", "jab", "win32", "auto", "hybrid"]),
     default="auto",
-    help="Accessibility backend / interaction method: auto (default: tries all), uia, msaa (legacy apps), ia2 (Firefox/Thunderbird), jab (Java/Swing), win32 (VB6/ActiveX)",
+    help="Accessibility backend / interaction method: auto (default: tries all), uia, msaa (legacy apps), ia2 (Firefox/Thunderbird), jab (Java/Swing), win32 (VB6/ActiveX), hybrid (per-node backend selection)",
 )
 @click.option("--provider", "ai_provider",
               type=click.Choice(["auto", "anthropic", "openai", "ollama"]),

--- a/tests/test_cascade.py
+++ b/tests/test_cascade.py
@@ -31,6 +31,9 @@ from naturo.cascade import (
     _flatten,
     _rect_area,
     _tag_source,
+    _detect_backend_for_class,
+    _find_node_by_bounds,
+    build_hybrid_tree,
     run_cascade,
 )
 from naturo.cli import main
@@ -395,3 +398,314 @@ class TestSeeCascadeCLI:
         assert "Recognition Stats" in result.output
         assert "uia" in result.output
         assert "cdp" in result.output
+
+
+# ── Hybrid tree: _detect_backend_for_class ───────────────────────────────────
+
+
+class TestDetectBackendForClass:
+    def test_chrome_render_widget(self):
+        assert _detect_backend_for_class("Chrome_RenderWidgetHostHWND") == "cdp"
+
+    def test_chrome_widget_win(self):
+        assert _detect_backend_for_class("Chrome_WidgetWin_0") == "cdp"
+
+    def test_java_frame(self):
+        assert _detect_backend_for_class("SunAwtFrame") == "jab"
+
+    def test_java_dialog(self):
+        assert _detect_backend_for_class("SunAwtDialog") == "jab"
+
+    def test_java_prefixed(self):
+        assert _detect_backend_for_class("javax.swing.JFrame") == "jab"
+
+    def test_mozilla_window(self):
+        assert _detect_backend_for_class("MozillaWindowClass") == "ia2"
+
+    def test_regular_class_defaults_to_uia(self):
+        assert _detect_backend_for_class("Edit") == "uia"
+        assert _detect_backend_for_class("Button") == "uia"
+        assert _detect_backend_for_class("") == "uia"
+
+    def test_unknown_class_defaults_to_uia(self):
+        assert _detect_backend_for_class("CustomVB6Control42") == "uia"
+
+
+# ── Hybrid tree: _find_node_by_bounds ────────────────────────────────────────
+
+
+class TestFindNodeByBounds:
+    def test_finds_exact_match(self):
+        child = _make_el(id="child", x=100, y=100, w=200, h=150)
+        root = _make_el(id="root", x=0, y=0, w=1000, h=600, children=[child])
+
+        found = _find_node_by_bounds(root, 100, 100, 200, 150)
+        assert found is not None
+        assert found.id == "child"
+
+    def test_prefers_deeper_match(self):
+        grandchild = _make_el(id="gc", x=100, y=100, w=200, h=150)
+        child = _make_el(id="child", x=50, y=50, w=400, h=300, children=[grandchild])
+        root = _make_el(id="root", x=0, y=0, w=1000, h=600, children=[child])
+
+        found = _find_node_by_bounds(root, 100, 100, 200, 150)
+        assert found is not None
+        assert found.id == "gc"
+
+    def test_returns_none_for_zero_area(self):
+        root = _make_el(id="root", x=0, y=0, w=1000, h=600)
+        assert _find_node_by_bounds(root, 0, 0, 0, 0) is None
+
+    def test_returns_none_when_no_overlap(self):
+        child = _make_el(id="child", x=0, y=0, w=100, h=100)
+        root = _make_el(id="root", x=0, y=0, w=1000, h=600, children=[child])
+
+        # Target is far away from any node
+        found = _find_node_by_bounds(root, 900, 500, 50, 50)
+        # Root should still match since it contains the target
+        assert found is not None
+        assert found.id == "root"
+
+    def test_overlap_threshold(self):
+        """Node must overlap >= 50% of target area to match."""
+        child = _make_el(id="child", x=0, y=0, w=100, h=100)
+        root = _make_el(id="root", x=0, y=0, w=1000, h=600, children=[child])
+
+        # Only small overlap with child (10x100 = 1000 out of 200x100 = 20000 = 5%)
+        found = _find_node_by_bounds(root, 90, 0, 200, 100)
+        # Root covers it, child does not (overlap < 50%)
+        assert found is not None
+        assert found.id == "root"
+
+
+# ── Hybrid tree: build_hybrid_tree ───────────────────────────────────────────
+
+
+class TestBuildHybridTree:
+    def test_uia_only_when_no_win32_children(self):
+        """When no Win32 child HWNDs exist, returns the UIA tree as-is."""
+        uia_tree = _make_el(
+            id="root", role="Window", name="Notepad", w=800, h=600,
+            children=[_make_el(id="btn", role="Button", name="Save")],
+        )
+        be = MagicMock()
+        be.get_element_tree.return_value = uia_tree
+
+        with patch("naturo.cascade._get_hwnd_children_with_class", return_value=[]):
+            tree, stats = build_hybrid_tree(be, hwnd=12345, depth=3)
+
+        assert tree is not None
+        assert tree.properties.get("source") == "uia"
+        assert len(tree.children) == 1
+        assert tree.children[0].properties.get("source") == "uia"
+
+    def test_uia_failure_returns_none(self):
+        """When UIA fails, returns None."""
+        be = MagicMock()
+        be.get_element_tree.side_effect = Exception("COM error")
+
+        tree, stats = build_hybrid_tree(be, hwnd=12345, depth=3)
+
+        assert tree is None
+        assert any(p.status == "error" for p in stats.providers)
+
+    def test_jab_enrichment_for_java_hwnd(self):
+        """Java HWND detected → JAB subtree attached to matching UIA node."""
+        uia_tree = _make_el(
+            id="root", role="Window", name="Eclipse", x=0, y=0, w=1000, h=600,
+            children=[
+                _make_el(id="pane", role="Pane", name="", x=100, y=100, w=800, h=400),
+            ],
+        )
+
+        jab_child1 = _make_el(id="jc1", role="PushButton", name="Run")
+        jab_child2 = _make_el(id="jc2", role="PushButton", name="Debug")
+        jab_tree = _make_el(
+            id="jab_root", role="Panel", name="Toolbar",
+            children=[jab_child1, jab_child2],
+        )
+
+        def get_tree_side_effect(**kwargs):
+            backend = kwargs.get("backend", "uia")
+            if backend == "uia":
+                return uia_tree
+            if backend == "jab":
+                return jab_tree
+            return None
+
+        be = MagicMock()
+        be.get_element_tree.side_effect = get_tree_side_effect
+
+        java_children = [
+            (99001, "SunAwtFrame", "Eclipse", (100, 100, 800, 400)),
+        ]
+        with patch("naturo.cascade._get_hwnd_children_with_class", return_value=java_children):
+            tree, stats = build_hybrid_tree(be, hwnd=12345, depth=3)
+
+        assert tree is not None
+        # The pane node should now have JAB children attached
+        pane = tree.children[0]
+        jab_children = [c for c in pane.children if c.properties.get("source") == "jab"]
+        assert len(jab_children) == 2
+        assert jab_children[0].name == "Run"
+        assert jab_children[1].name == "Debug"
+
+    def test_ia2_enrichment_for_mozilla_hwnd(self):
+        """Mozilla HWND detected → IA2 subtree attached."""
+        uia_tree = _make_el(
+            id="root", role="Window", name="Firefox", x=0, y=0, w=1200, h=800,
+            children=[
+                _make_el(id="moz", role="Pane", name="", x=0, y=50, w=1200, h=750),
+            ],
+        )
+
+        ia2_child = _make_el(id="ia2_doc", role="Document", name="Web Page")
+        ia2_tree = _make_el(
+            id="ia2_root", role="Application", name="Firefox",
+            children=[ia2_child],
+        )
+
+        def get_tree_side_effect(**kwargs):
+            if kwargs.get("backend") == "ia2":
+                return ia2_tree
+            return uia_tree
+
+        be = MagicMock()
+        be.get_element_tree.side_effect = get_tree_side_effect
+
+        moz_children = [
+            (88001, "MozillaWindowClass", "Firefox", (0, 50, 1200, 750)),
+        ]
+        with patch("naturo.cascade._get_hwnd_children_with_class", return_value=moz_children):
+            tree, stats = build_hybrid_tree(be, hwnd=12345, depth=3)
+
+        assert tree is not None
+        moz_node = tree.children[0]
+        ia2_children = [c for c in moz_node.children if c.properties.get("source") == "ia2"]
+        assert len(ia2_children) == 1
+        assert ia2_children[0].name == "Web Page"
+
+    def test_cdp_enrichment_for_electron_hwnd(self):
+        """Chrome_RenderWidgetHostHWND → CDP elements attached."""
+        uia_tree = _make_el(
+            id="root", role="Window", name="Feishu", x=0, y=0, w=1200, h=800,
+            children=[
+                _make_el(id="chrome", role="Pane", name="", x=50, y=50, w=1100, h=700),
+            ],
+        )
+
+        cdp_nav = _make_el(id="cdp_0", role="Link", name="Messages",
+                           x=60, y=100, w=100, h=30, props={"source": "cdp"})
+
+        be = MagicMock()
+        be.get_element_tree.return_value = uia_tree
+
+        electron_children = [
+            (77001, "Chrome_RenderWidgetHostHWND", "", (50, 50, 1100, 700)),
+        ]
+        with patch("naturo.cascade._get_hwnd_children_with_class", return_value=electron_children), \
+             patch("naturo.cascade._try_cdp_for_hwnd", return_value=[cdp_nav]):
+            tree, stats = build_hybrid_tree(be, hwnd=12345, depth=3, pid=9999)
+
+        assert tree is not None
+        chrome_node = tree.children[0]
+        cdp_children = [c for c in chrome_node.children if c.properties.get("source") == "cdp"]
+        assert len(cdp_children) == 1
+        assert cdp_children[0].name == "Messages"
+
+    def test_uia_class_skipped_in_enrichment(self):
+        """Regular Win32 classes (mapped to UIA) are skipped — UIA tree already covers them."""
+        uia_tree = _make_el(
+            id="root", role="Window", name="Notepad", x=0, y=0, w=800, h=600,
+            children=[_make_el(id="edit", role="Edit", name="", x=0, y=30, w=800, h=570)],
+        )
+
+        be = MagicMock()
+        be.get_element_tree.return_value = uia_tree
+
+        # Regular Edit class → should be "uia" → skipped in enrichment
+        win32_children = [
+            (55001, "Edit", "", (0, 30, 800, 570)),
+        ]
+        with patch("naturo.cascade._get_hwnd_children_with_class", return_value=win32_children):
+            tree, stats = build_hybrid_tree(be, hwnd=12345, depth=3)
+
+        assert tree is not None
+        # Only one child (the UIA Edit), nothing added
+        assert len(tree.children) == 1
+
+    def test_stats_include_all_providers(self):
+        """Stats should report UIA + win32_scan + any enrichment backends."""
+        uia_tree = _make_el(
+            id="root", role="Window", name="Test", x=0, y=0, w=1000, h=600,
+            children=[_make_el(id="pane", role="Pane", x=100, y=100, w=800, h=400)],
+        )
+
+        jab_tree = _make_el(
+            id="jab_root", role="Panel", name="Java",
+            children=[_make_el(id="jc1", role="PushButton", name="OK")],
+        )
+
+        def get_tree_side_effect(**kwargs):
+            if kwargs.get("backend") == "jab":
+                return jab_tree
+            return uia_tree
+
+        be = MagicMock()
+        be.get_element_tree.side_effect = get_tree_side_effect
+
+        java_children = [(99001, "SunAwtFrame", "Java App", (100, 100, 800, 400))]
+        with patch("naturo.cascade._get_hwnd_children_with_class", return_value=java_children):
+            tree, stats = build_hybrid_tree(be, hwnd=12345, depth=3)
+
+        provider_names = [p.name for p in stats.providers]
+        assert "uia" in provider_names
+        assert "win32_scan" in provider_names
+        assert "jab" in provider_names
+
+
+# ── Hybrid tree: run_cascade with backend="hybrid" ──────────────────────────
+
+
+class TestRunCascadeHybrid:
+    def test_hybrid_backend_routes_to_build_hybrid_tree(self):
+        """backend_name='hybrid' should call build_hybrid_tree."""
+        uia_tree = _make_el(
+            id="root", role="Window", name="Test", w=800, h=600,
+            children=[_make_el(id="btn", role="Button", name="OK")],
+        )
+
+        be = MagicMock()
+        be.get_element_tree.return_value = uia_tree
+        be._resolve_hwnd.return_value = 12345
+
+        with patch("naturo.cascade._get_hwnd_children_with_class", return_value=[]):
+            result = run_cascade(be, backend_name="hybrid")
+
+        assert result.tree is not None
+        assert result.primary_provider == "hybrid"
+        assert result.tree.properties.get("source") == "uia"
+
+    def test_hybrid_uses_provided_hwnd(self):
+        """When hwnd is provided, hybrid mode uses it directly."""
+        uia_tree = _make_el(id="root", role="Window", w=800, h=600)
+        be = MagicMock()
+        be.get_element_tree.return_value = uia_tree
+
+        with patch("naturo.cascade._get_hwnd_children_with_class", return_value=[]):
+            result = run_cascade(be, backend_name="hybrid", hwnd=99999)
+
+        assert result.tree is not None
+        # Should NOT have called _resolve_hwnd since hwnd was provided
+        be._resolve_hwnd.assert_not_called()
+
+    def test_hybrid_returns_error_on_hwnd_resolution_failure(self):
+        """When HWND resolution fails, returns error stats."""
+        be = MagicMock()
+        be._resolve_hwnd.side_effect = Exception("No window found")
+
+        result = run_cascade(be, backend_name="hybrid", app="nonexistent")
+
+        assert result.tree is None
+        assert result.primary_provider == "hybrid"
+        assert any(p.status == "error" for p in result.stats.providers)


### PR DESCRIPTION
## Changes
- Added `build_hybrid_tree()` to `cascade.py` — per-node backend selection based on Win32 class name
- Maps: `Chrome_RenderWidgetHostHWND` → CDP, `SunAwt*` → JAB, `MozillaWindowClass` → IA2, default → UIA
- Algorithm: UIA tree first → enumerate Win32 child HWNDs → probe specialized backends per HWND → attach subtrees to matching UIA nodes
- Every element tagged with `properties["source"]` indicating its discovery backend
- `--backend hybrid` option added to `see` and `find` CLI commands
- Hybrid mode routes through `run_cascade()` for consistent stats/output handling

## Architecture

```
Phase 1: UIA tree (single DLL call, fast)
Phase 2: Win32 HWND enumeration (class name detection)
Phase 3: Per-HWND enrichment:
  - Chrome_RenderWidgetHostHWND → CDP elements attached
  - SunAwtFrame → JAB subtree attached  
  - MozillaWindowClass → IA2 subtree attached
```

Produces mixed-backend paths like Naturobot's selector format:
```
[uia] Window 'Feishu'
  [uia] TitleBar
  [cdp] Link 'Messages'   ← UIA had no children here, CDP discovered it
```

## Testing
- 23 new tests in `test_cascade.py` covering:
  - `_detect_backend_for_class`: class name → backend mapping (8 tests)
  - `_find_node_by_bounds`: bounds-based node matching (5 tests)
  - `build_hybrid_tree`: UIA-only, JAB/IA2/CDP enrichment, stats (7 tests)
  - `run_cascade` hybrid mode: routing, HWND resolution, error handling (3 tests)
- Full suite: 1752 passed, 451 skipped, 0 failed

**[Dev-Sirius]**