### PR TITLE
fix: make build-python check run report success for auto-merge (fixes #603)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,9 @@ jobs:
     runs-on: windows-latest
     needs: build-dll
     timeout-minutes: 15
-    continue-on-error: true  # Do not block PRs — desktop tests run on self-hosted runner
+    continue-on-error: true  # Do not block workflow — desktop tests run on self-hosted runner
+    # NOTE: Step-level continue-on-error ensures the check run reports "success"
+    # so that auto-merge works with branch protection (#603).
     steps:
       - uses: actions/checkout@v6
 
@@ -207,6 +209,7 @@ jobs:
           "
 
       - name: Collect tests (dry run)
+        continue-on-error: true  # May fail on headless runner — don't block the check (#603)
         shell: bash
         timeout-minutes: 2
         run: |
@@ -217,6 +220,7 @@ jobs:
             2>&1 | tail -10
 
       - name: Run all tests
+        continue-on-error: true  # Step failures must not fail the job check run (#603)
         shell: bash
         timeout-minutes: 10
         run: |


### PR DESCRIPTION
## Changes

- Added `continue-on-error: true` at the **step level** on "Collect tests (dry run)" and "Run all tests" steps in the `build-python` job
- Updated job-level comment to explain the full strategy

### Why this fixes auto-merge

The `build-python` job already had `continue-on-error: true` at the job level, which prevents the *workflow* from failing. However, GitHub branch protection checks the **check run status** of individual jobs, not the workflow outcome. A job with `continue-on-error: true` that has failing steps still reports its check run as "failure" — which blocks auto-merge.

Adding `continue-on-error: true` at the step level means failing steps don't fail the job itself, so the check run reports "success". Combined with the existing job-level `continue-on-error`, this makes auto-merge work as documented.

### What doesn't change

- Test results are still visible in logs and artifacts (JUnit XML, coverage)
- The `continue-on-error: true` at the job level is preserved (as required by CI architecture doc)
- CI Gate logic is unchanged — it already excludes `build-python`
- Desktop tests still run on the self-hosted runner via `desktop-tests.yml`

## Testing

- YAML syntax validated
- This PR's own CI will demonstrate the fix: if `build-python` check reports "success" despite test failures, auto-merge can be enabled

**[Dev-Sirius]**