### PR TITLE
fix: deprioritize Program Manager when resolving --app explorer (fixes #524)

### DIFF
--- a/naturo/backends/windows.py
+++ b/naturo/backends/windows.py
@@ -18,7 +18,7 @@ from naturo.backends.base import (
 from naturo.bridge import NaturoCore, populate_hierarchy
 from naturo.errors import NaturoError
 from naturo.models.menu import MenuItem
-from typing import List, Optional
+from typing import ClassVar, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -880,6 +880,36 @@ class WindowsBackend(Backend):
         except Exception:
             return 0
 
+    @staticmethod
+    def _get_window_class_name(hwnd: int) -> str:
+        """Get the window class name for a given HWND.
+
+        Used to identify special windows like Program Manager ("Progman")
+        which should be deprioritized during app resolution (#524).
+
+        Args:
+            hwnd: Window handle.
+
+        Returns:
+            Window class name, or empty string on failure.
+        """
+        try:
+            import ctypes
+            buf = ctypes.create_unicode_buffer(256)
+            ctypes.windll.user32.GetClassNameW(hwnd, buf, 256)
+            return buf.value
+        except Exception:
+            return ""
+
+    # Window classes that represent the desktop shell rather than real
+    # application windows.  explorer.exe hosts both the desktop and File
+    # Explorer; when --app explorer is used, these should be deprioritized
+    # so actual File Explorer windows are preferred (#524).
+    _DESKTOP_SHELL_CLASSES: ClassVar[frozenset[str]] = frozenset({
+        "Progman",   # Program Manager (desktop icons)
+        "WorkerW",   # Desktop worker window (wallpaper layer)
+    })
+
     def _resolve_hwnd(self, app: Optional[str] = None,
                       window_title: Optional[str] = None,
                       hwnd: Optional[int] = None,
@@ -1025,6 +1055,17 @@ class WindowsBackend(Backend):
 
             if score == 0:
                 continue
+
+            # (#524) Desktop shell deprioritization: explorer.exe hosts both
+            # File Explorer and the desktop (Program Manager, class "Progman").
+            # When --app explorer is used, users expect File Explorer, not the
+            # desktop.  Detect shell windows by class name and reduce their
+            # score to 1, so any real File Explorer window (score 3-4) wins.
+            # If no File Explorer windows exist, the desktop still matches.
+            if match_process:
+                wclass = self._get_window_class_name(w.handle)
+                if wclass in self._DESKTOP_SHELL_CLASSES:
+                    score = 1  # demote desktop shell windows
 
             # Session-aware ranking (#230): prefer windows in the active
             # console session over windows in Session 0 (services session).

--- a/tests/test_explorer_program_manager.py
+++ b/tests/test_explorer_program_manager.py
@@ -1,0 +1,219 @@
+"""Tests for explorer.exe desktop shell deprioritization (#524).
+
+explorer.exe hosts both the desktop (Program Manager, class "Progman") and
+File Explorer windows.  When --app explorer is used, _resolve_hwnd should
+prefer actual File Explorer windows over the desktop.
+"""
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from naturo.backends.base import WindowInfo
+
+
+def _make_backend():
+    """Create a WindowsBackend class for testing _resolve_hwnd."""
+    try:
+        from naturo.backends.windows import WindowsBackend
+        return WindowsBackend
+    except Exception:
+        pytest.skip("WindowsBackend not available on this platform")
+
+
+class TestExplorerProgramManager:
+    """Verify --app explorer prefers File Explorer over Program Manager (#524)."""
+
+    def _make_explorer_windows(self):
+        """Program Manager (desktop) + File Explorer window."""
+        return [
+            WindowInfo(
+                handle=0x10010,
+                title="Program Manager",
+                process_name="explorer.exe",
+                pid=1000,
+                x=0, y=0, width=1920, height=1080,  # full screen
+                is_visible=True, is_minimized=False,
+            ),
+            WindowInfo(
+                handle=0x20020,
+                title="Windows (C:) - File Explorer",
+                process_name="explorer.exe",
+                pid=1000,
+                x=100, y=100, width=900, height=600,  # smaller
+                is_visible=True, is_minimized=False,
+            ),
+        ]
+
+    def _setup_backend(self, windows, class_map=None):
+        """Create a mock backend with the given windows and class names.
+
+        Args:
+            windows: List of WindowInfo to return from list_windows.
+            class_map: Dict mapping hwnd -> class name string.
+        """
+        BackendClass = _make_backend()
+        backend = MagicMock(spec=BackendClass)
+        backend.list_windows = MagicMock(return_value=windows)
+        backend._resolve_hwnd = BackendClass._resolve_hwnd.__get__(backend)
+        backend._get_console_session_id = MagicMock(return_value=-1)
+        backend._get_process_session_id = MagicMock(return_value=1)
+        backend._get_foreground_hwnd = MagicMock(return_value=0)
+        backend._APP_ALIASES = BackendClass._APP_ALIASES
+        backend._DESKTOP_SHELL_CLASSES = BackendClass._DESKTOP_SHELL_CLASSES
+
+        if class_map is None:
+            class_map = {}
+        backend._get_window_class_name = MagicMock(
+            side_effect=lambda h: class_map.get(h, "")
+        )
+        return backend
+
+    def test_prefers_file_explorer_over_program_manager(self):
+        """--app explorer should pick File Explorer, not Program Manager."""
+        windows = self._make_explorer_windows()
+        class_map = {
+            0x10010: "Progman",        # desktop
+            0x20020: "CabinetWClass",  # File Explorer
+        }
+        backend = self._setup_backend(windows, class_map)
+
+        result = backend._resolve_hwnd(app="explorer")
+        assert result == 0x20020, (
+            "Expected File Explorer (0x20020), got Program Manager (0x10010)"
+        )
+
+    def test_workerw_also_deprioritized(self):
+        """WorkerW (desktop wallpaper layer) should also be deprioritized."""
+        windows = [
+            WindowInfo(
+                handle=0x10010,
+                title="",
+                process_name="explorer.exe",
+                pid=1000,
+                x=0, y=0, width=1920, height=1080,
+                is_visible=True, is_minimized=False,
+            ),
+            WindowInfo(
+                handle=0x20020,
+                title="Downloads - File Explorer",
+                process_name="explorer.exe",
+                pid=1000,
+                x=100, y=100, width=900, height=600,
+                is_visible=True, is_minimized=False,
+            ),
+        ]
+        class_map = {
+            0x10010: "WorkerW",
+            0x20020: "CabinetWClass",
+        }
+        backend = self._setup_backend(windows, class_map)
+
+        result = backend._resolve_hwnd(app="explorer")
+        assert result == 0x20020
+
+    def test_program_manager_still_matches_when_only_option(self):
+        """When no File Explorer windows exist, Program Manager should still match."""
+        windows = [
+            WindowInfo(
+                handle=0x10010,
+                title="Program Manager",
+                process_name="explorer.exe",
+                pid=1000,
+                x=0, y=0, width=1920, height=1080,
+                is_visible=True, is_minimized=False,
+            ),
+        ]
+        class_map = {0x10010: "Progman"}
+        backend = self._setup_backend(windows, class_map)
+
+        result = backend._resolve_hwnd(app="explorer")
+        assert result == 0x10010, (
+            "Program Manager should still match when it's the only explorer window"
+        )
+
+    def test_chinese_locale_explorer_preferred(self):
+        """Chinese locale: File Explorer with Chinese title preferred over desktop."""
+        windows = [
+            WindowInfo(
+                handle=0x10010,
+                title="Program Manager",
+                process_name="explorer.exe",
+                pid=1000,
+                x=0, y=0, width=1920, height=1080,
+                is_visible=True, is_minimized=False,
+            ),
+            WindowInfo(
+                handle=0x20020,
+                title="Windows (C:) - 文件资源管理器",
+                process_name="explorer.exe",
+                pid=1000,
+                x=100, y=100, width=900, height=600,
+                is_visible=True, is_minimized=False,
+            ),
+        ]
+        class_map = {
+            0x10010: "Progman",
+            0x20020: "CabinetWClass",
+        }
+        backend = self._setup_backend(windows, class_map)
+
+        result = backend._resolve_hwnd(app="explorer")
+        assert result == 0x20020
+
+    def test_multiple_explorer_windows_picks_largest(self):
+        """Among multiple File Explorer windows, largest area wins."""
+        windows = [
+            WindowInfo(
+                handle=0x10010,
+                title="Program Manager",
+                process_name="explorer.exe",
+                pid=1000,
+                x=0, y=0, width=1920, height=1080,
+                is_visible=True, is_minimized=False,
+            ),
+            WindowInfo(
+                handle=0x20020,
+                title="Downloads - File Explorer",
+                process_name="explorer.exe",
+                pid=1000,
+                x=100, y=100, width=400, height=300,
+                is_visible=True, is_minimized=False,
+            ),
+            WindowInfo(
+                handle=0x30030,
+                title="Documents - File Explorer",
+                process_name="explorer.exe",
+                pid=1000,
+                x=200, y=200, width=1000, height=700,
+                is_visible=True, is_minimized=False,
+            ),
+        ]
+        class_map = {
+            0x10010: "Progman",
+            0x20020: "CabinetWClass",
+            0x30030: "CabinetWClass",
+        }
+        backend = self._setup_backend(windows, class_map)
+
+        result = backend._resolve_hwnd(app="explorer")
+        assert result == 0x30030, "Should pick the largest File Explorer window"
+
+    def test_non_explorer_apps_unaffected(self):
+        """Desktop shell deprioritization only applies to process name matches."""
+        windows = [
+            WindowInfo(
+                handle=0xAAAA,
+                title="Untitled - Notepad",
+                process_name="notepad.exe",
+                pid=2000,
+                x=0, y=0, width=800, height=600,
+                is_visible=True, is_minimized=False,
+            ),
+        ]
+        class_map = {0xAAAA: "Notepad"}
+        backend = self._setup_backend(windows, class_map)
+
+        result = backend._resolve_hwnd(app="notepad")
+        assert result == 0xAAAA


### PR DESCRIPTION
## Changes
- Added `_get_window_class_name()` helper to detect window classes via Win32 API
- Added `_DESKTOP_SHELL_CLASSES` constant (`Progman`, `WorkerW`)
- In `_resolve_hwnd`, desktop shell windows are demoted to score 1 when matching by process name, so real File Explorer windows (score 3-4) always win
- If no File Explorer windows exist, Program Manager still matches as fallback

## Root Cause
explorer.exe hosts both the desktop (Program Manager, class "Progman") and File Explorer windows. `_resolve_hwnd` scored both at 4 (exact process name match), and the largest-area tiebreaker always picked Program Manager (1920x1080 full-screen).

## Testing
- 6 new tests in `test_explorer_program_manager.py`:
  - File Explorer preferred over Program Manager
  - WorkerW also deprioritized
  - Program Manager still matches when it's the only explorer window
  - Chinese locale File Explorer titles handled correctly
  - Multiple File Explorer windows: largest area wins
  - Non-explorer apps unaffected
- Full suite: 2035 passed, 557 skipped
- ruff: clean
- mypy: clean

**[Dev-Sirius]**