### PR TITLE
feat: add --app-id to scroll, drag, move, find, highlight, menu-inspect (fixes #593)

### DIFF
--- a/naturo/backends/base.py
+++ b/naturo/backends/base.py
@@ -372,8 +372,13 @@ class Backend(ABC):
         """Click a menu item by path. Not all platforms support this."""
         raise NotImplementedError(f"menu_click not supported on {self.platform_name}")
 
-    def get_menu_items(self, window_title: Optional[str] = None) -> list:
+    def get_menu_items(self, window_title: Optional[str] = None,
+                       hwnd: Optional[int] = None) -> list:
         """Get structured menu items from the application menu bar.
+
+        Args:
+            window_title: Optional window title or app name filter.
+            hwnd: Optional direct window handle (overrides window_title).
 
         Returns:
             List of MenuItem objects (from naturo.models.menu).

--- a/naturo/backends/macos.py
+++ b/naturo/backends/macos.py
@@ -952,11 +952,13 @@ class MacOSBackend(Backend):
 
     # === Menu ===
 
-    def get_menu_items(self, window_title: Optional[str] = None) -> list:
+    def get_menu_items(self, window_title: Optional[str] = None,
+                       hwnd: Optional[int] = None) -> list:
         """Get menu items from the application menu bar.
 
         Args:
             window_title: Application name to inspect menus for.
+            hwnd: Window handle (ignored on macOS).
 
         Returns:
             List of menu item dicts.

--- a/naturo/backends/windows.py
+++ b/naturo/backends/windows.py
@@ -3084,7 +3084,8 @@ class WindowsBackend(Backend):
         """Click a menu item. Phase 3 feature."""
         raise NotImplementedError("menu_click coming in Phase 3")
 
-    def get_menu_items(self, window_title: Optional[str] = None) -> List[MenuItem]:
+    def get_menu_items(self, window_title: Optional[str] = None,
+                       hwnd: Optional[int] = None) -> List[MenuItem]:
         """Get menu items using Win32 API with UIA fallback.
 
         Strategy:
@@ -3096,11 +3097,13 @@ class WindowsBackend(Backend):
 
         Args:
             window_title: Optional window title or app name filter.
+            hwnd: Optional direct window handle (overrides window_title).
 
         Returns:
             List of top-level MenuItem objects with nested submenus.
         """
-        handle = self._resolve_hwnd(app=window_title, window_title=window_title)
+        handle = self._resolve_hwnd(app=window_title, window_title=window_title,
+                                    hwnd=hwnd)
 
         # Strategy 1: Win32 Menu API (native menus)
         items = self._get_menu_items_win32(handle)

--- a/naturo/cli/core.py
+++ b/naturo/cli/core.py
@@ -1100,6 +1100,8 @@ def see(app, window_title, hwnd, pid, mode, depth, path, annotate, store_snapsho
 @click.option("--screenshot", type=click.Path(), default=None,
               help="Use existing screenshot (for --ai mode)")
 @click.option("--app", default=None, help="Target app window")
+@click.option("--app-id", "app_id", default=None,
+              help='Stable app/window ID from "naturo app list" output (e.g. a1)')
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.option(
     "--backend", "--method", "-b", "-m",
@@ -1115,7 +1117,7 @@ def see(app, window_title, hwnd, pid, mode, depth, path, annotate, store_snapsho
 @click.option("--api-key", "ai_api_key", default=None,
               help="AI provider API key (overrides env var)")
 def find_cmd(query, query_opt, find_all, role, actionable, depth, limit, ai,
-             ai_provider, ai_model, ai_api_key, screenshot, app, json_output, backend):
+             ai_provider, ai_model, ai_api_key, screenshot, app, app_id, json_output, backend):
     """Search for UI elements matching a query.
 
     Supports fuzzy name matching, role filtering, and combined queries.
@@ -1135,6 +1137,21 @@ def find_cmd(query, query_opt, find_all, role, actionable, depth, limit, ai,
         naturo find "search field" --ai --app "Chrome"  # AI + specific app
         naturo find "OK" --backend msaa          # MSAA for legacy apps
     """
+    # (#593) Resolve --app-id to hwnd before any other logic
+    hwnd = None
+    if app_id is not None:
+        from naturo.app_ids import get_app_id_map
+        id_map = get_app_id_map()
+        entry = id_map.resolve(app_id)
+        if entry is None:
+            msg = f'App ID "{app_id}" not found or expired. Run "naturo app list" to refresh.'
+            if json_output:
+                click.echo(_json_error_str("APP_ID_NOT_FOUND", msg))
+            else:
+                click.echo(f"Error: {msg}", err=True)
+            raise SystemExit(1)
+        hwnd = entry.handle
+
     # Resolve query: --all flag → wildcard, --query option → override positional
     if find_all:
         query = "*"
@@ -1183,7 +1200,7 @@ def find_cmd(query, query_opt, find_all, role, actionable, depth, limit, ai,
 
     try:
         be = _get_backend(json_output)
-        tree = be.get_element_tree(app=app, depth=depth, backend=backend)
+        tree = be.get_element_tree(app=app, hwnd=hwnd, depth=depth, backend=backend)
         if tree is None:
             msg = "No window found or UI tree is empty."
             if json_output:
@@ -1400,14 +1417,31 @@ def _find_with_ai(
 
 @click.command("menu_cmd")
 @click.option("--app", help="Application name")
+@click.option("--app-id", "app_id", default=None,
+              help='Stable app/window ID from "naturo app list" output (e.g. a1)')
 @click.option("--flat", is_flag=True, help="Flatten menu tree into paths")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def menu_inspect(app, flat, json_output):
+def menu_inspect(app, app_id, flat, json_output):
     """List the menu bar structure of the foreground application.
 
     Traverses the application's MenuBar via UIAutomation and displays
     all menu items with their keyboard shortcuts.
     """
+    # (#593) Resolve --app-id to hwnd before any other logic
+    hwnd = None
+    if app_id is not None:
+        from naturo.app_ids import get_app_id_map
+        id_map = get_app_id_map()
+        entry = id_map.resolve(app_id)
+        if entry is None:
+            msg = f'App ID "{app_id}" not found or expired. Run "naturo app list" to refresh.'
+            if json_output:
+                click.echo(_json_error_str("APP_ID_NOT_FOUND", msg))
+            else:
+                click.echo(f"Error: {msg}", err=True)
+            raise SystemExit(1)
+        hwnd = entry.handle
+
     if not _platform_supports_gui():
         msg = _platform_error_msg("Menu inspection")
         if json_output:
@@ -1438,7 +1472,7 @@ def menu_inspect(app, flat, json_output):
             except Exception:
                 pass  # find_process failed for other reasons, fall through
 
-        items = backend.get_menu_items(window_title=app)
+        items = backend.get_menu_items(window_title=app, hwnd=hwnd)
 
         if not items:
             msg = "No menu items found."
@@ -1759,6 +1793,8 @@ def learn(topic):
 @click.option("--ref", "-r", "ref_option", multiple=True, help="Specific refs to highlight (e.g. -r e5 -r e10). Omit for all.")
 @click.option("--app", "-a", help="Application name (partial match)")
 @click.option("--hwnd", type=int, help="Direct window handle")
+@click.option("--app-id", "app_id", default=None,
+              help='Stable app/window ID from "naturo app list" output (e.g. a1)')
 @click.option("--depth", "-d", type=int, default=30, help="Tree depth for element discovery")
 @click.option("--duration", type=float, default=5.0, help="Highlight duration in seconds")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
@@ -1773,7 +1809,7 @@ def learn(topic):
               help="Save annotated screenshot to file instead of live overlay (requires Pillow)")
 @click.option("--filter", "role_filter", default=None,
               help="Filter elements by role (e.g. --filter Button)")
-def highlight(positional_refs, on_ref, ref_option, app, hwnd, depth, duration,
+def highlight(positional_refs, on_ref, ref_option, app, hwnd, app_id, depth, duration,
               json_output, backend, show_all, annotate_path, role_filter):
     """Highlight UI elements on screen with colored borders and labels.
 
@@ -1798,6 +1834,20 @@ def highlight(positional_refs, on_ref, ref_option, app, hwnd, depth, duration,
       naturo highlight --app notepad --duration 10
       naturo highlight --app legacy --backend win32
     """
+    # (#593) Resolve --app-id to hwnd before any other logic
+    if app_id is not None:
+        from naturo.app_ids import get_app_id_map
+        id_map = get_app_id_map()
+        entry = id_map.resolve(app_id)
+        if entry is None:
+            msg = f'App ID "{app_id}" not found or expired. Run "naturo app list" to refresh.'
+            if json_output:
+                click.echo(_json_error_str("APP_ID_NOT_FOUND", msg))
+            else:
+                click.echo(f"Error: {msg}", err=True)
+            raise SystemExit(1)
+        hwnd = entry.handle
+
     import json as _json
     be = _get_backend(json_output)
     try:

--- a/naturo/cli/interaction.py
+++ b/naturo/cli/interaction.py
@@ -1997,10 +1997,11 @@ def hotkey(keys, keys_option, hold_duration, app, window_title, hwnd,
 @click.option("--hwnd", type=int, default=None, help="Window handle (HWND)")
 @_selector_option
 @_method_option
+@_app_id_option
 @_see_options
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 def scroll(direction_arg, direction_option, amount, on_text, ref_alias, element_id, coords,
-           smooth, delay, app, window_title, hwnd, selector, method, see_after, settle,
+           smooth, delay, app, window_title, hwnd, selector, method, app_id, see_after, settle,
            json_output):
     """Scroll in a direction.
 
@@ -2017,6 +2018,12 @@ def scroll(direction_arg, direction_option, amount, on_text, ref_alias, element_
     # --ref is a hidden deprecated alias for --on (#381)
     if ref_alias and not on_text:
         on_text = ref_alias
+
+    # (#593) Resolve --app-id to app/hwnd before any other logic
+    app, hwnd, _pid = _resolve_app_id(app_id, app, hwnd, None, json_output)
+    if app_id and hwnd is None:
+        return  # Error already emitted by _resolve_app_id
+
     direction = direction_arg or direction_option or "down"
     if amount < 1:
         _json_err(f"--amount must be >= 1, got {amount}", json_output, code="INVALID_INPUT")
@@ -2152,10 +2159,11 @@ def scroll(direction_arg, direction_option, amount, on_text, ref_alias, element_
 @click.option("--window-title", "window_title", default=None, hidden=True, help="")
 @click.option("--hwnd", type=int, default=None, help="Window handle (HWND)")
 @_method_option
+@_app_id_option
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 def drag(from_text, from_coords, from_selector, to_text, to_coords, to_selector,
          duration, steps, modifiers, profile, app, window_title, hwnd, method,
-         json_output):
+         app_id, json_output):
     """Drag from one element/position to another.
 
     \b
@@ -2165,6 +2173,11 @@ def drag(from_text, from_coords, from_selector, to_text, to_coords, to_selector,
       naturo drag --from e5 --to-coords 500 300
       naturo drag --from-selector 'app://*/ListItem[@name="File1"]' --to-selector 'app://*/TreeItem[@name="Folder"]'
     """
+    # (#593) Resolve --app-id to app/hwnd before any other logic
+    app, hwnd, _pid = _resolve_app_id(app_id, app, hwnd, None, json_output)
+    if app_id and hwnd is None:
+        return  # Error already emitted by _resolve_app_id
+
     # Resolve element refs (eN) from snapshot for --from and --to (#154)
     import re as _re
     from naturo.snapshot import get_snapshot_manager
@@ -2293,9 +2306,10 @@ def drag(from_text, from_coords, from_selector, to_text, to_coords, to_selector,
 @click.option("--hwnd", type=int, default=None, help="Window handle (HWND)")
 @_selector_option
 @_method_option
+@_app_id_option
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 def move(to_text, coords, element_id, duration, app, window_title, hwnd,
-         selector, method, json_output):
+         selector, method, app_id, json_output):
     """Move the mouse cursor to a target element or coordinates.
 
     \b
@@ -2303,6 +2317,11 @@ def move(to_text, coords, element_id, duration, app, window_title, hwnd,
       naturo move --coords 500 300
       naturo move --selector 'app://*/Button[@name="Save"]'
     """
+    # (#593) Resolve --app-id to app/hwnd before any other logic
+    app, hwnd, _pid = _resolve_app_id(app_id, app, hwnd, None, json_output)
+    if app_id and hwnd is None:
+        return  # Error already emitted by _resolve_app_id
+
     backend = _get_backend(json_output)
 
     # Resolve target: --selector > --coords

--- a/tests/test_cli_consistency.py
+++ b/tests/test_cli_consistency.py
@@ -177,9 +177,16 @@ def test_list_apps_delegates_to_app_list():
     ["dialog", "type"],
     # desktop commands (#584)
     ["desktop", "move-window"],
+    # interaction + core commands (#593)
+    ["scroll"],
+    ["drag"],
+    ["move"],
+    ["find"],
+    ["highlight"],
+    ["menu-inspect"],
 ])
 def test_app_id_option_in_help(cmd_args):
-    """#584: window/dialog/desktop commands must show --app-id in help."""
+    """#584/#593: commands with --app must also show --app-id in help."""
     result = runner.invoke(main, cmd_args + ["--help"])
     assert result.exit_code == 0, f"naturo {' '.join(cmd_args)} --help failed"
     assert "--app-id" in result.output, (


### PR DESCRIPTION
## Changes\n- Added `--app-id` support to 6 commands that were missed in #584:\n  - **interaction.py**: `scroll`, `drag`, `move` — uses existing `_resolve_app_id` helper\n  - **core.py**: `find`, `highlight`, `menu-inspect` — uses inline resolution pattern matching `see`/`capture`\n- Updated `get_menu_items` in `base.py`, `windows.py`, `macos.py` to accept optional `hwnd` parameter\n- Added 6 parametrized test cases to `test_cli_consistency.py`\n\n## Testing\n- 2204 passed, 374 skipped, 155 deselected\n- All 20 `test_app_id_option_in_help` cases pass (14 existing + 6 new)\n- `ruff check` clean, `mypy` clean\n\n**[Dev-Sirius]**