### PR TITLE
fix: stable hash-based element refs prevent eN shift across snapshots (fixes #456)

### DIFF
--- a/naturo/cli/core.py
+++ b/naturo/cli/core.py
@@ -743,51 +743,13 @@ def see(app, window_title, hwnd, pid, mode, depth, path, annotate, store_snapsho
             mgr = get_snapshot_manager(session=session)
             snapshot_id = mgr.create_snapshot()
 
-            # Flatten element tree into ui_map and build ref→element mapping
-            # (BUG-071: sequential refs e1, e2, ... for click integration)
-            ui_map = {}
-            _ref_seq = [0]
-            ref_map = {}  # "e1" → element_id (backend id)
+            # Flatten element tree into ui_map and build ref→element mapping.
+            # (#456) eN refs are now hash-based (stable across snapshots) instead
+            # of sequential.  The same element gets the same eN even if the tree
+            # changes between snapshots (e.g. Calculator display update after Clear).
+            from naturo.refs import assign_stable_refs
 
-            import re as _re_mod
-
-            def _flatten(el, parent_id=None):
-                _ref_seq[0] += 1
-                ref = f"e{_ref_seq[0]}"
-                props = getattr(el, "properties", {})
-                # (#229) Only store identifier if it's a real UIA AutomationId,
-                # not a tree-assigned sequential ID like "e1", "e2", etc.
-                # populate_hierarchy assigns "eN" to elements with empty ids,
-                # so we must filter those out to avoid false AutomationId lookups.
-                _raw_id = str(el.id) if el.id else None
-                if _raw_id and _re_mod.fullmatch(r"e\d+", _raw_id):
-                    _raw_id = None  # Tree-assigned, not a real AutomationId
-                # (#237) Always use the sequential ref as canonical key in
-                # ui_map.  Multiple elements can share the same UIA
-                # AutomationId (e.g. Notepad status bar texts), so using
-                # el.id as key caused overwrites and duplicate display IDs.
-                # The original AutomationId is preserved in `identifier`.
-                child_refs = []
-                for child in el.children:
-                    child_refs.append(_flatten(child, parent_id=ref))
-                ui_map[ref] = UIElement(
-                    id=ref,
-                    element_id=f"element_{ref}",
-                    role=el.role,
-                    title=el.name,
-                    label=el.name,
-                    value=el.value,
-                    identifier=_raw_id,
-                    frame=(el.x, el.y, el.width, el.height),
-                    is_actionable=getattr(el, "is_actionable", False),
-                    parent_id=parent_id,
-                    children=child_refs,
-                    keyboard_shortcut=props.get("keyboard_shortcut"),
-                )
-                ref_map[ref] = el.id
-                return ref
-
-            _flatten(tree)
+            ui_map, ref_map = assign_stable_refs(tree, UIElement)
             mgr.store_detection_result(snapshot_id, ui_map)
             # Persist ref mapping so click/type can resolve e<N> refs
             mgr.store_ref_map(snapshot_id, ref_map)
@@ -1149,42 +1111,13 @@ def find_cmd(query, query_opt, find_all, role, actionable, depth, limit, ai,
         mgr = get_snapshot_manager()
         snapshot_id = mgr.create_snapshot()
 
-        ui_map = {}
-        _ref_seq = [0]
-        ref_map = {}
-        # Build a mapping from backend element id → eN ref
-        _element_id_to_ref = {}
+        # (#456) Use stable hash-based refs (same as `see` command)
+        from naturo.refs import assign_stable_refs
 
-        import re as _re_mod
-
-        def _flatten_for_find(el, parent_id=None):
-            _ref_seq[0] += 1
-            ref = f"e{_ref_seq[0]}"
-            _element_id_to_ref[id(el)] = ref
-            _raw_id = str(el.id) if el.id else None
-            if _raw_id and _re_mod.fullmatch(r"e\d+", _raw_id):
-                _raw_id = None
-            child_refs = []
-            for child in el.children:
-                child_refs.append(_flatten_for_find(child, parent_id=ref))
-            ui_map[ref] = UIElement(
-                id=ref,
-                element_id=f"element_{ref}",
-                role=el.role,
-                title=el.name,
-                label=el.name,
-                value=el.value,
-                identifier=_raw_id,
-                frame=(el.x, el.y, el.width, el.height),
-                is_actionable=getattr(el, "is_actionable", False),
-                parent_id=parent_id,
-                children=child_refs,
-                keyboard_shortcut=getattr(el, "keyboard_shortcut", None),
-            )
-            ref_map[ref] = el.id
-            return ref
-
-        _flatten_for_find(bridge_tree)
+        _element_id_to_ref: dict[int, str] = {}
+        ui_map, ref_map = assign_stable_refs(
+            bridge_tree, UIElement, element_obj_to_ref=_element_id_to_ref,
+        )
         mgr.store_detection_result(snapshot_id, ui_map)
         mgr.store_ref_map(snapshot_id, ref_map)
 

--- a/naturo/refs.py
+++ b/naturo/refs.py
@@ -1,0 +1,136 @@
+"""Stable element reference assignment for UI snapshots.
+
+Generates deterministic ``eN`` refs based on element identity (AutomationId,
+role, name, parent chain) so the same UI element receives the same ref across
+consecutive snapshots — even when the tree changes slightly (e.g. Calculator
+display update after pressing Clear).
+
+Replaces the old sequential assignment (e1, e2, e3 in DFS order) which caused
+refs to shift whenever elements were added, removed, or reordered (#456).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Any, Dict, Tuple, Type
+
+_TREE_ASSIGNED_RE = re.compile(r"e\d+")
+
+
+def _get_real_automation_id(el: Any) -> str | None:
+    """Extract a real UIA AutomationId, filtering out tree-assigned eN IDs.
+
+    ``populate_hierarchy`` in ``bridge.py`` assigns ``"eN"`` IDs to elements
+    with empty ids.  Those are not real AutomationIds and must be excluded
+    (#229).
+    """
+    raw = str(el.id) if el.id else None
+    if raw and _TREE_ASSIGNED_RE.fullmatch(raw):
+        return None
+    return raw
+
+
+def _build_identity_path(el: Any, parent_path: str, sibling_index: int) -> str:
+    """Build a stable identity path for an element.
+
+    Uses AutomationId when available, falls back to role + name + sibling
+    index for disambiguation.
+    """
+    auto_id = _get_real_automation_id(el)
+    if auto_id:
+        segment = f"{el.role}:{auto_id}"
+    else:
+        name = el.name or ""
+        segment = f"{el.role}:{name}[{sibling_index}]"
+    return f"{parent_path}/{segment}"
+
+
+def _hash_to_ref_number(path: str) -> int:
+    """Hash an identity path to a deterministic ref number in [1, 9999]."""
+    digest = hashlib.sha256(path.encode("utf-8")).hexdigest()
+    return int(digest[:8], 16) % 9999 + 1
+
+
+def assign_stable_refs(
+    tree: Any,
+    ui_element_cls: Type,
+    element_obj_to_ref: Dict[int, str] | None = None,
+) -> Tuple[Dict[str, Any], Dict[str, str]]:
+    """Traverse an element tree and assign stable ``eN`` refs.
+
+    Each element receives a deterministic ref based on a hash of its identity
+    path (AutomationId / role / name / parent chain / sibling position).  The
+    same element in two consecutive snapshots of the same app will receive the
+    same ``eN`` ref, even if other parts of the tree change.
+
+    Parameters
+    ----------
+    tree:
+        Root of the backend element tree.
+    ui_element_cls:
+        The ``UIElement`` dataclass to instantiate for each element.
+    element_obj_to_ref:
+        Optional dict that will be populated with ``id(el)`` → ``eN`` ref
+        mappings.  Used by the ``find`` command to correlate search results
+        back to snapshot refs.
+
+    Returns
+    -------
+    tuple[dict[str, UIElement], dict[str, str]]
+        ``(ui_map, ref_map)`` — the snapshot element map keyed by ``eN`` refs,
+        and the ref → backend element id mapping for persistence.
+    """
+    ui_map: Dict[str, Any] = {}
+    ref_map: Dict[str, str] = {}
+    used_numbers: set[int] = set()
+
+    def _resolve_number(path: str) -> int:
+        """Get a unique ref number for the given path, handling collisions."""
+        n = _hash_to_ref_number(path)
+        while n in used_numbers:
+            n = n % 9999 + 1
+        used_numbers.add(n)
+        return n
+
+    def _walk(el: Any, identity_path: str, parent_ref: str | None) -> str:
+        """DFS: assign stable ref, build UIElement, recurse into children."""
+        auto_id = _get_real_automation_id(el)
+        ref_num = _resolve_number(identity_path)
+        ref = f"e{ref_num}"
+        if element_obj_to_ref is not None:
+            element_obj_to_ref[id(el)] = ref
+        props = getattr(el, "properties", {})
+
+        # Track sibling (role, identity) counts to disambiguate children
+        # that share the same role + name under this parent.
+        sibling_counts: dict[tuple[str, str], int] = {}
+        child_refs: list[str] = []
+        for child in el.children:
+            child_auto = _get_real_automation_id(child)
+            child_key = (child.role, child_auto) if child_auto else (child.role, child.name or "")
+            idx = sibling_counts.get(child_key, 0)
+            sibling_counts[child_key] = idx + 1
+            child_path = _build_identity_path(child, identity_path, sibling_index=idx)
+            child_refs.append(_walk(child, child_path, parent_ref=ref))
+
+        ui_map[ref] = ui_element_cls(
+            id=ref,
+            element_id=f"element_{ref}",
+            role=el.role,
+            title=el.name,
+            label=el.name,
+            value=el.value,
+            identifier=auto_id,
+            frame=(el.x, el.y, el.width, el.height),
+            is_actionable=getattr(el, "is_actionable", False),
+            parent_id=parent_ref,
+            children=child_refs,
+            keyboard_shortcut=props.get("keyboard_shortcut"),
+        )
+        ref_map[ref] = el.id
+        return ref
+
+    root_path = _build_identity_path(tree, parent_path="", sibling_index=0)
+    _walk(tree, root_path, parent_ref=None)
+    return ui_map, ref_map

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -1,0 +1,295 @@
+"""Tests for stable element reference assignment (#456)."""
+
+from dataclasses import dataclass, field
+from typing import List, Optional, Tuple
+
+import pytest
+
+from naturo.refs import (
+    _build_identity_path,
+    _get_real_automation_id,
+    _hash_to_ref_number,
+    assign_stable_refs,
+)
+
+
+# ── Minimal stubs ──────────────────────────────────────────────────────────
+
+
+@dataclass
+class FakeElement:
+    """Minimal element stub matching the interface expected by assign_stable_refs."""
+
+    id: str = ""
+    role: str = ""
+    name: str = ""
+    value: Optional[str] = None
+    x: int = 0
+    y: int = 0
+    width: int = 100
+    height: int = 30
+    children: list = field(default_factory=list)
+    is_actionable: bool = False
+    properties: dict = field(default_factory=dict)
+
+
+@dataclass
+class FakeUIElement:
+    """Minimal UIElement stub for testing."""
+
+    id: str = ""
+    element_id: str = ""
+    role: str = ""
+    title: Optional[str] = None
+    label: Optional[str] = None
+    value: Optional[str] = None
+    identifier: Optional[str] = None
+    frame: Tuple[int, int, int, int] = (0, 0, 0, 0)
+    is_actionable: bool = False
+    parent_id: Optional[str] = None
+    children: List[str] = field(default_factory=list)
+    keyboard_shortcut: Optional[str] = None
+
+
+# ── Unit tests for helpers ──────────────────────────────────────────────────
+
+
+class TestGetRealAutomationId:
+
+    def test_real_id(self):
+        el = FakeElement(id="num7Button")
+        assert _get_real_automation_id(el) == "num7Button"
+
+    def test_tree_assigned_id_filtered(self):
+        el = FakeElement(id="e42")
+        assert _get_real_automation_id(el) is None
+
+    def test_empty_id(self):
+        el = FakeElement(id="")
+        assert _get_real_automation_id(el) is None
+
+    def test_none_id(self):
+        el = FakeElement()
+        el.id = None
+        assert _get_real_automation_id(el) is None
+
+
+class TestBuildIdentityPath:
+
+    def test_with_automation_id(self):
+        el = FakeElement(id="num7Button", role="Button", name="7")
+        path = _build_identity_path(el, "/root", sibling_index=0)
+        assert path == "/root/Button:num7Button"
+
+    def test_without_automation_id(self):
+        el = FakeElement(id="", role="Text", name="Status")
+        path = _build_identity_path(el, "/root", sibling_index=2)
+        assert path == "/root/Text:Status[2]"
+
+    def test_tree_assigned_id_uses_fallback(self):
+        el = FakeElement(id="e5", role="Button", name="OK")
+        path = _build_identity_path(el, "/parent", sibling_index=0)
+        assert path == "/parent/Button:OK[0]"
+
+
+class TestHashToRefNumber:
+
+    def test_returns_in_range(self):
+        for path in ["/a/b/c", "/x/y/z", "", "/Button:num7Button"]:
+            n = _hash_to_ref_number(path)
+            assert 1 <= n <= 9999
+
+    def test_deterministic(self):
+        path = "/Window:Calculator/Button:num7Button"
+        assert _hash_to_ref_number(path) == _hash_to_ref_number(path)
+
+    def test_different_paths_different_numbers(self):
+        n1 = _hash_to_ref_number("/Button:num7Button")
+        n2 = _hash_to_ref_number("/Button:num8Button")
+        assert n1 != n2
+
+
+# ── Integration tests for assign_stable_refs ────────────────────────────────
+
+
+def _make_calculator_tree(display_text="0"):
+    """Build a simplified Calculator element tree."""
+    display = FakeElement(
+        id="CalculatorResults", role="Text", name=display_text,
+        x=10, y=10, width=300, height=50,
+    )
+    btn_7 = FakeElement(
+        id="num7Button", role="Button", name="七",
+        x=10, y=100, width=70, height=50, is_actionable=True,
+    )
+    btn_plus = FakeElement(
+        id="plusButton", role="Button", name="加",
+        x=90, y=100, width=70, height=50, is_actionable=True,
+    )
+    btn_3 = FakeElement(
+        id="num3Button", role="Button", name="三",
+        x=170, y=100, width=70, height=50, is_actionable=True,
+    )
+    btn_eq = FakeElement(
+        id="equalButton", role="Button", name="等于",
+        x=250, y=100, width=70, height=50, is_actionable=True,
+    )
+    btn_clear = FakeElement(
+        id="clearButton", role="Button", name="Clear",
+        x=10, y=160, width=70, height=50, is_actionable=True,
+    )
+    root = FakeElement(
+        id="Calculator", role="Window", name="Calculator",
+        x=0, y=0, width=340, height=220,
+        children=[display, btn_7, btn_plus, btn_3, btn_eq, btn_clear],
+    )
+    return root
+
+
+class TestStableRefsAcrossSnapshots:
+    """Core test: same element gets same eN across different snapshots."""
+
+    def test_same_tree_same_refs(self):
+        """Identical trees produce identical ref assignments."""
+        tree1 = _make_calculator_tree("0")
+        tree2 = _make_calculator_tree("0")
+        ui_map1, _ = assign_stable_refs(tree1, FakeUIElement)
+        ui_map2, _ = assign_stable_refs(tree2, FakeUIElement)
+
+        refs1 = {el.identifier or el.title: ref for ref, el in ui_map1.items()}
+        refs2 = {el.identifier or el.title: ref for ref, el in ui_map2.items()}
+        assert refs1 == refs2
+
+    def test_display_change_preserves_button_refs(self):
+        """When display text changes (after Clear), button refs stay stable.
+
+        This is the exact scenario from issue #456: pressing Clear changes
+        the display element's name/value, but buttons should keep their eN.
+        """
+        tree_before = _make_calculator_tree("7 + 3 = 10")
+        tree_after = _make_calculator_tree("0")
+
+        ui_before, _ = assign_stable_refs(tree_before, FakeUIElement)
+        ui_after, _ = assign_stable_refs(tree_after, FakeUIElement)
+
+        # Collect button refs by AutomationId
+        def button_refs(ui_map):
+            return {
+                el.identifier: ref
+                for ref, el in ui_map.items()
+                if el.identifier and el.identifier != "CalculatorResults"
+            }
+
+        before_buttons = button_refs(ui_before)
+        after_buttons = button_refs(ui_after)
+
+        # Every button must have the same eN in both snapshots
+        assert before_buttons == after_buttons
+
+    def test_element_added_preserves_existing_refs(self):
+        """Adding a new child element does not shift existing elements' refs."""
+        tree1 = _make_calculator_tree("0")
+        ui_map1, _ = assign_stable_refs(tree1, FakeUIElement)
+
+        # Add a history panel element
+        tree2 = _make_calculator_tree("0")
+        history = FakeElement(
+            id="historyPanel", role="Group", name="History",
+            x=10, y=220, width=300, height=100,
+        )
+        tree2.children.append(history)
+        ui_map2, _ = assign_stable_refs(tree2, FakeUIElement)
+
+        # All original elements should keep their refs
+        refs1 = {el.identifier or el.title: ref for ref, el in ui_map1.items()}
+        refs2 = {el.identifier or el.title: ref for ref, el in ui_map2.items()}
+        for key in refs1:
+            assert refs1[key] == refs2[key], f"Ref shifted for {key}: {refs1[key]} → {refs2[key]}"
+
+    def test_element_removed_preserves_remaining_refs(self):
+        """Removing an element does not shift remaining elements' refs."""
+        tree1 = _make_calculator_tree("0")
+        ui_map1, _ = assign_stable_refs(tree1, FakeUIElement)
+
+        # Remove the Clear button
+        tree2 = _make_calculator_tree("0")
+        tree2.children = [c for c in tree2.children if c.id != "clearButton"]
+        ui_map2, _ = assign_stable_refs(tree2, FakeUIElement)
+
+        # Remaining elements should keep their refs
+        refs1 = {el.identifier or el.title: ref for ref, el in ui_map1.items()}
+        refs2 = {el.identifier or el.title: ref for ref, el in ui_map2.items()}
+        for key in refs2:
+            assert refs1[key] == refs2[key], f"Ref shifted for {key}: {refs1[key]} → {refs2[key]}"
+
+
+class TestAssignStableRefsBasics:
+
+    def test_all_elements_get_unique_refs(self):
+        tree = _make_calculator_tree("0")
+        ui_map, _ = assign_stable_refs(tree, FakeUIElement)
+        refs = list(ui_map.keys())
+        assert len(refs) == len(set(refs)), "Duplicate refs found"
+
+    def test_ref_format(self):
+        tree = _make_calculator_tree("0")
+        ui_map, _ = assign_stable_refs(tree, FakeUIElement)
+        import re
+        for ref in ui_map:
+            assert re.fullmatch(r"e\d+", ref), f"Bad ref format: {ref}"
+
+    def test_ref_map_matches_ui_map_keys(self):
+        tree = _make_calculator_tree("0")
+        ui_map, ref_map = assign_stable_refs(tree, FakeUIElement)
+        assert set(ui_map.keys()) == set(ref_map.keys())
+
+    def test_parent_child_refs_consistent(self):
+        tree = _make_calculator_tree("0")
+        ui_map, _ = assign_stable_refs(tree, FakeUIElement)
+
+        for ref, el in ui_map.items():
+            for child_ref in el.children:
+                assert child_ref in ui_map, f"Child ref {child_ref} not in ui_map"
+                assert ui_map[child_ref].parent_id == ref
+
+    def test_root_has_no_parent(self):
+        tree = _make_calculator_tree("0")
+        ui_map, _ = assign_stable_refs(tree, FakeUIElement)
+        root_els = [el for el in ui_map.values() if el.parent_id is None]
+        assert len(root_els) == 1
+        assert root_els[0].role == "Window"
+
+    def test_element_obj_to_ref_mapping(self):
+        tree = _make_calculator_tree("0")
+        obj_map: dict[int, str] = {}
+        ui_map, _ = assign_stable_refs(tree, FakeUIElement, element_obj_to_ref=obj_map)
+
+        # Every element in the tree should have an entry
+        assert id(tree) in obj_map
+        for child in tree.children:
+            assert id(child) in obj_map
+
+        # Refs should match ui_map
+        for obj_id, ref in obj_map.items():
+            assert ref in ui_map
+
+    def test_identifier_preserved(self):
+        tree = _make_calculator_tree("0")
+        ui_map, _ = assign_stable_refs(tree, FakeUIElement)
+
+        identifiers = {el.identifier for el in ui_map.values() if el.identifier}
+        assert "num7Button" in identifiers
+        assert "clearButton" in identifiers
+
+    def test_siblings_same_role_name_get_different_refs(self):
+        """Two unnamed Text elements under the same parent get different refs."""
+        text1 = FakeElement(role="Text", name="", x=0, y=0, width=50, height=20)
+        text2 = FakeElement(role="Text", name="", x=60, y=0, width=50, height=20)
+        root = FakeElement(
+            id="root", role="Window", name="App",
+            children=[text1, text2],
+        )
+        ui_map, _ = assign_stable_refs(root, FakeUIElement)
+        refs = list(ui_map.keys())
+        assert len(refs) == 3  # root + 2 texts
+        assert len(set(refs)) == 3  # all unique


### PR DESCRIPTION
## Changes
- Replaced sequential eN assignment (e1, e2, e3 in DFS order) with deterministic hash-based refs derived from each element's identity path (AutomationId, role, name, parent chain, sibling position)
- Extracted ref assignment logic into new `naturo/refs.py` module, shared by both `see` and `find` commands (eliminates code duplication)
- The same UI element now receives the same eN ref across consecutive snapshots, even when other parts of the tree change

## Root Cause
`_flatten()` assigned eN IDs sequentially during DFS traversal. When Calculator state changed (e.g. after pressing Clear), the display element's text changed, which could add/remove/reorder child elements — shifting all subsequent eN numbers. Button e45 ("七"/7) in snapshot 1 could become e43 or e47 in snapshot 2, causing `click --id e45` to hit the wrong button.

## Design
Each element's ref is derived from a SHA-256 hash of its **identity path**:
- Elements with a real UIA AutomationId (e.g. `num7Button`) → path includes AutomationId
- Elements without → path includes role + name + sibling index among same-role-name siblings
- Parent chain is included for full disambiguation

Hash is mapped to range [1, 9999] with collision resolution.

## Testing
- 22 new tests in `test_refs.py`:
  - Unit tests for helpers (`_get_real_automation_id`, `_build_identity_path`, `_hash_to_ref_number`)
  - Stability tests: same tree → same refs, display change → buttons stable, element added/removed → remaining refs stable
  - Structural tests: unique refs, parent-child consistency, `element_obj_to_ref` mapping
- Full suite: 1844 passed, 547 skipped, 0 failed

**[Dev-Sirius]**