### PR TITLE
fix: add usage examples to menu-inspect --help (fixes #591)

### DIFF
--- a/naturo/cli/core.py
+++ b/naturo/cli/core.py
@@ -1407,6 +1407,13 @@ def menu_inspect(app, flat, json_output):
 
     Traverses the application's MenuBar via UIAutomation and displays
     all menu items with their keyboard shortcuts.
+
+    \b
+    Examples:
+      naturo menu-inspect                     # Foreground app
+      naturo menu-inspect --app notepad       # Specific app
+      naturo menu-inspect --flat              # Flat path list
+      naturo menu-inspect --app notepad --json # JSON output
     """
     if not _platform_supports_gui():
         msg = _platform_error_msg("Menu inspection")


### PR DESCRIPTION
## Changes\n- Added usage examples to `menu-inspect` command's `--help` output\n- Shows common patterns: foreground app, specific app, flat mode, JSON output\n- `menu-inspect` was the only CLI command without examples in its help text\n\n## Testing\n- Verified `naturo menu-inspect --help` now displays examples\n- All 2198 tests still pass\n\n**[Dev-Sirius]**