### PR TITLE
feat: add --app-id to window, dialog, and desktop commands (fixes #584)

### DIFF
--- a/naturo/cli/desktop_cmd.py
+++ b/naturo/cli/desktop_cmd.py
@@ -23,6 +23,7 @@ import click as _click
 
 from naturo.cli.error_helpers import emit_error, emit_exception_error
 from naturo.cli.fuzzy_group import FuzzyGroup
+from naturo.cli.options import app_id_option, resolve_app_id_to_hwnd
 
 
 def _ensure_pyvda() -> None:
@@ -218,26 +219,33 @@ def desktop_close(index: int | None, json_output: bool) -> None:
 @_click.argument("index", type=int)
 @_click.option("--app", default=None, help="Application name (partial match)")
 @_click.option("--hwnd", type=int, default=None, help="Window handle")
+@app_id_option
 @_click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 def desktop_move_window(
     index: int,
     app: str | None,
     hwnd: int | None,
+    app_id: str | None,
     json_output: bool,
 ) -> None:
     """Move a window to a different virtual desktop.
 
     INDEX is the target desktop (zero-based). Identify the window by
-    --app name or --hwnd handle. If neither is given, moves the
+    --app name, --hwnd handle, or --app-id. If none given, moves the
     foreground window.
 
     \b
     Examples:
         naturo desktop move-window 1 --app "Notepad"    # Move Notepad
         naturo desktop move-window 0 --hwnd 12345       # Move by handle
+        naturo desktop move-window 1 --app-id a1        # Move by app ID
         naturo desktop move-window 2                    # Move foreground
-        naturo desktop move-window 1 --app X --json     # JSON output
     """
+    # (#584) Resolve --app-id to hwnd
+    hwnd = resolve_app_id_to_hwnd(app_id, hwnd, json_output)
+    if app_id and hwnd is None:
+        raise SystemExit(1)
+
     from naturo.backends.base import get_backend
     from naturo.errors import NaturoError
 

--- a/naturo/cli/dialog_cmd.py
+++ b/naturo/cli/dialog_cmd.py
@@ -23,6 +23,7 @@ import click
 
 from naturo.cli.error_helpers import emit_error, emit_exception_error
 from naturo.cli.fuzzy_group import FuzzyGroup
+from naturo.cli.options import app_id_option, resolve_app_id_to_hwnd
 
 
 @click.group(cls=FuzzyGroup)
@@ -48,8 +49,9 @@ def dialog():
 @dialog.command()
 @click.option("--app", help="Filter by owner application name")
 @click.option("--hwnd", type=int, help="Filter by dialog window handle")
+@app_id_option
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def detect(app, hwnd, json_output):
+def detect(app, hwnd, app_id, json_output):
     """Detect active dialog windows.
 
     Scans for system dialogs including message boxes, file pickers,
@@ -62,8 +64,14 @@ def detect(app, hwnd, json_output):
     Examples:
         naturo dialog detect                   # List all dialogs
         naturo dialog detect --app notepad     # Filter by app
+        naturo dialog detect --app-id a1       # Filter by app ID
         naturo dialog detect --json            # JSON output
     """
+    # (#584) Resolve --app-id to hwnd
+    hwnd = resolve_app_id_to_hwnd(app_id, hwnd, json_output)
+    if app_id and hwnd is None:
+        raise SystemExit(1)
+
     from naturo.backends.base import get_backend
     from naturo.errors import NaturoError
 
@@ -107,8 +115,9 @@ def detect(app, hwnd, json_output):
 @dialog.command()
 @click.option("--app", help="Owner application name filter")
 @click.option("--hwnd", type=int, help="Specific dialog window handle")
+@app_id_option
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def accept(app, hwnd, json_output):
+def accept(app, hwnd, app_id, json_output):
     """Accept (confirm) the active dialog.
 
     Clicks the first accept-type button found: OK, Yes, Open, Save,
@@ -118,8 +127,14 @@ def accept(app, hwnd, json_output):
     Examples:
         naturo dialog accept                   # Accept first dialog
         naturo dialog accept --app notepad     # Accept notepad's dialog
+        naturo dialog accept --app-id a1       # Accept by app ID
         naturo dialog accept --json            # JSON output
     """
+    # (#584) Resolve --app-id to hwnd
+    hwnd = resolve_app_id_to_hwnd(app_id, hwnd, json_output)
+    if app_id and hwnd is None:
+        raise SystemExit(1)
+
     from naturo.backends.base import get_backend
     from naturo.errors import NaturoError
     from naturo.dialog import _ACCEPT_BUTTONS
@@ -172,8 +187,9 @@ def accept(app, hwnd, json_output):
 @dialog.command()
 @click.option("--app", help="Owner application name filter")
 @click.option("--hwnd", type=int, help="Specific dialog window handle")
+@app_id_option
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def dismiss(app, hwnd, json_output):
+def dismiss(app, hwnd, app_id, json_output):
     """Dismiss (cancel) the active dialog.
 
     Clicks the first dismiss-type button found: Cancel, No, Close,
@@ -183,8 +199,14 @@ def dismiss(app, hwnd, json_output):
     Examples:
         naturo dialog dismiss                  # Dismiss first dialog
         naturo dialog dismiss --app notepad    # Dismiss notepad's dialog
+        naturo dialog dismiss --app-id a1      # Dismiss by app ID
         naturo dialog dismiss --json           # JSON output
     """
+    # (#584) Resolve --app-id to hwnd
+    hwnd = resolve_app_id_to_hwnd(app_id, hwnd, json_output)
+    if app_id and hwnd is None:
+        raise SystemExit(1)
+
     from naturo.backends.base import get_backend
     from naturo.errors import NaturoError
     from naturo.dialog import _DISMISS_BUTTONS
@@ -238,8 +260,9 @@ def dismiss(app, hwnd, json_output):
 @click.argument("button")
 @click.option("--app", help="Owner application name filter")
 @click.option("--hwnd", type=int, help="Specific dialog window handle")
+@app_id_option
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def click_button(button, app, hwnd, json_output):
+def click_button(button, app, hwnd, app_id, json_output):
     """Click a specific button in the active dialog.
 
     Finds a button by name (case-insensitive, supports partial match)
@@ -247,10 +270,15 @@ def click_button(button, app, hwnd, json_output):
 
     \b
     Examples:
-        naturo dialog click-button "Save"         # Click Save
-        naturo dialog click-button "Don't Save"   # Click Don't Save
-        naturo dialog click-button "Retry"         # Click Retry
+        naturo dialog click-button "Save"              # Click Save
+        naturo dialog click-button "Don't Save"        # Click Don't Save
+        naturo dialog click-button "Retry" --app-id a1 # By app ID
     """
+    # (#584) Resolve --app-id to hwnd
+    hwnd = resolve_app_id_to_hwnd(app_id, hwnd, json_output)
+    if app_id and hwnd is None:
+        raise SystemExit(1)
+
     from naturo.backends.base import get_backend
     from naturo.errors import NaturoError
 
@@ -282,8 +310,9 @@ def click_button(button, app, hwnd, json_output):
               help="Click OK/Accept after typing")
 @click.option("--app", help="Owner application name filter")
 @click.option("--hwnd", type=int, help="Specific dialog window handle")
