### PR TITLE
fix: poll for Notepad window in E2E tests (fixes #560)

### DIFF
--- a/tests/test_app_control.py
+++ b/tests/test_app_control.py
@@ -443,6 +443,30 @@ class TestAppLifecycleE2EWindows:
             return True
         return False
 
+    @staticmethod
+    def _poll_for_notepad(backend, is_notepad_fn, timeout=10.0, interval=0.5):
+        """Poll for a visible Notepad window with retry (#560).
+
+        UWP Notepad on Windows 11 launches through a broker process;
+        the actual window may take several seconds to appear.
+
+        Returns:
+            List of matching visible WindowInfo objects.
+        """
+        import time
+        deadline = time.monotonic() + timeout
+        while True:
+            windows = backend.list_windows()
+            notepad_wins = [
+                w for w in windows
+                if is_notepad_fn(w) and w.is_visible
+            ]
+            if notepad_wins:
+                return notepad_wins
+            if time.monotonic() >= deadline:
+                return []
+            time.sleep(interval)
+
     @pytest.mark.xfail(reason="window close/minimize not yet implemented", raises=NotImplementedError)
     def test_notepad_lifecycle(self):
         """T039 – launch notepad, verify in list, close, verify gone."""
@@ -453,13 +477,7 @@ class TestAppLifecycleE2EWindows:
 
         proc = subprocess.Popen(["notepad.exe"])
         try:
-            time.sleep(1.5)
-
-            windows = backend.list_windows()
-            notepad_wins = [
-                w for w in windows
-                if self._is_notepad_window(w) and w.is_visible
-            ]
+            notepad_wins = self._poll_for_notepad(backend, self._is_notepad_window)
             assert len(notepad_wins) >= 1, "Notepad not found in window list after launch"
 
             handle = notepad_wins[0].handle
@@ -498,13 +516,8 @@ class TestAppLifecycleE2EWindows:
 
         proc = subprocess.Popen(["notepad.exe"])
         try:
-            time.sleep(1.5)
-
-            windows = backend.list_windows()
-            notepad = next(
-                (w for w in windows if self._is_notepad_window(w) and w.is_visible),
-                None
-            )
+            notepad_wins = self._poll_for_notepad(backend, self._is_notepad_window)
+            notepad = notepad_wins[0] if notepad_wins else None
             assert notepad is not None
 
             # Minimize

--- a/tests/test_cli_phase2.py
+++ b/tests/test_cli_phase2.py
@@ -540,23 +540,27 @@ class TestNotepadAutomation:
 
         proc = subprocess.Popen(["notepad.exe"])
         try:
-            time.sleep(1.5)
-
             # Find Notepad window (UWP/WinUI3 Notepad on Win11 may be
             # hosted by ApplicationFrameHost.exe, so check title too #534)
             def _is_notepad(w):
-                proc = w.process_name.lower()
-                if "notepad" in proc:
+                pname = w.process_name.lower()
+                if "notepad" in pname:
                     return True
-                if proc.startswith("applicationframehost") and "notepad" in w.title.lower():
+                if pname.startswith("applicationframehost") and "notepad" in w.title.lower():
                     return True
                 return False
 
-            windows = core.list_windows()
-            notepad = next(
-                (w for w in windows if _is_notepad(w) and w.is_visible),
-                None
-            )
+            # (#560) Poll for Notepad window — UWP launch is slow
+            deadline = time.monotonic() + 10.0
+            notepad = None
+            while notepad is None and time.monotonic() < deadline:
+                windows = core.list_windows()
+                notepad = next(
+                    (w for w in windows if _is_notepad(w) and w.is_visible),
+                    None
+                )
+                if notepad is None:
+                    time.sleep(0.5)
             assert notepad is not None, "Notepad window not found"
 
             # Click center of window (approximate edit area)


### PR DESCRIPTION
## Changes
- Replaced flat `time.sleep(1.5)` with polling loop (10s timeout, 0.5s interval) in all 3 failing tests
- Added `_poll_for_notepad` helper to `TestAppLifecycleE2EWindows` for reuse
- Inline polling in `test_notepad_open_type_close` (different test class/file)
- Fixed shadowed `proc` variable in `_is_notepad` helper (renamed to `pname`)

## Root Cause
UWP Notepad on Windows 11 launches through a broker process. The actual window can take 3-5+ seconds to appear on the CI desktop runner (ROBOT-COMPILE), far exceeding the previous 1.5s flat sleep.

## Testing
- All 2138 unit tests pass locally (Linux, non-desktop tests)
- Desktop runner will validate the actual Notepad detection timing
- The polling approach is robust: succeeds as soon as window appears, fails only after 10s timeout

**[Dev-Sirius]**