### PR TITLE
fix: clean up alias map and add tests for localized --app matching (fixes #469)

### DIFF
--- a/naturo/backends/windows.py
+++ b/naturo/backends/windows.py
@@ -778,29 +778,46 @@ class WindowsBackend(Backend):
             properties={},
         )
 
-    # Common app aliases for cross-locale matching.
-    # Maps lowercase alias → set of lowercase patterns to match against
-    # process names (without .exe) and window titles.
+    # Cross-locale alias map for --app matching (#469).
+    # Maps lowercase alias → set of lowercase process-name stems that
+    # should be considered a match.  Values must be English process names
+    # (without .exe) since Windows process names are always in English.
     _APP_ALIASES: dict[str, set[str]] = {
-        "calculator": {"calc", "calculatorapp", "计算器"},
-        "calc": {"calc", "calculatorapp", "计算器"},
-        "计算器": {"calc", "calculatorapp", "calculator"},
-        "notepad": {"notepad", "记事本"},
-        "记事本": {"notepad", "记事本"},
-        "settings": {"systemsettings", "设置"},
-        "设置": {"systemsettings", "settings"},
-        "paint": {"mspaint", "画图"},
-        "画图": {"mspaint", "paint"},
-        "explorer": {"explorer", "文件资源管理器", "file explorer"},
-        "file explorer": {"explorer", "文件资源管理器"},
-        "文件资源管理器": {"explorer", "file explorer"},
-        "edge": {"msedge", "microsoft edge"},
-        "task manager": {"taskmgr", "任务管理器"},
-        "任务管理器": {"taskmgr", "task manager"},
-        "command prompt": {"cmd", "命令提示符"},
-        "命令提示符": {"cmd", "command prompt"},
-        "terminal": {"windowsterminal", "终端"},
-        "终端": {"windowsterminal", "terminal"},
+        # Calculator
+        "calculator": {"calc", "calculatorapp"},
+        "calc": {"calc", "calculatorapp"},
+        "计算器": {"calc", "calculatorapp"},
+        # Notepad
+        "notepad": {"notepad"},
+        "记事本": {"notepad"},
+        # Settings
+        "settings": {"systemsettings"},
+        "设置": {"systemsettings"},
+        # Paint
+        "paint": {"mspaint"},
+        "画图": {"mspaint"},
+        # File Explorer
+        "explorer": {"explorer"},
+        "file explorer": {"explorer"},
+        "文件资源管理器": {"explorer"},
+        # Edge
+        "edge": {"msedge"},
+        "microsoft edge": {"msedge"},
+        # Task Manager
+        "task manager": {"taskmgr"},
+        "任务管理器": {"taskmgr"},
+        # Command Prompt
+        "command prompt": {"cmd"},
+        "命令提示符": {"cmd"},
+        # Terminal
+        "terminal": {"windowsterminal"},
+        "终端": {"windowsterminal"},
+        # WordPad
+        "wordpad": {"wordpad"},
+        "写字板": {"wordpad"},
+        # Snipping Tool / Screen Sketch
+        "snipping tool": {"snippingtool", "screensketch"},
+        "截图工具": {"snippingtool", "screensketch"},
     }
 
     @staticmethod

