### PR TITLE
fix: WindowInfo handle/hwnd bidirectional alias (fixes #504)

### DIFF
--- a/naturo/backends/base.py
+++ b/naturo/backends/base.py
@@ -21,6 +21,11 @@ class WindowInfo:
     is_visible: bool
     is_minimized: bool
 
+    @property
+    def hwnd(self) -> int:
+        """Alias for ``handle`` for bridge API compatibility (#504)."""
+        return self.handle
+
 
 @dataclass
 class ElementInfo:

--- a/naturo/bridge.py
+++ b/naturo/bridge.py
@@ -69,6 +69,8 @@ class WindowInfo:
         height: Window height in pixels.
         is_visible: Whether the window is visible.
         is_minimized: Whether the window is minimized (iconic).
+        handle: Alias for ``hwnd`` — matches the cross-platform
+            ``backends.base.WindowInfo.handle`` attribute (#504).
     """
     hwnd: int
     title: str
@@ -80,6 +82,11 @@ class WindowInfo:
     height: int
     is_visible: bool
     is_minimized: bool
+
+    @property
+    def handle(self) -> int:
+        """Alias for ``hwnd`` for cross-platform API compatibility (#504)."""
+        return self.hwnd
 
 
 @dataclass

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -12,6 +12,25 @@ def test_window_info_dataclass():
     assert w.handle == 12345
 
 
+def test_base_window_info_hwnd_alias():
+    """backends.base.WindowInfo.hwnd is an alias for .handle (#504)."""
+    w = WindowInfo(handle=99999, title="Test", process_name="test.exe",
+                   pid=42, x=0, y=0, width=100, height=100,
+                   is_visible=True, is_minimized=False)
+    assert w.hwnd == 99999
+    assert w.hwnd == w.handle
+
+
+def test_bridge_window_info_handle_alias():
+    """bridge.WindowInfo.handle is an alias for .hwnd (#504)."""
+    from naturo.bridge import WindowInfo as BridgeWindowInfo
+    w = BridgeWindowInfo(hwnd=88888, title="Bridge", process_name="b.exe",
+                         pid=7, x=10, y=20, width=200, height=300,
+                         is_visible=True, is_minimized=False)
+    assert w.handle == 88888
+    assert w.handle == w.hwnd
+
+
 def test_element_info_dataclass():
     e = ElementInfo(id="E1", role="Button", name="OK", value=None,
                     x=100, y=200, width=80, height=30, children=[], properties={})


### PR DESCRIPTION
## Changes
- Added `handle` property to `bridge.WindowInfo` (alias for `hwnd`)
- Added `hwnd` property to `backends.base.WindowInfo` (alias for `handle`)
- 2 new tests verifying bidirectional alias works

## Root Cause
Two `WindowInfo` dataclasses exist at different abstraction layers with different attribute names for the window handle. Code crossing layers (like `test_window_lifecycle` using bridge objects with `.handle`) would crash with `AttributeError`.

## Testing
- 2004 passed, 499 skipped, 0 failures
- ruff: clean
- mypy: clean

**[Dev-Sirius]**