### PR TITLE
fix: --app flag non-deterministic when multiple windows match (fixes #449)

### DIFF
--- a/naturo/backends/windows.py
+++ b/naturo/backends/windows.py
@@ -849,6 +849,20 @@ class WindowsBackend(Backend):
         except Exception:
             return -1
 
+    @staticmethod
+    def _get_foreground_hwnd() -> int:
+        """Get the currently focused foreground window handle.
+
+        Returns:
+            HWND of the foreground window, or 0 on failure.
+        """
+        try:
+            import ctypes
+            hwnd = ctypes.windll.user32.GetForegroundWindow()
+            return hwnd or 0
+        except Exception:
+            return 0
+
     def _resolve_hwnd(self, app: Optional[str] = None,
                       window_title: Optional[str] = None,
                       hwnd: Optional[int] = None) -> int:
@@ -870,6 +884,11 @@ class WindowsBackend(Backend):
         scores, windows in the active console session are strongly preferred
         over windows in Session 0 (the non-interactive services session).
         This prevents schtasks/remote contexts from targeting ghost windows.
+
+        Foreground preference (#449): When multiple windows match with equal
+        scores and session status, the foreground (focused) window is
+        preferred.  This ensures consecutive commands (``type`` then
+        ``capture``) target the same window deterministically.
 
         Case-insensitive throughout.  Among equal scores the window with
         the largest area wins (#440: popup menus are tiny top-level windows
@@ -903,11 +922,15 @@ class WindowsBackend(Backend):
         # Get console session for session-aware ranking (#230)
         console_session = self._get_console_session_id()
 
+        # Get foreground HWND for deterministic tie-breaking (#449)
+        fg_hwnd = self._get_foreground_hwnd()
+
         # --app → match process name first; --window-title → match title only
         match_process = app is not None
 
         best_score = 0
         best_session_bonus = False  # True if best_window is in console session
+        best_is_foreground = False  # True if best_window is the foreground window
         best_window = None
 
         for w in windows:
@@ -961,25 +984,38 @@ class WindowsBackend(Backend):
                 w_session = self._get_process_session_id(w.pid)
                 in_console = (w_session == console_session)
 
+            # (#449) Check if this window is the foreground window
+            is_foreground = (fg_hwnd != 0 and w.handle == fg_hwnd)
+
             # Decision: pick this window if it has a higher score, or if
             # scores are equal but this window is in the console session
-            # while the current best is not, or if all else is equal,
+            # while the current best is not.  Among equal score + session,
+            # prefer the foreground window (#449: consecutive commands
+            # should target the same window deterministically).  Finally,
             # prefer the larger window area (#440: popup menus are tiny
             # top-level windows that should not beat the main window).
             if score > best_score:
                 best_score = score
                 best_session_bonus = in_console
+                best_is_foreground = is_foreground
                 best_window = w
             elif score == best_score and best_window is not None:
                 if in_console and not best_session_bonus:
                     # Same score but this one is in the interactive session
                     best_session_bonus = in_console
+                    best_is_foreground = is_foreground
                     best_window = w
                 elif in_console == best_session_bonus:
-                    w_area = w.width * w.height
-                    best_area = best_window.width * best_window.height
-                    if w_area > best_area:
+                    # (#449) Prefer the foreground window for deterministic
+                    # resolution when multiple windows match equally.
+                    if is_foreground and not best_is_foreground:
+                        best_is_foreground = True
                         best_window = w
+                    elif is_foreground == best_is_foreground:
+                        w_area = w.width * w.height
+                        best_area = best_window.width * best_window.height
+                        if w_area > best_area:
+                            best_window = w
 
         if best_window is not None:
             # UWP/WinUI apps: the real UI tree lives under

--- a/tests/test_resolve_hwnd_session.py
+++ b/tests/test_resolve_hwnd_session.py
@@ -60,6 +60,7 @@ class TestResolveHwndSessionAwareness:
         backend._get_process_session_id = MagicMock(
             side_effect=lambda pid: 0 if pid == 100 else 1
         )
+        backend._get_foreground_hwnd = MagicMock(return_value=0)
         backend._APP_ALIASES = BackendClass._APP_ALIASES
 
         result = backend._resolve_hwnd(app="notepad")
@@ -89,6 +90,7 @@ class TestResolveHwndSessionAwareness:
         backend._resolve_hwnd = BackendClass._resolve_hwnd.__get__(backend)
         backend._get_console_session_id = MagicMock(return_value=-1)
         backend._get_process_session_id = MagicMock(return_value=-1)
+        backend._get_foreground_hwnd = MagicMock(return_value=0)
         backend._APP_ALIASES = BackendClass._APP_ALIASES
 
         result = backend._resolve_hwnd(app="notepad")
@@ -118,6 +120,7 @@ class TestResolveHwndSessionAwareness:
         backend._resolve_hwnd = BackendClass._resolve_hwnd.__get__(backend)
         backend._get_console_session_id = MagicMock(return_value=1)
         backend._get_process_session_id = MagicMock(return_value=1)
+        backend._get_foreground_hwnd = MagicMock(return_value=0)
         backend._APP_ALIASES = BackendClass._APP_ALIASES
 
         result = backend._resolve_hwnd(app="notepad")
@@ -150,10 +153,109 @@ class TestResolveHwndSessionAwareness:
         backend._get_process_session_id = MagicMock(
             side_effect=lambda pid: 1 if pid == 100 else 0
         )
+        backend._get_foreground_hwnd = MagicMock(return_value=0)
         backend._APP_ALIASES = BackendClass._APP_ALIASES
 
         result = backend._resolve_hwnd(app="notepad")
         # PID 200 has exact process name match (score 4),
         # PID 100 only has title substring (score 1).
         # Higher score wins regardless of session.
+        assert result == 2002
+
+
+class TestResolveHwndForegroundPreference:
+    """Verify _resolve_hwnd prefers the foreground window when scores are equal (#449)."""
+
+    def test_foreground_window_preferred_among_equal_matches(self):
+        """When multiple windows match identically, prefer the foreground one."""
+        BackendClass = _make_backend()
+        backend = MagicMock(spec=BackendClass)
+
+        windows = [
+            WindowInfo(
+                handle=1001, title="Untitled - Notepad",
+                process_name="Notepad.exe", pid=100,
+                x=0, y=0, width=800, height=600,
+                is_visible=True, is_minimized=False,
+            ),
+            WindowInfo(
+                handle=2002, title="Document - Notepad",
+                process_name="Notepad.exe", pid=200,
+                x=100, y=100, width=800, height=600,
+                is_visible=True, is_minimized=False,
+            ),
+        ]
+        backend.list_windows = MagicMock(return_value=windows)
+        backend._resolve_hwnd = BackendClass._resolve_hwnd.__get__(backend)
+        backend._get_console_session_id = MagicMock(return_value=1)
+        backend._get_process_session_id = MagicMock(return_value=1)
+        # Window 2002 is the foreground window
+        backend._get_foreground_hwnd = MagicMock(return_value=2002)
+        backend._APP_ALIASES = BackendClass._APP_ALIASES
+
+        result = backend._resolve_hwnd(app="notepad")
+        # Both match on process name (score 4), same session, same area.
+        # Foreground window (2002) should win.
+        assert result == 2002
+
+    def test_foreground_window_preferred_even_when_listed_first(self):
+        """Foreground preference works regardless of iteration order."""
+        BackendClass = _make_backend()
+        backend = MagicMock(spec=BackendClass)
+
+        windows = [
+            WindowInfo(
+                handle=2002, title="Document - Notepad",
+                process_name="Notepad.exe", pid=200,
+                x=100, y=100, width=800, height=600,
+                is_visible=True, is_minimized=False,
+            ),
+            WindowInfo(
+                handle=1001, title="Untitled - Notepad",
+                process_name="Notepad.exe", pid=100,
+                x=0, y=0, width=800, height=600,
+                is_visible=True, is_minimized=False,
+            ),
+        ]
+        backend.list_windows = MagicMock(return_value=windows)
+        backend._resolve_hwnd = BackendClass._resolve_hwnd.__get__(backend)
+        backend._get_console_session_id = MagicMock(return_value=1)
+        backend._get_process_session_id = MagicMock(return_value=1)
+        # Window 1001 is the foreground window (listed second)
+        backend._get_foreground_hwnd = MagicMock(return_value=1001)
+        backend._APP_ALIASES = BackendClass._APP_ALIASES
+
+        result = backend._resolve_hwnd(app="notepad")
+        # Foreground window 1001 should win even though it's listed second
+        assert result == 1001
+
+    def test_larger_area_still_wins_when_no_foreground(self):
+        """When no foreground match, area tie-breaker still works."""
+        BackendClass = _make_backend()
+        backend = MagicMock(spec=BackendClass)
+
+        windows = [
+            WindowInfo(
+                handle=1001, title="Untitled - Notepad",
+                process_name="Notepad.exe", pid=100,
+                x=0, y=0, width=800, height=600,
+                is_visible=True, is_minimized=False,
+            ),
+            WindowInfo(
+                handle=2002, title="Document - Notepad",
+                process_name="Notepad.exe", pid=200,
+                x=100, y=100, width=1200, height=800,
+                is_visible=True, is_minimized=False,
+            ),
+        ]
+        backend.list_windows = MagicMock(return_value=windows)
+        backend._resolve_hwnd = BackendClass._resolve_hwnd.__get__(backend)
+        backend._get_console_session_id = MagicMock(return_value=1)
+        backend._get_process_session_id = MagicMock(return_value=1)
+        # Foreground is some unrelated window
+        backend._get_foreground_hwnd = MagicMock(return_value=9999)
+        backend._APP_ALIASES = BackendClass._APP_ALIASES
+
+        result = backend._resolve_hwnd(app="notepad")
+        # Neither is foreground, so larger area (2002) wins
         assert result == 2002


### PR DESCRIPTION
## Changes
- Added `_get_foreground_hwnd()` static method to query the currently focused window
- Modified `_resolve_hwnd` tie-breaking chain: score > session > **foreground** > area
- When multiple windows match `--app` with equal scores, the foreground window is preferred, ensuring consecutive commands target the same window

## Root Cause
`_resolve_hwnd` tie-breaking for equal-scoring windows used only session + area. With multiple Notepad windows of the same size in the same session, the result depended on `list_windows()` iteration order — non-deterministic. After `naturo type --app notepad`, the typed-into window is in the foreground, but a subsequent `naturo capture --app notepad` could pick a different window.

## Testing
- 3 new tests in `TestResolveHwndForegroundPreference` (foreground wins, iteration-order independent, area fallback)
- 4 existing tests updated with `_get_foreground_hwnd` mock
- All 7 tests pass

**[Dev-Sirius]**