### PR TITLE
fix: negative element coordinates on 4K/DPI UWP apps (fixes #613)

### DIFF
--- a/naturo/backends/windows.py
+++ b/naturo/backends/windows.py
@@ -158,6 +158,112 @@ class WindowsBackend(Backend):
             return x, y
         return int(x * scale), int(y * scale)
 
+    def _fixup_element_coords(self, root, handle: int):
+        """Fix UIA coordinate mismatch on UWP apps with high-DPI displays.
+
+        On 4K displays with DPI scaling, UWP apps hosted by
+        ApplicationFrameHost can return element coordinates with a large
+        negative offset (e.g. -31991 instead of 777). This happens because
+        UIA returns coordinates in a different DPI context than the calling
+        thread's Per-Monitor v2 context.
+
+        Detection: root element has zero bounds (0,0,0,0) while children
+        have large negative x/y (more than 10000 pixels below zero).
+
+        Fix: get the actual window position via GetWindowRect and compute
+        the offset between where elements are and where they should be.
+
+        Args:
+            root: Root ElementInfo from the C++ DLL.
+            handle: Window handle (HWND).
+
+        Returns:
+            The root element, possibly with corrected coordinates.
+        """
+        # Only trigger when root has zero bounds but children exist
+        root_zero = (root.x == 0 and root.y == 0
+                     and root.width == 0 and root.height == 0)
+        if not root_zero or not root.children:
+            return root
+
+        # Check if children have large negative coordinates
+        first_child = root.children[0]
+        if first_child.x >= -1000 and first_child.y >= -1000:
+            return root  # Coordinates look normal, no fixup needed
+
+        # Get actual window rect via Win32 API
+        try:
+            win_left, win_top, win_right, win_bottom = self._get_window_rect(handle)
+        except Exception:
+            return root  # Can't get window rect — skip fixup
+
+        win_w = win_right - win_left
+        win_h = win_bottom - win_top
+        if win_w <= 0 or win_h <= 0:
+            return root  # Minimized or invalid — skip
+
+        # Fix root element bounds from the actual window rect
+        root.x = win_left
+        root.y = win_top
+        root.width = win_w
+        root.height = win_h
+
+        # Compute the offset: find the first child with reasonable dimensions
+        # and check if its coordinates need correction.
+        # Strategy: try common offsets (multiples of 32768 from 16-bit wrap,
+        # or the direct difference between expected and actual position).
+        child_x = first_child.x
+        child_y = first_child.y
+
+        # Try 32768 increments (16-bit signed wrap)
+        best_offset_x, best_offset_y = 0, 0
+        for multiple in range(1, 4):
+            candidate_x = child_x + 32768 * multiple
+            candidate_y = child_y + 32768 * multiple
+            # Check if corrected position falls within or near the window
+            if (win_left - 200 <= candidate_x <= win_right + 200
+                    and win_top - 200 <= candidate_y <= win_bottom + 200):
+                best_offset_x = 32768 * multiple
+                best_offset_y = 32768 * multiple
+                break
+
+        if best_offset_x == 0 and best_offset_y == 0:
+            # No 32768-multiple worked — try direct offset from window position
+            # The child's dimensions should roughly match the window, so use
+            # the window position as the expected top-left
+            if (abs(first_child.width - win_w) < win_w * 0.3
+                    and abs(first_child.height - win_h) < win_h * 0.3):
+                best_offset_x = win_left - child_x
+                best_offset_y = win_top - child_y
+
+        if best_offset_x == 0 and best_offset_y == 0:
+            return root  # Can't determine correction — leave as-is
+
+        logger.info(
+            "DPI coordinate fixup (#613): applying offset (%+d, %+d) to %d "
+            "elements (window at %d,%d %dx%d)",
+            best_offset_x, best_offset_y,
+            sum(1 for _ in self._iter_elements(root)),
+            win_left, win_top, win_w, win_h,
+        )
+
+        # Apply offset to all elements in the tree (except root, already fixed)
+        for el in self._iter_elements(root):
+            if el is not root:
+                el.x += best_offset_x
+                el.y += best_offset_y
+
+        return root
+
+    @staticmethod
+    def _iter_elements(root):
+        """Yield all elements in the tree via depth-first traversal."""
+        stack = [root]
+        while stack:
+            el = stack.pop()
+            yield el
+            stack.extend(reversed(el.children))
+
     def _ensure_core(self) -> NaturoCore:
         """Lazily load and initialize the native core library.
 
@@ -1934,6 +2040,11 @@ class WindowsBackend(Backend):
 
         if result is None:
             return None
+
+        # (#613) Fix coordinate mismatch on UWP/high-DPI: UIA may return
+        # large negative coords for UWP apps when DPI contexts conflict.
+        if handle:
+            result = self._fixup_element_coords(result, handle)
 
         # Post-process: assign sequential IDs and fill parent_id
         populate_hierarchy(result)

--- a/tests/test_dpi_coord_fixup.py
+++ b/tests/test_dpi_coord_fixup.py
@@ -1,0 +1,221 @@
+"""Tests for DPI coordinate fixup — fix for #613.
+
+Verifies that _fixup_element_coords detects and corrects large negative
+coordinates on UWP apps with high-DPI 4K displays.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+from unittest.mock import patch
+
+import pytest
+
+
+@dataclass
+class _MockElementInfo:
+    """Minimal ElementInfo mock for testing coordinate fixup."""
+    id: str = ""
+    role: str = ""
+    name: str = ""
+    value: Optional[str] = None
+    x: int = 0
+    y: int = 0
+    width: int = 0
+    height: int = 0
+    children: list = field(default_factory=list)
+    parent_id: Optional[str] = None
+    keyboard_shortcut: Optional[str] = None
+    hwnd: Optional[int] = None
+
+
+def _make_uwp_tree_negative_coords():
+    """Create a mock UWP element tree with the #613 negative coords pattern.
+
+    Simulates: Window (0,0 0x0) → Pane (-31991,-31888 2862x1370)
+    Actual window is at (777,880) on a 4K display.
+    """
+    menuitem = _MockElementInfo(
+        role="MenuItem", name="File", x=-31985, y=-31938, width=72, height=48,
+    )
+    document = _MockElementInfo(
+        role="Document", name="Editor", x=-31991, y=-31888, width=2862, height=1370,
+    )
+    pane = _MockElementInfo(
+        role="Pane", name="", x=-31991, y=-31888, width=2862, height=1370,
+        children=[document, menuitem],
+    )
+    root = _MockElementInfo(
+        role="Window", name="*hello - Notepad", x=0, y=0, width=0, height=0,
+        children=[pane],
+    )
+    return root
+
+
+def _make_normal_tree():
+    """Create a normal Win32 app tree with correct coordinates."""
+    button = _MockElementInfo(
+        role="Button", name="OK", x=100, y=200, width=80, height=30,
+    )
+    root = _MockElementInfo(
+        role="Window", name="Chrome", x=0, y=0, width=1920, height=1080,
+        children=[button],
+    )
+    return root
+
+
+def _make_zero_root_normal_children():
+    """Zero-bounds root but children with small/normal coordinates."""
+    button = _MockElementInfo(
+        role="Button", name="OK", x=100, y=200, width=80, height=30,
+    )
+    root = _MockElementInfo(
+        role="Window", name="App", x=0, y=0, width=0, height=0,
+        children=[button],
+    )
+    return root
+
+
+class TestFixupElementCoords:
+    """Test _fixup_element_coords on WindowsBackend."""
+
+    def _get_backend(self):
+        """Create a WindowsBackend with mocked DPI init."""
+        with patch.object(_WindowsBackendClass, "_ensure_dpi_awareness"):
+            return _WindowsBackendClass()
+
+    def test_32768_wrap_correction(self):
+        """Negative coords from 16-bit wrap should be corrected."""
+        backend = self._get_backend()
+        root = _make_uwp_tree_negative_coords()
+
+        # Window is at physical position (777, 880) with size 2862x1370
+        with patch.object(backend, "_get_window_rect", return_value=(777, 880, 3639, 2250)):
+            result = backend._fixup_element_coords(root, handle=12345)
+
+        # Root should now have window bounds
+        assert result.x == 777
+        assert result.y == 880
+        assert result.width == 2862
+        assert result.height == 1370
+
+        # Pane: -31991 + 32768 = 777
+        pane = result.children[0]
+        assert pane.x == 777
+        assert pane.y == 880
+
+        # Document inside pane
+        doc = pane.children[0]
+        assert doc.x == 777
+        assert doc.y == 880
+
+        # MenuItem: -31985 + 32768 = 783
+        menu = pane.children[1]
+        assert menu.x == 783
+        assert menu.y == 830  # -31938 + 32768 = 830
+
+    def test_normal_tree_no_change(self):
+        """Normal tree coordinates should not be modified."""
+        backend = self._get_backend()
+        root = _make_normal_tree()
+
+        result = backend._fixup_element_coords(root, handle=12345)
+
+        assert result.x == 0
+        assert result.y == 0
+        assert result.width == 1920
+        assert result.children[0].x == 100
+        assert result.children[0].y == 200
+
+    def test_zero_root_small_children_no_change(self):
+        """Zero-bounds root with normal children should only fix root bounds."""
+        backend = self._get_backend()
+        root = _make_zero_root_normal_children()
+
+        with patch.object(backend, "_get_window_rect", return_value=(50, 50, 850, 650)):
+            result = backend._fixup_element_coords(root, handle=12345)
+
+        # Root should NOT be fixed (children have normal coords > -1000)
+        # Actually, children x=100, y=200, so first_child.x >= -1000 → returns early
+        assert result.children[0].x == 100
+        assert result.children[0].y == 200
+
+    def test_get_window_rect_fails_gracefully(self):
+        """If GetWindowRect fails, no fixup applied."""
+        backend = self._get_backend()
+        root = _make_uwp_tree_negative_coords()
+
+        with patch.object(backend, "_get_window_rect", side_effect=Exception("no window")):
+            result = backend._fixup_element_coords(root, handle=12345)
+
+        # Coords should be unchanged
+        assert result.children[0].x == -31991
+
+    def test_minimized_window_no_fixup(self):
+        """Minimized window (zero size rect) should not apply fixup."""
+        backend = self._get_backend()
+        root = _make_uwp_tree_negative_coords()
+
+        with patch.object(backend, "_get_window_rect", return_value=(0, 0, 0, 0)):
+            result = backend._fixup_element_coords(root, handle=12345)
+
+        assert result.children[0].x == -31991
+
+    def test_direct_offset_correction(self):
+        """Non-32768 offset should use direct window position correction."""
+        backend = self._get_backend()
+
+        # Simulate a different offset pattern (not 32768 multiple)
+        pane = _MockElementInfo(
+            role="Pane", x=-5000, y=-3000, width=1920, height=1080,
+        )
+        root = _MockElementInfo(
+            role="Window", x=0, y=0, width=0, height=0,
+            children=[pane],
+        )
+
+        # Window at (500, 300), same size as pane
+        with patch.object(backend, "_get_window_rect", return_value=(500, 300, 2420, 1380)):
+            result = backend._fixup_element_coords(root, handle=12345)
+
+        # Root gets window bounds
+        assert result.x == 500
+        assert result.y == 300
+        # Pane: offset = 500 - (-5000) = 5500
+        assert result.children[0].x == 500
+        assert result.children[0].y == 300
+
+    def test_empty_children_no_crash(self):
+        """Root with no children should not crash."""
+        backend = self._get_backend()
+        root = _MockElementInfo(
+            role="Window", x=0, y=0, width=0, height=0, children=[],
+        )
+        result = backend._fixup_element_coords(root, handle=12345)
+        assert result is root
+
+
+# Import the backend class — handle non-Windows gracefully
+try:
+    from naturo.backends.windows import WindowsBackend as _WindowsBackendClass
+except Exception:
+    # On non-Windows, WindowsBackend init might fail. Use a mock-friendly subclass.
+    import sys
+    # Create a minimal WindowsBackend that skips DPI init
+    from naturo.backends import windows as _win_mod
+
+    class _FakeWindowsBackend:
+        """Minimal WindowsBackend for testing coordinate fixup on non-Windows."""
+        _dpi_aware = False
+        _core = None
+        _initialized = False
+
+        def _ensure_dpi_awareness(self):
+            pass
+
+        # Borrow the methods we need to test
+        _fixup_element_coords = _win_mod.WindowsBackend._fixup_element_coords
+        _iter_elements = _win_mod.WindowsBackend._iter_elements
+        _get_window_rect = _win_mod.WindowsBackend._get_window_rect
+
+    _WindowsBackendClass = _FakeWindowsBackend


### PR DESCRIPTION
## Changes\n- Added `_fixup_element_coords()` post-processing step in `WindowsBackend.get_element_tree`\n- Detects root elements with zero bounds (0,0,0,0) but children with large negative coordinates (< -1000)\n- Gets actual window position via `GetWindowRect`\n- Tries 32768-multiple offsets (16-bit signed wrap pattern) and direct offset correction\n- Applies correction to all elements in the tree\n- 7 new tests with mocked `_get_window_rect`\n\n## Root Cause\nOn 4K displays with DPI scaling, UWP apps hosted by `ApplicationFrameHost` return UIA element coordinates with a ~32768 negative offset. For example, a Notepad window at screen position (777, 880) has elements at (-31991, -31888) where `-31991 + 32768 = 777`.\n\nThis is caused by a DPI context mismatch: the Python thread sets `Per-Monitor v2` DPI awareness (`-4`), but UIA returns coordinates for UWP content in a different coordinate space, causing a 16-bit signed wrap.\n\nChrome (Win32) is unaffected because native windows don't go through the `ApplicationFrameHost` DPI layer.\n\n## Design Decision\nFix applied in Python post-processing rather than in the C++ DLL or DPI awareness setup. This is safer (no risk of breaking existing coordinate behavior for non-UWP apps) and testable without a Windows desktop.\n\n## Testing\n- `python -m pytest tests/test_dpi_coord_fixup.py -x -q` — 7 passed\n- `python -m pytest tests/ -x -q -m \"not ui and not integration and not desktop and not windows\"` — 2268 passed\n- `ruff check naturo/backends/windows.py` — passed\n- Requires real 4K+DPI+UWP desktop verification for full confidence\n\n**[Dev-Sirius]**