### PR TITLE
docs: add MCP server setup instructions to README (fixes #547)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,49 @@
 pip install naturo
 ```
 
-Or start the MCP server directly:
+## MCP Server Setup
+
+Naturo includes a built-in [MCP](https://modelcontextprotocol.io/) server with 60+ tools for AI agent integration.
+
+### Claude Desktop / Claude Code
+
+Add to your Claude configuration file (`claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "naturo": {
+      "command": "naturo",
+      "args": ["mcp", "start"]
+    }
+  }
+}
+```
+
+> **Config file location:**
+> - Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+> - macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+
+### Other AI Agents (SSE / HTTP)
+
+For agents that connect over HTTP instead of stdio:
 
 ```bash
-naturo mcp start
+# SSE transport (Server-Sent Events)
+naturo mcp start --transport sse --port 3100
+
+# Streamable HTTP transport
+naturo mcp start --transport streamable-http --port 3100
+```
+
+### Verify Setup
+
+```bash
+# List all 60+ MCP tools
+naturo mcp tools
+
+# Install MCP dependencies if needed
+naturo mcp install
 ```
 
 ## Quick Start


### PR DESCRIPTION
## Changes
- Added "MCP Server Setup" section to README with Claude Desktop/Code config example
- Documented stdio, SSE, and streamable-http transport options
- Added config file paths for Windows and macOS
- Added verify setup instructions

This is the #1 gap for users trying to integrate naturo with AI agents — previously there was no setup guide at all.

## Testing
- README renders correctly (verified markdown syntax)
- All configuration examples match actual CLI flags from `naturo mcp start --help`

**[Dev-Sirius]**