### PR TITLE
fix: add --raw flag to type command to disable escape interpretation (fixes #619)

### DIFF
--- a/naturo/cli/interaction.py
+++ b/naturo/cli/interaction.py
@@ -1251,12 +1251,13 @@ def click_cmd(query, on_text, ref_alias, element_id, coords, double, right, app,
 @_app_id_option
 @_verify_options
 @_see_options
+@click.option("--raw", is_flag=True, help="Disable escape sequence interpretation (type text literally)")
 @click.option("--process-name", "app", default=None, hidden=True, help="")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 def type_cmd(text, delay, profile, wpm, press_return, tab_count, escape,
              delete, clear, paste_mode, file_path, restore, on_element, ref_alias, app, pid,
              window_title, hwnd, input_mode, method, selector, app_id, verify, see_after,
-             settle, json_output):
+             settle, raw, json_output):
     """Type text with configurable speed and profile.
 
     TEXT is the string to type. Supports human-like variable-speed typing
@@ -1314,8 +1315,8 @@ def type_cmd(text, delay, profile, wpm, press_return, tab_count, escape,
     # Interpret C-style escape sequences (\t, \n, \r, \\) in text so that
     # shell-provided literal backslash+letter sequences become real whitespace
     # characters.  File-sourced text (--file) already contains real characters,
-    # so skip processing for that path.
-    if text and not file_path:
+    # so skip processing for that path.  --raw disables this entirely (#619).
+    if text and not file_path and not raw:
         text = (
             text.replace("\\\\", "\x00")   # placeholder for literal backslash
             .replace("\\t", "\t")

--- a/tests/test_type_paste_and_on.py
+++ b/tests/test_type_paste_and_on.py
@@ -356,6 +356,43 @@ class TestTypeEscapeSequences:
         # Clipboard should receive the processed text with real tab
         mock_backend.clipboard_set.assert_called_once_with("A\tB")
 
+    @_win_only
+    def test_type_raw_disables_escape_interpretation(self, runner):
+        """#619: --raw flag types text literally without escape processing."""
+        from naturo.cli.interaction import type_cmd
+
+        mock_backend = MagicMock()
+
+        with patch("naturo.cli.interaction._get_backend", return_value=mock_backend), \
+             patch("naturo.cli.interaction._auto_route", return_value={}):
+            result = runner.invoke(type_cmd, [
+                r"C:\Users\test\report.txt", "--raw", "--json", "--no-verify",
+            ])
+
+        data = json.loads(result.output)
+        assert data["success"] is True
+        typed_text = mock_backend.type_text.call_args[0][0]
+        # With --raw, backslash sequences should NOT be interpreted
+        assert typed_text == r"C:\Users\test\report.txt"
+        assert "\t" not in typed_text
+        assert "\r" not in typed_text
+
+    @_win_only
+    def test_type_without_raw_still_interprets_escapes(self, runner):
+        """Without --raw, escape sequences are still interpreted as before."""
+        from naturo.cli.interaction import type_cmd
+
+        mock_backend = MagicMock()
+
+        with patch("naturo.cli.interaction._get_backend", return_value=mock_backend), \
+             patch("naturo.cli.interaction._auto_route", return_value={}):
+            result = runner.invoke(type_cmd, [r"A\tB", "--json", "--no-verify"])
+
+        data = json.loads(result.output)
+        assert data["success"] is True
+        typed_text = mock_backend.type_text.call_args[0][0]
+        assert typed_text == "A\tB"  # \t still becomes real tab
+
 
 class TestTypeNewlineBypassesUIA:
     """When text contains \\n or \\r, type must bypass UIA SetValue (#563).


### PR DESCRIPTION
## Changes
- Added `--raw` flag to `type` command that disables C-style escape sequence interpretation
- When `--raw` is set, `\t`, `\n`, `\r` are typed literally instead of being converted to tab/newline/CR
- 2 new tests verifying raw mode and that default escape behavior is preserved

## Root Cause
Windows file paths like `C:\Users\test\report.txt` get corrupted: `\t` becomes tab, `\r` is consumed. The existing `\\` escape works but requires users to double-escape every backslash, which is impractical for paths.

## Usage
```bash
naturo type 'C:\Users\test\report.txt' --raw --app notepad
```

## Testing
- `python -m pytest tests/test_type_paste_and_on.py -x -q` — all passed (raw tests skip on Linux as expected)
- `python -m pytest tests/ -x -q -m "not ui and not integration and not desktop and not windows"` — 2318 passed
- `ruff check naturo/cli/interaction.py` — passed

**[Dev-Sirius]**