### PR TITLE
fix: MCP launch_app returns PID and process info (fixes #575)

### DIFF
--- a/naturo/mcp_server.py
+++ b/naturo/mcp_server.py
@@ -15,6 +15,7 @@ from mcp.server.fastmcp import FastMCP
 
 from naturo.backends.base import get_backend, Backend
 from naturo.errors import NaturoError
+from naturo.process import launch_app as _launch_app
 
 logger = logging.getLogger(__name__)
 
@@ -1085,11 +1086,17 @@ def create_server(host: str = "localhost", port: int = 3100) -> FastMCP:
             name: Application name or executable path.
 
         Returns:
-            Dict with success flag.
+            Dict with success flag, pid, and process info.
         """
-        backend = _get_backend()
-        backend.launch_app(name=name)
-        return {"success": True}
+        info = _launch_app(name=name)
+        return {
+            "success": True,
+            "pid": info.pid,
+            "name": info.name,
+            "path": info.path,
+            "is_running": info.is_running,
+            "window_count": info.window_count,
+        }
 
     @server.tool()
     @_safe_tool

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -362,13 +362,19 @@ class TestToolFunctionsWithMockedBackend:
             assert len(data["apps"]) == 1
 
     def test_launch_app(self, mock_backend):
-        """launch_app calls backend."""
-        with patch("naturo.mcp_server.get_backend", return_value=mock_backend):
+        """launch_app returns PID and process info (#575)."""
+        from naturo.process import ProcessInfo
+
+        mock_info = ProcessInfo(pid=12345, name="notepad", path="C:\\Windows\\notepad.exe", is_running=True, window_count=1)
+        with patch("naturo.mcp_server.get_backend", return_value=mock_backend), \
+             patch("naturo.mcp_server._launch_app", return_value=mock_info) as mock_launch:
             srv = create_server()
             result = self._call_tool(srv, "launch_app", {"name": "notepad"})
             data = json.loads(result[0].text)
             assert data["success"] is True
-            mock_backend.launch_app.assert_called_once_with(name="notepad")
+            assert data["pid"] == 12345
+            assert data["name"] == "notepad"
+            mock_launch.assert_called_once_with(name="notepad")
 
     def test_quit_app(self, mock_backend):
         """quit_app calls backend."""


### PR DESCRIPTION
## Changes\n- MCP `launch_app` handler now uses `naturo.process.launch_app()` instead of `backend.launch_app()`, matching the CLI implementation\n- Response now includes `pid`, `name`, `path`, `is_running`, and `window_count` fields\n- Updated test to verify PID and process info are returned\n\n## Root Cause\nThe MCP handler called `backend.launch_app()` which returns `None`, discarding the PID. The CLI already used `naturo.process.launch_app()` which returns a `ProcessInfo` dataclass with full process details.\n\n## Testing\n- `pytest tests/test_mcp_server.py` — 46/46 passed\n- `ruff check naturo/mcp_server.py` — clean\n\n**[Dev-Sirius]**