### PR TITLE
fix: standardize --input-mode help text on all action commands (fixes #589)

### DIFF
--- a/naturo/cli/interaction.py
+++ b/naturo/cli/interaction.py
@@ -1193,7 +1193,7 @@ def click_cmd(query, on_text, ref_alias, element_id, coords, double, right, app,
     "--input-mode",
     type=click.Choice(["normal", "hardware", "hook"]),
     default="normal",
-    help="Input method: normal (SendInput), hardware (Phys32), hook (MinHook)",
+    help="Input method: normal (SendInput), hardware (Phys32 driver), hook (MinHook injection)",
 )
 @_method_option
 @_selector_option
@@ -1648,7 +1648,7 @@ def _is_combo(key_str: str) -> bool:
     "--input-mode",
     type=click.Choice(["normal", "hardware", "hook"]),
     default="normal",
-    help="Input method",
+    help="Input method: normal (SendInput), hardware (Phys32 driver), hook (MinHook injection)",
 )
 @_method_option
 @_selector_option
@@ -1922,7 +1922,7 @@ def press(keys, count, delay, hold_duration, on_element, ref_alias, app, pid, wi
     "--input-mode",
     type=click.Choice(["normal", "hardware", "hook"]),
     default="normal",
-    help="Input method",
+    help="Input method: normal (SendInput), hardware (Phys32 driver), hook (MinHook injection)",
 )
 @_method_option
 @_verify_options


### PR DESCRIPTION
## Changes\n- Standardized `--input-mode` help text across all 4 action commands (click, type, press, hotkey)\n- Previously: `press` and `hotkey` showed only \"Input method\" with no description of modes; `type` had a shortened version\n- Now: all consistently show \"Input method: normal (SendInput), hardware (Phys32 driver), hook (MinHook injection)\"\n\n## Testing\n- 33 CLI tests passed, ruff clean\n- Verified all 4 occurrences match with grep\n\n**[Dev-Sirius]**