+@app_id_option
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def dialog_type(text, do_accept, app, hwnd, json_output):
+def dialog_type(text, do_accept, app, hwnd, app_id, json_output):
     """Type text into a dialog's input field.
 
     Finds the dialog's input/edit control, clears it, and types
@@ -291,10 +320,15 @@ def dialog_type(text, do_accept, app, hwnd, json_output):
 
     \b
     Examples:
-        naturo dialog type "hello.txt"            # Type filename
-        naturo dialog type "hello.txt" --accept   # Type then click OK
-        naturo dialog type "C:\\Users" --app notepad
+        naturo dialog type "hello.txt"                  # Type filename
+        naturo dialog type "hello.txt" --accept         # Type then click OK
+        naturo dialog type "C:\\Users" --app-id a1       # By app ID
     """
+    # (#584) Resolve --app-id to hwnd
+    hwnd = resolve_app_id_to_hwnd(app_id, hwnd, json_output)
+    if app_id and hwnd is None:
+        raise SystemExit(1)
+
     from naturo.backends.base import get_backend
     from naturo.errors import NaturoError
     from naturo.dialog import _ACCEPT_BUTTONS

--- a/naturo/cli/options.py
+++ b/naturo/cli/options.py
@@ -87,6 +87,51 @@ def on_option(func):
 
 
 
