### PR TITLE
docs: add --raw flag to type command documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,9 @@ naturo desktop create --name "Work"        # Create named desktop
 naturo desktop close                       # Close current desktop
 naturo desktop move-window 1 --app "Notepad"  # Move window to desktop 1
 
+# Type Windows paths literally (--raw disables escape interpretation)
+naturo type "C:\Users\test\report.txt" --raw --app notepad
+
 # Paste text via clipboard (fast for large content)
 naturo type "large content" --paste        # Set clipboard → Ctrl+V → restore
 naturo type --paste --file data.txt        # Read file → paste

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -607,6 +607,7 @@ Type text with configurable speed and profile.
 | `--pid` | integer | Process ID |
 | `--window` | text | Window title pattern (substring match) |
 | `--hwnd` | integer | Window handle (HWND) |
+| `--raw` | boolean | Disable escape sequence interpretation (type text literally) |
 | `--input-mode` | {normal, hardware, hook} | Input method: normal (SendInput), hardware (Phys32), hook (MinHook) (default: `normal`) |
 | `--method`, `-m` | {auto, cdp, uia, msaa, ia2, jab, vision} | Interaction method override: auto (default), cdp, uia, msaa, ia2, jab, vision. Bypasses auto-detection when set explicitly. |
 | `--selector` | text | Unified selector to locate target element. URI format: app://notepad.exe/Button[@name="Save"]. XML format: <selector app="notepad.exe"><node role="Button" name="Save"/></selector>. |
@@ -628,6 +629,7 @@ naturo type --paste                        # paste current clipboard
 naturo type "hello" --on e42               # click e42 then type
 naturo type "hello" --on e42 --app feishu  # target app + element
 naturo type "hello" --selector 'app://notepad.exe/Edit[@automationid="15"]'
+naturo type "C:\Users\test\report.txt" --raw  # literal backslashes (no escape)
 ```
 
 ---


### PR DESCRIPTION
## Changes
- Added `--raw` example to README (typing Windows paths literally)
- Added `--raw` flag to CLI_REFERENCE.md options table and examples

Follows up on PR #624 which added the `--raw` flag to the `type` command.

**[Dev-Sirius]**