### PR TITLE
fix: remove redundant skipif(CI) and increase Notepad poll timeout (fixes #567)

### DIFF
--- a/tests/test_app_control.py
+++ b/tests/test_app_control.py
@@ -426,10 +426,6 @@ def _window_management_implemented():
     reason="E2E app control tests require Windows with implemented window management methods",
 )
 @pytest.mark.desktop
-@pytest.mark.skipif(
-    os.environ.get("CI") == "true" or os.environ.get("GITHUB_ACTIONS") == "true",
-    reason="Requires interactive desktop session (not available in CI)",
-)
 class TestAppLifecycleE2EWindows:
     """T039 – Window lifecycle E2E: launch → appears → close → disappears."""
 
@@ -444,7 +440,7 @@ class TestAppLifecycleE2EWindows:
         return False
 
     @staticmethod
-    def _poll_for_notepad(backend, is_notepad_fn, timeout=10.0, interval=0.5):
+    def _poll_for_notepad(backend, is_notepad_fn, timeout=20.0, interval=0.5):
         """Poll for a visible Notepad window with retry (#560).
 
         UWP Notepad on Windows 11 launches through a broker process;


### PR DESCRIPTION
## Changes
- Removed `skipif(CI or GITHUB_ACTIONS)` from `TestAppLifecycleE2EWindows` class — this guard was redundant with `@pytest.mark.desktop` and actively prevented tests from running on the self-hosted desktop runner (GitHub Actions sets `CI=true` even on self-hosted runners)
- Increased `_poll_for_notepad` default timeout from 10s to 20s to handle slow UWP Notepad launches on CI

## Root Cause
The headless CI (`build.yml`) already excludes desktop tests via `-m "not desktop"`. The `skipif(CI)` was meant as a safety guard but actually blocked the desktop runner (`desktop-tests.yml`) from running these tests — the only runner that CAN run them. When the guard was bypassed (e.g., manual runs), the 10s poll timeout was too short for UWP Notepad on slow CI hardware.

## Testing
- ruff clean
- Minimal change: removing 4 lines of decorator + changing one default parameter value
- CI will validate

**[Dev-Sirius]**