### PR TITLE
fix: UWP menu click uses wrong method name and missing ExpandCollapsePattern (fixes #672)

### DIFF
--- a/naturo/backends/windows/_input.py
+++ b/naturo/backends/windows/_input.py
@@ -105,7 +105,30 @@ class InputMixin:
             elem_name = element.CurrentName or ""
             logger.debug("UIA click: found element %r at (%d, %d)", elem_name, x, y)
 
-            # Try InvokePattern first (buttons, links, menu items)
+            # (#672) Try ExpandCollapsePattern first (menu items, combo boxes,
+            # tree items).  Top-level menu bar items (File, Edit, View…) support
+            # ExpandCollapsePattern to open their dropdown.  InvokePattern on
+            # these elements fires the command action instead of expanding,
+            # causing wrong behaviour on UWP apps like Notepad.
+            try:
+                pattern = element.GetCurrentPattern(mod.UIA_ExpandCollapsePatternId)
+                if pattern is not None:
+                    ecp = pattern.QueryInterface(mod.IUIAutomationExpandCollapsePattern)
+                    # Only expand if currently collapsed — avoids toggling an
+                    # already-open menu closed.
+                    state = ecp.CurrentExpandCollapseState
+                    if state == 0:  # ExpandCollapseState_Collapsed
+                        ecp.Expand()
+                        logger.info("UIA click: expanded %r via ExpandCollapsePattern", elem_name)
+                        return True
+                    elif state == 1:  # ExpandCollapseState_Expanded
+                        ecp.Collapse()
+                        logger.info("UIA click: collapsed %r via ExpandCollapsePattern", elem_name)
+                        return True
+            except (COMError, AttributeError):
+                pass
+
+            # Try InvokePattern (buttons, links, simple menu items)
             try:
                 pattern = element.GetCurrentPattern(mod.UIA_InvokePatternId)
                 if pattern is not None:
@@ -139,7 +162,7 @@ class InputMixin:
                 pass
 
             logger.debug(
-                "UIA click: element %r at (%d, %d) supports no invoke/toggle/select pattern",
+                "UIA click: element %r at (%d, %d) supports no expand/invoke/toggle/select pattern",
                 elem_name, x, y,
             )
             return False

--- a/naturo/cli/interaction/_click.py
+++ b/naturo/cli/interaction/_click.py
@@ -205,9 +205,9 @@ def click_cmd(query: str | None, on_text: str | None, ref_alias: str | None,
             logger.debug("HWND resolution for focus failed: %s", exc)
     if _focus_hwnd:
         # Detect UWP apps for UIA click fallback (#248)
-        if hasattr(backend, "_is_applicationframehost"):
+        if hasattr(backend, "_is_afh_window"):
             try:
-                _is_uwp = backend._is_applicationframehost(_focus_hwnd)
+                _is_uwp = backend._is_afh_window(_focus_hwnd)
             except Exception as exc:
                 logger.debug("UWP detection failed (hwnd=%s): %s", _focus_hwnd, exc)
         try:

--- a/tests/test_click_app_foreground.py
+++ b/tests/test_click_app_foreground.py
@@ -217,7 +217,7 @@ class TestClickAppForeground:
 
         backend = MagicMock()
         backend.focus_window.side_effect = OSError("focus failed")
-        backend._is_applicationframehost.return_value = False
+        backend._is_afh_window.return_value = False
         mock_get_backend.return_value = backend
 
         runner = CliRunner()

--- a/tests/test_uwp_fallback.py
+++ b/tests/test_uwp_fallback.py
@@ -312,6 +312,85 @@ class TestClickElementUia:
             result = backend.click_element_uia(x=100, y=200)
         assert result is False
 
+    def test_click_element_uia_tries_expand_collapse_before_invoke(self, backend):
+        """ExpandCollapsePattern should be tried before InvokePattern (#672).
+
+        Menu items (File, Edit, View…) support ExpandCollapsePattern to open
+        their dropdown.  InvokePattern fires the command action instead of
+        expanding, causing wrong behaviour on UWP apps.
+        """
+        mock_mod = MagicMock()
+        mock_uia = MagicMock()
+
+        # Element supports both ExpandCollapse and Invoke
+        mock_element = MagicMock()
+        mock_element.CurrentName = "File"
+        mock_uia.ElementFromPoint.return_value = mock_element
+
+        # ExpandCollapsePattern mock — state=collapsed (0)
+        mock_ecp_pattern = MagicMock()
+        mock_ecp = MagicMock()
+        mock_ecp.CurrentExpandCollapseState = 0  # Collapsed
+        mock_ecp_pattern.QueryInterface.return_value = mock_ecp
+
+        # InvokePattern mock
+        mock_invoke_pattern = MagicMock()
+        mock_invoke = MagicMock()
+        mock_invoke_pattern.QueryInterface.return_value = mock_invoke
+
+        def _get_pattern(pattern_id):
+            if pattern_id == mock_mod.UIA_ExpandCollapsePatternId:
+                return mock_ecp_pattern
+            if pattern_id == mock_mod.UIA_InvokePatternId:
+                return mock_invoke_pattern
+            return None
+
+        mock_element.GetCurrentPattern.side_effect = _get_pattern
+
+        # Mock ctypes.wintypes and comtypes.COMError for non-Windows
+        mock_wintypes = MagicMock()
+        mock_comtypes = MagicMock()
+        with patch.object(backend, "_init_comtypes_uia", return_value=(mock_uia, mock_mod)), \
+             patch.dict("sys.modules", {
+                 "ctypes.wintypes": mock_wintypes,
+                 "comtypes": mock_comtypes,
+             }):
+            result = backend.click_element_uia(x=100, y=200)
+
+        assert result is True
+        # ExpandCollapsePattern.Expand() should have been called
+        mock_ecp.Expand.assert_called_once()
+        # InvokePattern should NOT have been called
+        mock_invoke.Invoke.assert_not_called()
+
+    def test_click_element_uia_collapses_expanded_element(self, backend):
+        """Clicking an already-expanded menu item should collapse it (#672)."""
+        mock_mod = MagicMock()
+        mock_uia = MagicMock()
+
+        mock_element = MagicMock()
+        mock_element.CurrentName = "File"
+        mock_uia.ElementFromPoint.return_value = mock_element
+
+        mock_ecp_pattern = MagicMock()
+        mock_ecp = MagicMock()
+        mock_ecp.CurrentExpandCollapseState = 1  # Expanded
+        mock_ecp_pattern.QueryInterface.return_value = mock_ecp
+
+        mock_element.GetCurrentPattern.return_value = mock_ecp_pattern
+
+        mock_wintypes = MagicMock()
+        mock_comtypes = MagicMock()
+        with patch.object(backend, "_init_comtypes_uia", return_value=(mock_uia, mock_mod)), \
+             patch.dict("sys.modules", {
+                 "ctypes.wintypes": mock_wintypes,
+                 "comtypes": mock_comtypes,
+             }):
+            result = backend.click_element_uia(x=100, y=200)
+
+        assert result is True
+        mock_ecp.Collapse.assert_called_once()
+
 
 class TestMsaaUwpFallback:
     """Tests for MSAA UWP child window fallback (#394)."""


### PR DESCRIPTION
## Changes
- Fixed method name mismatch: click command checked `_is_applicationframehost` but backend provides `_is_afh_window` — UWP detection silently failed, so SendInput was used instead of UIA patterns
- Added `ExpandCollapsePattern` as the first UIA pattern tried in `click_element_uia` — menu bar items (File, Edit, View…) need Expand to open their dropdown, not Invoke which fires the command action
- Updated existing test to use correct method name
- Added 2 new tests verifying ExpandCollapsePattern priority over InvokePattern

## Root Cause
Two independent bugs combined to break UWP menu clicks:
1. `hasattr(backend, "_is_applicationframehost")` always returned False because the actual method is `_is_afh_window` → `_is_uwp` stayed False → UIA click path skipped entirely
2. Even if UIA click path was reached, `click_element_uia` tried InvokePattern first, which fires the menu item's command instead of expanding the dropdown menu

## Testing
- 3228 tests pass, 0 failures
- ruff lint clean on changed files
- New tests verify ExpandCollapsePattern is tried before InvokePattern
- New tests verify collapse behavior for already-expanded elements

**[Dev-Sirius]**