### PR TITLE
refactor: remove dead java/sap CLI stubs (fixes #553)

### DIFF
--- a/naturo/cli/extensions.py
+++ b/naturo/cli/extensions.py
@@ -1,29 +1,8 @@
-"""Windows-specific extensions: excel, java, sap."""
-import json as json_module
-import sys
+"""Windows-specific CLI extensions: excel."""
 from typing import Any
 
 import click
 from naturo.cli.fuzzy_group import FuzzyGroup
-
-
-def _not_implemented(name: str, phase: str, json_output: bool) -> None:
-    """Emit a NOT_IMPLEMENTED error with correct exit code.
-
-    Args:
-        name: Command name for the error message.
-        phase: Phase identifier (e.g., '5C.1').
-        json_output: Whether to emit JSON output.
-    """
-    msg = f"{name} is not implemented yet — coming in Phase {phase}"
-    if json_output:
-        click.echo(json_module.dumps({
-            "success": False,
-            "error": {"code": "NOT_IMPLEMENTED", "message": msg},
-        }))
-    else:
-        click.echo(f"Error: {msg}", err=True)
-    sys.exit(1)
 
 
 # ── excel ───────────────────────────────────────
@@ -260,92 +239,3 @@ def excel_info(path, sheet, json_output):
         click.echo(f"Sheet: {result['sheet']}")
         click.echo(f"Used range: {result['used_range']}")
         click.echo(f"Rows: {result['rows']}, Columns: {result['columns']}")
-
-
-# ── java ────────────────────────────────────────
-
-
-@click.group(cls=FuzzyGroup)
-def java():
-    """Java application automation via Java Access Bridge (Windows-specific).
-
-    Automate Java Swing/AWT applications using the Java Access Bridge API.
-    """
-    pass
-
-
-@java.command(name="list")
-@click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def java_list(json_output):
-    """List Java applications with Access Bridge enabled."""
-    _not_implemented("java list", "5B.3", json_output)
-
-
-@java.command()
-@click.option("--pid", type=int, help="Java process ID")
-@click.option("--title", help="Window title")
-@click.option("--depth", type=int, default=5, help="Tree depth")
-@click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def tree(pid, title, depth, json_output):
-    """Inspect Java UI element tree."""
-    _not_implemented("java tree", "5B.3", json_output)
-
-
-@java.command(name="click")
-@click.argument("query")
-@click.option("--pid", type=int, help="Java process ID")
-@click.option("--title", help="Window title")
-@click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def java_click(query, pid, title, json_output):
-    """Click a Java UI element."""
-    _not_implemented("java click", "5B.3", json_output)
-
-
-# ── sap ─────────────────────────────────────────
-
-
-@click.group(cls=FuzzyGroup)
-def sap():
-    """SAP GUI Scripting automation (Windows-specific).
-
-    Automate SAP GUI for Windows using the SAP Scripting API.
-    """
-    pass
-
-
-@sap.command(name="list")
-@click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def sap_list(json_output):
-    """List SAP GUI sessions."""
-    _not_implemented("sap list", "5B.4", json_output)
-
-
-@sap.command()
-@click.argument("transaction")
-@click.option("--session", type=int, default=0, help="Session index")
-@click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def run(transaction, session, json_output):
-    """Run a SAP transaction code."""
-    _not_implemented("sap run", "5B.4", json_output)
-
-
-@sap.command(name="get")
-@click.argument("field_id")
-@click.option("--session", type=int, default=0, help="Session index")
-@click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def sap_get(field_id, session, json_output):
-    """Get a SAP GUI field value."""
-    _not_implemented("sap get", "5B.4", json_output)
-
-
-@sap.command(name="set")
-@click.argument("field_id")
-@click.argument("value")
-@click.option("--session", type=int, default=0, help="Session index")
-@click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def sap_set(field_id, value, session, json_output):
-    """Set a SAP GUI field value."""
-    _not_implemented("sap set", "5B.4", json_output)
-
-
-# ── registry ────────────────────────────────────

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -309,24 +309,6 @@ def test_excel_help(runner):
     assert "run-macro" in result.output
 
 
-@pytest.mark.skip(reason='command hidden — stub not exposed to users')
-def test_java_help(runner):
-    result = runner.invoke(main, ["java", "--help"])
-    assert result.exit_code == 0
-    assert "list" in result.output
-    assert "tree" in result.output
-    assert "click" in result.output
-
-
-@pytest.mark.skip(reason='command hidden — stub not exposed to users')
-def test_sap_help(runner):
-    result = runner.invoke(main, ["sap", "--help"])
-    assert result.exit_code == 0
-    assert "list" in result.output
-    assert "run" in result.output
-    assert "get" in result.output
-    assert "set" in result.output
-
 
 @pytest.mark.skip(reason='command hidden — stub not exposed to users')
 @pytest.mark.skip(reason="registry command removed in v0.2.0")

--- a/tests/test_cli_consistency.py
+++ b/tests/test_cli_consistency.py
@@ -165,7 +165,7 @@ def test_hidden_commands_not_in_help():
     result = runner.invoke(main, ["--help"])
     # Known hidden top-level groups that were removed entirely
     for name in ["menu",
-                 "excel", "java", "sap",
+                 "excel",
                  "tools"]:
         # These should not appear as commands in help
         # (they may appear in description text, so check the Commands section)


### PR DESCRIPTION
## Changes
- Removed unregistered `java` and `sap` command groups from `naturo/cli/extensions.py` (~90 lines)
- Removed `_not_implemented` helper (only used by these stubs)
- Removed already-skipped tests for java/sap in `test_cli.py`
- Updated hidden commands list in `test_cli_consistency.py`

These commands were defined but never wired into the CLI via `__init__.py`. Users got "No such command" errors. SAP GUI Scripting is tracked in #39 for proper implementation.

## Testing
- 2192 tests pass, 0 failures
- `ruff check naturo/` clean

**[Dev-Sirius]**