### PR TITLE
fix: UWP --app matching probes AFH child process name (fixes #569)

### DIFF
--- a/naturo/backends/windows.py
+++ b/naturo/backends/windows.py
@@ -1170,6 +1170,18 @@ class WindowsBackend(Backend):
 
             return best_window.handle
 
+        # (#569) UWP fallback: UWP apps (Calculator, Settings, etc.) have
+        # their windows owned by ApplicationFrameHost.exe, not by the
+        # actual app process (e.g. CalculatorApp.exe).  When process-name
+        # matching finds nothing, probe each AFH window's content child
+        # to find the real app process and match against that.
+        if match_process and best_window is None:
+            best_window = self._uwp_afh_fallback(
+                search_lower, windows, console_session,
+            )
+            if best_window is not None:
+                return best_window.handle
+
         # No match — build candidate suggestions (BUG-070)
         from naturo.errors import WindowNotFoundError
 
@@ -1331,6 +1343,16 @@ class WindowsBackend(Backend):
             if h not in seen:
                 seen.add(h)
                 result.append(h)
+
+        # (#569) UWP fallback: when no windows matched by process name,
+        # probe AFH windows' content children for the real app process.
+        if not result and match_process:
+            console_session = self._get_console_session_id()
+            afh_match = self._uwp_afh_fallback(
+                search_lower, windows, console_session,
+            )
+            if afh_match is not None:
+                result.append(afh_match.handle)
 
         return result
 
@@ -1587,6 +1609,89 @@ class WindowsBackend(Backend):
             return found[0]
         except Exception:
             return False
+
+    def _uwp_afh_fallback(
+        self,
+        search_lower: str,
+        windows: list,
+        console_session: int,
+    ) -> Optional["BaseWindowInfo"]:
+        """UWP fallback: find an AFH window whose child process matches (#569).
+
+        UWP apps (Calculator, Settings, etc.) have their top-level windows
+        owned by ApplicationFrameHost.exe.  Normal process-name matching
+        cannot find these because the AFH process name never matches
+        user-facing app names like "calculator".
+
+        This method probes each AFH window's content child (CoreWindow) to
+        discover the real app process (e.g. CalculatorApp.exe), then checks
+        if that process name matches the search term or its aliases.
+
+        Only called when the primary scoring loop found no matches.
+
+        Args:
+            search_lower: Lowercase search term from ``--app``.
+            windows: Full window list from ``list_windows()``.
+            console_session: Console session ID for session-aware ranking.
+
+        Returns:
+            The best matching AFH WindowInfo, or None if no match.
+        """
+        import os as _os
+
+        # Build the set of process stems to match against (search + aliases)
+        target_stems: set[str] = {search_lower}
+        aliases = self._APP_ALIASES.get(search_lower, set())
+        target_stems.update(aliases)
+
+        best_afh = None
+        best_in_console = False
+
+        for w in windows:
+            proc = _os.path.basename(w.process_name).lower()
+            if proc.endswith(".exe"):
+                proc = proc[:-4]
+            if proc != "applicationframehost":
+                continue
+            if not self._afh_has_content_window(w.handle):
+                continue
+
+            # Resolve the real app PID/exe inside this AFH window
+            child_pid, child_exe = self._resolve_uwp_child_pid(w.handle)
+            if child_pid is None or child_exe is None:
+                continue
+
+            child_stem = _os.path.basename(child_exe).lower()
+            if child_stem.endswith(".exe"):
+                child_stem = child_stem[:-4]
+
+            # Check if the child process matches any target stem
+            matched = False
+            for stem in target_stems:
+                if stem == child_stem or stem in child_stem:
+                    matched = True
+                    break
+            if not matched:
+                continue
+
+            # Session-aware ranking: prefer console session
+            in_console = False
+            if console_session >= 0:
+                w_session = self._get_process_session_id(w.pid)
+                in_console = (w_session == console_session)
+
+            if best_afh is None or (in_console and not best_in_console):
+                best_afh = w
+                best_in_console = in_console
+
+        if best_afh is not None:
+            logger.debug(
+                "UWP AFH fallback (#569): matched AFH hwnd=%s for "
+                "search '%s'",
+                best_afh.handle, search_lower,
+            )
+
+        return best_afh
 
     def _is_afh_window(self, handle: int) -> bool:
         """Check if a window handle belongs to ApplicationFrameHost.exe.

--- a/tests/test_uwp_afh_resolve.py
+++ b/tests/test_uwp_afh_resolve.py
@@ -1,0 +1,235 @@
+"""Tests for UWP ApplicationFrameHost fallback in _resolve_hwnd/_resolve_hwnds (#569).
+
+UWP apps (Calculator, Settings, etc.) have their top-level windows owned by
+ApplicationFrameHost.exe, not by their actual process.  When --app is used,
+process-name matching fails because "calculator" doesn't match
+"applicationframehost".  The UWP fallback probes each AFH window's content
+child to discover the real app process and match against it.
+"""
+
+from naturo.backends.base import WindowInfo
+from naturo.backends.windows import WindowsBackend
+from naturo.errors import WindowNotFoundError
+import pytest
+
+
+def _make_backend(monkeypatch, windows):
+    """Create a WindowsBackend with mocked window list and session helpers."""
+    backend = WindowsBackend()
+    monkeypatch.setattr(backend, "list_windows", lambda: windows)
+    monkeypatch.setattr(backend, "_get_console_session_id", lambda: 1)
+    monkeypatch.setattr(backend, "_get_process_session_id", lambda pid: 1)
+    monkeypatch.setattr(backend, "_get_foreground_hwnd", lambda: 0)
+    monkeypatch.setattr(backend, "_get_window_class_name", lambda h: "")
+    return backend
+
+
+# -- Window fixtures -----------------------------------------------------------
+
+AFH_CALCULATOR = WindowInfo(
+    handle=1000,
+    title="计算器",
+    process_name="ApplicationFrameHost.exe",
+    pid=500,
+    x=0, y=0, width=400, height=600,
+    is_visible=True, is_minimized=False,
+)
+
+AFH_SETTINGS = WindowInfo(
+    handle=2000,
+    title="设置",
+    process_name="ApplicationFrameHost.exe",
+    pid=501,
+    x=0, y=0, width=1000, height=700,
+    is_visible=True, is_minimized=False,
+)
+
+NOTEPAD_WINDOW = WindowInfo(
+    handle=3000,
+    title="无标题 - 记事本",
+    process_name="notepad.exe",
+    pid=200,
+    x=0, y=0, width=800, height=600,
+    is_visible=True, is_minimized=False,
+)
+
+
+class TestUwpAfhFallbackResolveHwnd:
+    """Tests for _resolve_hwnd UWP AFH fallback (#569)."""
+
+    def test_calculator_english_name(self, monkeypatch):
+        """--app calculator should match AFH-hosted Calculator via child PID."""
+        backend = _make_backend(monkeypatch, [AFH_CALCULATOR, NOTEPAD_WINDOW])
+        monkeypatch.setattr(
+            backend, "_afh_has_content_window", lambda h: h == 1000,
+        )
+        monkeypatch.setattr(
+            backend, "_resolve_uwp_child_pid",
+            lambda h: (100, "C:\\Program Files\\CalculatorApp.exe")
+            if h == 1000 else (None, None),
+        )
+
+        result = backend._resolve_hwnd(app="calculator")
+        assert result == 1000
+
+    def test_calculator_chinese_name(self, monkeypatch):
+        """--app 计算器 should match AFH-hosted Calculator via child PID."""
+        backend = _make_backend(monkeypatch, [AFH_CALCULATOR])
+        monkeypatch.setattr(
+            backend, "_afh_has_content_window", lambda h: True,
+        )
+        monkeypatch.setattr(
+            backend, "_resolve_uwp_child_pid",
+            lambda h: (100, "CalculatorApp.exe"),
+        )
+
+        result = backend._resolve_hwnd(app="计算器")
+        assert result == 1000
+
+    def test_no_fallback_when_process_matches(self, monkeypatch):
+        """Should use normal matching when process name matches directly."""
+        calc_direct = WindowInfo(
+            handle=9000,
+            title="Calculator",
+            process_name="CalculatorApp.exe",
+            pid=100,
+            x=0, y=0, width=400, height=600,
+            is_visible=True, is_minimized=False,
+        )
+        backend = _make_backend(monkeypatch, [calc_direct])
+
+        result = backend._resolve_hwnd(app="calculatorapp")
+        # Should match CalculatorApp.exe directly (score 4)
+        assert result == 9000
+
+    def test_fallback_skips_afh_without_content(self, monkeypatch):
+        """AFH windows without content children should be skipped."""
+        backend = _make_backend(monkeypatch, [AFH_CALCULATOR])
+        monkeypatch.setattr(
+            backend, "_afh_has_content_window", lambda h: False,
+        )
+
+        with pytest.raises(WindowNotFoundError):
+            backend._resolve_hwnd(app="calculator")
+
+    def test_fallback_skips_non_matching_child(self, monkeypatch):
+        """AFH with non-matching child process should not match."""
+        backend = _make_backend(monkeypatch, [AFH_CALCULATOR])
+        monkeypatch.setattr(
+            backend, "_afh_has_content_window", lambda h: True,
+        )
+        # Child is a different app
+        monkeypatch.setattr(
+            backend, "_resolve_uwp_child_pid",
+            lambda h: (300, "SomeOtherApp.exe"),
+        )
+
+        with pytest.raises(WindowNotFoundError):
+            backend._resolve_hwnd(app="calculator")
+
+    def test_settings_english_name(self, monkeypatch):
+        """--app settings should match AFH-hosted Settings."""
+        backend = _make_backend(monkeypatch, [AFH_SETTINGS])
+        monkeypatch.setattr(
+            backend, "_afh_has_content_window", lambda h: True,
+        )
+        monkeypatch.setattr(
+            backend, "_resolve_uwp_child_pid",
+            lambda h: (301, "SystemSettings.exe"),
+        )
+
+        result = backend._resolve_hwnd(app="settings")
+        assert result == 2000
+
+
+class TestUwpAfhFallbackResolveHwnds:
+    """Tests for _resolve_hwnds UWP AFH fallback (#569)."""
+
+    def test_calculator_returns_afh_handle(self, monkeypatch):
+        """_resolve_hwnds should return AFH handle for UWP apps."""
+        backend = _make_backend(monkeypatch, [AFH_CALCULATOR])
+        monkeypatch.setattr(
+            backend, "_afh_has_content_window", lambda h: True,
+        )
+        monkeypatch.setattr(
+            backend, "_resolve_uwp_child_pid",
+            lambda h: (100, "CalculatorApp.exe"),
+        )
+
+        result = backend._resolve_hwnds(app="calculator")
+        assert result == [1000]
+
+    def test_empty_when_no_match(self, monkeypatch):
+        """Should return empty list when no AFH child matches."""
+        backend = _make_backend(monkeypatch, [AFH_CALCULATOR])
+        monkeypatch.setattr(
+            backend, "_afh_has_content_window", lambda h: True,
+        )
+        monkeypatch.setattr(
+            backend, "_resolve_uwp_child_pid",
+            lambda h: (300, "UnrelatedApp.exe"),
+        )
+
+        result = backend._resolve_hwnds(app="calculator")
+        assert result == []
+
+    def test_no_fallback_when_process_matches_directly(self, monkeypatch):
+        """Should not use fallback when process name already matched."""
+        calc_direct = WindowInfo(
+            handle=9000,
+            title="Calculator",
+            process_name="CalculatorApp.exe",
+            pid=100,
+            x=0, y=0, width=400, height=600,
+            is_visible=True, is_minimized=False,
+        )
+        backend = _make_backend(monkeypatch, [calc_direct])
+        # The fallback should not be called since CalculatorApp matches
+        # "calculator" via substring
+
+        result = backend._resolve_hwnds(app="calculator")
+        assert 9000 in result
+
+
+class TestUwpAfhFallbackHelper:
+    """Tests for _uwp_afh_fallback helper method."""
+
+    def test_returns_none_when_no_afh_windows(self, monkeypatch):
+        """Should return None when no AFH windows exist."""
+        backend = _make_backend(monkeypatch, [NOTEPAD_WINDOW])
+
+        result = backend._uwp_afh_fallback("calculator", [NOTEPAD_WINDOW], 1)
+        assert result is None
+
+    def test_returns_none_when_child_resolution_fails(self, monkeypatch):
+        """Should return None when _resolve_uwp_child_pid returns None."""
+        backend = _make_backend(monkeypatch, [AFH_CALCULATOR])
+        monkeypatch.setattr(
+            backend, "_afh_has_content_window", lambda h: True,
+        )
+        monkeypatch.setattr(
+            backend, "_resolve_uwp_child_pid",
+            lambda h: (None, None),
+        )
+
+        result = backend._uwp_afh_fallback(
+            "calculator", [AFH_CALCULATOR], 1,
+        )
+        assert result is None
+
+    def test_matches_via_alias(self, monkeypatch):
+        """Should match via _APP_ALIASES (e.g. calc -> calculatorapp)."""
+        backend = _make_backend(monkeypatch, [AFH_CALCULATOR])
+        monkeypatch.setattr(
+            backend, "_afh_has_content_window", lambda h: True,
+        )
+        monkeypatch.setattr(
+            backend, "_resolve_uwp_child_pid",
+            lambda h: (100, "CalculatorApp.exe"),
+        )
+
+        result = backend._uwp_afh_fallback(
+            "calc", [AFH_CALCULATOR], 1,
+        )
+        assert result is not None
+        assert result.handle == 1000


### PR DESCRIPTION
## Changes
- Added `_uwp_afh_fallback` helper that probes ApplicationFrameHost windows' content children via `_resolve_uwp_child_pid` to discover the real app process name
- Integrated fallback into both `_resolve_hwnd` and `_resolve_hwnds` — triggers only when primary process-name scoring finds no match
- Matches child process name against search term + `_APP_ALIASES` (supports both English and Chinese names)
- Session-aware ranking preserved in fallback path

## Root Cause
UWP apps (Calculator, Settings) have their top-level windows owned by `ApplicationFrameHost.exe`, not by their actual process (e.g. `CalculatorApp.exe`). The `--app` flag matches by process name only (#465), so `--app calculator` could never match `applicationframehost`. The existing UWP fixup only activates AFTER a match is found (swapping matched window to its AFH counterpart), so it couldn't help when no initial match existed.

## Testing
- 12 new unit tests covering: English/Chinese name resolution, alias matching, no-match scenarios, fallback skip when process matches directly
- All 2155 existing tests pass (0 failures)
- ruff lint clean

**[Dev-Sirius]**