### PR TITLE
feat: wire CDP into cascade — see/click web content inside Chrome/Electron (fixes #617)

### DIFF
--- a/naturo/cascade.py
+++ b/naturo/cascade.py
@@ -253,18 +253,19 @@ def _fetch_cdp_elements(
 
     try:
         client = CDPClient(port=debug_port)
-        # Fetch interactive elements using DOM.querySelectorAll
-        # This is a best-effort list of common interactive selectors
-        SELECTOR = (
-            "button, input, textarea, select, a[href], "
-            "[role='button'], [role='checkbox'], [role='combobox'], "
-            "[role='menuitem'], [role='option'], [role='tab'], "
-            "[role='textbox'], [role='link'], [onclick], "
-            "[tabindex]:not([tabindex='-1'])"
-        )
-        dom_elements = client.query_selector_all(SELECTOR)
+        client.connect()
+        try:
+            dom_elements = client.get_interactive_elements()
+        finally:
+            client.close()
+
         elements: List[ElementInfo] = []
         px, py = parent_bounds[0], parent_bounds[1]
+
+        _ROLE_MAP = {
+            "button": "Button", "input": "Edit", "a": "Link",
+            "textarea": "Edit", "select": "ComboBox",
+        }
 
         for dom_el in dom_elements:
             bounds = dom_el.get("bounds", {})
@@ -273,24 +274,29 @@ def _fetch_cdp_elements(
             ew = int(bounds.get("width", 0))
             eh = int(bounds.get("height", 0))
 
-            if ew == 0 or eh == 0:
-                continue  # Invisible element
+            if ew <= 0 or eh <= 0:
+                continue
 
-            tag = dom_el.get("tagName", "").lower()
-            role_map = {"button": "Button", "input": "Edit", "a": "Link",
-                        "textarea": "Edit", "select": "ComboBox"}
-            aria_role = dom_el.get("ariaRole", "")
-            role = aria_role.capitalize() or role_map.get(tag, "Text")
+            tag = dom_el.get("tagName", "")
+            raw_role = dom_el.get("role", "")
+            role = raw_role.capitalize() if raw_role else _ROLE_MAP.get(tag, "Text")
+            name = dom_el.get("name", "")
+            css_selector = dom_el.get("selector", "")
 
-            el_id = f"cdp_{dom_el.get('nodeId', id(dom_el))}"
+            el_id = f"cdp_{dom_el.get('nodeIndex', id(dom_el))}"
             elements.append(ElementInfo(
                 id=el_id,
                 role=role,
-                name=dom_el.get("ariaLabel") or dom_el.get("textContent", "")[:80],
+                name=name,
                 value=dom_el.get("value"),
                 x=ex, y=ey, width=ew, height=eh,
                 children=[],
-                properties={"source": "cdp", "tag": tag, "parent_id": None},
+                properties={
+                    "source": "cdp",
+                    "tag": tag,
+                    "css_selector": css_selector,
+                    "parent_id": None,
+                },
             ))
 
         return elements
@@ -639,19 +645,11 @@ def _try_cdp_for_hwnd(
     Returns:
         List of tagged CDP elements, or empty list.
     """
-    if pid is None:
-        return []
-
-    try:
-        from naturo.electron import get_debug_port
-        debug_port = get_debug_port(pid)
-    except Exception:
-        return []
-
+    debug_port = find_cdp_port(pid)
     if not debug_port:
         return []
 
-    elements = _fetch_cdp_elements(pid, debug_port, bounds)
+    elements = _fetch_cdp_elements(pid or 0, debug_port, bounds)
     return [_tag_source(el, "cdp") for el in elements]
 
 
@@ -695,6 +693,184 @@ def _try_backend_for_hwnd(
     return tagged.children
 
 
+# ── CDP port discovery ───────────────────────────────────────────────────────
+
+
+def find_cdp_port(pid: Optional[int] = None) -> Optional[int]:
+    """Find an active CDP debug port for a process or on common ports.
+
+    Checks the process command line for ``--remote-debugging-port=<N>``,
+    then falls back to probing common ports (9222, 9229, 9333).
+
+    Args:
+        pid: Process ID to check.  When ``None``, only probes common ports.
+
+    Returns:
+        Port number if a CDP endpoint responds, ``None`` otherwise.
+    """
+    import platform
+
+    # Phase 1: check process command line (Windows only)
+    if pid is not None and platform.system() == "Windows":
+        try:
+            import subprocess
+
+            result = subprocess.run(
+                ["wmic", "process", "where", f"ProcessId={pid}",
+                 "get", "CommandLine", "/format:list"],
+                capture_output=True, text=True, timeout=5,
+            )
+            if result.returncode == 0:
+                for line in result.stdout.splitlines():
+                    if "--remote-debugging-port=" in line:
+                        for part in line.split():
+                            if part.startswith("--remote-debugging-port="):
+                                port_str = part.split("=", 1)[1]
+                                return int(port_str)
+        except Exception as exc:
+            logger.debug("Failed to get command line for PID %d: %s", pid, exc)
+
+    # Phase 2: probe common debug ports via HTTP
+    for port in [9222, 9229, 9333]:
+        try:
+            import urllib.request
+            import urllib.error
+
+            url = f"http://127.0.0.1:{port}/json/version"
+            req = urllib.request.Request(url)
+            with urllib.request.urlopen(req, timeout=1.0) as resp:
+                if resp.status == 200:
+                    return port
+        except Exception:
+            pass
+
+    return None
+
+
+# ── CDP-only mode ────────────────────────────────────────────────────────────
+
+
+def _run_cdp_only(
+    backend,
+    *,
+    app: Optional[str] = None,
+    window_title: Optional[str] = None,
+    hwnd: Optional[int] = None,
+    pid: Optional[int] = None,
+    depth: int = 3,
+) -> CascadeResult:
+    """Run CDP as the primary provider, with UIA for window chrome.
+
+    Used when ``--backend cdp`` is specified explicitly.  Fetches web
+    content via CDP and optionally enriches with UIA for non-web UI
+    (address bar, tabs, toolbars).
+
+    Args:
+        backend: Platform backend instance.
+        app: Target application name.
+        window_title: Window title filter.
+        hwnd: Window handle.
+        pid: Process ID.
+        depth: Max tree depth for UIA fallback.
+
+    Returns:
+        CascadeResult with CDP elements (and optional UIA chrome).
+    """
+    stats = CascadeStats()
+
+    # Resolve PID if only app name given
+    resolved_pid = pid
+    if resolved_pid is None and app is not None:
+        try:
+            from naturo.process import find_process
+            proc = find_process(name=app)
+            if proc is not None:
+                resolved_pid = proc.pid
+        except Exception:
+            pass
+
+    # Find CDP port
+    debug_port = find_cdp_port(resolved_pid)
+
+    if debug_port is None:
+        logger.warning(
+            "CDP: No debug port found. Start Chrome/Electron with "
+            "--remote-debugging-port=9222 to enable CDP."
+        )
+        stats.providers.append(ProviderStat(
+            name="cdp", status="error",
+        ))
+        return CascadeResult(tree=None, stats=stats, primary_provider="cdp")
+
+    # Get UIA tree first for window structure (address bar, tabs, etc.)
+    t0 = time.monotonic()
+    root_tree: Optional[ElementInfo] = None
+    try:
+        tree = backend.get_element_tree(
+            app=app, window_title=window_title, hwnd=hwnd, pid=pid,
+            depth=depth, backend="uia",
+        )
+        if tree is not None:
+            root_tree = _tag_source(tree, "uia")
+    except Exception as exc:
+        logger.debug("CDP mode: UIA tree failed (non-fatal): %s", exc)
+    uia_elapsed = (time.monotonic() - t0) * 1000
+
+    if root_tree is not None:
+        uia_flat = _flatten(root_tree)
+        stats.providers.append(ProviderStat(
+            name="uia", elements=len(uia_flat),
+            elapsed_ms=uia_elapsed, status="ok",
+        ))
+
+    # Fetch CDP elements
+    t0 = time.monotonic()
+    bounds = (
+        (root_tree.x, root_tree.y, root_tree.width, root_tree.height)
+        if root_tree is not None
+        else (0, 0, 1920, 1080)
+    )
+    cdp_elements = _fetch_cdp_elements(resolved_pid or 0, debug_port, bounds)
+    cdp_elapsed = (time.monotonic() - t0) * 1000
+
+    if cdp_elements:
+        stats.providers.append(ProviderStat(
+            name="cdp", elements=len(cdp_elements),
+            elapsed_ms=cdp_elapsed, status="ok",
+        ))
+        # Merge CDP elements into root tree (or create a synthetic root)
+        if root_tree is not None:
+            for el in cdp_elements:
+                root_tree.children.append(_tag_source(el, "cdp"))
+        else:
+            root_tree = ElementInfo(
+                id="root",
+                role="Window",
+                name=app or window_title or "Browser",
+                value=None,
+                x=bounds[0], y=bounds[1],
+                width=bounds[2], height=bounds[3],
+                children=[_tag_source(el, "cdp") for el in cdp_elements],
+                properties={"source": "cdp"},
+            )
+    else:
+        stats.providers.append(ProviderStat(
+            name="cdp", elapsed_ms=cdp_elapsed, status="no_elements",
+        ))
+
+    # Final stats
+    if root_tree is not None:
+        all_flat = _flatten(root_tree)
+        stats.total_elements = len(all_flat)
+        window_area = _window_area(root_tree)
+        if window_area > 0:
+            stats.coverage_estimate = _estimate_coverage(all_flat[1:], window_area)
+
+    return CascadeResult(
+        tree=root_tree, stats=stats, primary_provider="cdp",
+    )
+
+
 # ── Main cascade entry point ──────────────────────────────────────────────────
 
 
@@ -729,8 +905,11 @@ def run_cascade(
     depth:
         Maximum tree depth for UIA/MSAA probes.
     backend_name:
-        Base accessibility backend: ``"uia"`` | ``"msaa"`` | ``"ia2"`` | ``"jab"`` | ``"auto"``.
+        Base accessibility backend: ``"uia"`` | ``"msaa"`` | ``"ia2"`` | ``"jab"`` |
+        ``"cdp"`` | ``"auto"`` | ``"hybrid"``.
         When ``"auto"``, each provider is tried in cascade order.
+        When ``"cdp"``, uses Chrome DevTools Protocol directly (browser must
+        have ``--remote-debugging-port`` enabled).
     coverage_target:
         When >0, also run CDP if UIA coverage < this threshold (0.0–1.0).
         Ignored when ``backend_name`` is ``"auto"`` (always cascades).
@@ -772,6 +951,13 @@ def run_cascade(
             tree=tree,
             stats=stats,
             primary_provider="hybrid",
+        )
+
+    # ── CDP-only mode: explicit --backend cdp ────────────────────────────
+    if backend_name == "cdp":
+        return _run_cdp_only(
+            backend, app=app, window_title=window_title,
+            hwnd=hwnd, pid=pid, depth=depth,
         )
 
     stats = CascadeStats()
@@ -852,16 +1038,17 @@ def run_cascade(
             debug_port: Optional[int] = None
 
             try:
-                # Try to detect CDP debug port for this app
-                from naturo.electron import get_debug_port
-                if pid:
-                    debug_port = get_debug_port(pid)
-                elif app:
-                    # Resolve app to PID
-                    from naturo.process import find_processes
-                    procs = find_processes(app)
-                    if procs:
-                        debug_port = get_debug_port(procs[0].pid)
+                # Try Electron-specific detection first, then generic CDP
+                try:
+                    from naturo.electron import get_debug_port as _electron_port
+                    if app:
+                        debug_port = _electron_port(app)
+                except Exception:
+                    pass
+
+                # Fall back to generic CDP port discovery (Chrome, Edge, etc.)
+                if debug_port is None:
+                    debug_port = find_cdp_port(pid)
             except Exception as exc:
                 logger.debug("CDP port detection failed: %s", exc)
 

--- a/naturo/cdp.py
+++ b/naturo/cdp.py
@@ -563,6 +563,89 @@ class CDPClient:
         """
         return self.evaluate("window.location.href") or ""
 
+    def get_interactive_elements(
+        self,
+        selector: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """Get interactive DOM elements with bounding boxes and metadata.
+
+        Evaluates JavaScript in the page to collect all interactive elements
+        (buttons, inputs, links, etc.) along with their bounding rectangles,
+        ARIA roles, labels, and tag names.
+
+        Args:
+            selector: Optional CSS selector override.  When ``None``, uses a
+                built-in selector that captures common interactive elements.
+
+        Returns:
+            List of dicts, each with keys:
+                - ``tagName`` (str): Lowercase HTML tag.
+                - ``role`` (str): ARIA role or inferred role.
+                - ``name`` (str): Accessible name (aria-label, title, text).
+                - ``value`` (str | None): Form element value.
+                - ``bounds`` (dict): ``{x, y, width, height}`` in viewport px.
+                - ``selector`` (str): CSS selector for re-targeting.
+                - ``nodeIndex`` (int): Ordinal index in the result set.
+
+        Raises:
+            CDPError: If not connected or evaluation fails.
+        """
+        if selector is None:
+            selector = (
+                "button, input, textarea, select, a[href], "
+                "[role='button'], [role='checkbox'], [role='combobox'], "
+                "[role='menuitem'], [role='option'], [role='tab'], "
+                "[role='textbox'], [role='link'], [onclick], "
+                "[tabindex]:not([tabindex='-1'])"
+            )
+
+        js = f"""
+        (() => {{
+            const sel = {json.dumps(selector)};
+            const els = Array.from(document.querySelectorAll(sel));
+            const seen = new Set();
+            const results = [];
+            for (let i = 0; i < els.length; i++) {{
+                const el = els[i];
+                if (seen.has(el)) continue;
+                seen.add(el);
+                const rect = el.getBoundingClientRect();
+                if (rect.width === 0 && rect.height === 0) continue;
+                const tag = el.tagName.toLowerCase();
+                const ariaRole = el.getAttribute('role') || '';
+                const ariaLabel = el.getAttribute('aria-label') || '';
+                const title = el.getAttribute('title') || '';
+                const text = (el.innerText || '').trim().substring(0, 80);
+                const name = ariaLabel || title || el.getAttribute('alt') || text;
+                const value = ('value' in el) ? (el.value || null) : null;
+                results.push({{
+                    tagName: tag,
+                    role: ariaRole || tag,
+                    name: name,
+                    value: value,
+                    bounds: {{
+                        x: Math.round(rect.x),
+                        y: Math.round(rect.y),
+                        width: Math.round(rect.width),
+                        height: Math.round(rect.height),
+                    }},
+                    selector: tag + (el.id ? '#' + el.id : '') +
+                              (el.className && typeof el.className === 'string'
+                               ? '.' + el.className.trim().split(/\\s+/).join('.')
+                               : ''),
+                    nodeIndex: i,
+                }});
+            }}
+            return results;
+        }})()
+        """
+        result = self.evaluate(js)
+        if result is None:
+            return []
+        if not isinstance(result, list):
+            return []
+        return result
+
     def wait_for_selector(
         self,
         selector: str,

--- a/naturo/cli/core.py
+++ b/naturo/cli/core.py
@@ -595,9 +595,9 @@ def permissions(json_output):
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.option(
     "--backend", "--method", "-b", "-m",
-    type=click.Choice(["uia", "msaa", "ia2", "jab", "win32", "win32hybrid", "auto", "hybrid"]),
+    type=click.Choice(["uia", "msaa", "ia2", "jab", "cdp", "win32", "win32hybrid", "auto", "hybrid"]),
     default="auto",
-    help="Accessibility backend / interaction method: auto (default: tries all), uia, msaa (legacy apps), ia2 (Firefox/Thunderbird), jab (Java/Swing), win32 (VB6/ActiveX), hybrid (per-node backend selection)",
+    help="Accessibility backend / interaction method: auto (default: tries all), uia, msaa (legacy apps), ia2 (Firefox/Thunderbird), jab (Java/Swing), cdp (Chrome/Electron web content via DevTools), win32 (VB6/ActiveX), hybrid (per-node backend selection)",
 )
 @click.option("--app-id", "app_id", default=None,
               help='Stable app/window ID from "naturo app list" output (e.g. a1)')
@@ -615,6 +615,9 @@ def see(app, window_title, hwnd, pid, mode, depth, path, annotate, store_snapsho
     don't expose UIAutomation elements. Use --backend ia2 for IA2-enabled
     applications (Firefox, Thunderbird, LibreOffice). Use --backend auto to
     try UIA first, then IA2, then MSAA automatically.
+
+    Use --backend cdp for Chrome/Electron apps with DevTools Protocol enabled.
+    The browser must be started with --remote-debugging-port=9222.
 
     Use --backend hybrid for per-node backend selection — each node in the
     tree picks the optimal backend based on its Win32 class (Electron→CDP,
@@ -1105,9 +1108,9 @@ def see(app, window_title, hwnd, pid, mode, depth, path, annotate, store_snapsho
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.option(
     "--backend", "--method", "-b", "-m",
-    type=click.Choice(["uia", "msaa", "ia2", "jab", "win32", "win32hybrid", "auto", "hybrid"]),
+    type=click.Choice(["uia", "msaa", "ia2", "jab", "cdp", "win32", "win32hybrid", "auto", "hybrid"]),
     default="auto",
-    help="Accessibility backend / interaction method: auto (default: tries all), uia, msaa (legacy apps), ia2 (Firefox/Thunderbird), jab (Java/Swing), win32 (VB6/ActiveX), hybrid (per-node backend selection)",
+    help="Accessibility backend / interaction method: auto (default: tries all), uia, msaa (legacy apps), ia2 (Firefox/Thunderbird), jab (Java/Swing), cdp (Chrome/Electron web content), win32 (VB6/ActiveX), hybrid (per-node backend selection)",
 )
 @click.option("--provider", "ai_provider",
               type=click.Choice(["auto", "anthropic", "openai", "ollama"]),

--- a/tests/test_cdp_cascade.py
+++ b/tests/test_cdp_cascade.py
@@ -1,0 +1,427 @@
+"""Tests for CDP integration in cascade engine and CDPClient.get_interactive_elements.
+
+These tests use full mock coverage and do NOT require a desktop or browser.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch, PropertyMock
+
+import pytest
+
+from naturo.backends.base import ElementInfo
+from naturo.cdp import CDPClient, CDPError
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _make_element(
+    id: str = "e1",
+    role: str = "Button",
+    name: str = "OK",
+    x: int = 100,
+    y: int = 100,
+    width: int = 80,
+    height: int = 30,
+    children: list | None = None,
+    properties: dict | None = None,
+) -> ElementInfo:
+    return ElementInfo(
+        id=id, role=role, name=name, value=None,
+        x=x, y=y, width=width, height=height,
+        children=children or [],
+        properties=properties or {},
+    )
+
+
+def _mock_cdp_ws_client(evaluate_result):
+    """Create a CDPClient with mocked WebSocket that returns evaluate_result."""
+    client = CDPClient(port=9222)
+    mock_ws = MagicMock()
+    mock_ws.connected = True
+    mock_ws.recv.return_value = json.dumps({
+        "id": 1,
+        "result": {"result": {"type": "object", "value": evaluate_result}},
+    })
+    client._ws = mock_ws
+    return client
+
+
+# ── CDPClient.get_interactive_elements ───────────────────────────────────────
+
+
+class TestGetInteractiveElements:
+    """Test the get_interactive_elements method on CDPClient."""
+
+    def test_returns_elements_with_bounds(self):
+        elements = [
+            {
+                "tagName": "button",
+                "role": "button",
+                "name": "Submit",
+                "value": None,
+                "bounds": {"x": 10, "y": 20, "width": 100, "height": 30},
+                "selector": "button#submit",
+                "nodeIndex": 0,
+            },
+            {
+                "tagName": "input",
+                "role": "textbox",
+                "name": "Email",
+                "value": "user@example.com",
+                "bounds": {"x": 10, "y": 60, "width": 200, "height": 25},
+                "selector": "input#email",
+                "nodeIndex": 1,
+            },
+        ]
+        client = _mock_cdp_ws_client(elements)
+        result = client.get_interactive_elements()
+
+        assert len(result) == 2
+        assert result[0]["tagName"] == "button"
+        assert result[0]["name"] == "Submit"
+        assert result[0]["bounds"]["width"] == 100
+        assert result[1]["value"] == "user@example.com"
+
+    def test_returns_empty_list_on_none(self):
+        client = _mock_cdp_ws_client(None)
+        result = client.get_interactive_elements()
+        assert result == []
+
+    def test_returns_empty_list_on_non_list(self):
+        client = _mock_cdp_ws_client("not a list")
+        result = client.get_interactive_elements()
+        assert result == []
+
+    def test_custom_selector(self):
+        client = _mock_cdp_ws_client([])
+        result = client.get_interactive_elements(selector="div.custom")
+        assert result == []
+        # Verify the custom selector was passed in the JS
+        sent = json.loads(client._ws.send.call_args[0][0])
+        assert "div.custom" in sent["params"]["expression"]
+
+    def test_not_connected_raises(self):
+        client = CDPClient()
+        with pytest.raises(CDPError, match="Not connected"):
+            client.get_interactive_elements()
+
+
+# ── cascade._fetch_cdp_elements ──────────────────────────────────────────────
+
+
+class TestFetchCdpElements:
+    """Test cascade._fetch_cdp_elements with mocked CDPClient."""
+
+    def test_fetches_and_converts_elements(self):
+        mock_elements = [
+            {
+                "tagName": "button",
+                "role": "button",
+                "name": "Sign In",
+                "value": None,
+                "bounds": {"x": 50, "y": 100, "width": 120, "height": 35},
+                "selector": "button.login",
+                "nodeIndex": 0,
+            },
+            {
+                "tagName": "a",
+                "role": "link",
+                "name": "Forgot Password",
+                "value": None,
+                "bounds": {"x": 50, "y": 150, "width": 100, "height": 20},
+                "selector": "a.forgot",
+                "nodeIndex": 1,
+            },
+        ]
+
+        mock_client = MagicMock()
+        mock_client.get_interactive_elements.return_value = mock_elements
+
+        with patch("naturo.cdp.CDPClient", return_value=mock_client):
+            from naturo.cascade import _fetch_cdp_elements
+
+            results = _fetch_cdp_elements(
+                pid=1234,
+                debug_port=9222,
+                parent_bounds=(100, 200, 800, 600),
+            )
+
+        assert len(results) == 2
+
+        btn = results[0]
+        assert btn.role == "Button"
+        assert btn.name == "Sign In"
+        # Bounds offset by parent_bounds (100, 200)
+        assert btn.x == 150  # 50 + 100
+        assert btn.y == 300  # 100 + 200
+        assert btn.width == 120
+        assert btn.height == 35
+        assert btn.properties["source"] == "cdp"
+        assert btn.properties["tag"] == "button"
+        assert btn.properties["css_selector"] == "button.login"
+
+        link = results[1]
+        assert link.role == "Link"
+        assert link.name == "Forgot Password"
+
+    def test_skips_zero_dimension_elements(self):
+        mock_elements = [
+            {
+                "tagName": "div",
+                "role": "",
+                "name": "",
+                "value": None,
+                "bounds": {"x": 0, "y": 0, "width": 0, "height": 0},
+                "selector": "div",
+                "nodeIndex": 0,
+            },
+        ]
+
+        mock_client = MagicMock()
+        mock_client.get_interactive_elements.return_value = mock_elements
+
+        with patch("naturo.cdp.CDPClient", return_value=mock_client):
+            from naturo.cascade import _fetch_cdp_elements
+
+            results = _fetch_cdp_elements(
+                pid=1234, debug_port=9222, parent_bounds=(0, 0, 800, 600),
+            )
+
+        assert len(results) == 0
+
+    def test_returns_empty_on_connection_error(self):
+        mock_client = MagicMock()
+        mock_client.connect.side_effect = Exception("Connection refused")
+
+        with patch("naturo.cdp.CDPClient", return_value=mock_client):
+            from naturo.cascade import _fetch_cdp_elements
+
+            results = _fetch_cdp_elements(
+                pid=1234, debug_port=9222, parent_bounds=(0, 0, 800, 600),
+            )
+
+        assert results == []
+
+    def test_role_mapping_fallback(self):
+        """When role is empty, falls back to tag-based role mapping."""
+        mock_elements = [
+            {
+                "tagName": "input",
+                "role": "",
+                "name": "Username",
+                "value": "",
+                "bounds": {"x": 10, "y": 10, "width": 200, "height": 25},
+                "selector": "input#user",
+                "nodeIndex": 0,
+            },
+            {
+                "tagName": "select",
+                "role": "",
+                "name": "Country",
+                "value": "US",
+                "bounds": {"x": 10, "y": 50, "width": 200, "height": 25},
+                "selector": "select#country",
+                "nodeIndex": 1,
+            },
+        ]
+
+        mock_client = MagicMock()
+        mock_client.get_interactive_elements.return_value = mock_elements
+
+        with patch("naturo.cdp.CDPClient", return_value=mock_client):
+            from naturo.cascade import _fetch_cdp_elements
+
+            results = _fetch_cdp_elements(
+                pid=1, debug_port=9222, parent_bounds=(0, 0, 800, 600),
+            )
+
+        assert results[0].role == "Edit"      # input → Edit
+        assert results[1].role == "ComboBox"   # select → ComboBox
+
+
+# ── cascade.find_cdp_port ────────────────────────────────────────────────────
+
+
+class TestFindCdpPort:
+    """Test the find_cdp_port utility."""
+
+    def test_finds_port_via_http_probe(self):
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            from naturo.cascade import find_cdp_port
+
+            port = find_cdp_port(pid=None)
+
+        assert port == 9222
+
+    def test_returns_none_when_no_port_responds(self):
+        with patch("urllib.request.urlopen", side_effect=Exception("refused")):
+            from naturo.cascade import find_cdp_port
+
+            port = find_cdp_port(pid=None)
+
+        assert port is None
+
+    @patch("platform.system", return_value="Linux")
+    def test_skips_wmic_on_linux(self, mock_sys):
+        """On non-Windows, skip command-line parsing and go straight to probing."""
+        with patch("urllib.request.urlopen", side_effect=Exception("refused")):
+            from naturo.cascade import find_cdp_port
+
+            port = find_cdp_port(pid=1234)
+
+        assert port is None
+
+
+# ── cascade._run_cdp_only ────────────────────────────────────────────────────
+
+
+class TestRunCdpOnly:
+    """Test the CDP-only cascade mode (--backend cdp)."""
+
+    def test_returns_error_when_no_port(self):
+        with patch("naturo.cascade.find_cdp_port", return_value=None):
+            from naturo.cascade import _run_cdp_only
+
+            mock_backend = MagicMock()
+            result = _run_cdp_only(mock_backend, app="chrome")
+
+        assert result.tree is None
+        assert result.primary_provider == "cdp"
+        assert result.stats.providers[0].status == "error"
+
+    def test_merges_uia_and_cdp_elements(self):
+        uia_tree = _make_element(
+            id="root", role="Window", name="Google Chrome",
+            x=0, y=0, width=1920, height=1080,
+            children=[
+                _make_element(id="e1", role="ToolBar", name="Main toolbar",
+                              x=0, y=0, width=1920, height=60),
+            ],
+        )
+
+        cdp_elements = [
+            _make_element(id="cdp_0", role="Button", name="Search",
+                          x=100, y=200, width=80, height=30,
+                          properties={"source": "cdp", "tag": "button",
+                                      "css_selector": "button.search",
+                                      "parent_id": None}),
+        ]
+
+        mock_backend = MagicMock()
+        mock_backend.get_element_tree.return_value = uia_tree
+
+        with (
+            patch("naturo.cascade.find_cdp_port", return_value=9222),
+            patch("naturo.cascade._fetch_cdp_elements", return_value=cdp_elements),
+        ):
+            from naturo.cascade import _run_cdp_only
+
+            result = _run_cdp_only(mock_backend, app="chrome", pid=1234)
+
+        assert result.tree is not None
+        assert result.primary_provider == "cdp"
+        # UIA elements + CDP elements merged
+        assert len(result.tree.children) == 2  # toolbar + cdp button
+        # CDP element is tagged
+        cdp_child = result.tree.children[1]
+        assert cdp_child.properties.get("source") == "cdp"
+
+    def test_creates_synthetic_root_without_uia(self):
+        """When UIA fails, CDP elements still get a synthetic root."""
+        cdp_elements = [
+            _make_element(id="cdp_0", role="Button", name="Login",
+                          x=50, y=100, width=100, height=30,
+                          properties={"source": "cdp"}),
+        ]
+
+        mock_backend = MagicMock()
+        mock_backend.get_element_tree.side_effect = Exception("No UIA")
+
+        with (
+            patch("naturo.cascade.find_cdp_port", return_value=9222),
+            patch("naturo.cascade._fetch_cdp_elements", return_value=cdp_elements),
+        ):
+            from naturo.cascade import _run_cdp_only
+
+            result = _run_cdp_only(mock_backend, app="chrome", pid=1234)
+
+        assert result.tree is not None
+        assert result.tree.role == "Window"
+        assert len(result.tree.children) == 1
+        assert result.tree.children[0].name == "Login"
+
+
+# ── cascade.run_cascade with CDP enrichment ──────────────────────────────────
+
+
+class TestRunCascadeWithCdp:
+    """Test that run_cascade properly enriches UIA tree with CDP elements."""
+
+    def test_auto_mode_tries_cdp_after_uia(self):
+        uia_tree = _make_element(
+            id="root", role="Window", name="Slack",
+            x=0, y=0, width=1920, height=1080,
+            children=[
+                _make_element(id="e1", role="Pane", name="Content",
+                              x=0, y=60, width=1920, height=1020),
+            ],
+        )
+
+        cdp_elements = [
+            _make_element(id="cdp_0", role="Button", name="Send",
+                          x=100, y=500, width=80, height=30,
+                          properties={"source": "cdp"}),
+        ]
+
+        mock_backend = MagicMock()
+        mock_backend.get_element_tree.return_value = uia_tree
+
+        with (
+            patch("naturo.cascade.find_cdp_port", return_value=9222),
+            patch("naturo.cascade._fetch_cdp_elements", return_value=cdp_elements),
+        ):
+            from naturo.cascade import run_cascade
+
+            result = run_cascade(
+                mock_backend,
+                app="slack",
+                pid=5678,
+                backend_name="auto",
+            )
+
+        assert result.tree is not None
+        # Check that CDP provider was attempted
+        cdp_providers = [p for p in result.stats.providers if p.name == "cdp"]
+        assert len(cdp_providers) == 1
+        assert cdp_providers[0].elements == 1
+
+    def test_cdp_backend_routes_to_cdp_only(self):
+        """--backend cdp should use _run_cdp_only path."""
+        mock_backend = MagicMock()
+        mock_backend.get_element_tree.return_value = _make_element(
+            id="root", role="Window", name="Chrome",
+            x=0, y=0, width=1920, height=1080,
+        )
+
+        with (
+            patch("naturo.cascade.find_cdp_port", return_value=9222),
+            patch("naturo.cascade._fetch_cdp_elements", return_value=[]),
+        ):
+            from naturo.cascade import run_cascade
+
+            result = run_cascade(
+                mock_backend,
+                app="chrome",
+                pid=1234,
+                backend_name="cdp",
+            )
+
+        assert result.primary_provider == "cdp"


### PR DESCRIPTION
## Changes

- **Fix broken CDP element fetching**: `_fetch_cdp_elements()` called `query_selector_all()` which returns node IDs (ints), then tried `.get("bounds")` on them — this never worked. Now uses the new `get_interactive_elements()` method.
- **Add `CDPClient.get_interactive_elements()`**: JS-based extraction of DOM elements with bounding boxes, ARIA roles, accessible names, values, and CSS selectors. Deduplicates elements and filters zero-area nodes in-browser for efficiency.
- **Add `find_cdp_port()`**: Reusable CDP port discovery — parses process command line for `--remote-debugging-port` (Windows), then probes common ports (9222, 9229, 9333) via HTTP `/json/version`. Works for Chrome, Edge, Electron, and any Chromium-based browser.
- **Add `--backend cdp`** to `see` and `find` CLI commands for explicit CDP mode.
- **Add `_run_cdp_only()`**: CDP-primary cascade mode that fetches UIA tree for window chrome (address bar, tabs, toolbars) + CDP elements for web content, merged into a unified tree.
- **Extend auto/cascade mode**: Now tries generic CDP port discovery after Electron-specific detection, so Chrome/Edge browsers with debug ports are detected automatically.
- **17 new mocked tests** covering `get_interactive_elements`, `_fetch_cdp_elements`, `find_cdp_port`, `_run_cdp_only`, and `run_cascade` CDP integration.

## Testing

- All 2304 existing tests pass (550 skipped — desktop-only)
- 17 new tests in `tests/test_cdp_cascade.py` — all pass
- ruff clean, mypy clean
- Full mock coverage — no desktop/browser required for CI

## What's NOT in this PR (future work)

- Playwright/Browseruse integration (per Ace's direction in #617 comment)
- Click/type routing through CDP for CDP-discovered elements (interaction layer)
- `naturo app launch chrome --debug` helper

**[Dev-Sirius]**