### PR TITLE
test: add 19 unit tests for verify.py edge cases and cross-platform paths

### DIFF
--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1017,15 +1017,16 @@ class TestCaptureBeforeStatePressAction:
 class TestCaptureFocusStateNonWindows:
     """Test _capture_focus_state on non-Windows platforms."""
 
-    def test_returns_platform_key_on_linux(self):
-        """On Linux, should return dict with platform key."""
+    def test_returns_platform_key_on_non_windows(self):
+        """On non-Windows (Linux/macOS), should return dict with platform key."""
         from naturo.verify import _capture_focus_state
 
         backend = MagicMock(spec=[])
         state = _capture_focus_state(backend)
 
         assert "platform" in state
-        assert state["platform"] == "Linux"
+        # Linux returns "Linux", macOS returns "Darwin"
+        assert state["platform"] in ("Linux", "Darwin")
 
 
 class TestCaptureUiTextsNonWindows:


### PR DESCRIPTION
## Changes
- 19 new unit tests for `naturo/verify.py` covering previously untested paths
- Covers verify_type UI text fallback exception handling (lines 263-264)
- Covers verify_press focus capture exception (lines 484-486)
- Covers capture_before_state for press action and edge cases
- Covers cross-platform paths (_capture_focus_state, _capture_ui_texts on Linux)
- Covers VerificationResult.to_dict edge cases

## Testing
- All 2485 tests pass, 502 skipped (Linux CI)
- verify.py coverage: 58% → 60%
- Remaining uncovered lines are Windows-only ctypes/comtypes code (desktop runner only)
- ruff clean, mypy clean

**[Dev-Sirius]**