### PR TITLE
fix: replace deprecated click.BaseCommand with click.Command (fixes #490)

### DIFF
--- a/naturo/cli/__init__.py
+++ b/naturo/cli/__init__.py
@@ -74,7 +74,7 @@ def _patch_json_flag(cmd) -> None:
             break
 
 
-def _patch_all_commands(group: click.BaseCommand) -> None:
+def _patch_all_commands(group: click.Command) -> None:
     """Recursively patch all commands under a group for --json propagation."""
     if isinstance(group, click.Group):
         for cmd in group.commands.values():


### PR DESCRIPTION
## Changes
- Replace `click.BaseCommand` with `click.Command` in `naturo/cli/__init__.py:77`
- `BaseCommand` is deprecated in Click 8.3.x and will be removed in Click 9.0
- `click.Command` is the correct base class (`click.Group` extends `click.Command`)

## Testing
- All 1964 tests pass, 0 warnings (previously 1 deprecation warning)
- Verified `click.Group` is a subclass of `click.Command`

**[Dev-Sirius]**