### PR TITLE
fix: find_process resolves Chinese aliases so type --app works (fixes #474)

### DIFF
--- a/naturo/process.py
+++ b/naturo/process.py
@@ -172,29 +172,42 @@ def find_process(
     # Name lookup: prefer interactive session processes (#230)
     assert name is not None
     name_lower = name.lower()
-    first_match: ProcessInfo | None = None
     console_session = _get_console_session_id()
 
-    for proc in processes:
-        if name_lower not in proc.name.lower():
-            continue
+    # Build search terms: direct name + alias-resolved names (#474)
+    search_terms = [name_lower]
+    aliases = _LAUNCH_ALIASES.get(name_lower, [])
+    for alias in aliases:
+        alias_lower = alias.lower()
+        if alias_lower not in search_terms:
+            search_terms.append(alias_lower)
 
-        # Session-aware filtering (#350): when require_interactive is True
-        # and we can determine session IDs, skip session 0 processes entirely.
-        if require_interactive and console_session >= 0:
-            proc_session = _get_process_session_id(proc.pid)
-            if proc_session == 0:
-                continue  # Skip non-interactive services session
+    first_match: ProcessInfo | None = None
 
-        if first_match is None:
-            first_match = proc
-        # If we can determine sessions, prefer the console session
-        if console_session >= 0:
-            proc_session = _get_process_session_id(proc.pid)
-            if proc_session == console_session:
-                return proc  # Found an interactive session match — use it
+    for term in search_terms:
+        for proc in processes:
+            if term not in proc.name.lower():
+                continue
 
-    return first_match  # Fallback to first match if no console session match
+            # Session-aware filtering (#350): when require_interactive is
+            # True and we can determine session IDs, skip session 0
+            # processes entirely.
+            if require_interactive and console_session >= 0:
+                proc_session = _get_process_session_id(proc.pid)
+                if proc_session == 0:
+                    continue  # Skip non-interactive services session
+
+            if first_match is None:
+                first_match = proc
+            # If we can determine sessions, prefer the console session
+            if console_session >= 0:
+                proc_session = _get_process_session_id(proc.pid)
+                if proc_session == console_session:
+                    return proc  # Found an interactive session match
+        if first_match is not None:
+            return first_match
+
+    return None
 
 
 def is_running(name: str) -> bool:

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -163,6 +163,81 @@ class TestFindProcess:
         assert result.pid == 100
 
 
+class TestFindProcessAliasResolution:
+    """Tests for alias-based process resolution (#474)."""
+
+    @patch("naturo.process._get_console_session_id", return_value=-1)
+    @patch("naturo.process._list_processes")
+    def test_chinese_notepad_alias(self, mock_list, _mock_session):
+        """find_process('记事本') resolves to notepad.exe via alias."""
+        mock_list.return_value = [
+            ProcessInfo(pid=10, name="notepad.exe"),
+        ]
+        result = find_process(name="记事本")
+        assert result is not None
+        assert result.pid == 10
+
+    @patch("naturo.process._get_console_session_id", return_value=-1)
+    @patch("naturo.process._list_processes")
+    def test_chinese_calculator_alias(self, mock_list, _mock_session):
+        """find_process('计算器') resolves to calc/calculatorapp via alias."""
+        mock_list.return_value = [
+            ProcessInfo(pid=20, name="CalculatorApp.exe"),
+        ]
+        result = find_process(name="计算器")
+        assert result is not None
+        assert result.pid == 20
+
+    @patch("naturo.process._get_console_session_id", return_value=-1)
+    @patch("naturo.process._list_processes")
+    def test_chinese_paint_alias(self, mock_list, _mock_session):
+        """find_process('画图') resolves to mspaint.exe via alias."""
+        mock_list.return_value = [
+            ProcessInfo(pid=30, name="mspaint.exe"),
+        ]
+        result = find_process(name="画图")
+        assert result is not None
+        assert result.pid == 30
+
+    @patch("naturo.process._get_console_session_id", return_value=-1)
+    @patch("naturo.process._list_processes")
+    def test_direct_match_preferred_over_alias(self, mock_list, _mock_session):
+        """Direct process name match should be tried before alias resolution."""
+        mock_list.return_value = [
+            ProcessInfo(pid=40, name="notepad.exe"),
+        ]
+        # "notepad" matches directly — should not need alias
+        result = find_process(name="notepad")
+        assert result is not None
+        assert result.pid == 40
+
+    @patch("naturo.process._get_console_session_id", return_value=-1)
+    @patch("naturo.process._list_processes")
+    def test_alias_no_match_returns_none(self, mock_list, _mock_session):
+        """When alias resolves but no process matches, returns None."""
+        mock_list.return_value = [
+            ProcessInfo(pid=50, name="python.exe"),
+        ]
+        result = find_process(name="记事本")
+        assert result is None
+
+    @patch("naturo.process._get_process_session_id")
+    @patch("naturo.process._get_console_session_id")
+    @patch("naturo.process._list_processes")
+    def test_alias_with_session_preference(self, mock_list, mock_console,
+                                           mock_proc_session):
+        """Alias-resolved match still respects session preference (#230)."""
+        mock_list.return_value = [
+            ProcessInfo(pid=100, name="Notepad.exe"),  # Session 0
+            ProcessInfo(pid=200, name="Notepad.exe"),  # Session 1
+        ]
+        mock_console.return_value = 1
+        mock_proc_session.side_effect = lambda pid: 0 if pid == 100 else 1
+        result = find_process(name="记事本")
+        assert result is not None
+        assert result.pid == 200, "Alias match should prefer interactive session"
+
+
 class TestSessionHelpers:
     """Tests for session ID helper functions."""
 

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -252,6 +252,53 @@ class TestResolveMethodWithPid:
         assert result.pid == 9999
 
 
+class TestResolveMethodAliasResolution:
+    """(#474) Tests for Chinese alias resolution via find_process aliases."""
+
+    @patch("naturo.detect.chain.detect")
+    @patch("naturo.process._get_console_session_id", return_value=-1)
+    @patch("naturo.process._list_processes")
+    def test_chinese_notepad_resolves_via_alias(self, mock_list, _mock_session,
+                                                 mock_detect):
+        """resolve_method(app='记事本') finds notepad.exe via alias (#474)."""
+        from naturo.process import ProcessInfo
+        mock_list.return_value = [
+            ProcessInfo(pid=1234, name="notepad.exe"),
+        ]
+        mock_method = MagicMock()
+        mock_method.method.value = "uia"
+        mock_method.confidence = 0.9
+        mock_result = MagicMock()
+        mock_result.best_method.return_value = mock_method
+        mock_result.frameworks = []
+        mock_detect.return_value = mock_result
+
+        result = resolve_method(app="记事本")
+        assert result.pid == 1234, "Should resolve 记事本 → notepad.exe"
+        assert result.method == "uia"
+
+    @patch("naturo.detect.chain.detect")
+    @patch("naturo.process._get_console_session_id", return_value=-1)
+    @patch("naturo.process._list_processes")
+    def test_chinese_calculator_resolves_via_alias(self, mock_list,
+                                                    _mock_session, mock_detect):
+        """resolve_method(app='计算器') finds CalculatorApp.exe via alias."""
+        from naturo.process import ProcessInfo
+        mock_list.return_value = [
+            ProcessInfo(pid=5678, name="CalculatorApp.exe"),
+        ]
+        mock_method = MagicMock()
+        mock_method.method.value = "uia"
+        mock_method.confidence = 0.8
+        mock_result = MagicMock()
+        mock_result.best_method.return_value = mock_method
+        mock_result.frameworks = []
+        mock_detect.return_value = mock_result
+
+        result = resolve_method(app="计算器")
+        assert result.pid == 5678, "Should resolve 计算器 → CalculatorApp.exe"
+
+
 class TestResolveMethodEdgeCases:
     """Edge cases and integration scenarios."""
 


### PR DESCRIPTION
## Changes
- `find_process()` now tries alias resolution via `_LAUNCH_ALIASES` when direct name matching fails
- Chinese app names like `记事本`, `计算器`, `画图` now resolve to their process names (`notepad.exe`, `CalculatorApp.exe`, `mspaint.exe`) at the process lookup level
- This fixes auto-routing for `type --app 记事本` which previously logged a misleading "App not found" warning and reported `pid: None` in output

## Root Cause
`find_process(name="记事本")` did substring matching against process names (e.g. `notepad.exe`). Since "记事本" is not a substring of "notepad.exe", it returned None. The `_LAUNCH_ALIASES` map (already in `process.py`) had the correct mapping but was only used for `app launch`, not `find_process`.

## Testing
- 6 new tests in `TestFindProcessAliasResolution` (direct alias, session preference, no-match)
- 2 new tests in `TestResolveMethodAliasResolution` (end-to-end routing with Chinese names)
- Full suite: 1844 passed, 363 skipped, 0 failed

**[Dev-Sirius]**