### PR TITLE
fix: bypass UIA SetValue for text containing newlines (fixes #563)

### DIFF
--- a/naturo/cli/interaction.py
+++ b/naturo/cli/interaction.py
@@ -1424,10 +1424,14 @@ def type_cmd(text, delay, profile, wpm, press_return, tab_count, escape,
             else:
                 # No text: paste current clipboard content directly (#165)
                 backend.hotkey("ctrl", "v")
-        elif _uia_method and text and hasattr(backend, "set_element_value"):
+        elif _uia_method and text and "\n" not in text and "\r" not in text and hasattr(backend, "set_element_value"):
             # UIA ValuePattern path (#226): bypasses SendInput entirely.
             # Resolves target HWND from --app and sets text directly on the
             # focused or first editable element in the window.
+            #
+            # Skip when text contains newline/CR (#563): UIA SetValue()
+            # silently strips these characters, causing a silent failure.
+            # SendInput handles them correctly as Enter keypresses.
             _target_hwnd = 0
             _target_name = None
             _target_aid = None

--- a/tests/test_type_paste_and_on.py
+++ b/tests/test_type_paste_and_on.py
@@ -355,3 +355,75 @@ class TestTypeEscapeSequences:
         assert data["success"] is True
         # Clipboard should receive the processed text with real tab
         mock_backend.clipboard_set.assert_called_once_with("A\tB")
+
+
+class TestTypeNewlineBypassesUIA:
+    """When text contains \\n or \\r, type must bypass UIA SetValue (#563).
+
+    UIA ValuePattern.SetValue() silently strips newline/CR characters,
+    causing a silent failure. The type command should detect this and
+    fall through to SendInput which handles them as Enter keypresses.
+    """
+
+    @_win_only
+    def test_newline_text_skips_uia_uses_sendinput(self, runner):
+        """type 'Line1\\nLine2' with UIA route should bypass SetValue."""
+        from naturo.cli.interaction import type_cmd
+
+        mock_backend = MagicMock()
+        mock_backend.set_element_value.return_value = True  # Would succeed if called
+
+        # Route says UIA is available
+        route_info = {"method": "uia"}
+        with patch("naturo.cli.interaction._get_backend", return_value=mock_backend), \
+             patch("naturo.cli.interaction._auto_route", return_value=route_info):
+            result = runner.invoke(type_cmd, [r"Line1\nLine2", "--json", "--no-verify"])
+
+        data = json.loads(result.output)
+        assert data["success"] is True
+        # SetValue should NOT have been called — newlines would be stripped
+        mock_backend.set_element_value.assert_not_called()
+        # SendInput (type_text) should have been used instead
+        mock_backend.type_text.assert_called_once()
+        typed_text = mock_backend.type_text.call_args[0][0]
+        assert typed_text == "Line1\nLine2"
+
+    @_win_only
+    def test_cr_text_skips_uia_uses_sendinput(self, runner):
+        """type 'A\\rB' with UIA route should bypass SetValue."""
+        from naturo.cli.interaction import type_cmd
+
+        mock_backend = MagicMock()
+        mock_backend.set_element_value.return_value = True
+
+        route_info = {"method": "uia"}
+        with patch("naturo.cli.interaction._get_backend", return_value=mock_backend), \
+             patch("naturo.cli.interaction._auto_route", return_value=route_info):
+            result = runner.invoke(type_cmd, [r"A\rB", "--json", "--no-verify"])
+
+        data = json.loads(result.output)
+        assert data["success"] is True
+        mock_backend.set_element_value.assert_not_called()
+        mock_backend.type_text.assert_called_once()
+        typed_text = mock_backend.type_text.call_args[0][0]
+        assert typed_text == "A\rB"
+
+    @_win_only
+    def test_tab_text_still_uses_uia(self, runner):
+        """type 'A\\tB' with UIA route should still use SetValue (tabs are safe)."""
+        from naturo.cli.interaction import type_cmd
+
+        mock_backend = MagicMock()
+        mock_backend.set_element_value.return_value = True
+
+        route_info = {"method": "uia"}
+        with patch("naturo.cli.interaction._get_backend", return_value=mock_backend), \
+             patch("naturo.cli.interaction._auto_route", return_value=route_info):
+            result = runner.invoke(type_cmd, [r"A\tB", "--json", "--no-verify"])
+
+        data = json.loads(result.output)
+        assert data["success"] is True
+        # SetValue SHOULD be called — tabs survive SetValue
+        mock_backend.set_element_value.assert_called_once()
+        # type_text should NOT be called
+        mock_backend.type_text.assert_not_called()


### PR DESCRIPTION
## Changes
- When text contains `\n` or `\r`, skip UIA `ValuePattern.SetValue()` and fall through to SendInput
- UIA SetValue silently strips newline/CR characters, causing a silent failure (#563)
- SendInput handles newlines correctly as Enter keypresses
- Tab characters (`\t`) still use UIA SetValue — they survive the call

## Root Cause
UIA `ValuePattern.SetValue()` silently strips `\n` and `\r` characters from the input string. The type command reported success (because SetValue returned successfully), but the actual text in the target application had no newlines — a silent failure that violates the "Never Lie" principle.

## Testing
- Added 3 new tests in `TestTypeNewlineBypassesUIA`:
  - `test_newline_text_skips_uia_uses_sendinput` — verifies `\n` text bypasses SetValue
  - `test_cr_text_skips_uia_uses_sendinput` — verifies `\r` text bypasses SetValue
  - `test_tab_text_still_uses_uia` — verifies `\t` text still uses SetValue (regression guard)
- All 2138 existing tests pass, ruff clean, mypy clean
- Validated logic on Linux via inline test execution

**[Dev-Sirius]**