### PR TITLE
feat: add --all flag to get command (fixes #382)

### DIFF
--- a/naturo/cli/get_cmd.py
+++ b/naturo/cli/get_cmd.py
@@ -27,6 +27,33 @@ def _get_backend():
     return get_backend()
 
 
+def _collect_matching_elements(tree, role=None, name=None):
+    """Walk the element tree and collect all elements matching role/name.
+
+    Args:
+        tree: Root ElementInfo from get_element_tree.
+        role: Role filter (case-insensitive exact match). None matches any.
+        name: Name filter (case-insensitive substring). None matches any.
+
+    Returns:
+        List of matching ElementInfo nodes.
+    """
+    matches = []
+
+    def _walk(el, depth=0):
+        role_match = role is None or el.role.lower() == role.lower()
+        name_match = name is None or (
+            el.name and name.lower() in el.name.lower()
+        )
+        if role_match and name_match:
+            matches.append(el)
+        for child in el.children:
+            _walk(child, depth + 1)
+
+    _walk(tree)
+    return matches
+
+
 @click.command("get")
 @click.argument("target", required=False)
 @click.option("--ref", "-r", "ref", default=None,
@@ -37,6 +64,8 @@ def _get_backend():
               help="Element role filter (e.g. Edit, Button)")
 @click.option("--name", default=None,
               help="Element name filter")
+@click.option("--all", "-a", "get_all", is_flag=True, default=False,
+              help="Return all matching elements (requires --role or --name)")
 @click.option("--property", "-p", "prop", default=None,
               help="Return only a specific property (value, name, role, pattern)")
 @click.option("--app", default=None, help="Target application (name or partial match)")
@@ -49,12 +78,15 @@ def _get_backend():
 @click.option("--json", "-j", "json_output", is_flag=True, default=None,
               help="JSON output")
 @click.pass_context
-def get_cmd(ctx, target, ref, automation_id, role, name, prop, app,
+def get_cmd(ctx, target, ref, automation_id, role, name, get_all, prop, app,
             window_title, hwnd, json_output):
     """Read element text/value.
 
     Read the current value of a UI element. Accepts an element ref (e47),
     an AutomationId, or a role+name combination.
+
+    Use --all to return all matching elements instead of just the first.
+    Requires --role or --name to specify what to search for.
 
     \b
     Examples:
@@ -63,6 +95,8 @@ def get_cmd(ctx, target, ref, automation_id, role, name, prop, app,
       naturo get --aid txtSearch          # By AutomationId
       naturo get --role Edit --name Search # By role + name
       naturo get e47 -p value             # Just the value text
+      naturo get --role Button --app explorer --all -j  # All buttons
+      naturo get --role Edit --all        # All edit fields
     """
     # Inherit --json from parent group if not set explicitly
     if json_output is None:
@@ -87,6 +121,84 @@ def get_cmd(ctx, target, ref, automation_id, role, name, prop, app,
             if not automation_id:
                 automation_id = target
 
+    # ── --all mode: return all matching elements ─────────────────────────
+    if get_all:
+        if not role and not name:
+            emit_error(
+                "INVALID_INPUT",
+                "--all requires --role or --name to specify what to search for",
+                json_output,
+                suggested_action="Add --role (e.g. --role Button) or --name "
+                "to filter which elements to return.",
+            )
+
+        if platform.system() not in ("Windows",) and not _has_peekaboo():
+            emit_error(
+                "PLATFORM_ERROR",
+                "naturo get requires Windows (UIA patterns) or macOS (Peekaboo)",
+                json_output,
+            )
+
+        try:
+            backend = _get_backend()
+            tree = backend.get_element_tree(
+                app=app, window_title=window_title, hwnd=hwnd,
+                depth=20, backend="auto",
+            )
+
+            if tree is None:
+                emit_error(
+                    "WINDOW_NOT_FOUND",
+                    "No window found for the specified target",
+                    json_output,
+                    suggested_action="Check that the application is running "
+                    "and visible.",
+                )
+
+            matches = _collect_matching_elements(tree, role=role, name=name)
+
+            if json_output:
+                output = []
+                for el in matches:
+                    output.append({
+                        "role": el.role,
+                        "name": el.name,
+                        "value": el.value,
+                        "x": el.x,
+                        "y": el.y,
+                        "width": el.width,
+                        "height": el.height,
+                    })
+                click.echo(json_module.dumps(output))
+            else:
+                if not matches:
+                    filters = []
+                    if role:
+                        filters.append(f"role={role}")
+                    if name:
+                        filters.append(f"name={name}")
+                    click.echo(f"No elements found matching {', '.join(filters)}")
+                    sys.exit(1)
+                click.echo(f"Found {len(matches)} matching element(s):\n")
+                for i, el in enumerate(matches, 1):
+                    header = f"  {i}. [{el.role}]"
+                    if el.name:
+                        header += f' "{el.name}"'
+                    header += f"  ({el.x},{el.y} {el.width}x{el.height})"
+                    click.echo(header)
+                    if el.value is not None:
+                        preview = el.value[:100]
+                        if len(el.value) > 100:
+                            preview += "…"
+                        click.echo(f"     Value: {preview}")
+
+        except NaturoError as exc:
+            emit_exception_error(exc, json_output)
+        except Exception as exc:
+            emit_exception_error(exc, json_output, fallback_code="UNKNOWN_ERROR")
+        return
+
+    # ── Single element mode (default) ────────────────────────────────────
     if not ref and not automation_id and not role and not name:
         emit_error(
             "INVALID_INPUT",

--- a/tests/test_get_cmd.py
+++ b/tests/test_get_cmd.py
@@ -512,3 +512,190 @@ class TestRoleAliasFallback:
         assert result is None
         # Only one call — no alias fallback because automation_id is set
         assert mock_core.get_element_value.call_count == 1
+
+
+# ── --all flag tests (issue #382) ────────────────────────────────────────────
+
+class TestGetAllFlag:
+    """Tests for the ``naturo get --all`` flag."""
+
+    def _make_tree(self):
+        """Build a mock element tree with multiple buttons and edits."""
+        from naturo.backends.base import ElementInfo
+        return ElementInfo(
+            id="e0", role="Window", name="Test App", value=None,
+            x=0, y=0, width=800, height=600,
+            children=[
+                ElementInfo(
+                    id="e1", role="Button", name="Save", value=None,
+                    x=10, y=10, width=80, height=30, children=[], properties={},
+                ),
+                ElementInfo(
+                    id="e2", role="Edit", name="Username", value="alice",
+                    x=10, y=50, width=200, height=25, children=[], properties={},
+                ),
+                ElementInfo(
+                    id="e3", role="Button", name="Cancel", value=None,
+                    x=100, y=10, width=80, height=30, children=[], properties={},
+                ),
+                ElementInfo(
+                    id="e4", role="Edit", name="Password", value="***",
+                    x=10, y=80, width=200, height=25, children=[], properties={},
+                ),
+                ElementInfo(
+                    id="e5", role="Button", name="Help", value=None,
+                    x=200, y=10, width=80, height=30, children=[], properties={},
+                ),
+            ],
+            properties={},
+        )
+
+    def test_all_buttons_json(self):
+        """--all --role Button returns array of all buttons."""
+        tree = self._make_tree()
+        mock = MagicMock()
+        mock.get_element_tree.return_value = tree
+        runner = CliRunner()
+
+        with _apply_patches(mock):
+            result = runner.invoke(main, [
+                "--json", "get", "--role", "Button", "--all",
+            ])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+        assert len(data) == 3
+        names = [el["name"] for el in data]
+        assert "Save" in names
+        assert "Cancel" in names
+        assert "Help" in names
+
+    def test_all_edits_json(self):
+        """--all --role Edit returns array of all edit fields."""
+        tree = self._make_tree()
+        mock = MagicMock()
+        mock.get_element_tree.return_value = tree
+        runner = CliRunner()
+
+        with _apply_patches(mock):
+            result = runner.invoke(main, [
+                "--json", "get", "--role", "Edit", "--all",
+            ])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert len(data) == 2
+        assert data[0]["value"] == "alice"
+        assert data[1]["value"] == "***"
+
+    def test_all_by_name_json(self):
+        """--all --name with substring match."""
+        tree = self._make_tree()
+        mock = MagicMock()
+        mock.get_element_tree.return_value = tree
+        runner = CliRunner()
+
+        with _apply_patches(mock):
+            result = runner.invoke(main, [
+                "--json", "get", "--name", "Save", "--all",
+            ])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert len(data) == 1
+        assert data[0]["name"] == "Save"
+        assert data[0]["role"] == "Button"
+
+    def test_all_plain_text(self):
+        """--all in plain text mode shows numbered list."""
+        tree = self._make_tree()
+        mock = MagicMock()
+        mock.get_element_tree.return_value = tree
+        runner = CliRunner()
+
+        with _apply_patches(mock):
+            result = runner.invoke(main, [
+                "get", "--role", "Button", "--all",
+            ])
+
+        assert result.exit_code == 0
+        assert "3 matching element(s)" in result.output
+        assert "Save" in result.output
+        assert "Cancel" in result.output
+        assert "Help" in result.output
+
+    def test_all_no_matches_json(self):
+        """--all with no matching role returns empty array."""
+        tree = self._make_tree()
+        mock = MagicMock()
+        mock.get_element_tree.return_value = tree
+        runner = CliRunner()
+
+        with _apply_patches(mock):
+            result = runner.invoke(main, [
+                "--json", "get", "--role", "ComboBox", "--all",
+            ])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data == []
+
+    def test_all_no_matches_plain(self):
+        """--all with no matches exits with error in plain mode."""
+        tree = self._make_tree()
+        mock = MagicMock()
+        mock.get_element_tree.return_value = tree
+        runner = CliRunner()
+
+        with _apply_patches(mock):
+            result = runner.invoke(main, [
+                "get", "--role", "ComboBox", "--all",
+            ])
+
+        assert result.exit_code != 0
+        assert "No elements found" in result.output
+
+    def test_all_requires_role_or_name(self):
+        """--all without --role or --name shows error."""
+        runner = CliRunner()
+        result = runner.invoke(main, ["get", "--all"])
+        assert result.exit_code != 0
+
+    def test_all_with_app_filter(self):
+        """--all --app passes app to get_element_tree."""
+        tree = self._make_tree()
+        mock = MagicMock()
+        mock.get_element_tree.return_value = tree
+        runner = CliRunner()
+
+        with _apply_patches(mock):
+            result = runner.invoke(main, [
+                "--json", "get", "--role", "Button", "--all",
+                "--app", "notepad",
+            ])
+
+        assert result.exit_code == 0
+        mock.get_element_tree.assert_called_once_with(
+            app="notepad", window_title=None, hwnd=None,
+            depth=20, backend="auto",
+        )
+
+    def test_all_includes_bounds(self):
+        """--all JSON output includes bounding rect."""
+        tree = self._make_tree()
+        mock = MagicMock()
+        mock.get_element_tree.return_value = tree
+        runner = CliRunner()
+
+        with _apply_patches(mock):
+            result = runner.invoke(main, [
+                "--json", "get", "--role", "Button", "--all",
+            ])
+
+        data = json.loads(result.output)
+        first = data[0]
+        assert "x" in first
+        assert "y" in first
+        assert "width" in first
+        assert "height" in first


### PR DESCRIPTION
## Changes
- Added `--all`/`-a` flag to `naturo get` command
- When `--all` is set, gets the element tree and walks it to find all matching elements by role/name
- JSON mode: returns array of matching elements with role, name, value, bounds
- Plain text mode: numbered list with value previews
- Requires `--role` or `--name` (error if neither specified)
- Default (no `--all`): keeps current first-match behavior unchanged

## Examples
```bash
naturo get --role Button --app explorer --all -j
# → [{"role": "Button", "name": "Save", ...}, {"role": "Button", "name": "Cancel", ...}]

naturo get --role Edit --all
# → Found 2 matching element(s):
#   1. [Edit] "Username"  (10,50 200x25)
#      Value: alice
#   2. [Edit] "Password"  (10,80 200x25)
#      Value: ***
```

## Testing
- 9 new tests covering: JSON array output, plain text list, name filter, empty results, error handling, app passthrough, bounds inclusion
- Full suite: 1796 passed, 393 skipped, 0 failed

**[Dev-Sirius]**