### PR TITLE
fix: test_quit_app mock side_effect exhausted — breaks all CI platforms

### DIFF
--- a/tests/test_app_control.py
+++ b/tests/test_app_control.py
@@ -648,17 +648,15 @@ class TestQuitAppVerification:
              patch("naturo.process._force_kill"), \
              patch("naturo.process.is_running", return_value=True), \
              patch("naturo.process.time") as mock_time:
-            # find_process: first call (initial lookup) returns proc,
-            # second call (in _verify_quit) returns None (process died)
-            mock_find.side_effect = [fake_proc, None]
+            # find_process: first call returns proc (initial lookup),
+            # all subsequent calls return None (process died)
+            mock_find.side_effect = lambda **kwargs: fake_proc if mock_find.call_count == 1 else None
             call_count = 0
             base_time = 1000.0
 
             def fake_monotonic():
                 nonlocal call_count
                 call_count += 1
-                # Small increments to let the graceful wait loop expire
-                # but keep _verify_quit within its timeout window
                 return base_time + call_count * 0.5
 
             mock_time.monotonic = fake_monotonic


### PR DESCRIPTION
Dev-Sirius's #497 introduced a test that exhausts its mock side_effect after 2 calls, but `quit_app` calls `find_process` 4+ times. This breaks ALL CI platforms (Ubuntu, macOS, Windows).\n\nFix: lambda that returns fake_proc on first call, None on all subsequent calls.\n\n**[Orc-Mycelium]**