### PR TITLE
fix: app quit resolves UWP child PID via backend window list (fixes #505)

### DIFF
--- a/naturo/process.py
+++ b/naturo/process.py
@@ -460,6 +460,28 @@ def launch_app(
     return info
 
 
+def _resolve_pid_from_backend(name: str) -> int | None:
+    """Resolve a PID via the window backend for UWP-aware lookup (#505).
+
+    The backend's ``list_windows()`` applies UWP child process resolution
+    (finding the real app PID inside ApplicationFrameHost), which raw
+    ``tasklist`` does not.  This ensures ``app quit notepad`` targets the
+    actual Notepad process, not the stale AFH host PID.
+    """
+    try:
+        from naturo.backends.base import get_backend
+
+        be = get_backend()
+        name_lower = name.lower()
+        for w in be.list_windows():
+            proc_name = os.path.basename(w.process_name).lower()
+            if name_lower in proc_name or name_lower in w.title.lower():
+                return w.pid
+    except Exception:
+        logger.debug("Backend PID resolution failed for %r, falling back", name)
+    return None
+
+
 def quit_app(
     name: str | None = None,
     pid: int | None = None,
@@ -477,6 +499,14 @@ def quit_app(
     Raises:
         AppNotFoundError: If no matching process is found.
     """
+    # (#505) For name-based lookup on Windows, first try the backend's
+    # window list which has UWP child process resolution.  This avoids
+    # targeting the stale ApplicationFrameHost PID.
+    if name and pid is None and platform.system() == "Windows":
+        backend_pid = _resolve_pid_from_backend(name)
+        if backend_pid is not None:
+            pid = backend_pid
+
     proc = find_process(name=name, pid=pid)
     if proc is None:
         identifier = name or str(pid)

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -6,7 +6,7 @@ from naturo.process import (
     ProcessInfo, find_process, is_running, launch_app, quit_app,
     relaunch_app, list_apps, _list_processes, _verify_quit,
     _get_console_session_id, _get_process_session_id,
-    _resolve_launch_name, _LAUNCH_ALIASES,
+    _resolve_launch_name, _resolve_pid_from_backend, _LAUNCH_ALIASES,
 )
 from naturo.errors import AppNotFoundError, InteractionFailedError, TimeoutError
 
@@ -568,6 +568,58 @@ class TestQuitApp:
         """When quit was by PID only (no name), verify by PID only."""
         mock_find.return_value = None
         _verify_quit(None, 100, target_pid=100, timeout=0.5)
+
+
+class TestResolvePidFromBackend:
+    """Tests for UWP-aware PID resolution via backend (#505)."""
+
+    @patch("naturo.backends.base.get_backend")
+    def test_resolves_uwp_pid_from_window_list(self, mock_get_backend):
+        """Backend window list returns the real PID for UWP apps."""
+        mock_window = MagicMock()
+        mock_window.process_name = "C:\\Windows\\Notepad.exe"
+        mock_window.title = "Untitled - Notepad"
+        mock_window.pid = 36328  # Real app PID (not AFH PID 37476)
+
+        mock_be = MagicMock()
+        mock_be.list_windows.return_value = [mock_window]
+        mock_get_backend.return_value = mock_be
+
+        pid = _resolve_pid_from_backend("notepad")
+        assert pid == 36328
+
+    @patch("naturo.backends.base.get_backend")
+    def test_returns_none_when_no_match(self, mock_get_backend):
+        """Returns None when no window matches the app name."""
+        mock_be = MagicMock()
+        mock_be.list_windows.return_value = []
+        mock_get_backend.return_value = mock_be
+
+        assert _resolve_pid_from_backend("nonexistent") is None
+
+    @patch("naturo.backends.base.get_backend")
+    def test_falls_back_on_backend_error(self, mock_get_backend):
+        """Returns None gracefully when backend raises."""
+        mock_get_backend.side_effect = Exception("No backend")
+        assert _resolve_pid_from_backend("notepad") is None
+
+    @patch("naturo.process._verify_quit")
+    @patch("naturo.process._force_kill")
+    @patch("naturo.process.find_process")
+    @patch("naturo.process._resolve_pid_from_backend")
+    @patch("naturo.process.platform")
+    def test_quit_app_uses_backend_pid_on_windows(
+        self, mock_platform, mock_resolve, mock_find, mock_kill, mock_verify,
+    ):
+        """quit_app uses backend-resolved PID for name-based quit on Windows (#505)."""
+        mock_platform.system.return_value = "Windows"
+        mock_resolve.return_value = 36328  # UWP-resolved PID
+        mock_find.return_value = ProcessInfo(pid=36328, name="notepad.exe")
+        mock_verify.return_value = None
+
+        quit_app(name="notepad", force=True)
+        mock_resolve.assert_called_once_with("notepad")
+        mock_kill.assert_called_once_with(36328, "Windows")
 
 
 class TestRelaunchApp:


### PR DESCRIPTION
## Changes
- Added `_resolve_pid_from_backend()` in `process.py` — resolves app name to PID via backend's `list_windows()` which has UWP child process resolution
- `quit_app()` now tries backend PID resolution first on Windows before falling back to raw `tasklist`-based `find_process()`
- 4 new tests: UWP PID resolution, no match, backend error fallback, integration with quit_app

## Root Cause
`quit_app()` used `find_process()` → `_list_processes()` → `tasklist /FO CSV` which returns ApplicationFrameHost's PID for UWP apps. The backend's `list_windows()` correctly resolves UWP child PIDs via `_resolve_uwp_child_pid()` but this path wasn't used by `quit_app()`.

## Testing
- 2006 passed, 499 skipped, 0 failures
- ruff: clean
- mypy: clean

**[Dev-Sirius]**