### PR TITLE
fix: skip auto-routing for eN ref clicks to reduce per-click overhead (fixes #448)

### DIFF
--- a/naturo/cli/interaction.py
+++ b/naturo/cli/interaction.py
@@ -641,13 +641,6 @@ def click_cmd(query, on_text, ref_alias, element_id, coords, double, right, app,
         on_text = ref_alias
     backend = _get_backend(json_output)
 
-    # --ref is a hidden deprecated alias for --on (#381)
-    if ref_alias and not on_text:
-        on_text = ref_alias
-
-    # Auto-routing: detect best interaction method for target app
-    route_info = _auto_route(app, pid, method, json_output)
-
     button = "right" if right else "left"
 
     # Resolve target coordinates or element_id
@@ -666,16 +659,30 @@ def click_cmd(query, on_text, ref_alias, element_id, coords, double, right, app,
         _json_err("Specify --coords X Y, --id, or --on TEXT", json_output, code="INVALID_INPUT")
         return
 
-    # BUG-074: Resolve eN refs from the most recent `see` snapshot
+    # (#448) Resolve eN refs BEFORE auto-routing so we can skip the
+    # expensive framework detection chain when we already have cached
+    # coordinates from a recent snapshot.
     import re as _re
     _zero_bounds_element = None  # Track element for Invoke fallback (#137)
+    _ref_resolved = False  # True when eN ref resolved to coordinates
+    _snapshot_hwnd = None  # HWND from snapshot metadata for window focus
     if target_id and _re.fullmatch(r"e\d+", target_id):
         from naturo.snapshot import get_snapshot_manager
         mgr = get_snapshot_manager()
         resolved = mgr.resolve_ref(target_id)
         if resolved:
             x, y = resolved[0], resolved[1]
+            _snap_id = resolved[2]
             target_id = None  # use coordinates instead
+            _ref_resolved = True
+            # (#448) Retrieve the snapshot's stored HWND so we can focus
+            # the target window without re-enumerating processes.
+            try:
+                snapshot = mgr.get_snapshot(_snap_id)
+                if snapshot.window_handle:
+                    _snapshot_hwnd = snapshot.window_handle
+            except Exception:
+                pass
         else:
             # resolve_ref returns None for both "not found" and "zero-bounds".
             # Check resolve_ref_element to distinguish: if the element exists
@@ -701,11 +708,31 @@ def click_cmd(query, on_text, ref_alias, element_id, coords, double, right, app,
                 )
                 return
 
+    # (#448) Skip auto-routing when eN ref already resolved to cached
+    # coordinates — the framework detection chain is unnecessary since
+    # we'll use coordinate-based SendInput.
+    if _ref_resolved:
+        route_info = {}
+    else:
+        route_info = _auto_route(app, pid, method, json_output)
+
     # (#226) When UIA routing is active and --app is specified, ensure
     # the target window has focus via UIA before sending mouse input.
+    # (#448) When eN ref resolved, use the snapshot's stored HWND for
+    # focus instead of re-enumerating processes.
     _uia_method = route_info.get("method") == "uia" if route_info else False
     _is_uwp = False  # Track UWP apps for UIA click fallback (#248)
-    if _uia_method and (app or hwnd) and hasattr(backend, "focus_element_uia"):
+    if _ref_resolved and _snapshot_hwnd:
+        # Fast path: use cached HWND from snapshot for window focus
+        try:
+            import ctypes
+            SW_RESTORE = 9
+            if hasattr(backend, "_is_iconic") and backend._is_iconic(_snapshot_hwnd):
+                ctypes.windll.user32.ShowWindow(_snapshot_hwnd, SW_RESTORE)
+            ctypes.windll.user32.SetForegroundWindow(_snapshot_hwnd)
+        except Exception as exc:
+            logger.debug("Snapshot HWND focus failed (hwnd=%s): %s", _snapshot_hwnd, exc)
+    elif _uia_method and (app or hwnd) and hasattr(backend, "focus_element_uia"):
         try:
             _target_hwnd = backend._resolve_hwnd(app=app, window_title=window_title, hwnd=hwnd)
             if _target_hwnd:

--- a/tests/test_click_ref_skip_routing.py
+++ b/tests/test_click_ref_skip_routing.py
@@ -1,0 +1,226 @@
+"""Tests for click eN ref performance optimization (#448).
+
+When clicking via an eN ref that resolves to cached coordinates from a
+recent snapshot, auto-routing (framework detection chain) should be
+skipped entirely — it adds ~0.5s per click with zero benefit since we
+already have absolute screen coordinates.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Dict, Optional, Tuple
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from naturo.models.snapshot import Snapshot, UIElement
+
+
+def _make_snapshot(
+    snapshot_id: str = "test-snap-001",
+    window_handle: Optional[int] = 0x12345,
+    elements: Optional[Dict[str, UIElement]] = None,
+) -> Snapshot:
+    """Create a test snapshot with element refs."""
+    if elements is None:
+        elements = {
+            "e25": UIElement(
+                id="e25",
+                element_id="element_25",
+                role="Button",
+                title="Clear",
+                frame=(100, 200, 40, 40),
+            ),
+            "e39": UIElement(
+                id="e39",
+                element_id="element_39",
+                role="Button",
+                title="1",
+                frame=(150, 250, 40, 40),
+            ),
+        }
+    return Snapshot(
+        snapshot_id=snapshot_id,
+        ui_map=elements,
+        window_handle=window_handle,
+        application_name="Calculator",
+        application_pid=1234,
+        window_title="Calculator",
+    )
+
+
+def _make_mock_snapshot_manager(snapshot: Snapshot) -> MagicMock:
+    """Create a mock SnapshotManager that resolves refs from the snapshot."""
+    mgr = MagicMock()
+
+    def resolve_ref(ref: str):
+        el = snapshot.ui_map.get(ref)
+        if el is None:
+            return None
+        ex, ey, ew, eh = el.frame
+        if ew == 0 and eh == 0:
+            return None
+        cx = ex + ew // 2
+        cy = ey + eh // 2
+        return (cx, cy, snapshot.snapshot_id)
+
+    def resolve_ref_element(ref: str):
+        el = snapshot.ui_map.get(ref)
+        if el is None:
+            return None
+        return (el, snapshot.snapshot_id)
+
+    mgr.resolve_ref.side_effect = resolve_ref
+    mgr.resolve_ref_element.side_effect = resolve_ref_element
+    mgr.get_snapshot.return_value = snapshot
+    return mgr
+
+
+class TestClickRefSkipsRouting:
+    """Verify that clicking via eN ref skips auto-routing."""
+
+    @patch("naturo.cli.interaction._auto_route")
+    @patch("naturo.snapshot.get_snapshot_manager")
+    @patch("naturo.cli.interaction._get_backend")
+    def test_en_ref_click_skips_auto_route(
+        self, mock_get_backend, mock_get_mgr, mock_auto_route
+    ):
+        """When an eN ref resolves to coordinates, _auto_route should NOT be called."""
+        from click.testing import CliRunner
+        from naturo.cli.interaction import click_cmd
+
+        snapshot = _make_snapshot()
+        mgr = _make_mock_snapshot_manager(snapshot)
+        mock_get_mgr.return_value = mgr
+
+        backend = MagicMock()
+        mock_get_backend.return_value = backend
+
+        runner = CliRunner()
+        result = runner.invoke(click_cmd, ["e25", "--no-verify"])
+
+        # _auto_route should NOT have been called — the ref resolved to coords
+        mock_auto_route.assert_not_called()
+
+    @patch("naturo.cli.interaction._auto_route")
+    @patch("naturo.cli.interaction._get_backend")
+    def test_non_ref_click_still_routes(self, mock_get_backend, mock_auto_route):
+        """Non-ref clicks (--coords, --id, --on text) should still auto-route."""
+        from click.testing import CliRunner
+        from naturo.cli.interaction import click_cmd
+
+        backend = MagicMock()
+        mock_get_backend.return_value = backend
+        mock_auto_route.return_value = {}
+
+        runner = CliRunner()
+        result = runner.invoke(click_cmd, ["--coords", "100", "200", "--no-verify"])
+
+        # _auto_route should have been called for coordinate-based clicks
+        mock_auto_route.assert_called_once()
+
+    @patch("naturo.cli.interaction._auto_route")
+    @patch("naturo.snapshot.get_snapshot_manager")
+    @patch("naturo.cli.interaction._get_backend")
+    def test_en_ref_click_with_app_flag_skips_auto_route(
+        self, mock_get_backend, mock_get_mgr, mock_auto_route
+    ):
+        """Even with --app flag, eN ref clicks should skip auto-routing."""
+        from click.testing import CliRunner
+        from naturo.cli.interaction import click_cmd
+
+        snapshot = _make_snapshot()
+        mgr = _make_mock_snapshot_manager(snapshot)
+        mock_get_mgr.return_value = mgr
+
+        backend = MagicMock()
+        mock_get_backend.return_value = backend
+
+        runner = CliRunner()
+        result = runner.invoke(click_cmd, ["e25", "--app", "calculator", "--no-verify"])
+
+        mock_auto_route.assert_not_called()
+
+    @patch("naturo.snapshot.get_snapshot_manager")
+    @patch("naturo.cli.interaction._get_backend")
+    def test_en_ref_retrieves_snapshot_hwnd(self, mock_get_backend, mock_get_mgr):
+        """eN ref click should retrieve the snapshot's stored window_handle."""
+        from click.testing import CliRunner
+        from naturo.cli.interaction import click_cmd
+
+        snapshot = _make_snapshot(window_handle=0xABCDE)
+        mgr = _make_mock_snapshot_manager(snapshot)
+        mock_get_mgr.return_value = mgr
+
+        backend = MagicMock()
+        mock_get_backend.return_value = backend
+
+        runner = CliRunner()
+        result = runner.invoke(click_cmd, ["e25", "--no-verify"])
+
+        # Snapshot should have been loaded to retrieve HWND
+        mgr.get_snapshot.assert_called_once_with(snapshot.snapshot_id)
+
+    @patch("naturo.cli.interaction._auto_route")
+    @patch("naturo.snapshot.get_snapshot_manager")
+    @patch("naturo.cli.interaction._get_backend")
+    def test_unresolved_ref_falls_through_to_error(
+        self, mock_get_backend, mock_get_mgr, mock_auto_route
+    ):
+        """When an eN ref doesn't resolve, the command should error (not route)."""
+        from click.testing import CliRunner
+        from naturo.cli.interaction import click_cmd
+
+        snapshot = _make_snapshot()
+        mgr = _make_mock_snapshot_manager(snapshot)
+        mock_get_mgr.return_value = mgr
+
+        backend = MagicMock()
+        mock_get_backend.return_value = backend
+
+        runner = CliRunner()
+        # e999 doesn't exist in the snapshot
+        result = runner.invoke(click_cmd, ["e999", "--no-verify"])
+
+        # Should have errored with REF_NOT_FOUND, not called auto_route
+        mock_auto_route.assert_not_called()
+
+    @patch("naturo.cli.interaction._auto_route")
+    @patch("naturo.cli.interaction._get_backend")
+    def test_text_click_still_routes(self, mock_get_backend, mock_auto_route):
+        """Click --on with plain text (not eN) should still auto-route."""
+        from click.testing import CliRunner
+        from naturo.cli.interaction import click_cmd
+
+        backend = MagicMock()
+        mock_get_backend.return_value = backend
+        mock_auto_route.return_value = {}
+
+        runner = CliRunner()
+        result = runner.invoke(click_cmd, ["--on", "Save", "--app", "notepad", "--no-verify"])
+
+        mock_auto_route.assert_called_once()
+
+    @patch("naturo.cli.interaction._auto_route")
+    @patch("naturo.snapshot.get_snapshot_manager")
+    @patch("naturo.cli.interaction._get_backend")
+    def test_en_ref_route_info_is_empty(
+        self, mock_get_backend, mock_get_mgr, mock_auto_route
+    ):
+        """When eN ref resolves, route_info should be empty dict (no routing metadata)."""
+        from click.testing import CliRunner
+        from naturo.cli.interaction import click_cmd
+
+        snapshot = _make_snapshot()
+        mgr = _make_mock_snapshot_manager(snapshot)
+        mock_get_mgr.return_value = mgr
+
+        backend = MagicMock()
+        mock_get_backend.return_value = backend
+
+        runner = CliRunner()
+        result = runner.invoke(click_cmd, ["e25", "--no-verify", "--json"])
+
+        # Since auto_route is skipped, route_info should be empty
+        mock_auto_route.assert_not_called()


### PR DESCRIPTION
## Changes
- Resolve eN refs BEFORE auto-routing in `click_cmd` so we can skip the expensive framework detection chain when cached coordinates are available
- When an eN ref resolves to coordinates from a recent snapshot, `_auto_route()` is skipped entirely (saves ~0.5s per click)
- Retrieve the snapshot's stored `window_handle` (HWND) and use it for window focus instead of re-enumerating processes via `_resolve_hwnd()` (saves ~0.2s per click)
- Removed a duplicate `--ref` alias check that was copy-pasted twice
- 7 new tests in `test_click_ref_skip_routing.py`

## Root Cause
Each `naturo click eN --app calculator` invocation ran the full framework detection chain (CDP → UIA → MSAA → JAB → IA2 → Vision) even when the eN ref already resolved to absolute screen coordinates from a cached snapshot. This added ~0.7s of pure overhead per click with zero benefit — coordinate-based clicks always use SendInput regardless of detected framework.

## Performance Impact
- **Before**: ~2.7s per eN ref click (includes ~0.5s routing + ~0.2s HWND resolution)
- **After**: ~2.0s per eN ref click (routing and HWND resolution skipped)
- **For 5 clicks**: ~13.7s → ~10s (estimated)

Note: The remaining gap vs pywinauto (1.0s for 5 clicks) is due to per-invocation Python startup (~0.7s) and post-action verification (~0.8s). These require architectural changes (daemon/batch mode or MCP server) to close further. The MCP server already avoids per-invocation overhead for agent workflows.

## Testing
- 7 new tests verifying routing is skipped for eN refs and preserved for non-ref clicks
- Full suite: 1836 passed, 547 skipped, 0 failed

**[Dev-Sirius]**