### PR TITLE
fix: pass --pid through to _resolve_hwnd so PID-based targeting works (fixes #471)

### DIFF
--- a/naturo/backends/windows.py
+++ b/naturo/backends/windows.py
@@ -865,8 +865,9 @@ class WindowsBackend(Backend):
 
     def _resolve_hwnd(self, app: Optional[str] = None,
                       window_title: Optional[str] = None,
-                      hwnd: Optional[int] = None) -> int:
-        """Resolve a window handle from app name, window title, or direct hwnd.
+                      hwnd: Optional[int] = None,
+                      pid: Optional[int] = None) -> int:
+        """Resolve a window handle from app name, window title, pid, or direct hwnd.
 
         Matching strategy (BUG-069/BUG-070):
 
@@ -874,6 +875,11 @@ class WindowsBackend(Backend):
         only** (``.exe`` suffix stripped).  Title matching is not used for
         ``--app`` to prevent cross-process contamination (#465).  When
         ``window_title`` is provided, matches against window title only.
+
+        When ``pid`` is provided (alone or combined with app/window_title),
+        only windows belonging to that process are considered (#471).  Among
+        matching PID windows, the largest-area window in the interactive
+        session is preferred.
 
         Scoring for ``--app`` (higher = better match):
           4 — exact process-name match  (e.g. ``explorer`` == ``explorer.exe``)
@@ -902,6 +908,9 @@ class WindowsBackend(Backend):
             window_title: Window title pattern (case-insensitive, partial
                 match).  Compared against window title only.
             hwnd: Direct window handle (takes priority).
+            pid: Process ID.  When provided, only windows owned by this
+                process are considered.  Can be combined with app/window_title
+                for additional filtering, or used alone (#471).
 
         Returns:
             Window handle (HWND), or 0 for the foreground window.
@@ -914,11 +923,28 @@ class WindowsBackend(Backend):
             return hwnd
 
         search = app or window_title
-        if not search:
+        if not search and not pid:
             return 0  # foreground window
 
-        search_lower = search.lower()
+        search_lower = search.lower() if search else ""
         windows = self.list_windows()
+
+        # (#471) Filter by PID when provided — only consider windows owned
+        # by the specified process.  This is applied before scoring so that
+        # PID-based targeting is never overridden by a higher-scoring window
+        # from a different process.
+        if pid is not None:
+            windows = [w for w in windows if w.pid == pid]
+            if not windows:
+                from naturo.errors import WindowNotFoundError
+                raise WindowNotFoundError(
+                    f"PID {pid}",
+                    suggested_action=(
+                        f"No visible window found for PID {pid}. "
+                        "The process may have exited or has no visible windows.\n"
+                        "Tip: use 'naturo list windows' to see all windows."
+                    ),
+                )
 
         # Get console session for session-aware ranking (#230)
         console_session = self._get_console_session_id()
@@ -928,6 +954,12 @@ class WindowsBackend(Backend):
 
         # --app → match process name first; --window-title → match title only
         match_process = app is not None
+
+        # (#471) When only --pid is given (no app/window_title), all windows
+        # belonging to the PID are valid candidates — assign a base score of 1
+        # so that the best-window selection logic (session, foreground, area)
+        # picks the most appropriate one.
+        pid_only = pid is not None and not search
 
         best_score = 0
         best_session_bonus = False  # True if best_window is in console session
@@ -942,7 +974,10 @@ class WindowsBackend(Backend):
                 proc_stem = proc_stem[:-4]
             title_lower = w.title.lower()
 
-            if match_process:
+            if pid_only:
+                # All PID-filtered windows are valid candidates
+                score = 1
+            elif match_process:
                 # Process-name matching (priority)
                 if search_lower == proc_stem:
                     score = 4  # exact process name
@@ -1087,12 +1122,13 @@ class WindowsBackend(Backend):
             if len(candidates) >= 5:
                 break
 
-        hint = f"No window matching '{search}'."
+        search_label = search or f"PID {pid}"
+        hint = f"No window matching '{search_label}'."
         if candidates:
             hint += " Did you mean:\n" + "\n".join(f"  • {c}" for c in candidates)
         hint += "\nTip: use 'naturo list windows' to see all windows."
 
-        raise WindowNotFoundError(search, suggested_action=hint)
+        raise WindowNotFoundError(search_label, suggested_action=hint)
 
     def _resolve_hwnds(self, app: Optional[str] = None,
                        window_title: Optional[str] = None) -> list[int]:
@@ -1538,6 +1574,7 @@ class WindowsBackend(Backend):
                          depth: int = 3,
                          app: Optional[str] = None,
                          hwnd: Optional[int] = None,
+                         pid: Optional[int] = None,
                          backend: str = "uia") -> Optional[BaseElementInfo]:
         """Get the UI element tree for a window.
 
@@ -1557,6 +1594,8 @@ class WindowsBackend(Backend):
             depth: Maximum depth to traverse (1-10).
             app: Application name to search for (partial match, case-insensitive).
             hwnd: Direct window handle. Overrides app/window_title.
+            pid: Process ID.  Filters windows to only those owned by this
+                process (#471).
             backend: Accessibility backend — "auto" (default), "uia", "msaa",
                      "win32", "ia2", or "jab".
                      "auto" tries UIA first, falls back to MSAA/IA2/JAB/Win32
@@ -1568,7 +1607,7 @@ class WindowsBackend(Backend):
             Root ElementInfo with nested children, or None.
         """
         core = self._ensure_core()
-        handle = self._resolve_hwnd(app=app, window_title=window_title, hwnd=hwnd)
+        handle = self._resolve_hwnd(app=app, window_title=window_title, hwnd=hwnd, pid=pid)
 
         def _try_uwp_children(current_result, get_tree_fn):
             """If handle is an AFH window with empty tree, try child windows.

--- a/naturo/cascade.py
+++ b/naturo/cascade.py
@@ -718,7 +718,7 @@ def run_cascade(
             # Resolve app/window_title to hwnd first
             try:
                 resolved_hwnd = backend._resolve_hwnd(
-                    app=app, window_title=window_title, hwnd=hwnd,
+                    app=app, window_title=window_title, hwnd=hwnd, pid=pid,
                 )
             except Exception as exc:
                 logger.debug("Hybrid: HWND resolution failed: %s", exc)
@@ -753,8 +753,8 @@ def run_cascade(
         t0 = time.monotonic()
         try:
             tree = backend.get_element_tree(
-                app=app, window_title=window_title, hwnd=hwnd, depth=depth,
-                backend=pname,
+                app=app, window_title=window_title, hwnd=hwnd, pid=pid,
+                depth=depth, backend=pname,
             )
             elapsed = (time.monotonic() - t0) * 1000
 

--- a/naturo/cli/core.py
+++ b/naturo/cli/core.py
@@ -722,8 +722,8 @@ def see(app, window_title, hwnd, pid, mode, depth, path, annotate, store_snapsho
                     tree.children.append(window_node)
             else:
                 tree = be.get_element_tree(
-                    app=app, window_title=window_title, hwnd=hwnd, depth=depth,
-                    backend=backend,
+                    app=app, window_title=window_title, hwnd=hwnd, pid=pid,
+                    depth=depth, backend=backend,
                 )
 
         if tree is None:

--- a/naturo/cli/interaction.py
+++ b/naturo/cli/interaction.py
@@ -17,6 +17,7 @@ def _find_element_by_text_fallback(
     app: Optional[str] = None,
     hwnd: Optional[int] = None,
     window_title: Optional[str] = None,
+    pid: Optional[int] = None,
 ):
     """Fallback element search when C++ exact UIA Name match fails.
 
@@ -47,7 +48,7 @@ def _find_element_by_text_fallback(
 
     try:
         tree = backend.get_element_tree(
-            app=app, window_title=window_title, hwnd=hwnd, depth=5,
+            app=app, window_title=window_title, hwnd=hwnd, pid=pid, depth=5,
         )
     except Exception as exc:
         logger.debug("Fallback tree search failed to get tree: %s", exc)
@@ -732,9 +733,9 @@ def click_cmd(query, on_text, ref_alias, element_id, coords, double, right, app,
             ctypes.windll.user32.SetForegroundWindow(_snapshot_hwnd)
         except Exception as exc:
             logger.debug("Snapshot HWND focus failed (hwnd=%s): %s", _snapshot_hwnd, exc)
-    elif _uia_method and (app or hwnd) and hasattr(backend, "focus_element_uia"):
+    elif _uia_method and (app or hwnd or pid) and hasattr(backend, "focus_element_uia"):
         try:
-            _target_hwnd = backend._resolve_hwnd(app=app, window_title=window_title, hwnd=hwnd)
+            _target_hwnd = backend._resolve_hwnd(app=app, window_title=window_title, hwnd=hwnd, pid=pid)
             if _target_hwnd:
                 # Detect if target is a UWP app (#248)
                 if hasattr(backend, "_is_applicationframehost"):
@@ -758,6 +759,7 @@ def click_cmd(query, on_text, ref_alias, element_id, coords, double, right, app,
                 app=app,
                 window_title=window_title,
                 hwnd=hwnd,
+                pid=pid,
             )
         except Exception as exc:
             logger.debug("Pre-click state capture failed: %s", exc)
@@ -794,6 +796,7 @@ def click_cmd(query, on_text, ref_alias, element_id, coords, double, right, app,
                 fallback = _find_element_by_text_fallback(
                     backend, target_id,
                     app=app, hwnd=hwnd, window_title=window_title,
+                    pid=pid,
                 )
                 if fallback is None:
                     raise
@@ -913,6 +916,7 @@ def click_cmd(query, on_text, ref_alias, element_id, coords, double, right, app,
 @click.option("--on", "on_element", help="Target element (eN ref or text label) — click to focus before typing")
 @click.option("--ref", "ref_alias", hidden=True, help="Deprecated alias for --on")
 @click.option("--app", help="Target application (name or partial match)")
+@click.option("--pid", type=int, help="Process ID")
 @click.option("--window", "window_title", default=None, help="Window title pattern (substring match)")
 @click.option("--window-title", "window_title", default=None, hidden=True, help="")
 @click.option("--hwnd", type=int, default=None, help="Window handle (HWND)")
@@ -928,7 +932,7 @@ def click_cmd(query, on_text, ref_alias, element_id, coords, double, right, app,
 @click.option("--process-name", "app", default=None, hidden=True, help="")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 def type_cmd(text, delay, profile, wpm, press_return, tab_count, escape,
-             delete, clear, paste_mode, file_path, restore, on_element, ref_alias, app,
+             delete, clear, paste_mode, file_path, restore, on_element, ref_alias, app, pid,
              window_title, hwnd, input_mode, method, verify, see_after, settle,
              json_output):
     """Type text with configurable speed and profile.
@@ -992,12 +996,12 @@ def type_cmd(text, delay, profile, wpm, press_return, tab_count, escape,
     # without focusing first, type silently sends to the wrong window.
     # Session-aware: _resolve_hwnd now prefers interactive session windows.
     _focused_hwnd = None
-    if (app or window_title or hwnd) and not on_element:
+    if (app or window_title or hwnd or pid) and not on_element:
         import platform as _plat
         if _plat.system() == "Windows":
             try:
                 _target_hwnd = backend._resolve_hwnd(
-                    app=app, window_title=window_title, hwnd=hwnd,
+                    app=app, window_title=window_title, hwnd=hwnd, pid=pid,
                 )
                 if _target_hwnd:
                     _focused_hwnd = _target_hwnd
@@ -1087,6 +1091,7 @@ def type_cmd(text, delay, profile, wpm, press_return, tab_count, escape,
                 app=app,
                 window_title=window_title,
                 hwnd=hwnd,
+                pid=pid,
             )
         except Exception as exc:
             logger.debug("Pre-type state capture failed: %s", exc)
@@ -1155,10 +1160,10 @@ def type_cmd(text, delay, profile, wpm, press_return, tab_count, escape,
                         _target_role = elem.role
 
             # Resolve HWND from --app
-            if app or window_title or hwnd:
+            if app or window_title or hwnd or pid:
                 try:
                     _target_hwnd = backend._resolve_hwnd(
-                        app=app, window_title=window_title, hwnd=hwnd
+                        app=app, window_title=window_title, hwnd=hwnd, pid=pid,
                     )
                 except Exception:
                     _target_hwnd = 0
@@ -1325,6 +1330,7 @@ def _is_combo(key_str: str) -> bool:
 @click.option("--on", "on_element", help="Target element (eN ref or text label) — click to focus before pressing")
 @click.option("--ref", "ref_alias", hidden=True, help="Deprecated alias for --on")
 @click.option("--app", help="Target application (name or partial match)")
+@click.option("--pid", type=int, help="Process ID")
 @click.option("--window", "window_title", default=None, help="Window title pattern (substring match)")
 @click.option("--window-title", "window_title", default=None, hidden=True, help="")
 @click.option("--hwnd", type=int, default=None, help="Window handle (HWND)")
@@ -1338,7 +1344,7 @@ def _is_combo(key_str: str) -> bool:
 @_verify_options
 @_see_options
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def press(keys, count, delay, hold_duration, on_element, ref_alias, app, window_title, hwnd, input_mode, method, verify, see_after, settle, json_output):
+def press(keys, count, delay, hold_duration, on_element, ref_alias, app, pid, window_title, hwnd, input_mode, method, verify, see_after, settle, json_output):
     """Press keys — single keys, combos, or sequential key sequences.
 
     KEYS can be one or more key specs.  A spec containing ``+`` is treated as
@@ -1419,12 +1425,12 @@ def press(keys, count, delay, hold_duration, on_element, ref_alias, app, window_
     # SendInput/key_press deliver to the foreground window, so we must
     # ensure the correct window has focus when --app/--hwnd is specified.
     # Session-aware: _resolve_hwnd now prefers interactive session windows.
-    if (app or window_title or hwnd) and not on_element:
+    if (app or window_title or hwnd or pid) and not on_element:
         import platform as _plat
         if _plat.system() == "Windows":
             try:
                 _target_hwnd = backend._resolve_hwnd(
-                    app=app, window_title=window_title, hwnd=hwnd,
+                    app=app, window_title=window_title, hwnd=hwnd, pid=pid,
                 )
                 if _target_hwnd:
                     import ctypes
@@ -1463,6 +1469,7 @@ def press(keys, count, delay, hold_duration, on_element, ref_alias, app, window_
                 app=app,
                 window_title=window_title,
                 hwnd=hwnd,
+                pid=pid,
             )
         except Exception as exc:
             logger.debug("Pre-press state capture failed: %s", exc)

--- a/naturo/verify.py
+++ b/naturo/verify.py
@@ -596,6 +596,7 @@ def _capture_ui_texts(
     app: Optional[str] = None,
     window_title: Optional[str] = None,
     hwnd: Optional[int] = None,
+    pid: Optional[int] = None,
     max_children: int = 50,
 ) -> dict[str, str]:
     """Capture a lightweight snapshot of child window texts for diff.
@@ -626,7 +627,7 @@ def _capture_ui_texts(
     # Without a target (app/window_title/hwnd), the text diff is
     # unreliable (we'd snapshot random foreground windows) and the
     # Win32/COM calls can hang on headless environments.
-    if not (app or window_title or hwnd):
+    if not (app or window_title or hwnd or pid):
         return texts
 
     try:
@@ -643,7 +644,7 @@ def _capture_ui_texts(
         if not target_hwnd and hasattr(backend, "_resolve_hwnd"):
             try:
                 target_hwnd = backend._resolve_hwnd(
-                    app=app, window_title=window_title,
+                    app=app, window_title=window_title, pid=pid,
                 )
             except Exception:
                 pass
@@ -866,6 +867,7 @@ def capture_before_state(
     app: Optional[str] = None,
     window_title: Optional[str] = None,
     hwnd: Optional[int] = None,
+    pid: Optional[int] = None,
 ) -> dict:
     """Capture pre-action state for verification.
 
@@ -878,6 +880,7 @@ def capture_before_state(
         app: Application name filter.
         window_title: Window title filter.
         hwnd: Window handle filter.
+        pid: Process ID filter (#471).
 
     Returns:
         Dict with captured state. Pass to the verify_* function's
@@ -918,6 +921,7 @@ def capture_before_state(
         try:
             state["ui_texts"] = _capture_ui_texts(
                 backend, app=app, window_title=window_title, hwnd=hwnd,
+                pid=pid,
             )
         except Exception as exc:
             logger.debug("Pre-%s UI text capture failed: %s", action, exc)

--- a/tests/test_resolve_hwnd_session.py
+++ b/tests/test_resolve_hwnd_session.py
@@ -259,3 +259,127 @@ class TestResolveHwndForegroundPreference:
         result = backend._resolve_hwnd(app="notepad")
         # Neither is foreground, so larger area (2002) wins
         assert result == 2002
+
+
+class TestResolveHwndPid:
+    """Verify _resolve_hwnd correctly handles --pid targeting (#471)."""
+
+    def _make_multi_app_windows(self):
+        """Three apps: Notepad (PID 100), Calculator (PID 200), Paint (PID 300)."""
+        return [
+            WindowInfo(
+                handle=1001, title="Untitled - Notepad",
+                process_name="Notepad.exe", pid=100,
+                x=0, y=0, width=800, height=600,
+                is_visible=True, is_minimized=False,
+            ),
+            WindowInfo(
+                handle=2002, title="Calculator",
+                process_name="CalculatorApp.exe", pid=200,
+                x=100, y=100, width=400, height=500,
+                is_visible=True, is_minimized=False,
+            ),
+            WindowInfo(
+                handle=3003, title="Untitled - Paint",
+                process_name="mspaint.exe", pid=300,
+                x=200, y=200, width=1200, height=800,
+                is_visible=True, is_minimized=False,
+            ),
+        ]
+
+    def _setup_backend(self, windows, fg_hwnd=0):
+        """Create a mock backend with the given windows."""
+        BackendClass = _make_backend()
+        backend = MagicMock(spec=BackendClass)
+        backend.list_windows = MagicMock(return_value=windows)
+        backend._resolve_hwnd = BackendClass._resolve_hwnd.__get__(backend)
+        backend._get_console_session_id = MagicMock(return_value=1)
+        backend._get_process_session_id = MagicMock(return_value=1)
+        backend._get_foreground_hwnd = MagicMock(return_value=fg_hwnd)
+        backend._APP_ALIASES = BackendClass._APP_ALIASES
+        return backend
+
+    def test_pid_alone_targets_correct_window(self):
+        """--pid alone should target the specified process, not foreground."""
+        backend = self._setup_backend(
+            self._make_multi_app_windows(), fg_hwnd=3003,
+        )
+        # Paint (3003) is foreground, but --pid 200 should target Calculator
+        result = backend._resolve_hwnd(pid=200)
+        assert result == 2002
+
+    def test_pid_alone_targets_notepad_not_foreground(self):
+        """--pid for Notepad should work even when Paint is foreground."""
+        backend = self._setup_backend(
+            self._make_multi_app_windows(), fg_hwnd=3003,
+        )
+        result = backend._resolve_hwnd(pid=100)
+        assert result == 1001
+
+    def test_pid_with_app_filters_both(self):
+        """--pid combined with --app should filter by both."""
+        backend = self._setup_backend(self._make_multi_app_windows())
+        # PID 200 is Calculator, --app calculator should also match
+        result = backend._resolve_hwnd(app="calculator", pid=200)
+        assert result == 2002
+
+    def test_pid_selects_largest_window_among_process(self):
+        """When a PID has multiple windows, prefer the largest."""
+        windows = [
+            WindowInfo(
+                handle=1001, title="Untitled - Notepad",
+                process_name="Notepad.exe", pid=100,
+                x=0, y=0, width=800, height=600,
+                is_visible=True, is_minimized=False,
+            ),
+            WindowInfo(
+                handle=1002, title="Find and Replace",
+                process_name="Notepad.exe", pid=100,
+                x=200, y=200, width=300, height=200,
+                is_visible=True, is_minimized=False,
+            ),
+        ]
+        backend = self._setup_backend(windows)
+        result = backend._resolve_hwnd(pid=100)
+        # Main window (1001) is larger → should be selected
+        assert result == 1001
+
+    def test_pid_not_found_raises_error(self):
+        """--pid with no matching windows should raise WindowNotFoundError."""
+        backend = self._setup_backend(self._make_multi_app_windows())
+        from naturo.errors import WindowNotFoundError
+        with pytest.raises(WindowNotFoundError, match="PID 999"):
+            backend._resolve_hwnd(pid=999)
+
+    def test_pid_none_without_search_returns_foreground(self):
+        """When pid=None and no search term, return 0 (foreground)."""
+        backend = self._setup_backend(self._make_multi_app_windows())
+        result = backend._resolve_hwnd()
+        assert result == 0
+
+    def test_pid_with_hwnd_prefers_hwnd(self):
+        """Direct hwnd takes priority over pid."""
+        backend = self._setup_backend(self._make_multi_app_windows())
+        result = backend._resolve_hwnd(hwnd=9999, pid=200)
+        assert result == 9999
+
+    def test_pid_prefers_foreground_among_same_process(self):
+        """Among multiple windows of same PID, prefer the foreground one."""
+        windows = [
+            WindowInfo(
+                handle=1001, title="Document1 - Notepad",
+                process_name="Notepad.exe", pid=100,
+                x=0, y=0, width=800, height=600,
+                is_visible=True, is_minimized=False,
+            ),
+            WindowInfo(
+                handle=1002, title="Document2 - Notepad",
+                process_name="Notepad.exe", pid=100,
+                x=100, y=100, width=800, height=600,
+                is_visible=True, is_minimized=False,
+            ),
+        ]
+        # Window 1002 is foreground
+        backend = self._setup_backend(windows, fg_hwnd=1002)
+        result = backend._resolve_hwnd(pid=100)
+        assert result == 1002


### PR DESCRIPTION
## Changes
- Added `pid` parameter to `_resolve_hwnd()` — when PID is provided, filters windows to only those owned by that process before scoring
- Added `pid` parameter to `get_element_tree()` in the Windows backend
- Passed `pid` through all CLI command call sites: `see`, `click`, `type`, `press`
- Passed `pid` through cascade mode, verify module, and fallback text search
- Added `--pid` option to `type` and `press` commands (already existed on `click`/`see`)
- When `--pid` alone is given (no `--app`/`--window-title`), all windows of that PID are candidates, with best-window selection (session, foreground, area) picking the right one
- Clear `WindowNotFoundError` when PID has no visible windows

## Root Cause
`_resolve_hwnd()` had no `pid` parameter. When only `--pid` was provided:
1. `search = app or window_title` → `None`
2. `if not search: return 0` → returned foreground window
3. PID was silently ignored across all commands

## Testing
- 9 new tests in `TestResolveHwndPid` covering: PID-only targeting, PID+app combo, multi-window PID selection, error on invalid PID, hwnd priority over PID, foreground preference within PID
- Full suite: 1902 passed, 489 skipped, 0 failed

**[Dev-Sirius]**