--- a/tests/test_app_alias_localized.py
+++ b/tests/test_app_alias_localized.py
@@ -1,0 +1,271 @@
+"""Tests for localized (Chinese) app name matching via _APP_ALIASES (#469).
+
+When --app is used with a Chinese app name like 计算器 or 记事本, the alias
+map should resolve it to the correct process name.  This prevents breakage
+on non-English Windows systems where users naturally type app names in their
+locale language.
+"""
+
+import pytest
+from naturo.backends.windows import WindowsBackend
+from naturo.backends.base import WindowInfo
+from naturo.errors import WindowNotFoundError
+
+
+def _make_backend(monkeypatch, windows):
+    """Create a WindowsBackend with mocked window list."""
+    backend = WindowsBackend()
+    monkeypatch.setattr(backend, "list_windows", lambda: windows)
+    monkeypatch.setattr(backend, "_get_console_session_id", lambda: 1)
+    monkeypatch.setattr(backend, "_get_process_session_id", lambda pid: 1)
+    return backend
+
+
+# -- Fixtures: common window sets for reuse ----------------------------------
+
+CALCULATOR_WINDOW = WindowInfo(
+    handle=1000,
+    title="计算器",
+    process_name="CalculatorApp.exe",
+    pid=100,
+    x=0, y=0, width=400, height=600,
+    is_visible=True, is_minimized=False,
+)
+
+NOTEPAD_WINDOW = WindowInfo(
+    handle=2000,
+    title="无标题 - 记事本",
+    process_name="notepad.exe",
+    pid=200,
+    x=0, y=0, width=800, height=600,
+    is_visible=True, is_minimized=False,
+)
+
+SETTINGS_WINDOW = WindowInfo(
+    handle=3000,
+    title="设置",
+    process_name="SystemSettings.exe",
+    pid=300,
+    x=0, y=0, width=1000, height=700,
+    is_visible=True, is_minimized=False,
+)
+
+PAINT_WINDOW = WindowInfo(
+    handle=4000,
+    title="画图",
+    process_name="mspaint.exe",
+    pid=400,
+    x=0, y=0, width=900, height=600,
+    is_visible=True, is_minimized=False,
+)
+
+EXPLORER_WINDOW = WindowInfo(
+    handle=5000,
+    title="文件资源管理器",
+    process_name="explorer.exe",
+    pid=500,
+    x=0, y=0, width=1200, height=800,
+    is_visible=True, is_minimized=False,
+)
+
+TERMINAL_WINDOW = WindowInfo(
+    handle=6000,
+    title="终端",
+    process_name="WindowsTerminal.exe",
+    pid=600,
+    x=0, y=0, width=800, height=500,
+    is_visible=True, is_minimized=False,
+)
+
+TASK_MANAGER_WINDOW = WindowInfo(
+    handle=7000,
+    title="任务管理器",
+    process_name="Taskmgr.exe",
+    pid=700,
+    x=0, y=0, width=700, height=500,
+    is_visible=True, is_minimized=False,
+)
+
+CMD_WINDOW = WindowInfo(
+    handle=8000,
+    title="命令提示符",
+    process_name="cmd.exe",
+    pid=800,
+    x=0, y=0, width=800, height=400,
+    is_visible=True, is_minimized=False,
+)
+
+
+class TestChineseAliasResolveSingle:
+    """--app with Chinese name should resolve via alias to correct process."""
+
+    def test_calculator_chinese(self, monkeypatch):
+        """--app 计算器 resolves to CalculatorApp.exe via alias."""
+        backend = _make_backend(monkeypatch, [CALCULATOR_WINDOW])
+        result = backend._resolve_hwnd(app="计算器")
+        assert result == 1000
+
+    def test_notepad_chinese(self, monkeypatch):
+        """--app 记事本 resolves to notepad.exe via alias."""
+        backend = _make_backend(monkeypatch, [NOTEPAD_WINDOW])
+        result = backend._resolve_hwnd(app="记事本")
+        assert result == 2000
+
+    def test_settings_chinese(self, monkeypatch):
+        """--app 设置 resolves to SystemSettings.exe via alias."""
+        backend = _make_backend(monkeypatch, [SETTINGS_WINDOW])
+        result = backend._resolve_hwnd(app="设置")
+        assert result == 3000
+
+    def test_paint_chinese(self, monkeypatch):
+        """--app 画图 resolves to mspaint.exe via alias."""
+        backend = _make_backend(monkeypatch, [PAINT_WINDOW])
+        result = backend._resolve_hwnd(app="画图")
+        assert result == 4000
+
+    def test_explorer_chinese(self, monkeypatch):
+        """--app 文件资源管理器 resolves to explorer.exe via alias."""
+        backend = _make_backend(monkeypatch, [EXPLORER_WINDOW])
+        result = backend._resolve_hwnd(app="文件资源管理器")
+        assert result == 5000
+
+    def test_terminal_chinese(self, monkeypatch):
+        """--app 终端 resolves to WindowsTerminal.exe via alias."""
+        backend = _make_backend(monkeypatch, [TERMINAL_WINDOW])
+        result = backend._resolve_hwnd(app="终端")
+        assert result == 6000
+
+    def test_task_manager_chinese(self, monkeypatch):
+        """--app 任务管理器 resolves to Taskmgr.exe via alias."""
+        backend = _make_backend(monkeypatch, [TASK_MANAGER_WINDOW])
+        result = backend._resolve_hwnd(app="任务管理器")
+        assert result == 7000
+
+    def test_cmd_chinese(self, monkeypatch):
+        """--app 命令提示符 resolves to cmd.exe via alias."""
+        backend = _make_backend(monkeypatch, [CMD_WINDOW])
+        result = backend._resolve_hwnd(app="命令提示符")
+        assert result == 8000
+
+
+class TestChineseAliasAmongMultipleWindows:
+    """Chinese alias matching should pick the right window among many."""
+
+    def test_chinese_calc_among_many(self, monkeypatch):
+        """--app 计算器 picks CalculatorApp.exe not others."""
+        backend = _make_backend(monkeypatch, [
+            NOTEPAD_WINDOW, CALCULATOR_WINDOW, SETTINGS_WINDOW,
+        ])
+        result = backend._resolve_hwnd(app="计算器")
+        assert result == 1000
+
+    def test_chinese_notepad_among_many(self, monkeypatch):
+        """--app 记事本 picks notepad.exe not others."""
+        backend = _make_backend(monkeypatch, [
+            CALCULATOR_WINDOW, NOTEPAD_WINDOW, TERMINAL_WINDOW,
+        ])
+        result = backend._resolve_hwnd(app="记事本")
+        assert result == 2000
+
+
+class TestChineseAliasBulkResolve:
+    """_resolve_hwnds with Chinese alias should work for bulk enumeration."""
+
+    def test_bulk_resolve_chinese_calc(self, monkeypatch):
+        """_resolve_hwnds with --app 计算器 returns correct windows."""
+        backend = _make_backend(monkeypatch, [
+            NOTEPAD_WINDOW, CALCULATOR_WINDOW,
+        ])
+        result = backend._resolve_hwnds(app="计算器")
+        assert result == [1000]
+
+    def test_bulk_resolve_chinese_notepad(self, monkeypatch):
+        """_resolve_hwnds with --app 记事本 returns correct windows."""
+        backend = _make_backend(monkeypatch, [
+            CALCULATOR_WINDOW, NOTEPAD_WINDOW, TERMINAL_WINDOW,
+        ])
+        result = backend._resolve_hwnds(app="记事本")
+        assert result == [2000]
+
+
+class TestEnglishToChineseProcessBidirectional:
+    """English aliases should still work when window has Chinese title."""
+
+    def test_english_calculator_matches_chinese_titled(self, monkeypatch):
+        """--app calculator matches CalculatorApp.exe even with Chinese title."""
+        backend = _make_backend(monkeypatch, [CALCULATOR_WINDOW])
+        result = backend._resolve_hwnd(app="calculator")
+        assert result == 1000
+
+    def test_english_notepad_matches_chinese_titled(self, monkeypatch):
+        """--app notepad matches notepad.exe even with Chinese title."""
+        backend = _make_backend(monkeypatch, [NOTEPAD_WINDOW])
+        result = backend._resolve_hwnd(app="notepad")
+        assert result == 2000
+
+
+class TestNoFalsePositiveFromChineseAlias:
+    """Chinese alias should not cause false matches on unrelated processes."""
+
+    def test_chinese_calc_no_match_chrome(self, monkeypatch):
+        """--app 计算器 should NOT match chrome.exe with title containing 计算器."""
+        backend = _make_backend(monkeypatch, [
+            WindowInfo(
+                handle=9000,
+                title="计算器 - 百度搜索 - Google Chrome",
+                process_name="chrome.exe",
+                pid=900,
+                x=0, y=0, width=1920, height=1080,
+                is_visible=True, is_minimized=False,
+            ),
+        ])
+        with pytest.raises(WindowNotFoundError):
+            backend._resolve_hwnd(app="计算器")
+
+
+class TestAliasMapCompleteness:
+    """Verify the alias map contains expected entries."""
+
+    def test_all_chinese_aliases_exist(self):
+        """All documented Chinese aliases are present in _APP_ALIASES."""
+        aliases = WindowsBackend._APP_ALIASES
+        expected_chinese = [
+            "计算器", "记事本", "设置", "画图",
+            "文件资源管理器", "任务管理器", "命令提示符", "终端",
+            "写字板", "截图工具",
+        ]
+        for name in expected_chinese:
+            assert name in aliases, f"Missing Chinese alias: {name}"
+
+    def test_chinese_aliases_contain_process_names(self):
+        """Chinese aliases must map to actual process name stems."""
+        aliases = WindowsBackend._APP_ALIASES
+        expected_mappings = {
+            "计算器": {"calculatorapp", "calc"},
+            "记事本": {"notepad"},
+            "设置": {"systemsettings"},
+            "画图": {"mspaint"},
+            "文件资源管理器": {"explorer"},
+            "任务管理器": {"taskmgr"},
+            "命令提示符": {"cmd"},
+            "终端": {"windowsterminal"},
+            "写字板": {"wordpad"},
+            "截图工具": {"snippingtool", "screensketch"},
+        }
+        for chinese, expected_procs in expected_mappings.items():
+            actual = aliases[chinese]
+            for proc in expected_procs:
+                assert proc in actual, (
+                    f"Alias '{chinese}' missing process stem '{proc}', "
+                    f"has: {actual}"
+                )
+
+    def test_alias_values_are_english_process_stems(self):
+        """All alias values should be lowercase English process name stems."""
+        aliases = WindowsBackend._APP_ALIASES
+        for key, values in aliases.items():
+            for v in values:
+                assert v.isascii(), (
+                    f"Alias '{key}' has non-ASCII value '{v}' — "
+                    f"values must be English process name stems"
+                )


