### PR TITLE
docs: mark Excel COM as shipped in ROADMAP.md (fixes #551)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -138,7 +138,7 @@ See [Unified Selector design doc](design/UNIFIED_SELECTOR.md).
 - [ ] User selector management (`naturo selector save/load/list/export`)
 
 ### Enterprise
-- [ ] Excel COM automation (read/write cells, run macros, create charts)
+- [x] Excel COM automation (read/write cells, run macros) — shipped in v0.1.1
 - [ ] SAP GUI Scripting
 - [ ] MinHook injection (function hooks, intercept/modify Win32 API calls)
 - [ ] Embedded Python 3.12 runtime (~40MB bundled)


### PR DESCRIPTION
## Changes
- Marked Excel COM automation as done in ROADMAP.md v0.4.0 Enterprise section
- Excel open/read/write/run-macro/list-sheets/info shipped in v0.1.1
- Removed "create charts" from the line item — chart creation is tracked separately in #38

## Testing
- Docs-only change, no code affected

**[Dev-Sirius]**