### PR TITLE
fix: highlight --help examples wrap into unreadable mess (fixes #543)

### DIFF
--- a/naturo/cli/core.py
+++ b/naturo/cli/core.py
@@ -1785,15 +1785,14 @@ def highlight(positional_refs, on_ref, ref_option, app, hwnd, depth, duration,
 
     \b
     Examples:
-
-        naturo highlight --app notepad                    # Actionable elements only
-        naturo highlight --app notepad --all              # All elements
-        naturo highlight e11 --app notepad                # Highlight specific ref
-        naturo highlight --app notepad --filter Button    # Only buttons
-        naturo highlight --app notepad -A out.png         # Save annotated screenshot
-        naturo highlight --hwnd 10697004 -r e69 -r e77   # Highlight specific refs
-        naturo highlight --app notepad --duration 10      # Show for 10 seconds
-        naturo highlight --app legacy --backend win32     # Win32 HWND fallback
+      naturo highlight --app notepad             # Actionable only
+      naturo highlight --app notepad --all       # All elements
+      naturo highlight e11 --app notepad         # Specific ref
+      naturo highlight --app notepad --filter Button
+      naturo highlight --app notepad -A out.png  # Annotated screenshot
+      naturo highlight --hwnd 10697004 -r e69 -r e77
+      naturo highlight --app notepad --duration 10
+      naturo highlight --app legacy --backend win32
     """
     import json as _json
     be = _get_backend(json_output)

--- a/tests/test_highlight.py
+++ b/tests/test_highlight.py
@@ -280,3 +280,26 @@ class TestActionableRoles:
 
         for role in ("Window", "Pane", "Group", "Text", "Image", "Document"):
             assert role not in ACTIONABLE_ROLES, f"{role} should NOT be in ACTIONABLE_ROLES"
+
+
+class TestHighlightHelp:
+    """Verify --help output formatting (regression for #543)."""
+
+    def test_help_examples_not_wrapped(self):
+        """Each example should be on its own line, not wrapped together."""
+        from click.testing import CliRunner
+
+        from naturo.cli import main
+
+        result = CliRunner().invoke(main, ["highlight", "--help"])
+        assert result.exit_code == 0
+        # Each example must start on its own line (not wrapped into previous)
+        assert "naturo highlight --app notepad" in result.output
+        # If wrapping occurred, "naturo" would appear mid-line after another command
+        lines = result.output.splitlines()
+        example_lines = [l for l in lines if "naturo highlight" in l]
+        for line in example_lines:
+            # Each line should contain exactly one "naturo highlight" invocation
+            assert line.strip().count("naturo highlight") == 1, (
+                f"Example wrapping detected: {line!r}"
+            )


### PR DESCRIPTION
## Changes
- Reduced example indent from 8 to 2 spaces in `highlight` command docstring
- Shortened trailing comments to keep lines under Click's wrap threshold
- Added regression test in `TestHighlightHelp` to catch future wrapping

## Testing
- `naturo highlight --help` now displays each example on its own line
- `python -m pytest tests/test_highlight.py::TestHighlightHelp -xvq` passes
- `ruff check naturo/` passes

**[Dev-Sirius]**