### PR TITLE
fix: replace internal \"Phase N\" labels in user-facing error messages (fixes #597)

### DIFF
--- a/naturo/backends/linux.py
+++ b/naturo/backends/linux.py
@@ -36,88 +36,88 @@ class LinuxBackend(Backend):
             return "x11"
         return "headless"
 
-    # All methods raise NotImplementedError — Phase 7 will implement
+    # All methods raise NotImplementedError — Linux support planned for v0.5.0
     def list_monitors(self):
-        raise NotImplementedError("Linux backend coming in Phase 7")
+        raise NotImplementedError("Linux desktop automation is not yet supported. See https://github.com/AcePeak/naturo#platform-support")
 
     def capture_screen(self, screen_index=0, output_path="capture.png") -> CaptureResult:
-        raise NotImplementedError("Linux backend coming in Phase 7")
+        raise NotImplementedError("Linux desktop automation is not yet supported. See https://github.com/AcePeak/naturo#platform-support")
 
     def capture_window(self, window_title=None, hwnd=None, output_path="capture.png") -> CaptureResult:
-        raise NotImplementedError("Linux backend coming in Phase 7")
+        raise NotImplementedError("Linux desktop automation is not yet supported. See https://github.com/AcePeak/naturo#platform-support")
 
     def list_windows(self) -> list[WindowInfo]:
-        raise NotImplementedError("Linux backend coming in Phase 7")
+        raise NotImplementedError("Linux desktop automation is not yet supported. See https://github.com/AcePeak/naturo#platform-support")
 
     def focus_window(self, title=None, hwnd=None) -> None:
-        raise NotImplementedError("Linux backend coming in Phase 7")
+        raise NotImplementedError("Linux desktop automation is not yet supported. See https://github.com/AcePeak/naturo#platform-support")
 
     def close_window(self, title=None, hwnd=None) -> None:
-        raise NotImplementedError("Linux backend coming in Phase 7")
+        raise NotImplementedError("Linux desktop automation is not yet supported. See https://github.com/AcePeak/naturo#platform-support")
 
     def minimize_window(self, title=None, hwnd=None) -> None:
-        raise NotImplementedError("Linux backend coming in Phase 7")
+        raise NotImplementedError("Linux desktop automation is not yet supported. See https://github.com/AcePeak/naturo#platform-support")
 
     def maximize_window(self, title=None, hwnd=None) -> None:
-        raise NotImplementedError("Linux backend coming in Phase 7")
+        raise NotImplementedError("Linux desktop automation is not yet supported. See https://github.com/AcePeak/naturo#platform-support")
 
     def move_window(self, x=0, y=0, title=None, hwnd=None) -> None:
-        raise NotImplementedError("Linux backend coming in Phase 7")
+        raise NotImplementedError("Linux desktop automation is not yet supported. See https://github.com/AcePeak/naturo#platform-support")
 
     def resize_window(self, width=800, height=600, title=None, hwnd=None) -> None:
-        raise NotImplementedError("Linux backend coming in Phase 7")
+        raise NotImplementedError("Linux desktop automation is not yet supported. See https://github.com/AcePeak/naturo#platform-support")
 
     def set_bounds(self, x=0, y=0, width=800, height=600, title=None, hwnd=None) -> None:
-        raise NotImplementedError("Linux backend coming in Phase 7")
+        raise NotImplementedError("Linux desktop automation is not yet supported. See https://github.com/AcePeak/naturo#platform-support")
 
     def restore_window(self, title=None, hwnd=None) -> None:
-        raise NotImplementedError("Linux backend coming in Phase 7")
+        raise NotImplementedError("Linux desktop automation is not yet supported. See https://github.com/AcePeak/naturo#platform-support")
 
     def find_element(self, selector="", window_title=None) -> Optional[ElementInfo]:
-        raise NotImplementedError("Linux backend coming in Phase 7")
+        raise NotImplementedError("Linux desktop automation is not yet supported. See https://github.com/AcePeak/naturo#platform-support")
 
     def get_element_tree(self, window_title=None, depth=3) -> Optional[ElementInfo]:
-        raise NotImplementedError("Linux backend coming in Phase 7")
+        raise NotImplementedError("Linux desktop automation is not yet supported. See https://github.com/AcePeak/naturo#platform-support")
 
     def click(self, x=None, y=None, element_id=None, button="left", double=False, input_mode="normal") -> None:
-        raise NotImplementedError("Linux backend coming in Phase 7")
+        raise NotImplementedError("Linux desktop automation is not yet supported. See https://github.com/AcePeak/naturo#platform-support")
 
     def type_text(self, text="", delay_ms=5, profile="human", wpm=120, input_mode="normal") -> None:
-        raise NotImplementedError("Linux backend coming in Phase 7")
+        raise NotImplementedError("Linux desktop automation is not yet supported. See https://github.com/AcePeak/naturo#platform-support")
 
     def press_key(self, key="", input_mode="normal") -> None:
