### PR TITLE
fix: click --on fails for Chinese text when using --app-id (fixes #525)

### DIFF
--- a/naturo/backends/windows.py
+++ b/naturo/backends/windows.py
@@ -737,7 +737,8 @@ class WindowsBackend(Backend):
 
     # === UI Element Inspection (Phase 1) ===
 
-    def find_element(self, selector: str = "", window_title: Optional[str] = None) -> Optional[BaseElementInfo]:
+    def find_element(self, selector: str = "", window_title: Optional[str] = None,
+                     hwnd: Optional[int] = None) -> Optional[BaseElementInfo]:
         """Find a UI element by selector string.
 
         The selector format is "role:name" (e.g., "Button:OK") or just a name.
@@ -745,6 +746,8 @@ class WindowsBackend(Backend):
         Args:
             selector: Element selector in "role:name" or "name" format.
             window_title: Not yet used (reserved for future).
+            hwnd: Target window handle.  When provided, searches within this
+                window instead of the foreground window (#525).
 
         Returns:
             ElementInfo if found, None otherwise.
@@ -761,7 +764,7 @@ class WindowsBackend(Backend):
         else:
             name = selector if selector else None
 
-        result = core.find_element(hwnd=0, role=role, name=name)
+        result = core.find_element(hwnd=hwnd or 0, role=role, name=name)
         if result is None:
             return None
 
@@ -2028,7 +2031,8 @@ class WindowsBackend(Backend):
 
     def click(self, x: Optional[int] = None, y: Optional[int] = None,
               element_id: Optional[str] = None, button: str = "left",
-              double: bool = False, input_mode: str = "normal") -> None:
+              double: bool = False, input_mode: str = "normal",
+              hwnd: Optional[int] = None) -> None:
         """Click at coordinates or on a UI element.
 
         If an element_id is provided, finds the element first and clicks its
@@ -2042,9 +2046,13 @@ class WindowsBackend(Backend):
             button: Mouse button — "left", "right", or "middle".
             double: True for double-click.
             input_mode: Ignored for now (Phase 3 will add hardware/hook modes).
+            hwnd: Target window handle for element search.  When provided,
+                searches within this window instead of the foreground
+                window (#525).
 
         Raises:
             ValueError: If neither coordinates nor element_id is provided.
+            ElementNotFoundError: When element_id is given but not found.
             NaturoCoreError: On system error.
         """
         core = self._ensure_core()
@@ -2054,10 +2062,10 @@ class WindowsBackend(Backend):
 
         if element_id is not None:
             # Find element and click its center
-            el = self.find_element(selector=element_id)
+            el = self.find_element(selector=element_id, hwnd=hwnd)
             if el is None:
-                from naturo.bridge import NaturoCoreError
-                raise NaturoCoreError(-1, f"click: element not found ({element_id!r})")
+                from naturo.errors import ElementNotFoundError
+                raise ElementNotFoundError(element_id)
             cx = el.x + el.width // 2
             cy = el.y + el.height // 2
             core.mouse_move(cx, cy)

--- a/naturo/cli/interaction.py
+++ b/naturo/cli/interaction.py
@@ -1020,8 +1020,10 @@ def click_cmd(query, on_text, ref_alias, element_id, coords, double, right, app,
                 return
         elif target_id:
             try:
+                # (#525) Pass resolved hwnd so find_element searches the
+                # correct window, not just the foreground window.
                 backend.click(element_id=target_id, button=button, double=double,
-                              input_mode=input_mode)
+                              input_mode=input_mode, hwnd=hwnd)
             except Exception:
                 # (#442) Fallback: search the app's element tree when C++
                 # exact UIA Name match fails.  Handles localized apps where

--- a/tests/test_click_on_chinese.py
+++ b/tests/test_click_on_chinese.py
@@ -1,0 +1,145 @@
+"""Tests for click --on with Chinese accessibility names (#525).
+
+Verifies that:
+1. find_element passes the target hwnd (not foreground) when provided
+2. click passes hwnd through to find_element
+3. ElementNotFoundError is raised (not NaturoCoreError -1) on miss
+4. The text fallback receives the correct window context
+"""
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import MagicMock, patch, call
+from inspect import signature
+
+from naturo.backends.base import WindowInfo, ElementInfo
+
+
+def _make_backend():
+    """Create a WindowsBackend class for testing."""
+    try:
+        from naturo.backends.windows import WindowsBackend
+        return WindowsBackend
+    except Exception:
+        pytest.skip("WindowsBackend not available on this platform")
+
+
+class TestFindElementHwnd:
+    """find_element should accept and use hwnd parameter (#525)."""
+
+    def test_find_element_accepts_hwnd(self):
+        """find_element signature includes hwnd parameter."""
+        BackendClass = _make_backend()
+        sig = signature(BackendClass.find_element)
+        assert "hwnd" in sig.parameters
+        assert sig.parameters["hwnd"].default is None
+
+    def test_find_element_passes_hwnd_to_core(self):
+        """find_element forwards hwnd to the C++ core."""
+        BackendClass = _make_backend()
+        backend = MagicMock(spec=BackendClass)
+        backend.find_element = BackendClass.find_element.__get__(backend)
+
+        mock_core = MagicMock()
+        mock_core.find_element.return_value = None  # not found
+        backend._ensure_core = MagicMock(return_value=mock_core)
+
+        result = backend.find_element(selector="七", hwnd=0x12345)
+
+        # Should pass hwnd=0x12345, not hwnd=0
+        mock_core.find_element.assert_called_once_with(
+            hwnd=0x12345, role=None, name="七",
+        )
+        assert result is None
+
+    def test_find_element_defaults_to_foreground(self):
+        """find_element uses hwnd=0 (foreground) when hwnd not provided."""
+        BackendClass = _make_backend()
+        backend = MagicMock(spec=BackendClass)
+        backend.find_element = BackendClass.find_element.__get__(backend)
+
+        mock_core = MagicMock()
+        mock_core.find_element.return_value = None
+        backend._ensure_core = MagicMock(return_value=mock_core)
+
+        backend.find_element(selector="七")
+
+        mock_core.find_element.assert_called_once_with(
+            hwnd=0, role=None, name="七",
+        )
+
+
+class TestClickHwnd:
+    """click should pass hwnd to find_element (#525)."""
+
+    def test_click_accepts_hwnd(self):
+        """click signature includes hwnd parameter."""
+        BackendClass = _make_backend()
+        sig = signature(BackendClass.click)
+        assert "hwnd" in sig.parameters
+
+    def test_click_passes_hwnd_to_find_element(self):
+        """click forwards hwnd to find_element for element search."""
+        BackendClass = _make_backend()
+        backend = MagicMock(spec=BackendClass)
+        backend.click = BackendClass.click.__get__(backend)
+
+        mock_element = MagicMock()
+        mock_element.x = 100
+        mock_element.y = 200
+        mock_element.width = 50
+        mock_element.height = 30
+        backend.find_element = MagicMock(return_value=mock_element)
+
+        mock_core = MagicMock()
+        backend._ensure_core = MagicMock(return_value=mock_core)
+
+        backend.click(element_id="七", hwnd=0xABCD)
+
+        backend.find_element.assert_called_once_with(
+            selector="七", hwnd=0xABCD,
+        )
+
+
+class TestClickNotFoundError:
+    """click should raise ElementNotFoundError, not NaturoCoreError (#525)."""
+
+    def test_raises_element_not_found_error(self):
+        """click raises ElementNotFoundError when element is not found."""
+        from naturo.errors import ElementNotFoundError
+
+        BackendClass = _make_backend()
+        backend = MagicMock(spec=BackendClass)
+        backend.click = BackendClass.click.__get__(backend)
+        backend.find_element = MagicMock(return_value=None)
+
+        mock_core = MagicMock()
+        backend._ensure_core = MagicMock(return_value=mock_core)
+
+        with pytest.raises(ElementNotFoundError) as exc_info:
+            backend.click(element_id="七")
+
+        # Error message should mention the selector, not "Invalid argument"
+        assert "七" in str(exc_info.value)
+        assert "Invalid argument" not in str(exc_info.value)
+
+    def test_not_found_error_for_chinese_text(self):
+        """Verify the error message is clear for Chinese element names."""
+        from naturo.errors import ElementNotFoundError
+
+        BackendClass = _make_backend()
+        backend = MagicMock(spec=BackendClass)
+        backend.click = BackendClass.click.__get__(backend)
+        backend.find_element = MagicMock(return_value=None)
+
+        mock_core = MagicMock()
+        backend._ensure_core = MagicMock(return_value=mock_core)
+
+        with pytest.raises(ElementNotFoundError):
+            backend.click(element_id="清除", hwnd=0x1234)
+
+        # find_element should have been called with the correct hwnd
+        backend.find_element.assert_called_once_with(
+            selector="清除", hwnd=0x1234,
+        )


### PR DESCRIPTION
## Changes
- `find_element` now accepts `hwnd` parameter, forwards to C++ core instead of always using hwnd=0 (foreground)
- `click` passes `hwnd` through to `find_element`
- `click` raises `ElementNotFoundError` instead of `NaturoCoreError(-1, ...)` — no more misleading "Invalid argument" suffix
- `click_cmd` passes resolved hwnd from `--app-id` to `backend.click`

## Root Cause
`find_element` always searched `hwnd=0` (foreground window), ignoring the target window resolved from `--app-id`. When the Calculator wasn't the foreground window, the C++ UIA search couldn't find Chinese element names like '七'. The text fallback also failed because the initial exception masked the real issue.

## Testing
- 7 new tests in `test_click_on_chinese.py`:
  - `find_element` accepts and forwards hwnd
  - `find_element` defaults to foreground when hwnd not provided
  - `click` accepts and passes hwnd to find_element
  - `click` raises `ElementNotFoundError` (not `NaturoCoreError`) on miss
  - Error message contains selector, not "Invalid argument"
  - Chinese element names handled correctly
- Full suite: 2100 passed, 499 skipped
- ruff: clean

**[Dev-Sirius]**