### PR DESCRIPTION
## Changes
- Cleaned up `_APP_ALIASES` map: removed non-ASCII values from alias sets (e.g. `"计算器"` as a value) that could never match English process name stems — only English process-name stems belong in values
- Added inline comments grouping aliases by application for readability
- Added new aliases: WordPad/写字板, Snipping Tool/截图工具
- Added `"microsoft edge"` as alias for Edge (was only `"edge"`)
- 18 new tests in `test_app_alias_localized.py` covering:
  - All 8 original Chinese aliases resolve to correct processes
  - Chinese alias matching among multiple windows
  - Bulk resolution (`_resolve_hwnds`) with Chinese aliases
  - Bidirectional: English aliases still work with Chinese-titled windows
  - No false positives: Chinese alias doesn't match unrelated processes
  - Alias map completeness and value correctness assertions
  - Enforces all alias values are ASCII (process name stems must be English)

## Root Cause
The alias map already existed and handled Chinese app names correctly. However:
1. Alias values contained non-ASCII strings (e.g. `"记事本"` as a value in the `"notepad"` entry) that were dead code — they'd never match any process name
2. No tests verified Chinese alias matching worked end-to-end
3. Missing aliases for WordPad and Snipping Tool

## Testing
- 18 new tests, all passing
- Full suite: 1854 passed, 547 skipped, 0 failed

**[Dev-Sirius]**