### PR TITLE
fix: AI Vision JSON parsing fails — handle arrays, code fences, wrapper objects (fixes #611)

### DIFF
--- a/naturo/providers/anthropic_provider.py
+++ b/naturo/providers/anthropic_provider.py
@@ -30,6 +30,7 @@ from naturo.providers.base import (
     VisionResult,
     detect_media_type,
     encode_image_base64,
+    parse_ai_elements_json,
     register_provider,
 )
 
@@ -563,21 +564,7 @@ class AnthropicVisionProvider:
             tokens_used = (response.usage.input_tokens or 0) + (response.usage.output_tokens or 0)
 
         # Parse the JSON response
-        elements = []
-        try:
-            # Extract JSON from response (might have markdown code fences)
-            json_text = raw_text.strip()
-            if json_text.startswith("```"):
-                lines = json_text.split("\n")
-                json_text = "\n".join(
-                    line for line in lines
-                    if not line.strip().startswith("```")
-                )
-            parsed = json.loads(json_text)
-            if isinstance(parsed, dict):
-                elements.append(parsed)
-        except json.JSONDecodeError:
-            logger.warning("Failed to parse element identification as JSON: %s", raw_text[:200])
+        elements = parse_ai_elements_json(raw_text)
 
         return VisionResult(
             description=raw_text.strip(),

--- a/naturo/providers/base.py
+++ b/naturo/providers/base.py
@@ -6,7 +6,10 @@ plus a factory function to instantiate providers by name.
 from __future__ import annotations
 
 import base64
+import json
+import logging
 import os
+import re
 from dataclasses import dataclass, field
 from typing import Any, Optional, Protocol, runtime_checkable
 
@@ -134,6 +137,118 @@ def detect_media_type(image_path: str) -> str:
         ".webp": "image/webp",
         ".bmp": "image/bmp",
     }.get(ext, "image/png")
+
+
+logger = logging.getLogger(__name__)
+
+# Regex to extract JSON from markdown code fences (```json ... ``` or ``` ... ```)
+_CODE_FENCE_RE = re.compile(r"```(?:json)?\s*\n(.*?)\n\s*```", re.DOTALL)
+
+
+def parse_ai_elements_json(raw_text: str) -> list[dict[str, Any]]:
+    """Parse AI vision response text into a list of element dicts.
+
+    Handles common AI response formats:
+    - A plain JSON array: ``[{"role": "Button", ...}, ...]``
+    - JSON wrapped in markdown code fences: ``\\`\\`\\`json\\n[...]\\n\\`\\`\\```
+    - A wrapper object with an array field: ``{"elements": [...]}``
+    - Prose before/after the JSON block
+
+    Args:
+        raw_text: Raw text response from an AI vision provider.
+
+    Returns:
+        List of element dicts. Empty list if parsing fails entirely.
+    """
+    if not raw_text or not raw_text.strip():
+        return []
+
+    json_text = _extract_json_text(raw_text)
+    if json_text is None:
+        logger.warning(
+            "Failed to parse element identification as JSON: %s",
+            raw_text[:200],
+        )
+        return []
+
+    try:
+        parsed = json.loads(json_text)
+    except json.JSONDecodeError:
+        logger.warning(
+            "Failed to parse element identification as JSON: %s",
+            raw_text[:200],
+        )
+        return []
+
+    return _normalize_parsed(parsed)
+
+
+def _extract_json_text(raw_text: str) -> Optional[str]:
+    """Extract JSON string from raw AI response text.
+
+    Tries in order:
+    1. Content inside markdown code fences
+    2. First JSON array ``[...]`` in the text
+    3. First JSON object ``{...}`` in the text
+    4. The entire stripped text as-is
+
+    Args:
+        raw_text: Raw AI response text.
+
+    Returns:
+        Extracted JSON string, or None if nothing looks like JSON.
+    """
+    text = raw_text.strip()
+
+    # 1. Try markdown code fences
+    match = _CODE_FENCE_RE.search(text)
+    if match:
+        return match.group(1).strip()
+
+    # 2. Try to find a JSON array
+    arr_start = text.find("[")
+    if arr_start != -1:
+        arr_end = text.rfind("]")
+        if arr_end > arr_start:
+            return text[arr_start:arr_end + 1]
+
+    # 3. Try to find a JSON object
+    obj_start = text.find("{")
+    if obj_start != -1:
+        obj_end = text.rfind("}")
+        if obj_end > obj_start:
+            return text[obj_start:obj_end + 1]
+
+    # 4. Try the whole thing
+    return text if text else None
+
+
+def _normalize_parsed(parsed: Any) -> list[dict[str, Any]]:
+    """Normalize parsed JSON into a flat list of element dicts.
+
+    Args:
+        parsed: Parsed JSON value (could be list, dict, or other).
+
+    Returns:
+        Flat list of element dicts.
+    """
+    # Already a list — return dicts only
+    if isinstance(parsed, list):
+        return [item for item in parsed if isinstance(item, dict)]
+
+    # A wrapper object — look for a known array field
+    if isinstance(parsed, dict):
+        for key in ("elements", "items", "results", "found_elements"):
+            if key in parsed and isinstance(parsed[key], list):
+                return [item for item in parsed[key] if isinstance(item, dict)]
+        # Single element dict with expected keys (role/name/bounds)
+        if any(k in parsed for k in ("role", "name", "bounds", "label")):
+            return [parsed]
+        # Unknown dict structure — return empty
+        logger.debug("AI returned dict without recognized element keys: %s", list(parsed.keys()))
+        return []
+
+    return []
 
 
 # ── Provider Registry ──────────────────────────

--- a/naturo/providers/ollama_provider.py
+++ b/naturo/providers/ollama_provider.py
@@ -14,6 +14,7 @@ from naturo.errors import AIAnalysisFailedError, AIProviderUnavailableError
 from naturo.providers.base import (
     VisionResult,
     encode_image_base64,
+    parse_ai_elements_json,
     register_provider,
 )
 
@@ -140,19 +141,7 @@ class OllamaVisionProvider:
         result = self._call_ollama(image_path, text_prompt)
 
         # Parse JSON from response
-        try:
-            json_text = result.description.strip()
-            if json_text.startswith("```"):
-                lines = json_text.split("\n")
-                json_text = "\n".join(
-                    line for line in lines
-                    if not line.strip().startswith("```")
-                )
-            parsed = json.loads(json_text)
-            if isinstance(parsed, dict):
-                result.elements = [parsed]
-        except json.JSONDecodeError:
-            logger.warning("Failed to parse Ollama response as JSON: %s", result.description[:200])
+        result.elements = parse_ai_elements_json(result.description)
 
         return result
 

--- a/naturo/providers/openai_provider.py
+++ b/naturo/providers/openai_provider.py
@@ -5,7 +5,6 @@ Requires OPENAI_API_KEY environment variable.
 """
 from __future__ import annotations
 
-import json
 import logging
 import os
 from typing import Any, Optional
@@ -15,6 +14,7 @@ from naturo.providers.base import (
     VisionResult,
     detect_media_type,
     encode_image_base64,
+    parse_ai_elements_json,
     register_provider,
 )
 
@@ -239,20 +239,7 @@ class OpenAIVisionProvider:
         if response.usage:
             tokens_used = (response.usage.prompt_tokens or 0) + (response.usage.completion_tokens or 0)
 
-        elements = []
-        try:
-            json_text = raw_text.strip()
-            if json_text.startswith("```"):
-                lines = json_text.split("\n")
-                json_text = "\n".join(
-                    line for line in lines
-                    if not line.strip().startswith("```")
-                )
-            parsed = json.loads(json_text)
-            if isinstance(parsed, dict):
-                elements.append(parsed)
-        except json.JSONDecodeError:
-            logger.warning("Failed to parse element identification as JSON: %s", raw_text[:200])
+        elements = parse_ai_elements_json(raw_text)
 
         return VisionResult(
             description=raw_text.strip(),

--- a/tests/test_parse_ai_elements_json.py
+++ b/tests/test_parse_ai_elements_json.py
@@ -1,0 +1,140 @@
+"""Tests for parse_ai_elements_json — shared AI response JSON parser.
+
+Covers the fix for #611: AI Vision returns elements but JSON parsing fails.
+"""
+from __future__ import annotations
+
+import pytest
+
+from naturo.providers.base import parse_ai_elements_json
+
+
+class TestPlainJsonArray:
+    """AI returns a clean JSON array."""
+
+    def test_flat_array(self) -> None:
+        raw = '[{"role": "Button", "name": "OK", "bounds": {"x": 10, "y": 20, "width": 80, "height": 30}}]'
+        result = parse_ai_elements_json(raw)
+        assert len(result) == 1
+        assert result[0]["role"] == "Button"
+        assert result[0]["name"] == "OK"
+
+    def test_multiple_elements(self) -> None:
+        raw = '[{"role": "Button", "name": "OK"}, {"role": "Input", "name": "Search"}]'
+        result = parse_ai_elements_json(raw)
+        assert len(result) == 2
+
+    def test_empty_array(self) -> None:
+        assert parse_ai_elements_json("[]") == []
+
+
+class TestMarkdownCodeFences:
+    """AI wraps JSON in markdown code fences."""
+
+    def test_json_fenced(self) -> None:
+        raw = '```json\n[{"role": "Button", "name": "Save"}]\n```'
+        result = parse_ai_elements_json(raw)
+        assert len(result) == 1
+        assert result[0]["name"] == "Save"
+
+    def test_plain_fenced(self) -> None:
+        raw = '```\n[{"role": "Tab", "name": "Home"}]\n```'
+        result = parse_ai_elements_json(raw)
+        assert len(result) == 1
+
+    def test_prose_before_fence(self) -> None:
+        raw = (
+            "Here are the UI elements I found:\n\n"
+            '```json\n[{"role": "Link", "name": "Settings"}]\n```\n\n'
+            "These elements are interactive."
+        )
+        result = parse_ai_elements_json(raw)
+        assert len(result) == 1
+        assert result[0]["role"] == "Link"
+
+
+class TestProseWithEmbeddedJson:
+    """AI returns prose with JSON embedded (no code fences)."""
+
+    def test_prose_then_array(self) -> None:
+        raw = (
+            'Looking at this interface, I can see:\n'
+            '[{"role": "Button", "name": "Submit", "bounds": {"x": 100, "y": 200, "width": 80, "height": 30}}]'
+        )
+        result = parse_ai_elements_json(raw)
+        assert len(result) == 1
+        assert result[0]["name"] == "Submit"
+
+    def test_prose_then_object(self) -> None:
+        raw = (
+            'I found the following element:\n'
+            '{"role": "Button", "name": "Close", "bounds": {"x": 50, "y": 10, "width": 30, "height": 30}}'
+        )
+        result = parse_ai_elements_json(raw)
+        assert len(result) == 1
+        assert result[0]["name"] == "Close"
+
+
+class TestWrapperObject:
+    """AI returns a wrapper object containing an elements array."""
+
+    def test_elements_key(self) -> None:
+        raw = '{"found": true, "elements": [{"role": "Button", "name": "OK"}]}'
+        result = parse_ai_elements_json(raw)
+        assert len(result) == 1
+        assert result[0]["name"] == "OK"
+
+    def test_items_key(self) -> None:
+        raw = '{"items": [{"role": "Input", "name": "Email"}]}'
+        result = parse_ai_elements_json(raw)
+        assert len(result) == 1
+
+    def test_results_key(self) -> None:
+        raw = '{"results": [{"role": "Tab", "name": "Home"}, {"role": "Tab", "name": "View"}]}'
+        result = parse_ai_elements_json(raw)
+        assert len(result) == 2
+
+    def test_single_element_dict(self) -> None:
+        raw = '{"role": "Button", "name": "Save", "bounds": {"x": 10, "y": 20, "width": 80, "height": 30}}'
+        result = parse_ai_elements_json(raw)
+        assert len(result) == 1
+        assert result[0]["role"] == "Button"
+
+    def test_unknown_wrapper_returns_empty(self) -> None:
+        raw = '{"status": "ok", "count": 5}'
+        assert parse_ai_elements_json(raw) == []
+
+
+class TestEdgeCases:
+    """Edge cases and error handling."""
+
+    def test_empty_string(self) -> None:
+        assert parse_ai_elements_json("") == []
+
+    def test_whitespace_only(self) -> None:
+        assert parse_ai_elements_json("   \n\t  ") == []
+
+    def test_pure_prose_no_json(self) -> None:
+        assert parse_ai_elements_json("I cannot identify any elements in this image.") == []
+
+    def test_invalid_json(self) -> None:
+        assert parse_ai_elements_json("[{invalid json}]") == []
+
+    def test_non_dict_items_filtered(self) -> None:
+        raw = '[{"role": "Button", "name": "OK"}, "not a dict", 42, {"role": "Input", "name": "Search"}]'
+        result = parse_ai_elements_json(raw)
+        assert len(result) == 2
+
+    def test_wrapper_with_empty_elements(self) -> None:
+        raw = '{"elements": []}'
+        assert parse_ai_elements_json(raw) == []
+
+    def test_nested_code_fence_with_wrapper(self) -> None:
+        raw = (
+            "```json\n"
+            '{"elements": [{"role": "Button", "name": "Apply"}]}\n'
+            "```"
+        )
+        result = parse_ai_elements_json(raw)
+        assert len(result) == 1
+        assert result[0]["name"] == "Apply"


### PR DESCRIPTION
## Changes\n- Extract shared `parse_ai_elements_json()` helper to `providers/base.py`\n- Fix 3 bugs in all providers (Anthropic, OpenAI, Ollama):\n  1. Markdown fence stripping only worked if response **started** with ` ``` ` — now uses regex to find fences anywhere\n  2. JSON arrays were silently dropped (only `isinstance(parsed, dict)` was handled) — now correctly returns array elements\n  3. Wrapper objects like `{\"elements\": [...]}` were treated as a single element — now extracts nested arrays\n- Remove duplicated broken parsing code from all 3 providers\n- 20 new tests covering all AI response formats\n\n## Root Cause\nAll three vision providers had identical broken JSON parsing that:\n- Only stripped markdown fences at the start of the response (AI often has prose before the fence)\n- Only handled `dict` results (the prompt asks for an **array**, so correct responses were dropped)\n- Never extracted elements from wrapper objects\n\n## Testing\n- `python -m pytest tests/test_parse_ai_elements_json.py -x -q` — 20 passed\n- `python -m pytest tests/ -x -q -m \"not ui and not integration and not desktop and not windows\"` — 2223 passed\n- `ruff check naturo/providers/` — all passed\n- `mypy naturo/providers/` — all passed\n\n**[Dev-Sirius]**