-        raise NotImplementedError("Linux backend coming in Phase 7")
+        raise NotImplementedError("Linux desktop automation is not yet supported. See https://github.com/AcePeak/naturo#platform-support")
 
     def hotkey(self, *keys, hold_duration_ms=50) -> None:
-        raise NotImplementedError("Linux backend coming in Phase 7")
+        raise NotImplementedError("Linux desktop automation is not yet supported. See https://github.com/AcePeak/naturo#platform-support")
 
     def scroll(self, direction="down", amount=3, x=None, y=None, smooth=False) -> None:
-        raise NotImplementedError("Linux backend coming in Phase 7")
+        raise NotImplementedError("Linux desktop automation is not yet supported. See https://github.com/AcePeak/naturo#platform-support")
 
     def drag(self, from_x=0, from_y=0, to_x=0, to_y=0, duration_ms=500, steps=10) -> None:
-        raise NotImplementedError("Linux backend coming in Phase 7")
+        raise NotImplementedError("Linux desktop automation is not yet supported. See https://github.com/AcePeak/naturo#platform-support")
 
     def move_mouse(self, x=0, y=0) -> None:
-        raise NotImplementedError("Linux backend coming in Phase 7")
+        raise NotImplementedError("Linux desktop automation is not yet supported. See https://github.com/AcePeak/naturo#platform-support")
 
     def clipboard_get(self) -> str:
-        raise NotImplementedError("Linux backend coming in Phase 7")
+        raise NotImplementedError("Linux desktop automation is not yet supported. See https://github.com/AcePeak/naturo#platform-support")
 
     def clipboard_set(self, text="") -> None:
-        raise NotImplementedError("Linux backend coming in Phase 7")
+        raise NotImplementedError("Linux desktop automation is not yet supported. See https://github.com/AcePeak/naturo#platform-support")
 
     def list_apps(self) -> list[dict]:
-        raise NotImplementedError("Linux backend coming in Phase 7")
+        raise NotImplementedError("Linux desktop automation is not yet supported. See https://github.com/AcePeak/naturo#platform-support")
 
     def launch_app(self, name="") -> None:
-        raise NotImplementedError("Linux backend coming in Phase 7")
+        raise NotImplementedError("Linux desktop automation is not yet supported. See https://github.com/AcePeak/naturo#platform-support")
 
     def quit_app(self, name="", force=False) -> None:
-        raise NotImplementedError("Linux backend coming in Phase 7")
+        raise NotImplementedError("Linux desktop automation is not yet supported. See https://github.com/AcePeak/naturo#platform-support")
 
     def open_uri(self, uri="") -> None:
-        raise NotImplementedError("Linux backend coming in Phase 7")
+        raise NotImplementedError("Linux desktop automation is not yet supported. See https://github.com/AcePeak/naturo#platform-support")
 
     def get_element_value(self, ref=None, automation_id=None, role=None,
                           name=None, app=None, window_title=None, hwnd=None) -> Optional[dict]:
-        raise NotImplementedError("Linux backend coming in Phase 7")
+        raise NotImplementedError("Linux desktop automation is not yet supported. See https://github.com/AcePeak/naturo#platform-support")

--- a/naturo/backends/windows.py
+++ b/naturo/backends/windows.py
@@ -3081,8 +3081,8 @@ class WindowsBackend(Backend):
         return [item.to_dict() for item in items]
 
     def menu_click(self, path: str = "", app: Optional[str] = None) -> None:
-        """Click a menu item. Phase 3 feature."""
-        raise NotImplementedError("menu_click coming in Phase 3")
+        """Click a menu item. Planned for a future release."""
+        raise NotImplementedError("menu_click is not yet implemented")
 
     def get_menu_items(self, window_title: Optional[str] = None,
                        hwnd: Optional[int] = None) -> List[MenuItem]:

--- a/naturo/cli/core.py
+++ b/naturo/cli/core.py
@@ -81,7 +81,7 @@ def _platform_error_msg(feature: str) -> str:
             "Install it from https://github.com/AcePeak/peekaboo"
         )
     if system == "Linux":
-        return f"{feature} is not yet supported on Linux (coming in Phase 7)."
+        return f"{feature} is not yet supported on Linux. See https://github.com/AcePeak/naturo#platform-support"
     return f"{feature} is not supported on {system}."
 
 