+def app_id_option(func):
+    """``--app-id`` — stable app/window ID from ``naturo app list``."""
+    return click.option(
+        "--app-id",
+        "app_id",
+        default=None,
+        help='Stable app/window ID from "naturo app list" output (e.g. a1)',
+    )(func)
+
+
+def resolve_app_id_to_hwnd(
+    app_id: str | None,
+    hwnd: int | None,
+    json_output: bool,
+) -> int | None:
+    """Resolve --app-id to a window handle.
+
+    Returns the resolved hwnd (from app_id or passed through), or None
+    with an error already emitted if the ID is invalid.
+
+    Args:
+        app_id: The stable ID string (e.g. "a1"), or None.
+        hwnd: Current --hwnd value (returned as-is when no app_id).
+        json_output: Whether to emit JSON error output.
+
+    Returns:
+        Window handle, or None if resolution failed.
+    """
+    if app_id is None:
+        return hwnd
+
+    from naturo.app_ids import get_app_id_map
+
+    id_map = get_app_id_map()
+    entry = id_map.resolve(app_id)
+    if entry is None:
+        msg = f'App ID "{app_id}" not found or expired. Run "naturo app list" to refresh.'
+        if json_output:
+            click.echo(f'{{"error": "APP_ID_NOT_FOUND", "message": "{msg}"}}')
+        else:
+            click.echo(f"Error: {msg}", err=True)
+        return None
+    return entry.handle
+
+
 def json_option(func):
     """``--json / -j`` — JSON output mode."""
     return click.option(

--- a/naturo/cli/window_cmd.py
+++ b/naturo/cli/window_cmd.py
@@ -14,6 +14,7 @@ import click
 from naturo.backends.base import get_backend as _get_backend_impl
 from naturo.cli.error_helpers import json_error
 from naturo.cli.fuzzy_group import FuzzyGroup
+from naturo.cli.options import app_id_option, resolve_app_id_to_hwnd
 
 
 def _safe_echo(text: str, **kwargs) -> None:
@@ -83,15 +84,21 @@ def window():
 @click.option("--app", help="Application/process name (partial match)")
 @click.option("--title", help="Window title pattern (partial match)")
 @click.option("--hwnd", type=int, help="Window handle")
+@app_id_option
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def focus(ctx, name, app, title, hwnd, json_output):
+def focus(ctx, name, app, title, hwnd, app_id, json_output):
     """Focus a window (bring to foreground)."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
     _emit_deprecation(json_output)
     # Support positional NAME for backward compat: naturo window focus "Notepad"
     if name and not app:
         app = name
+    # (#584) Resolve --app-id to hwnd
+    hwnd = resolve_app_id_to_hwnd(app_id, hwnd, json_output)
+    if app_id and hwnd is None:
+        sys.exit(1)
+        return
     from naturo.errors import NaturoError
 
     if not app and not title and not hwnd:
@@ -130,14 +137,20 @@ def focus(ctx, name, app, title, hwnd, json_output):
 @click.option("--title", help="Window title pattern (partial match)")
 @click.option("--hwnd", type=int, help="Window handle")
 @click.option("--force", is_flag=True, help="Force terminate the process")
+@app_id_option
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def close(ctx, name, app, title, hwnd, force, json_output):
+def close(ctx, name, app, title, hwnd, force, app_id, json_output):
     """Close a window (graceful or forced)."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
     _emit_deprecation(json_output)
     if name and not app:
         app = name
+    # (#584) Resolve --app-id to hwnd
+    hwnd = resolve_app_id_to_hwnd(app_id, hwnd, json_output)
+    if app_id and hwnd is None:
+        sys.exit(1)
+        return
     from naturo.errors import NaturoError
 
     if not app and not title and not hwnd:
@@ -177,14 +190,19 @@ def close(ctx, name, app, title, hwnd, force, json_output):
 @click.option("--app", help="Application/process name (partial match)")
 @click.option("--title", help="Window title pattern (partial match)")
 @click.option("--hwnd", type=int, help="Window handle")
+@app_id_option
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def minimize(ctx, name, app, title, hwnd, json_output):
+def minimize(ctx, name, app, title, hwnd, app_id, json_output):
     """Minimize a window."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
     _emit_deprecation(json_output)
     if name and not app:
         app = name
+    hwnd = resolve_app_id_to_hwnd(app_id, hwnd, json_output)
+    if app_id and hwnd is None:
+        sys.exit(1)
+        return
     from naturo.errors import NaturoError
 
     if not app and not title and not hwnd:
@@ -222,14 +240,19 @@ def minimize(ctx, name, app, title, hwnd, json_output):
 @click.option("--app", help="Application/process name (partial match)")
 @click.option("--title", help="Window title pattern (partial match)")
 @click.option("--hwnd", type=int, help="Window handle")
+@app_id_option
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def maximize(ctx, name, app, title, hwnd, json_output):
+def maximize(ctx, name, app, title, hwnd, app_id, json_output):
     """Maximize a window."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
     _emit_deprecation(json_output)
     if name and not app:
         app = name
+    hwnd = resolve_app_id_to_hwnd(app_id, hwnd, json_output)
+    if app_id and hwnd is None:
+        sys.exit(1)
+        return
     from naturo.errors import NaturoError
 
     if not app and not title and not hwnd:
@@ -267,14 +290,19 @@ def maximize(ctx, name, app, title, hwnd, json_output):
 @click.option("--app", help="Application/process name (partial match)")
 @click.option("--title", help="Window title pattern (partial match)")
 @click.option("--hwnd", type=int, help="Window handle")
+@app_id_option
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def restore(ctx, name, app, title, hwnd, json_output):
+def restore(ctx, name, app, title, hwnd, app_id, json_output):
     """Restore a minimized or maximized window to normal state."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
     _emit_deprecation(json_output)
     if name and not app:
         app = name
+    hwnd = resolve_app_id_to_hwnd(app_id, hwnd, json_output)
+    if app_id and hwnd is None:
+        sys.exit(1)
+        return
     from naturo.errors import NaturoError
 
     if not app and not title and not hwnd:
@@ -311,14 +339,19 @@ def restore(ctx, name, app, title, hwnd, json_output):
 @click.option("--app", help="Application/process name (partial match)")
 @click.option("--title", help="Window title pattern (partial match)")
 @click.option("--hwnd", type=int, help="Window handle")
+@app_id_option
 @click.option("--x", type=int, default=None, help="Target X position")
 @click.option("--y", type=int, default=None, help="Target Y position")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def window_move(ctx, app, title, hwnd, x, y, json_output):
+def window_move(ctx, app, title, hwnd, app_id, x, y, json_output):
     """Move a window to a position (keeps current size)."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
     _emit_deprecation(json_output)
+    hwnd = resolve_app_id_to_hwnd(app_id, hwnd, json_output)
+    if app_id and hwnd is None:
+        sys.exit(1)
+        return
     from naturo.errors import NaturoError
 
     if x is None or y is None:
@@ -364,14 +397,19 @@ def window_move(ctx, app, title, hwnd, x, y, json_output):
 @click.option("--app", help="Application/process name (partial match)")
 @click.option("--title", help="Window title pattern (partial match)")
 @click.option("--hwnd", type=int, help="Window handle")
+@app_id_option
 @click.option("--width", type=int, default=None, help="New width in pixels")
 @click.option("--height", type=int, default=None, help="New height in pixels")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def resize(ctx, app, title, hwnd, width, height, json_output):
+def resize(ctx, app, title, hwnd, app_id, width, height, json_output):
     """Resize a window (keeps current position)."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
     _emit_deprecation(json_output)
+    hwnd = resolve_app_id_to_hwnd(app_id, hwnd, json_output)
+    if app_id and hwnd is None:
+        sys.exit(1)
+        return
     from naturo.errors import NaturoError
 
     if width is None or height is None:
@@ -426,16 +464,21 @@ def resize(ctx, app, title, hwnd, width, height, json_output):
 @click.option("--app", help="Application/process name (partial match)")
 @click.option("--title", help="Window title pattern (partial match)")
 @click.option("--hwnd", type=int, help="Window handle")
+@app_id_option
 @click.option("--x", type=int, default=None, help="X position")
 @click.option("--y", type=int, default=None, help="Y position")
 @click.option("--width", type=int, default=None, help="Width in pixels")
 @click.option("--height", type=int, default=None, help="Height in pixels")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def set_bounds(ctx, app, title, hwnd, x, y, width, height, json_output):
+def set_bounds(ctx, app, title, hwnd, app_id, x, y, width, height, json_output):
     """Set window position and size at once."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
     _emit_deprecation(json_output)
+    hwnd = resolve_app_id_to_hwnd(app_id, hwnd, json_output)
+    if app_id and hwnd is None:
+        sys.exit(1)
+        return
     from naturo.errors import NaturoError
 
     missing = []

--- a/tests/test_cli_consistency.py
+++ b/tests/test_cli_consistency.py
@@ -159,6 +159,34 @@ def test_list_apps_delegates_to_app_list():
         )
 
 
