### PR TITLE
fix: _resolve_hwnds AFH fixup searches all windows (fixes #559)

### DIFF
--- a/naturo/backends/windows.py
+++ b/naturo/backends/windows.py
@@ -1273,8 +1273,13 @@ class WindowsBackend(Backend):
         # Extract HWNDs
         hwnds = [m[3].handle for m in matches]
 
-        # UWP/ApplicationFrameHost fixup: prefer frame windows when available
-        # (same logic as _resolve_hwnd, but applied to all matches)
+        # UWP/ApplicationFrameHost fixup: prefer frame windows when available.
+        # Search ALL windows (not just scored matches) for AFH counterparts,
+        # matching the same logic as _resolve_hwnd (#559).  UWP apps like
+        # Calculator run under CalculatorApp.exe but their UI tree lives
+        # under the ApplicationFrameHost.exe window.  The AFH window may
+        # not score any points for the search term (e.g. "计算器") so we
+        # must search the full window list.
         import os as _os
         fixed_hwnds = []
         for hwnd in hwnds:
@@ -1289,21 +1294,31 @@ class WindowsBackend(Backend):
                 proc = proc[:-4]
 
             if proc != "applicationframehost":
-                # Check if there's a frame window with same title
-                frame_hwnd = None
-                for m in matches:
-                    frame_proc = _os.path.basename(m[3].process_name).lower()
+                # (#559) Search ALL windows for AFH with matching title,
+                # then prefer one with a CoreWindow child (live UI),
+                # mirroring _resolve_hwnd logic (#394).
+                afh_candidates = []
+                for w in windows:
+                    frame_proc = _os.path.basename(w.process_name).lower()
                     if frame_proc.endswith(".exe"):
                         frame_proc = frame_proc[:-4]
                     if (
                         frame_proc == "applicationframehost"
-                        and m[3].title == w_info.title
-                        and m[3].handle != hwnd
+                        and w.title == w_info.title
+                        and w.handle != hwnd
                     ):
-                        frame_hwnd = m[3].handle
-                        break
-                if frame_hwnd:
-                    fixed_hwnds.append(frame_hwnd)
+                        afh_candidates.append(w)
+
+                if afh_candidates:
+                    # Prefer AFH with content window (CoreWindow/XAML)
+                    chosen_afh = None
+                    for afh_w in afh_candidates:
+                        if self._afh_has_content_window(afh_w.handle):
+                            chosen_afh = afh_w
+                            break
+                    if chosen_afh is None:
+                        chosen_afh = afh_candidates[0]
+                    fixed_hwnds.append(chosen_afh.handle)
                 else:
                     fixed_hwnds.append(hwnd)
             else:

--- a/tests/test_resolve_all_windows.py
+++ b/tests/test_resolve_all_windows.py
@@ -171,3 +171,95 @@ class TestResolveAllWindows:
         # No app or window_title → empty list
         result = backend._resolve_hwnds()
         assert result == []
+
+    def test_resolve_hwnds_uwp_afh_fixup_searches_all_windows(self, monkeypatch):
+        """_resolve_hwnds AFH fixup must search ALL windows, not just scored matches.
+
+        Regression test for #559: UWP Calculator's CalculatorApp.exe window
+        matches via alias, but its ApplicationFrameHost.exe window (which
+        contains the actual UI tree) scores 0 for the search term "计算器".
+        The fixup must find the AFH window in the full window list.
+        """
+        backend = WindowsBackend()
+
+        calculator_app = WindowInfo(
+            handle=1000,
+            title="计算器",
+            process_name="CalculatorApp.exe",
+            pid=100,
+            x=0, y=0, width=400, height=600,
+            is_visible=True, is_minimized=False,
+        )
+        afh_calculator = WindowInfo(
+            handle=2000,
+            title="计算器",
+            process_name="ApplicationFrameHost.exe",
+            pid=200,
+            x=0, y=0, width=400, height=600,
+            is_visible=True, is_minimized=False,
+        )
+        notepad_window = WindowInfo(
+            handle=3000,
+            title="无标题 - 记事本",
+            process_name="notepad.exe",
+            pid=300,
+            x=0, y=0, width=800, height=600,
+            is_visible=True, is_minimized=False,
+        )
+
+        monkeypatch.setattr(backend, "list_windows",
+                            lambda: [calculator_app, afh_calculator, notepad_window])
+        monkeypatch.setattr(backend, "_get_console_session_id", lambda: 1)
+        monkeypatch.setattr(backend, "_get_process_session_id", lambda pid: 1)
+        # AFH window has a content child (CoreWindow)
+        monkeypatch.setattr(WindowsBackend, "_afh_has_content_window",
+                            staticmethod(lambda hwnd: hwnd == 2000))
+
+        result = backend._resolve_hwnds(app="计算器")
+        # Should return the AFH window (2000), not CalculatorApp (1000)
+        assert result == [2000]
+
+    def test_resolve_hwnds_uwp_afh_fixup_prefers_content_window(self, monkeypatch):
+        """AFH fixup in _resolve_hwnds should prefer AFH with content child.
+
+        When multiple AFH windows exist with the same title (e.g. stale
+        windows from schtasks), prefer the one with CoreWindow/XAML child.
+        """
+        backend = WindowsBackend()
+
+        calculator_app = WindowInfo(
+            handle=1000,
+            title="计算器",
+            process_name="CalculatorApp.exe",
+            pid=100,
+            x=0, y=0, width=400, height=600,
+            is_visible=True, is_minimized=False,
+        )
+        stale_afh = WindowInfo(
+            handle=2000,
+            title="计算器",
+            process_name="ApplicationFrameHost.exe",
+            pid=200,
+            x=0, y=0, width=400, height=600,
+            is_visible=True, is_minimized=False,
+        )
+        live_afh = WindowInfo(
+            handle=3000,
+            title="计算器",
+            process_name="ApplicationFrameHost.exe",
+            pid=201,
+            x=0, y=0, width=400, height=600,
+            is_visible=True, is_minimized=False,
+        )
+
+        monkeypatch.setattr(backend, "list_windows",
+                            lambda: [calculator_app, stale_afh, live_afh])
+        monkeypatch.setattr(backend, "_get_console_session_id", lambda: 1)
+        monkeypatch.setattr(backend, "_get_process_session_id", lambda pid: 1)
+        # Only live_afh (3000) has content child
+        monkeypatch.setattr(WindowsBackend, "_afh_has_content_window",
+                            staticmethod(lambda hwnd: hwnd == 3000))
+
+        result = backend._resolve_hwnds(app="计算器")
+        # Should pick the live AFH (3000), not the stale one (2000)
+        assert result == [3000]


### PR DESCRIPTION
## Changes
- Fixed `_resolve_hwnds()` AFH fixup to search ALL windows instead of only scored `matches`
- Added `_afh_has_content_window` check to prefer live AFH windows over stale ones
- Mirrors the existing `_resolve_hwnd()` logic from #394

## Root Cause
UWP Calculator's `CalculatorApp.exe` window matches via alias for "计算器", but its `ApplicationFrameHost.exe` window (which contains the actual UI tree) scores 0 because "applicationframehost" doesn't match the search term. The old code only searched scored matches for AFH counterparts, so it never found the AFH window.

`_resolve_hwnd()` (single-window) already searched all windows correctly at line 1134. `_resolve_hwnds()` (multi-window) was inconsistent.

## Testing
- Added `test_resolve_hwnds_uwp_afh_fixup_searches_all_windows` — verifies AFH found in full window list
- Added `test_resolve_hwnds_uwp_afh_fixup_prefers_content_window` — verifies live AFH preferred over stale
- All 2138 existing tests pass, 0 failures

**[Dev-Sirius]**