### PR TITLE
fix: see --path used wrong variable for capture_screen (fixes #503)

### DIFF
--- a/naturo/cli/core.py
+++ b/naturo/cli/core.py
@@ -771,7 +771,7 @@ def see(app, window_title, hwnd, pid, mode, depth, path, annotate, store_snapsho
 
             # Optionally capture screenshot into snapshot
             if path:
-                result = backend.capture_screen(output_path=path)
+                result = be.capture_screen(output_path=path)
                 metadata = {
                     "window_handle": hwnd,
                     "application_name": app,
@@ -949,7 +949,7 @@ def see(app, window_title, hwnd, pid, mode, depth, path, annotate, store_snapsho
 
         # Capture screenshot (when not already done above)
         if path and not store_snapshot:
-            result = backend.capture_screen(output_path=path)
+            result = be.capture_screen(output_path=path)
             click.echo(f"\nScreenshot saved: {result.path}")
 
     except WindowNotFoundError as e:


### PR DESCRIPTION
## Changes
- Fixed `backend.capture_screen()` → `be.capture_screen()` in two places in the `see` command
- `backend` is the CLI option string (e.g. "uia"), `be` is the actual backend object

## Root Cause
Variable name confusion: `backend` (string) vs `be` (object). The `see` command correctly uses `be` for `get_element_tree()` but incorrectly used `backend` for `capture_screen()`.

## Testing
- 2002 passed, 499 skipped, 0 failures
- ruff: clean
- mypy: clean

**[Dev-Sirius]**