### PR TITLE
fix: add NoReturn annotations and fix 15 mypy type errors (fixes #654)

### DIFF
--- a/naturo/cli/core/_see.py
+++ b/naturo/cli/core/_see.py
@@ -227,7 +227,7 @@ def see(app, window_title, hwnd, pid, mode, depth, path, annotate, store_snapsho
             raise SystemExit(1)
 
         snapshot_id = None
-        ref_map = {}  # Maps "eN" → backend element id; built when snapshot is stored
+        ref_map: dict[str, str] = {}  # Maps "eN" → backend element id
         if store_snapshot:
             from naturo.snapshot import get_snapshot_manager
             from naturo.models.snapshot import UIElement

--- a/naturo/cli/error_helpers.py
+++ b/naturo/cli/error_helpers.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import json
 import sys
-from typing import Any, Optional
+from typing import Any, NoReturn, Optional
 
 import click
 
@@ -295,7 +295,7 @@ def emit_error(
     suggested_action: Optional[str] = None,
     recoverable: Optional[bool] = None,
     exit_code: int = 1,
-) -> None:
+) -> NoReturn:
     """Emit an error message and exit.
 
     In JSON mode, outputs a structured error with recovery hints.
@@ -324,7 +324,7 @@ def emit_exception_error(
     *,
     fallback_code: str = "UNKNOWN_ERROR",
     exit_code: int = 1,
-) -> None:
+) -> NoReturn:
     """Emit an error from an exception and exit.
 
     If the exception is a NaturoError, uses its full structured data.

--- a/naturo/cli/get_cmd.py
+++ b/naturo/cli/get_cmd.py
@@ -270,7 +270,7 @@ def get_cmd(ctx, target, ref, automation_id, role, name, get_all, prop, app,
             )
 
         if json_output:
-            output = {
+            element_data = {
                 "ref": ref,
                 "role": result.get("role"),
                 "name": result.get("name"),
@@ -282,7 +282,7 @@ def get_cmd(ctx, target, ref, automation_id, role, name, get_all, prop, app,
                 "width": result.get("width"),
                 "height": result.get("height"),
             }
-            click.echo(json_module.dumps(output))
+            click.echo(json_module.dumps(element_data))
         elif prop:
             # Return just the requested property
             val = result.get(prop)

--- a/naturo/cli/interaction/_click.py
+++ b/naturo/cli/interaction/_click.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 import click
 
@@ -332,7 +333,7 @@ def click_cmd(query, on_text, ref_alias, element_id, coords, double, right, app,
         loc = f"{_zero_bounds_element.title or _zero_bounds_element.role} (via UIA Invoke)"
     else:
         loc = f"({x}, {y})" if coords else (target_id or "element")
-    result_data = {"action": action, "target": str(loc), "button": button}
+    result_data: dict[str, Any] = {"action": action, "target": str(loc), "button": button}
     if _clipboard_action:
         result_data["clipboard_action"] = _clipboard_action
     # (#248) Indicate UIA click was used for UWP apps


### PR DESCRIPTION
## Changes
- `emit_error()` and `emit_exception_error()` now return `NoReturn` instead of `None` — they call `sys.exit()`, so mypy should know control never continues past them
- Renamed shadowed `output` → `element_data` in `get_cmd.py` (was typed as `list` in `--all` branch, `dict` in single-element branch)
- Widened `result_data` type in `_click.py` to `dict[str, Any]` (stores bools and nested dicts, not just strings)
- Added explicit `dict[str, str]` type annotation to `ref_map` in `_see.py`

## Impact
- `mypy naturo/` (default): still 0 errors ✅
- `mypy naturo/ --check-untyped-defs`: **18 → 3 errors** (remaining 3 are `ctypes.windll` on non-Windows — unfixable)

## Testing
- All 3264 tests pass
- `ruff check` clean
- `mypy` clean

**[Dev-Sirius]**