### PR TITLE
fix: UWP Notepad test fixtures match by title not just process name (fixes #534)

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -167,20 +167,65 @@ def has_desktop():
     return True
 
 
+def _find_notepad_window_pid() -> Optional[int]:
+    """Find the PID of the process owning a visible Notepad window.
+
+    On Windows 11, UWP/WinUI3 Notepad is launched via a broker whose PID
+    differs from the window-owning process.  Instead of relying on tasklist
+    (which may return the broker PID), enumerate windows and find one whose
+    title contains "Notepad" (#534).
+
+    Returns:
+        PID of the Notepad window owner, or None.
+    """
+    try:
+        import ctypes
+        from ctypes import wintypes
+
+        user32 = ctypes.WinDLL("user32", use_last_error=True)
+        found_pid = ctypes.c_ulong(0)
+
+        @ctypes.WINFUNCTYPE(wintypes.BOOL, wintypes.HWND, wintypes.LPARAM)
+        def enum_callback(hwnd, lparam):
+            if not user32.IsWindowVisible(hwnd):
+                return True
+            buf = ctypes.create_unicode_buffer(256)
+            user32.GetWindowTextW(hwnd, buf, 256)
+            title = buf.value
+            if "notepad" in title.lower() and title.strip():
+                window_pid = wintypes.DWORD()
+                user32.GetWindowThreadProcessId(hwnd, ctypes.byref(window_pid))
+                found_pid.value = window_pid.value
+                return False  # stop
+            return True
+
+        user32.EnumWindows(enum_callback, 0)
+        return found_pid.value or None
+    except Exception:
+        return None
+
+
 @pytest.fixture(scope="module")
 def notepad_app(has_desktop) -> Generator[int, None, None]:
     """Launch Notepad and yield its PID. Clean up on teardown.
 
     Notepad is a classic Win32 application — the baseline test target.
+    On Windows 11, the UWP/WinUI3 version uses a launcher PID that differs
+    from the window-owning process.  We resolve the actual PID by finding
+    the visible Notepad window (#534).
     """
     proc = _launch_app("notepad.exe", wait_seconds=2.0)
     if proc is None:
         pytest.skip("Could not launch Notepad")
 
-    # Windows 11 UWP Notepad: launcher PID differs from the actual Notepad process.
-    # Look up the real process the same way calculator_app handles UWP apps.
+    # (#534) Find the PID that owns the visible Notepad window.
+    # This handles UWP Notepad where the launcher PID differs from
+    # the actual window-owning process.
     time.sleep(1)
-    actual_pid = _find_process_by_name("Notepad.exe")
+    actual_pid = _find_notepad_window_pid()
+    if actual_pid is None:
+        # Fallback: try tasklist
+        actual_pid = _find_process_by_name("Notepad.exe")
     if actual_pid is None:
         actual_pid = proc.pid
 

--- a/tests/integration/test_unified_app_model.py
+++ b/tests/integration/test_unified_app_model.py
@@ -233,7 +233,12 @@ class TestCLIIntegration:
     def test_see_notepad(self, notepad_app):
         """'naturo see' should return UI elements from Notepad."""
         try:
-            output = _run_naturo("see", "--pid", str(notepad_app))
+            # (#534) Try --app first (handles UWP PID mismatch), fall back
+            # to --pid for classic Win32 Notepad.
+            try:
+                output = _run_naturo("see", "--app", "notepad")
+            except (subprocess.CalledProcessError, json.JSONDecodeError):
+                output = _run_naturo("see", "--pid", str(notepad_app))
             assert "elements" in output or "error" not in output
         except (subprocess.TimeoutExpired, json.JSONDecodeError):
             pytest.skip("CLI not available or timed out")
@@ -241,7 +246,10 @@ class TestCLIIntegration:
     def test_find_in_notepad(self, notepad_app):
         """'naturo find' should locate elements in Notepad."""
         try:
-            output = _run_naturo("find", "--pid", str(notepad_app), "--all")
+            try:
+                output = _run_naturo("find", "--app", "notepad", "--all")
+            except (subprocess.CalledProcessError, json.JSONDecodeError):
+                output = _run_naturo("find", "--pid", str(notepad_app), "--all")
             # Should return some elements or an empty list (not crash)
             assert isinstance(output, (dict, list))
         except (subprocess.TimeoutExpired, json.JSONDecodeError):
@@ -250,7 +258,10 @@ class TestCLIIntegration:
     def test_capture_notepad(self, notepad_app):
         """'naturo capture' should capture Notepad window."""
         try:
-            output = _run_naturo("capture", "--pid", str(notepad_app))
+            try:
+                output = _run_naturo("capture", "--app", "notepad")
+            except (subprocess.CalledProcessError, json.JSONDecodeError):
+                output = _run_naturo("capture", "--pid", str(notepad_app))
             # Should return path to captured image
             assert "path" in output or "image" in output or "error" not in output
         except (subprocess.TimeoutExpired, json.JSONDecodeError):

--- a/tests/test_app_control.py
+++ b/tests/test_app_control.py
@@ -433,6 +433,16 @@ def _window_management_implemented():
 class TestAppLifecycleE2EWindows:
     """T039 – Window lifecycle E2E: launch → appears → close → disappears."""
 
+    @staticmethod
+    def _is_notepad_window(w) -> bool:
+        """Match Notepad windows including UWP/WinUI3 on Win11 (#534)."""
+        proc = w.process_name.lower()
+        if "notepad" in proc:
+            return True
+        if proc.startswith("applicationframehost") and "notepad" in w.title.lower():
+            return True
+        return False
+
     @pytest.mark.xfail(reason="window close/minimize not yet implemented", raises=NotImplementedError)
     def test_notepad_lifecycle(self):
         """T039 – launch notepad, verify in list, close, verify gone."""
@@ -448,7 +458,7 @@ class TestAppLifecycleE2EWindows:
             windows = backend.list_windows()
             notepad_wins = [
                 w for w in windows
-                if "notepad" in w.process_name.lower() and w.is_visible
+                if self._is_notepad_window(w) and w.is_visible
             ]
             assert len(notepad_wins) >= 1, "Notepad not found in window list after launch"
 
@@ -464,6 +474,14 @@ class TestAppLifecycleE2EWindows:
             assert len(still_open) == 0, "Notepad window still in list after close"
 
         finally:
+            # UWP Notepad: launcher PID differs from app PID, taskkill by name
+            try:
+                subprocess.run(
+                    ["taskkill", "/F", "/IM", "Notepad.exe"],
+                    capture_output=True, timeout=5,
+                )
+            except Exception:
+                pass
             try:
                 proc.terminate()
                 proc.wait(timeout=3)
@@ -484,7 +502,7 @@ class TestAppLifecycleE2EWindows:
 
             windows = backend.list_windows()
             notepad = next(
-                (w for w in windows if "notepad" in w.process_name.lower() and w.is_visible),
+                (w for w in windows if self._is_notepad_window(w) and w.is_visible),
                 None
             )
             assert notepad is not None
@@ -502,6 +520,13 @@ class TestAppLifecycleE2EWindows:
             assert target is not None
 
         finally:
+            try:
+                subprocess.run(
+                    ["taskkill", "/F", "/IM", "Notepad.exe"],
+                    capture_output=True, timeout=5,
+                )
+            except Exception:
+                pass
             try:
                 proc.terminate()
                 proc.wait(timeout=3)

--- a/tests/test_cli_phase2.py
+++ b/tests/test_cli_phase2.py
@@ -542,10 +542,19 @@ class TestNotepadAutomation:
         try:
             time.sleep(1.5)
 
-            # Find Notepad window
+            # Find Notepad window (UWP/WinUI3 Notepad on Win11 may be
+            # hosted by ApplicationFrameHost.exe, so check title too #534)
+            def _is_notepad(w):
+                proc = w.process_name.lower()
+                if "notepad" in proc:
+                    return True
+                if proc.startswith("applicationframehost") and "notepad" in w.title.lower():
+                    return True
+                return False
+
             windows = core.list_windows()
             notepad = next(
-                (w for w in windows if "notepad" in w.process_name.lower() and w.is_visible),
+                (w for w in windows if _is_notepad(w) and w.is_visible),
                 None
             )
             assert notepad is not None, "Notepad window not found"

--- a/tests/test_e2e_notepad.py
+++ b/tests/test_e2e_notepad.py
@@ -46,6 +46,21 @@ def _launch_notepad():
     return subprocess.Popen(["notepad.exe"])
 
 
+def _is_notepad_window(w) -> bool:
+    """Check if a window belongs to Notepad (handles UWP/WinUI3 on Win11).
+
+    On Windows 11, UWP Notepad windows are hosted by ApplicationFrameHost.exe,
+    so process_name alone is insufficient.  Also match by window title (#534).
+    """
+    proc = w.process_name.lower()
+    if "notepad" in proc:
+        return True
+    # UWP: window owned by ApplicationFrameHost but titled "Notepad" or similar
+    if proc.startswith("applicationframehost") and "notepad" in w.title.lower():
+        return True
+    return False
+
+
 def _kill_process(proc):
     """Kill a process gracefully."""
     try:
@@ -79,7 +94,7 @@ class TestMultiWindowChaos:
             windows = core.list_windows()
             notepad_windows = [
                 w for w in windows
-                if "notepad" in w.process_name.lower()
+                if _is_notepad_window(w)
             ]
 
             # Should find at least our 3 notepad windows
@@ -93,7 +108,7 @@ class TestMultiWindowChaos:
                 assert w.pid > 0
                 assert w.hwnd > 0
                 assert isinstance(w.title, str)
-                assert "notepad" in w.process_name.lower()
+                assert _is_notepad_window(w)
                 hwnds.add(w.hwnd)
 
             # Each window must have a distinct HWND (even if PIDs are shared
@@ -120,7 +135,7 @@ class TestMultiWindowChaos:
             windows = core.list_windows()
             notepad_windows = [
                 w for w in windows
-                if "notepad" in w.process_name.lower()
+                if _is_notepad_window(w)
                 and w.is_visible
                 and not w.is_minimized
             ]
@@ -160,7 +175,7 @@ class TestMultiWindowChaos:
             windows = core.list_windows()
             notepad_windows = [
                 w for w in windows
-                if "notepad" in w.process_name.lower()
+                if _is_notepad_window(w)
                 and w.is_visible
                 and not w.is_minimized
             ]
@@ -193,7 +208,7 @@ class TestNotepadElements:
             windows = core.list_windows()
             notepad_windows = [
                 w for w in windows
-                if "notepad" in w.process_name.lower()
+                if _is_notepad_window(w)
                 and w.is_visible
             ]
             if not notepad_windows:
@@ -233,7 +248,7 @@ class TestNotepadElements:
             windows = core.list_windows()
             notepad_windows = [
                 w for w in windows
-                if "notepad" in w.process_name.lower()
+                if _is_notepad_window(w)
                 and w.is_visible
             ]
             if not notepad_windows:
@@ -280,7 +295,7 @@ class TestAIAgentPerspective:
             windows = core.list_windows()
             notepad_windows = [
                 w for w in windows
-                if "notepad" in w.process_name.lower()
+                if _is_notepad_window(w)
                 and w.is_visible
             ]
             if not notepad_windows:


### PR DESCRIPTION
## Changes
- Added `_is_notepad_window()` helper in test files that matches Notepad windows by process name OR by ApplicationFrameHost process with "Notepad" in the window title
- Updated `notepad_app` fixture in `tests/integration/conftest.py` to find the actual window-owning PID by enumerating visible windows, instead of relying on `tasklist` which may return the UWP broker/launcher PID
- Updated CLI integration tests (`test_see_notepad`, `test_find_in_notepad`, `test_capture_notepad`) to try `--app notepad` first, falling back to `--pid` — `--app` uses `_resolve_hwnd` which handles UWP routing correctly
- Added `taskkill /F /IM Notepad.exe` to test teardown blocks for reliable UWP cleanup (launcher PID != app PID)

## Files Changed
- `tests/integration/conftest.py` — `_find_notepad_window_pid()` + fixture update
- `tests/integration/test_unified_app_model.py` — CLI tests use `--app notepad`
- `tests/test_app_control.py` — `_is_notepad_window()` + taskkill cleanup
- `tests/test_cli_phase2.py` — UWP-aware window matching
- `tests/test_e2e_notepad.py` — `_is_notepad_window()` for all 7 matching sites

## Testing
- 2125 tests pass, 499 skipped (desktop/Windows tests skip on Linux CI)
- ruff lint: all checks passed
- Desktop tests need verification on ROBOT-COMPILE runner (I'm on Linux)

**[Dev-Sirius]**