### PR TITLE
fix: app quit false failure when ghost process survives without windows (fixes #620)

### DIFF
--- a/naturo/process.py
+++ b/naturo/process.py
@@ -641,14 +641,49 @@ def _verify_quit(
         time.sleep(0.5)
         surviving = find_process(name=name)
         if surviving is not None:
-            raise InteractionFailedError(
-                message=(
-                    f"Failed to quit '{name}': target process "
-                    f"(PID {target_pid}) was killed but the application "
-                    f"is still running under PID {surviving.pid}. "
-                    f"Try: naturo app quit --pid {surviving.pid} --force"
-                ),
-            )
+            # #620: A surviving process with no visible windows is a ghost
+            # (e.g. lingering ApplicationFrameHost).  The app is effectively
+            # closed if no windows remain — only fail if windows exist.
+            if _app_has_visible_windows(name, exclude_pid=target_pid):
+                raise InteractionFailedError(
+                    message=(
+                        f"Failed to quit '{name}': target process "
+                        f"(PID {target_pid}) was killed but the application "
+                        f"is still running under PID {surviving.pid}. "
+                        f"Try: naturo app quit --pid {surviving.pid} --force"
+                    ),
+                )
+
+
+def _app_has_visible_windows(name: str, exclude_pid: int | None = None) -> bool:
+    """Check if an app has any visible windows via the backend.
+
+    Used by ``_verify_quit`` to distinguish a true respawn (windows visible)
+    from a ghost host process with no windows (#620).
+
+    Args:
+        name: Application name (fuzzy-matched against process names/titles).
+        exclude_pid: PID to ignore (the already-killed target).
+
+    Returns:
+        True if the app has at least one visible window.
+    """
+    try:
+        from naturo.backends.base import get_backend
+
+        be = get_backend()
+        name_lower = name.lower()
+        for w in be.list_windows():
+            if exclude_pid is not None and w.pid == exclude_pid:
+                continue
+            proc_name = os.path.basename(w.process_name).lower()
+            if name_lower in proc_name or name_lower in w.title.lower():
+                return True
+    except Exception:
+        logger.debug("Backend unavailable for window check of %r", name)
+        # If we can't check windows, assume the worst (still running)
+        return True
+    return False
 
 
 def _force_kill(pid: int, system: str) -> None:

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -5,7 +5,7 @@ from unittest.mock import patch, MagicMock
 from naturo.process import (
     ProcessInfo, find_process, is_running, launch_app, quit_app,
     relaunch_app, list_apps, _list_processes, _verify_quit,
-    _close_all_windows_for_app,
+    _close_all_windows_for_app, _app_has_visible_windows,
     _get_console_session_id, _get_process_session_id,
     _resolve_launch_name, _resolve_pid_from_backend, _LAUNCH_ALIASES,
 )
@@ -569,6 +569,40 @@ class TestQuitApp:
         """When quit was by PID only (no name), verify by PID only."""
         mock_find.return_value = None
         _verify_quit(None, 100, target_pid=100, timeout=0.5)
+
+    @patch("naturo.process._app_has_visible_windows", return_value=False)
+    @patch("naturo.process.find_process")
+    def test_verify_quit_ghost_process_no_windows(self, mock_find, mock_has_windows):
+        """#620: surviving process with no visible windows is not a failure.
+
+        After killing PID 100, find_process finds PID 200 by name, but the
+        surviving process has no visible windows (e.g. lingering AFH host).
+        Quit should succeed because no windows means the app is effectively closed.
+        """
+        def find_side_effect(name=None, pid=None, **kwargs):
+            if pid == 100:
+                return None  # Target PID is dead
+            if name == "notepad":
+                return ProcessInfo(pid=200, name="notepad.exe")
+            return None
+        mock_find.side_effect = find_side_effect
+        # Should NOT raise — surviving process has no windows
+        _verify_quit("notepad", None, target_pid=100, timeout=0.5)
+        mock_has_windows.assert_called_once_with("notepad", exclude_pid=100)
+
+    @patch("naturo.process._app_has_visible_windows", return_value=True)
+    @patch("naturo.process.find_process")
+    def test_verify_quit_respawned_with_windows_still_fails(self, mock_find, mock_has_windows):
+        """#620: surviving process WITH visible windows is a real respawn — still fail."""
+        def find_side_effect(name=None, pid=None, **kwargs):
+            if pid == 100:
+                return None
+            if name == "notepad":
+                return ProcessInfo(pid=200, name="notepad.exe")
+            return None
+        mock_find.side_effect = find_side_effect
+        with pytest.raises(InteractionFailedError, match="still running"):
+            _verify_quit("notepad", None, target_pid=100, timeout=0.5)
 
 
 class TestResolvePidFromBackend:


### PR DESCRIPTION
## Changes
- Added `_app_has_visible_windows()` helper that checks the backend window list
- `_verify_quit()` now only fails if the surviving process has visible windows
- Ghost processes (e.g. lingering ApplicationFrameHost) without windows are treated as successful quits
- 2 new tests: ghost process passes, real respawn with windows still fails

## Root Cause
After killing the target PID, `_verify_quit` called `find_process(name=name)` which found a surviving host process (like ApplicationFrameHost PID 37476) by name match. It reported failure even though the app had no visible windows and `naturo list apps` showed nothing.

## Testing
- `python -m pytest tests/test_process.py -x -q -k verify_quit` — 5 passed
- `python -m pytest tests/ -x -q -m "not ui and not integration and not desktop and not windows"` — 2262 passed
- `ruff check naturo/process.py` — all passed

**[Dev-Sirius]**