### PR TITLE
fix: add CI concurrency group — cancel stale runs automatically

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Lint & Type Check


### PR DESCRIPTION
## Problem

Dev agent merges PRs rapidly → multiple CI runs triggered on main simultaneously → older runs get cancelled by GitHub's concurrency limits → misleading cancel status in Actions tab.

## Fix

Added `concurrency` group per branch with `cancel-in-progress: true`. When a new commit arrives on the same branch, the old run is immediately cancelled (not after wasting minutes). Only the latest commit's CI runs to completion.

**[Orc-Mycelium]**