+@pytest.mark.parametrize("cmd_args", [
+    # window commands (#584)
+    ["window", "focus"],
+    ["window", "close"],
+    ["window", "minimize"],
+    ["window", "maximize"],
+    ["window", "restore"],
+    ["window", "move"],
+    ["window", "resize"],
+    ["window", "set-bounds"],
+    # dialog commands (#584)
+    ["dialog", "detect"],
+    ["dialog", "accept"],
+    ["dialog", "dismiss"],
+    ["dialog", "click-button"],
+    ["dialog", "type"],
+    # desktop commands (#584)
+    ["desktop", "move-window"],
+])
+def test_app_id_option_in_help(cmd_args):
+    """#584: window/dialog/desktop commands must show --app-id in help."""
+    result = runner.invoke(main, cmd_args + ["--help"])
+    assert result.exit_code == 0, f"naturo {' '.join(cmd_args)} --help failed"
+    assert "--app-id" in result.output, (
+        f"naturo {' '.join(cmd_args)} --help missing --app-id:\n{result.output}"
+    )
+
+
 def test_hidden_commands_not_in_help():
     """Hidden commands must not appear in any --help output."""
     # Check top level


### PR DESCRIPTION
## Changes
- Added shared `app_id_option` decorator and `resolve_app_id_to_hwnd` helper to `options.py`
- Added `--app-id` to 14 commands across 3 files:
  - **window_cmd.py**: focus, close, minimize, maximize, restore, move, resize, set-bounds
  - **dialog_cmd.py**: detect, accept, dismiss, click-button, type
  - **desktop_cmd.py**: move-window
- Resolution uses the same pattern as click/type/press: resolve to hwnd only, never leak process_name (#576)
- 14 parametrized tests verify `--app-id` appears in `--help` for each command

## Testing
- 2234 passed, 506 skipped
- `ruff check` clean
- `mypy` clean

**[Dev-Sirius]**