### PR TITLE
fix: increase Windows CI timeout from 20 to 35 minutes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,7 @@ jobs:
     name: Python Tests with DLL (Windows)
     runs-on: windows-latest
     needs: build-dll
-    timeout-minutes: 35
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
 
@@ -103,6 +103,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          cache: "pip"
 
       - name: Download DLL
         uses: actions/download-artifact@v5


### PR DESCRIPTION
## Changes
- Increased `timeout-minutes` for "Python Tests with DLL (Windows)" job from 20 to 45 minutes
- Added pip dependency caching via `actions/setup-python` `cache: "pip"` to speed up installs

## Root Cause
The Windows CI job consistently times out on busy GitHub Actions Windows runners. The previous 20-minute timeout was too low, and an initial attempt at 35 minutes also proved insufficient (cancelled at exactly 40min = 35 + 5min grace period).

The combined time for `pip install` with windows extras, pywin32 postinstall, environment verification, and full test suite exceeds 35 minutes. Adding pip caching should significantly reduce install time on repeat runs.

This blocks all open PRs (#466, #473, #475, #476, #479, #480) since this is a required check.

## Testing
- CI configuration change — validated by CI running on this PR
- All other checks (Lint, Ubuntu, macOS, C++ Build, Version Check) pass consistently

**[Dev-Sirius]**