### PR TITLE
fix: click eN ref resolves display refs from see output (fixes #502)

### DIFF
--- a/naturo/cli/core.py
+++ b/naturo/cli/core.py
@@ -749,7 +749,10 @@ def see(app, window_title, hwnd, pid, mode, depth, path, annotate, store_snapsho
             # changes between snapshots (e.g. Calculator display update after Clear).
             from naturo.refs import assign_stable_refs
 
-            ui_map, ref_map = assign_stable_refs(tree, UIElement)
+            _element_obj_to_ref: dict[int, str] = {}
+            ui_map, ref_map = assign_stable_refs(
+                tree, UIElement, element_obj_to_ref=_element_obj_to_ref,
+            )
             mgr.store_detection_result(snapshot_id, ui_map)
             # Persist ref mapping so click/type can resolve e<N> refs
             mgr.store_ref_map(snapshot_id, ref_map)
@@ -780,6 +783,11 @@ def see(app, window_title, hwnd, pid, mode, depth, path, annotate, store_snapsho
                 }
                 mgr.store_screenshot(snapshot_id, result.path, metadata)
 
+        # (#502) Build mapping from sequential display refs (e1, e2, …) to
+        # stable hash-based refs (e1876, e2473, …) so that ``click eN`` can
+        # resolve the refs shown in ``see`` output.
+        _display_ref_map: dict[str, str] = {}
+
         if json_output:
             # (#237) Use a sequential counter matching _flatten() DFS order
             # to assign unique display IDs.  The previous reverse-map approach
@@ -799,6 +807,12 @@ def see(app, window_title, hwnd, pid, mode, depth, path, annotate, store_snapsho
                 """
                 _json_ref_seq[0] += 1
                 display_id = f"e{_json_ref_seq[0]}"
+
+                # (#502) Map display ref → stable ref for click resolution
+                if store_snapshot:
+                    stable_ref = _element_obj_to_ref.get(id(el))
+                    if stable_ref:
+                        _display_ref_map[display_id] = stable_ref
 
                 # (#295) Expose AutomationId separately.  The raw
                 # el.id from the bridge may be an AutomationId or a
@@ -884,6 +898,12 @@ def see(app, window_title, hwnd, pid, mode, depth, path, annotate, store_snapsho
                 _ref_counter[0] += 1
                 ref = f"e{_ref_counter[0]}"
 
+                # (#502) Map display ref → stable ref for click resolution
+                if store_snapshot:
+                    stable_ref = _element_obj_to_ref.get(id(el))
+                    if stable_ref:
+                        _display_ref_map[ref] = stable_ref
+
                 # (#365) Zero-bounds = offscreen
                 _is_offscreen = (el.x == 0 and el.y == 0 and el.width == 0 and el.height == 0)
 
@@ -926,6 +946,11 @@ def see(app, window_title, hwnd, pid, mode, depth, path, annotate, store_snapsho
                 click.echo("  Providers:")
                 for p in cascade_stats.providers:
                     click.echo(f"    {p.name:<12} {p.elements:>4} elements  {p.elapsed_ms:>6.0f}ms  [{p.status}]")
+
+        # (#502) Persist display ref → stable ref mapping so that
+        # ``click eN`` can resolve the sequential refs shown in ``see``.
+        if store_snapshot and snapshot_id and _display_ref_map:
+            mgr.store_display_ref_map(snapshot_id, _display_ref_map)
 
         # Generate annotated screenshot
         if annotate and store_snapshot and snapshot_id:

--- a/naturo/snapshot.py
+++ b/naturo/snapshot.py
@@ -304,6 +304,55 @@ class SnapshotManager:
             self._write_json_atomic(ref_path, ref_map)
         logger.debug("Stored ref map for snapshot %s (%d refs)", snapshot_id, len(ref_map))
 
+    def store_display_ref_map(
+        self, snapshot_id: str, display_map: Dict[str, str],
+    ) -> None:
+        """Persist the display ref → stable ref mapping for a snapshot.
+
+        The ``see`` command shows sequential display refs (e1, e2, e3…) but
+        stores hash-based stable refs (e1876, e2473…) in ``refs.json``.
+        This mapping allows ``click eN`` to translate the display ref the
+        user sees into the stable ref used internally (#502).
+
+        Parameters
+        ----------
+        snapshot_id:
+            Target snapshot.
+        display_map:
+            Mapping from display ref (e.g. ``"e1"``) to stable ref
+            (e.g. ``"e1876"``).
+        """
+        snap_dir = self._snap_dir(snapshot_id)
+        with self._lock:
+            path = snap_dir / "display_refs.json"
+            self._write_json_atomic(path, display_map)
+        logger.debug(
+            "Stored display ref map for snapshot %s (%d refs)",
+            snapshot_id, len(display_map),
+        )
+
+    def _translate_display_ref(
+        self, ref: str, snap_dir: Path,
+    ) -> str:
+        """Translate a sequential display ref to its stable hash-based ref.
+
+        The ``see`` command shows sequential refs (e1, e2, e3…) while storing
+        hash-based refs (e1876, e2473…).  If a ``display_refs.json`` mapping
+        exists, this translates the display ref; otherwise returns ``ref``
+        unchanged (#502).
+        """
+        display_path = snap_dir / "display_refs.json"
+        with self._lock:
+            if not display_path.exists():
+                return ref
+            try:
+                display_map = json.loads(
+                    display_path.read_text(encoding="utf-8"),
+                )
+            except (OSError, json.JSONDecodeError):
+                return ref
+        return display_map.get(ref, ref)
+
     def resolve_ref(self, ref: str) -> Optional[tuple]:
         """Resolve a short element ref (e.g. ``e3``) to center coordinates.
 
@@ -337,7 +386,14 @@ class SnapshotManager:
             except (OSError, json.JSONDecodeError):
                 return None
 
-        element_id = ref_map.get(ref)
+        # (#502) Translate sequential display ref (e1, e2…) to stable
+        # hash-based ref (e1876…) if a display_refs.json mapping exists.
+        stable_ref = self._translate_display_ref(ref, snap_dir)
+
+        element_id = ref_map.get(stable_ref)
+        if not element_id:
+            # Fallback: try the original ref in case it's already a stable ref
+            element_id = ref_map.get(ref)
         if not element_id:
             return None
 
@@ -347,8 +403,13 @@ class SnapshotManager:
             return None
 
         # (#237) ui_map may be keyed by ref ("e1") or by backend id,
-        # depending on snapshot version.  Try ref first, then backend id.
-        element = snapshot.ui_map.get(ref) or snapshot.ui_map.get(element_id)
+        # depending on snapshot version.  Try stable ref first, then
+        # backend id, then original ref.
+        element = (
+            snapshot.ui_map.get(stable_ref)
+            or snapshot.ui_map.get(element_id)
+            or snapshot.ui_map.get(ref)
+        )
         if not element:
             return None
 
@@ -401,7 +462,12 @@ class SnapshotManager:
             except (OSError, json.JSONDecodeError):
                 return None
 
-        element_id = ref_map.get(ref)
+        # (#502) Translate sequential display ref to stable hash-based ref.
+        stable_ref = self._translate_display_ref(ref, snap_dir)
+
+        element_id = ref_map.get(stable_ref)
+        if not element_id:
+            element_id = ref_map.get(ref)
         if not element_id:
             return None
 
@@ -410,8 +476,12 @@ class SnapshotManager:
         except Exception:
             return None
 
-        # (#237) ui_map may be keyed by ref ("e1") or by backend id.
-        element = snapshot.ui_map.get(ref) or snapshot.ui_map.get(element_id)
+        # (#237) ui_map may be keyed by ref or by backend id.
+        element = (
+            snapshot.ui_map.get(stable_ref)
+            or snapshot.ui_map.get(element_id)
+            or snapshot.ui_map.get(ref)
+        )
         if not element:
             return None
 

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -864,5 +864,117 @@ class TestResolveRefDuplicateBackendIds:
         assert result_b[0].title == "系统"
 
 
+class TestDisplayRefMap:
+    """Tests for display ref → stable ref translation (#502).
+
+    The ``see`` command shows sequential display refs (e1, e2, e3…) but
+    stores hash-based stable refs (e1876, e2473…) in refs.json.  The
+    display_refs.json mapping allows ``click eN`` to resolve the display
+    ref the user sees.
+    """
+
+    def test_resolve_ref_with_display_mapping(
+        self, mgr: SnapshotManager, png_file: Path,
+    ) -> None:
+        """resolve_ref translates display ref via display_refs.json."""
+        sid = mgr.create_snapshot()
+        mgr.store_screenshot(sid, str(png_file))
+
+        # Stable refs use hash-based keys (like the real system)
+        el = UIElement(
+            id="e1876", element_id="element_e1876", role="Button",
+            title="OK", label="OK", value=None,
+            frame=(100, 200, 80, 30), is_actionable=True,
+            parent_id=None, children=[],
+        )
+        ui_map = {"e1876": el}
+        ref_map = {"e1876": "backend_id_ok"}
+        mgr.store_detection_result(sid, ui_map)
+        mgr.store_ref_map(sid, ref_map)
+
+        # Without display_refs.json, "e1" should NOT resolve
+        assert mgr.resolve_ref("e1") is None
+
+        # Store display ref mapping: e1 (shown to user) → e1876 (stable)
+        mgr.store_display_ref_map(sid, {"e1": "e1876"})
+
+        # Now "e1" should resolve to the element's center
+        result = mgr.resolve_ref("e1")
+        assert result is not None
+        cx, cy, snap_id = result
+        assert snap_id == sid
+        assert cx == 140  # 100 + 80//2
+        assert cy == 215  # 200 + 30//2
+
+    def test_resolve_ref_element_with_display_mapping(
+        self, mgr: SnapshotManager, png_file: Path,
+    ) -> None:
+        """resolve_ref_element translates display ref via display_refs.json."""
+        sid = mgr.create_snapshot()
+        mgr.store_screenshot(sid, str(png_file))
+
+        el = UIElement(
+            id="e2473", element_id="element_e2473", role="Edit",
+            title="Search", label="Search", value="hello",
+            frame=(50, 60, 200, 25), is_actionable=True,
+            parent_id=None, children=[],
+        )
+        ui_map = {"e2473": el}
+        ref_map = {"e2473": "backend_search"}
+        mgr.store_detection_result(sid, ui_map)
+        mgr.store_ref_map(sid, ref_map)
+        mgr.store_display_ref_map(sid, {"e3": "e2473"})
+
+        result = mgr.resolve_ref_element("e3")
+        assert result is not None
+        element, snap_id = result
+        assert snap_id == sid
+        assert element.role == "Edit"
+        assert element.title == "Search"
+
+    def test_stable_refs_still_work_directly(
+        self, mgr: SnapshotManager, png_file: Path,
+    ) -> None:
+        """Stable refs (e1876) still resolve even when display_refs.json exists."""
+        sid = mgr.create_snapshot()
+        mgr.store_screenshot(sid, str(png_file))
+
+        el = UIElement(
+            id="e1876", element_id="element_e1876", role="Button",
+            title="Cancel", label="Cancel", value=None,
+            frame=(200, 300, 60, 30), is_actionable=True,
+            parent_id=None, children=[],
+        )
+        ui_map = {"e1876": el}
+        ref_map = {"e1876": "backend_cancel"}
+        mgr.store_detection_result(sid, ui_map)
+        mgr.store_ref_map(sid, ref_map)
+        mgr.store_display_ref_map(sid, {"e1": "e1876"})
+
+        # Direct stable ref should still work
+        result = mgr.resolve_ref("e1876")
+        assert result is not None
+        cx, cy, _ = result
+        assert cx == 230  # 200 + 60//2
+        assert cy == 315  # 300 + 30//2
+
+    def test_display_ref_map_not_required(
+        self, mgr: SnapshotManager, png_file: Path,
+        sample_ui_map: Dict[str, UIElement],
+    ) -> None:
+        """Without display_refs.json, resolve_ref works as before (#237 compat)."""
+        sid = mgr.create_snapshot()
+        mgr.store_screenshot(sid, str(png_file))
+        mgr.store_detection_result(sid, sample_ui_map)
+        mgr.store_ref_map(sid, {"e1": "element_0", "e2": "element_1"})
+
+        # Old-style: ref_map keys match ui_map keys directly
+        result = mgr.resolve_ref("e1")
+        assert result is not None
+        cx, cy, _ = result
+        assert cx == 50   # 10 + 80//2
+        assert cy == 35   # 20 + 30//2
+
+
 # ── need os for backdate test ─────────────────────────────────────────────────
 import os  # noqa: E402  (placed here intentionally to keep test-only import)


### PR DESCRIPTION
## Changes
- `see` command now stores a `display_refs.json` mapping sequential display refs (e1, e2, e3…) to stable hash-based refs (e1876, e2473…)
- `resolve_ref` and `resolve_ref_element` in `SnapshotManager` translate display refs via this mapping before looking up the stable ref
- Backward compatible: old snapshots without `display_refs.json` continue to work unchanged

## Root Cause
The `see` command displays sequential refs (e1, e2, e3…) but `assign_stable_refs` (#456) stores hash-based refs (e1876, e2473…) in `refs.json`. When `click e3` tried to look up `e3` in `refs.json`, it didn't exist — causing "Element ref not found" for every ref.

## Testing
- 4 new tests in `TestDisplayRefMap`: display ref resolution, element resolution, stable ref passthrough, backward compat
- Full suite: 1948 passed, 557 skipped, 0 failures
- ruff: clean
- mypy: clean

**[Dev-Sirius]**