### PR TITLE
fix: quit app via WM_CLOSE on all windows to avoid session restore (fixes #586)

### DIFF
--- a/naturo/process.py
+++ b/naturo/process.py
@@ -482,6 +482,44 @@ def _resolve_pid_from_backend(name: str) -> int | None:
     return None
 
 
+def _close_all_windows_for_app(name: str) -> list[int]:
+    """Close all windows belonging to an app by sending WM_CLOSE (#586).
+
+    Uses the backend to enumerate windows and send WM_CLOSE to each one
+    matching the app name.  WM_CLOSE triggers a proper graceful close that
+    does not activate Windows session restore (unlike ``taskkill /F``).
+
+    Args:
+        name: Application name (fuzzy-matched against process names and titles).
+
+    Returns:
+        List of PIDs that had windows closed.
+    """
+    try:
+        from naturo.backends.base import get_backend
+
+        be = get_backend()
+        windows = be.list_windows()
+    except Exception:
+        logger.debug("Backend unavailable for window-based close of %r", name)
+        return []
+
+    name_lower = name.lower()
+    closed_pids: list[int] = []
+
+    for w in windows:
+        proc_name = os.path.basename(w.process_name).lower()
+        if name_lower in proc_name or name_lower in w.title.lower():
+            try:
+                be.close_window(hwnd=w.handle)
+                if w.pid not in closed_pids:
+                    closed_pids.append(w.pid)
+            except Exception:
+                logger.debug("Failed to close window hwnd=%s for %r", w.handle, name)
+
+    return closed_pids
+
+
 def quit_app(
     name: str | None = None,
     pid: int | None = None,
@@ -518,27 +556,38 @@ def quit_app(
     if force:
         _force_kill(target_pid, system)
     else:
-        # Graceful shutdown
-        try:
-            if system == "Windows":
-                subprocess.run(
-                    ["taskkill", "/PID", str(target_pid)],
-                    capture_output=True, timeout=timeout,
-                )
-            else:
-                os.kill(target_pid, signal.SIGTERM)
-        except (subprocess.TimeoutExpired, ProcessLookupError, OSError):
-            pass
+        # Graceful shutdown: send WM_CLOSE to all matching windows (#586).
+        # This avoids taskkill /F which triggers Windows session restore
+        # for UWP apps like Notepad, causing closed tabs to respawn.
+        closed_pids: list[int] = []
+        if system == "Windows" and name:
+            closed_pids = _close_all_windows_for_app(name)
 
-        # Wait for exit
+        if not closed_pids:
+            # Fallback: no windows found via backend, use taskkill
+            try:
+                if system == "Windows":
+                    subprocess.run(
+                        ["taskkill", "/PID", str(target_pid)],
+                        capture_output=True, timeout=timeout,
+                    )
+                else:
+                    os.kill(target_pid, signal.SIGTERM)
+            except (subprocess.TimeoutExpired, ProcessLookupError, OSError):
+                pass
+
+        # Wait for exit — check all PIDs that had windows closed
+        pids_to_check = set(closed_pids) | {target_pid}
         start = time.monotonic()
         while time.monotonic() - start < timeout:
-            if find_process(pid=target_pid) is None:
+            if all(find_process(pid=p) is None for p in pids_to_check):
                 break
             time.sleep(0.3)
         else:
             # Still alive after timeout — force kill as fallback
-            _force_kill(target_pid, system)
+            for p in pids_to_check:
+                if find_process(pid=p) is not None:
+                    _force_kill(p, system)
 
     # Always verify the process is actually dead (#496, #484).
     # Check both the target PID and the app name to catch respawns.

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -5,6 +5,7 @@ from unittest.mock import patch, MagicMock
 from naturo.process import (
     ProcessInfo, find_process, is_running, launch_app, quit_app,
     relaunch_app, list_apps, _list_processes, _verify_quit,
+    _close_all_windows_for_app,
     _get_console_session_id, _get_process_session_id,
     _resolve_launch_name, _resolve_pid_from_backend, _LAUNCH_ALIASES,
 )
@@ -620,6 +621,170 @@ class TestResolvePidFromBackend:
         quit_app(name="notepad", force=True)
         mock_resolve.assert_called_once_with("notepad")
         mock_kill.assert_called_once_with(36328, "Windows")
+
+
+class TestCloseAllWindowsForApp:
+    """Tests for WM_CLOSE-based window close (#586)."""
+
+    @patch("naturo.backends.base.get_backend")
+    def test_closes_all_matching_windows(self, mock_get_backend):
+        """All windows matching the app name get WM_CLOSE."""
+        w1 = MagicMock(process_name="C:\\Windows\\Notepad.exe",
+                        title="Tab 1 - Notepad", pid=100, handle=0x1001)
+        w2 = MagicMock(process_name="C:\\Windows\\Notepad.exe",
+                        title="Tab 2 - Notepad", pid=100, handle=0x1002)
+        w3 = MagicMock(process_name="C:\\Windows\\explorer.exe",
+                        title="File Explorer", pid=200, handle=0x2001)
+
+        mock_be = MagicMock()
+        mock_be.list_windows.return_value = [w1, w2, w3]
+        mock_get_backend.return_value = mock_be
+
+        pids = _close_all_windows_for_app("notepad")
+
+        assert mock_be.close_window.call_count == 2
+        mock_be.close_window.assert_any_call(hwnd=0x1001)
+        mock_be.close_window.assert_any_call(hwnd=0x1002)
+        assert pids == [100]
+
+    @patch("naturo.backends.base.get_backend")
+    def test_returns_multiple_pids_for_multi_process_app(self, mock_get_backend):
+        """UWP apps may have windows under different PIDs."""
+        w1 = MagicMock(process_name="Notepad.exe",
+                        title="Tab 1", pid=100, handle=0x1001)
+        w2 = MagicMock(process_name="Notepad.exe",
+                        title="Tab 2", pid=101, handle=0x1002)
+
+        mock_be = MagicMock()
+        mock_be.list_windows.return_value = [w1, w2]
+        mock_get_backend.return_value = mock_be
+
+        pids = _close_all_windows_for_app("notepad")
+
+        assert set(pids) == {100, 101}
+        assert mock_be.close_window.call_count == 2
+
+    @patch("naturo.backends.base.get_backend")
+    def test_no_match_returns_empty(self, mock_get_backend):
+        """Returns empty list when no windows match."""
+        mock_be = MagicMock()
+        mock_be.list_windows.return_value = []
+        mock_get_backend.return_value = mock_be
+
+        assert _close_all_windows_for_app("notepad") == []
+
+    @patch("naturo.backends.base.get_backend")
+    def test_backend_failure_returns_empty(self, mock_get_backend):
+        """Gracefully returns empty on backend error."""
+        mock_get_backend.side_effect = Exception("No backend")
+        assert _close_all_windows_for_app("notepad") == []
+
+    @patch("naturo.backends.base.get_backend")
+    def test_matches_by_title(self, mock_get_backend):
+        """Matches windows by title when process name doesn't match."""
+        w1 = MagicMock(process_name="ApplicationFrameHost.exe",
+                        title="Untitled - Notepad", pid=100, handle=0x1001)
+
+        mock_be = MagicMock()
+        mock_be.list_windows.return_value = [w1]
+        mock_get_backend.return_value = mock_be
+
+        pids = _close_all_windows_for_app("notepad")
+
+        assert pids == [100]
+        mock_be.close_window.assert_called_once_with(hwnd=0x1001)
+
+    @patch("naturo.backends.base.get_backend")
+    def test_individual_close_failure_continues(self, mock_get_backend):
+        """If one window fails to close, others still get closed."""
+        w1 = MagicMock(process_name="Notepad.exe",
+                        title="Tab 1", pid=100, handle=0x1001)
+        w2 = MagicMock(process_name="Notepad.exe",
+                        title="Tab 2", pid=100, handle=0x1002)
+
+        mock_be = MagicMock()
+        mock_be.list_windows.return_value = [w1, w2]
+        mock_be.close_window.side_effect = [Exception("Failed"), None]
+        mock_get_backend.return_value = mock_be
+
+        pids = _close_all_windows_for_app("notepad")
+
+        assert mock_be.close_window.call_count == 2
+        # Second call succeeded, so PID should still be in the list
+        assert 100 in pids
+
+
+class TestQuitAppWindowClose:
+    """Tests for quit_app using WM_CLOSE instead of taskkill (#586)."""
+
+    @patch("naturo.process._verify_quit")
+    @patch("naturo.process._close_all_windows_for_app")
+    @patch("naturo.process.find_process")
+    @patch("naturo.process._resolve_pid_from_backend")
+    @patch("naturo.process.platform")
+    def test_graceful_quit_uses_wm_close_on_windows(
+        self, mock_platform, mock_resolve, mock_find, mock_close_all, mock_verify,
+    ):
+        """Graceful quit on Windows sends WM_CLOSE to all windows (#586)."""
+        mock_platform.system.return_value = "Windows"
+        mock_resolve.return_value = 100
+        mock_find.side_effect = [
+            ProcessInfo(pid=100, name="notepad.exe"),  # initial find
+            None,  # all PIDs dead check
+        ]
+        mock_close_all.return_value = [100]
+        mock_verify.return_value = None
+
+        quit_app(name="notepad", timeout=0.1)
+
+        mock_close_all.assert_called_once_with("notepad")
+
+    @patch("naturo.process._verify_quit")
+    @patch("naturo.process._close_all_windows_for_app")
+    @patch("naturo.process.find_process")
+    @patch("naturo.process._resolve_pid_from_backend")
+    @patch("naturo.process.platform")
+    @patch("naturo.process.subprocess")
+    def test_falls_back_to_taskkill_when_no_windows(
+        self, mock_subprocess, mock_platform, mock_resolve, mock_find,
+        mock_close_all, mock_verify,
+    ):
+        """Falls back to taskkill when backend finds no windows."""
+        mock_platform.system.return_value = "Windows"
+        mock_resolve.return_value = 100
+        mock_find.side_effect = [
+            ProcessInfo(pid=100, name="notepad.exe"),  # initial find
+            None,  # PID dead check
+        ]
+        mock_close_all.return_value = []  # No windows found
+        mock_verify.return_value = None
+
+        quit_app(name="notepad", timeout=0.1)
+
+        mock_close_all.assert_called_once()
+        mock_subprocess.run.assert_called_once()
+
+    @patch("naturo.process._verify_quit")
+    @patch("naturo.process._force_kill")
+    @patch("naturo.process._close_all_windows_for_app")
+    @patch("naturo.process.find_process")
+    @patch("naturo.process._resolve_pid_from_backend")
+    @patch("naturo.process.platform")
+    def test_force_kills_surviving_pids_after_timeout(
+        self, mock_platform, mock_resolve, mock_find, mock_close_all,
+        mock_kill, mock_verify,
+    ):
+        """PIDs surviving after WM_CLOSE timeout get force-killed."""
+        mock_platform.system.return_value = "Windows"
+        mock_resolve.return_value = 100
+        # find_process: initial find returns proc, then always returns proc (still alive)
+        mock_find.return_value = ProcessInfo(pid=100, name="notepad.exe")
+        mock_close_all.return_value = [100]
+        mock_verify.return_value = None
+
+        quit_app(name="notepad", timeout=0.1)
+
+        mock_kill.assert_called_once_with(100, "Windows")
 
 
 class TestRelaunchApp:


### PR DESCRIPTION
## Changes
- Added `_close_all_windows_for_app()` — enumerates all windows matching the app name via backend and sends WM_CLOSE to each
- Modified `quit_app()` to use WM_CLOSE-based close on Windows instead of `taskkill /PID`
- Falls back to `taskkill /PID` when backend is unavailable or finds no windows
- After timeout, force-kills ALL surviving PIDs (not just the original target)
- 9 new tests for `_close_all_windows_for_app` and the updated `quit_app` flow

## Root Cause
`taskkill /F` triggers Windows session restore for UWP apps like Notepad, causing closed tabs to respawn. WM_CLOSE triggers a proper graceful close that doesn't activate crash recovery.

## Testing
- 2171 passed, 564 skipped
- `ruff check` clean
- `mypy` clean

**[Dev-Sirius]**