--- a/naturo/cli/interaction.py
+++ b/naturo/cli/interaction.py
@@ -1989,7 +1989,7 @@ def hotkey(keys, keys_option, hold_duration, app, window_title, hwnd,
 @click.option("--ref", "ref_alias", hidden=True, help="Deprecated alias for --on")
 @click.option("--id", "element_id", help="Element ID to scroll on")
 @click.option("--coords", nargs=2, type=int, metavar="X Y", help="Coordinates to scroll at")
-@click.option("--smooth", is_flag=True, help="Smooth scrolling (Phase 3)")
+@click.option("--smooth", is_flag=True, help="Smooth scrolling (planned)")
 @click.option("--delay", type=float, help="Delay between scroll steps (ms)")
 @click.option("--app", help="Target application (name or partial match)")
 @click.option("--window", "window_title", default=None, help="Window title pattern (substring match)")

--- a/naturo/cli/system.py
+++ b/naturo/cli/system.py
@@ -22,7 +22,7 @@ def app():
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 def launch(name, args, wait, json_output):
     """Launch an application by name or path."""
-    click.echo("Not implemented yet — coming in Phase 2")
+    click.echo("Not implemented yet. See 'naturo app --help' for available commands.")
 
 
 @app.command(hidden=True)
@@ -32,7 +32,7 @@ def launch(name, args, wait, json_output):
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 def quit(name, pid, force, json_output):
     """Quit an application gracefully (or force kill)."""
-    click.echo("Not implemented yet — coming in Phase 2")
+    click.echo("Not implemented yet. See 'naturo app --help' for available commands.")
 
 
 @app.command(hidden=True)
@@ -40,14 +40,14 @@ def quit(name, pid, force, json_output):
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 def relaunch(name, json_output):
     """Quit and relaunch an application."""
-    click.echo("Not implemented yet — coming in Phase 2")
+    click.echo("Not implemented yet. See 'naturo app --help' for available commands.")
 
 
 @app.command(name="list", hidden=True)
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 def app_list(json_output):
     """List running applications."""
-    click.echo("Not implemented yet — coming in Phase 2")
+    click.echo("Not implemented yet. See 'naturo app --help' for available commands.")
 
 
 # ── menu ────────────────────────────────────────
@@ -68,7 +68,7 @@ def menu():
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 def menu_click(path, app, window_title, hwnd, json_output):
     """Click a menu item by path (e.g. 'File > Save As')."""
-    click.echo("Not implemented yet — coming in Phase 3")
+    click.echo("Not implemented yet. This feature is planned for a future release.")
 
 
 @menu.command(name="list")
@@ -80,7 +80,7 @@ def menu_click(path, app, window_title, hwnd, json_output):
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 def menu_list(app, window_title, hwnd, depth, json_output):
     """List menu items of an application."""
-    click.echo("Not implemented yet — coming in Phase 3")
+    click.echo("Not implemented yet. This feature is planned for a future release.")
 
 
 # ── taskbar (Windows-specific, maps to Peekaboo dock) ──
@@ -100,7 +100,7 @@ def taskbar():
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 def pin(name, json_output):
     """Pin an application to the taskbar."""
-    click.echo("Not implemented yet — coming in Phase 3")
+    click.echo("Not implemented yet. This feature is planned for a future release.")
 
 
 @taskbar.command()
@@ -108,14 +108,14 @@ def pin(name, json_output):
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 def unpin(name, json_output):
     """Unpin an application from the taskbar."""
-    click.echo("Not implemented yet — coming in Phase 3")
+    click.echo("Not implemented yet. This feature is planned for a future release.")
 
 
 @taskbar.command(name="list")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 def taskbar_list(json_output):
     """List taskbar pinned items."""
-    click.echo("Not implemented yet — coming in Phase 3")
+    click.echo("Not implemented yet. This feature is planned for a future release.")
 
 
 # ── tray (Windows-specific, maps to Peekaboo menubar) ──
@@ -134,7 +134,7 @@ def tray():
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 def tray_list(json_output):
     """List system tray icons."""
-    click.echo("Not implemented yet — coming in Phase 3")
+    click.echo("Not implemented yet. This feature is planned for a future release.")
 
 
 @tray.command(name="click")
@@ -144,7 +144,7 @@ def tray_list(json_output):
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 def tray_click(name, double, right, json_output):
     """Click a system tray icon by name."""
-    click.echo("Not implemented yet — coming in Phase 3")
+    click.echo("Not implemented yet. This feature is planned for a future release.")
 
 
 # ── desktop — moved to naturo/cli/desktop_cmd.py (Phase 5A.3) ──


### PR DESCRIPTION
## Changes

- **`linux.py`**: Replaced 28 occurrences of "Linux backend coming in Phase 7" with "Linux desktop automation is not yet supported. See https://github.com/AcePeak/naturo#platform-support"
- **`cli/core.py`**: Updated Linux error message to remove "Phase 7"
- **`cli/system.py`**: Replaced "coming in Phase 2/3" in hidden CLI stubs with user-friendly text
- **`backends/windows.py`**: Updated `menu_click` stub
- **`cli/interaction.py`**: Updated `--smooth` help text from "Phase 3" to "planned"

Internal code comments with "Phase N" are left unchanged — they're not user-facing.

## Testing

- Full suite: 2249 passed, 506 skipped
- Lint (ruff): all checks passed
- Verified error messages on Linux are now clear and actionable

**[Dev-Sirius]**