### PR TITLE
fix: --app-id resolves to hwnd+pid only, not process name (fixes #573)

### DIFF
--- a/naturo/cli/core.py
+++ b/naturo/cli/core.py
@@ -145,7 +145,8 @@ def capture(app, pid, window_title, hwnd, screen, path, fmt, store_snapshot, ses
             else:
                 click.echo(f"Error: {msg}", err=True)
             raise SystemExit(1)
-        app = entry.process_name
+        # (#573) Use hwnd for precise targeting.  Do NOT set app
+        # to process_name — it may be a full path that breaks fuzzy matching.
         hwnd = entry.handle
 
     if not _platform_supports_gui():
@@ -643,7 +644,8 @@ def see(app, window_title, hwnd, pid, mode, depth, path, annotate, store_snapsho
             else:
                 click.echo(f"Error: {msg}", err=True)
             raise SystemExit(1)
-        app = entry.process_name
+        # (#573) Use hwnd + pid for precise targeting.  Do NOT set app
+        # to process_name — it may be a full path that breaks fuzzy matching.
         hwnd = entry.handle
         pid = entry.pid
 

--- a/naturo/cli/interaction.py
+++ b/naturo/cli/interaction.py
@@ -377,8 +377,11 @@ def _resolve_app_id(
     """Resolve --app-id to (app, hwnd, pid) overrides.
 
     If ``app_id`` is provided, looks up the stored ID map and returns the
-    stored process name and window handle.  Otherwise returns the original
-    values unchanged.
+    stored window handle and PID.  The ``app`` value is left as ``None``
+    because the ID map provides precise targeting via hwnd+pid — passing
+    the stored process name as ``app`` would trigger fuzzy name matching
+    downstream (``_resolve_hwnds``, ``_auto_route``) which fails when the
+    stored name is a full path (#573).
 
     Args:
         app_id: The stable ID string (e.g. "a1"), or None.
@@ -406,7 +409,11 @@ def _resolve_app_id(
         )
         return None, None, None
 
-    return entry.process_name, entry.handle, entry.pid
+    # (#573) Return hwnd + pid only.  Do NOT populate app — the stored
+    # process_name may be a full path (e.g. "C:\...\chrome.exe") which
+    # breaks fuzzy matching in _resolve_hwnds and _auto_route.  The hwnd
+    # and pid are sufficient for precise window targeting.
+    return None, entry.handle, entry.pid
 
 
 def _elementinfo_to_dict(el) -> dict:
@@ -874,7 +881,7 @@ def click_cmd(query, on_text, ref_alias, element_id, coords, double, right, app,
 
     # (#361) Resolve --app-id to app/hwnd/pid before any other logic
     app, hwnd, pid = _resolve_app_id(app_id, app, hwnd, pid, json_output)
-    if app_id and app is None:
+    if app_id and hwnd is None:
         return  # Error already emitted by _resolve_app_id
 
     backend = _get_backend(json_output)
@@ -1224,7 +1231,7 @@ def type_cmd(text, delay, profile, wpm, press_return, tab_count, escape,
     """
     # (#361) Resolve --app-id to app/hwnd/pid before any other logic
     app, hwnd, pid = _resolve_app_id(app_id, app, hwnd, pid, json_output)
-    if app_id and app is None:
+    if app_id and hwnd is None:
         return  # Error already emitted by _resolve_app_id
 
     # --ref is a hidden deprecated alias for --on (#381)
@@ -1666,7 +1673,7 @@ def press(keys, count, delay, hold_duration, on_element, ref_alias, app, pid, wi
     """
     # (#361) Resolve --app-id to app/hwnd/pid before any other logic
     app, hwnd, pid = _resolve_app_id(app_id, app, hwnd, pid, json_output)
-    if app_id and app is None:
+    if app_id and hwnd is None:
         return  # Error already emitted by _resolve_app_id
 
     # --ref is a hidden deprecated alias for --on (#381)

--- a/tests/test_app_ids.py
+++ b/tests/test_app_ids.py
@@ -188,7 +188,8 @@ class TestResolveAppIdHelper:
         assert hwnd == 123
         assert pid == 456
 
-    def test_resolve_overrides_app_hwnd_pid(self, tmp_storage):
+    def test_resolve_returns_hwnd_pid_without_app(self, tmp_storage):
+        """#573: _resolve_app_id must NOT populate app — only hwnd + pid."""
         from naturo.cli.interaction import _resolve_app_id
 
         # Set up an ID map
@@ -207,8 +208,58 @@ class TestResolveAppIdHelper:
         app_ids_mod.get_app_id_map = _patched
         try:
             app, hwnd, pid = _resolve_app_id("a1", None, None, None, False)
-            assert app == "excel.exe"
+            # (#573) app must be None — process_name may be a full path that
+            # breaks fuzzy matching downstream.  hwnd + pid suffice.
+            assert app is None
             assert hwnd == 999
             assert pid == 42
+        finally:
+            app_ids_mod.get_app_id_map = orig_factory
+
+    def test_resolve_full_path_process_name_does_not_leak(self, tmp_storage):
+        """#573: Full path in process_name must not become the app filter."""
+        from naturo.cli.interaction import _resolve_app_id
+
+        id_map = AppIdMap(session="default", storage_root=tmp_storage)
+        id_map.assign_ids([
+            FakeWindow(
+                pid=100,
+                handle=5555,
+                process_name=r"C:\Program Files\Google\Chrome\Application\chrome.exe",
+                title="Google Chrome",
+            ),
+        ])
+
+        import naturo.app_ids as app_ids_mod
+        orig_factory = app_ids_mod.get_app_id_map
+
+        def _patched(session=None):
+            return AppIdMap(session=session, storage_root=tmp_storage)
+
+        app_ids_mod.get_app_id_map = _patched
+        try:
+            app, hwnd, pid = _resolve_app_id("a1", None, None, None, False)
+            assert app is None, "app must not be set to full process path"
+            assert hwnd == 5555
+            assert pid == 100
+        finally:
+            app_ids_mod.get_app_id_map = orig_factory
+
+    def test_resolve_error_exits(self, tmp_storage):
+        """On invalid app_id, _resolve_app_id exits with error."""
+        from naturo.cli.interaction import _resolve_app_id
+
+        # Empty storage — no IDs
+        import naturo.app_ids as app_ids_mod
+        orig_factory = app_ids_mod.get_app_id_map
+
+        def _patched(session=None):
+            return AppIdMap(session=session, storage_root=tmp_storage)
+
+        app_ids_mod.get_app_id_map = _patched
+        try:
+            import pytest
+            with pytest.raises(SystemExit):
+                _resolve_app_id("a99", None, None, None, False)
         finally:
             app_ids_mod.get_app_id_map = orig_factory


### PR DESCRIPTION
## Changes
- `_resolve_app_id` now returns `(None, entry.handle, entry.pid)` instead of `(entry.process_name, entry.handle, entry.pid)`
- The stored `process_name` may be a full path (e.g. `C:\Program Files\...\chrome.exe`) which breaks fuzzy matching in `_resolve_hwnds` and `_auto_route`
- `hwnd` + `pid` provide precise window targeting — fuzzy `app` name matching is unnecessary
- Updated error checks from `app is None` to `hwnd is None` in click, type, and press commands
- Applied same fix to `see` and `capture` for consistency

## Root Cause
`_resolve_app_id` returned the stored `process_name` as the `app` parameter. Downstream code (`_resolve_hwnds`, `_auto_route`) used `app` for fuzzy process-name matching, comparing against `.exe` basenames. When `process_name` was a full path, the fuzzy match always failed:
- `click --app-id a3 --on e1` → validation at line 962 called `_resolve_hwnds(app="C:\...\chrome.exe")` → no match → "No windows found"
- `type/press --app-id a3` → `_auto_route(app="C:\...\chrome.exe")` → `resolve_method` couldn't find app → "App not found"

## Testing
- 3 new unit tests: hwnd+pid without app, full-path process name does not leak, error exits
- All 2157 existing tests pass (0 failures)
- ruff lint clean, mypy clean

**[Dev-Sirius]**