### PR TITLE
feat: --app flag falls back to window title matching (fixes #671)

### DIFF
--- a/naturo/backends/windows/_element.py
+++ b/naturo/backends/windows/_element.py
@@ -202,9 +202,12 @@ class ElementMixin:
         Matching strategy (BUG-069/BUG-070):
 
         When ``app`` is provided, matches against **process name and aliases
-        only** (``.exe`` suffix stripped).  Title matching is not used for
-        ``--app`` to prevent cross-process contamination (#465).  When
-        ``window_title`` is provided, matches against window title only.
+        first** (``.exe`` suffix stripped).  If no process name match is
+        found, falls back to **window title matching** (#671).  This allows
+        ``--app claude`` to find a Terminal window titled "claude" while
+        still preventing cross-process contamination when a process name
+        match exists (#465).  When ``window_title`` is provided, matches
+        against window title only.
 
         When ``pid`` is provided (alone or combined with app/window_title),
         only windows belonging to that process are considered (#471).  Among
@@ -462,6 +465,59 @@ class ElementMixin:
             if best_window is not None:
                 return best_window.handle
 
+        # (#671) Window title fallback for --app: when no process name
+        # matched, try matching against window titles.  This allows
+        # `--app claude` to find a Terminal window titled "claude" when
+        # no process named "claude" exists.  Title matches use score 2
+        # (below process name matches at 3-4) so they never override
+        # a valid process name match.  The initial process-name-only
+        # pass above (#465) prevents cross-process contamination when
+        # a process name match exists.
+        if match_process and best_window is None:
+            for w in windows:
+                title_lower = w.title.lower()
+                if not title_lower:
+                    continue
+
+                score = 0
+                if search_lower == title_lower:
+                    score = 4  # exact title match
+                elif search_lower in title_lower:
+                    score = 2  # substring in title
+
+                if score == 0:
+                    continue
+
+                in_console = False
+                if console_session >= 0:
+                    w_session = self._get_process_session_id(w.pid)
+                    in_console = (w_session == console_session)
+
+                is_foreground = (fg_hwnd != 0 and w.handle == fg_hwnd)
+
+                if score > best_score:
+                    best_score = score
+                    best_session_bonus = in_console
+                    best_is_foreground = is_foreground
+                    best_window = w
+                elif score == best_score and best_window is not None:
+                    if in_console and not best_session_bonus:
+                        best_session_bonus = in_console
+                        best_is_foreground = is_foreground
+                        best_window = w
+                    elif in_console == best_session_bonus:
+                        if is_foreground and not best_is_foreground:
+                            best_is_foreground = True
+                            best_window = w
+                        elif is_foreground == best_is_foreground:
+                            w_area = w.width * w.height
+                            best_area = best_window.width * best_window.height
+                            if w_area > best_area:
+                                best_window = w
+
+            if best_window is not None:
+                return best_window.handle
+
         # No match — build candidate suggestions (BUG-070)
         from naturo.errors import WindowNotFoundError
 
@@ -633,6 +689,33 @@ class ElementMixin:
             )
             if afh_match is not None:
                 result.append(afh_match.handle)
+
+        # (#671) Window title fallback for --app: when no process name
+        # matched, try matching against window titles.  This allows
+        # `--app claude` to find a Terminal window titled "claude".
+        if not result and match_process:
+            title_matches = []
+            for w in windows:
+                title_lower = w.title.lower()
+                if not title_lower:
+                    continue
+                score = 0
+                if search_lower == title_lower:
+                    score = 4
+                elif search_lower in title_lower:
+                    score = 2
+                if score > 0:
+                    in_console = False
+                    if console_session >= 0:
+                        w_session = self._get_process_session_id(w.pid)
+                        in_console = (w_session == console_session)
+                    title_matches.append((score, in_console, len(w.title), w))
+
+            if title_matches:
+                title_matches.sort(
+                    key=lambda x: (x[0], x[1], -x[2]), reverse=True,
+                )
+                result = [m[3].handle for m in title_matches]
 
         return result
 

--- a/tests/test_app_alias_localized.py
+++ b/tests/test_app_alias_localized.py
@@ -205,10 +205,33 @@ class TestEnglishToChineseProcessBidirectional:
 
 
 class TestNoFalsePositiveFromChineseAlias:
-    """Chinese alias should not cause false matches on unrelated processes."""
+    """Chinese alias should prefer process matches over title matches."""
 
-    def test_chinese_calc_no_match_chrome(self, monkeypatch):
-        """--app 计算器 should NOT match chrome.exe with title containing 计算器."""
+    def test_chinese_calc_prefers_process_over_chrome_title(self, monkeypatch):
+        """--app 计算器 should prefer CalculatorApp.exe over Chrome with '计算器' in title."""
+        backend = _make_backend(monkeypatch, [
+            WindowInfo(
+                handle=9000,
+                title="计算器 - 百度搜索 - Google Chrome",
+                process_name="chrome.exe",
+                pid=900,
+                x=0, y=0, width=1920, height=1080,
+                is_visible=True, is_minimized=False,
+            ),
+            WindowInfo(
+                handle=9001,
+                title="计算器",
+                process_name="CalculatorApp.exe",
+                pid=901,
+                x=0, y=0, width=400, height=600,
+                is_visible=True, is_minimized=False,
+            ),
+        ])
+        result = backend._resolve_hwnd(app="计算器")
+        assert result == 9001, "Process/alias match must beat title fallback"
+
+    def test_chinese_calc_falls_back_to_title(self, monkeypatch):
+        """--app 计算器 falls back to title match when Calculator not running (#671)."""
         backend = _make_backend(monkeypatch, [
             WindowInfo(
                 handle=9000,
@@ -219,8 +242,8 @@ class TestNoFalsePositiveFromChineseAlias:
                 is_visible=True, is_minimized=False,
             ),
         ])
-        with pytest.raises(WindowNotFoundError):
-            backend._resolve_hwnd(app="计算器")
+        result = backend._resolve_hwnd(app="计算器")
+        assert result == 9000, "Title fallback should match when no process matches"
 
 
 class TestAliasMapCompleteness:

--- a/tests/test_app_filter_process_priority.py
+++ b/tests/test_app_filter_process_priority.py
@@ -1,8 +1,10 @@
-"""Tests for --app process-name-only matching (#465).
+"""Tests for --app matching priority (#465, #671).
 
-When --app is used, matching should only consider process name and aliases,
-NOT window title.  Title-only matches caused cross-process contamination:
-e.g. --app notepad picking a Chrome window titled "help with notepad".
+When --app is used, process name and aliases are matched first.  If no
+process name match is found, window title is tried as a fallback (#671).
+This allows `--app claude` to find a Terminal window titled "claude"
+while still preventing cross-process contamination when a process name
+match exists (#465).
 """
 
 import pytest
@@ -20,11 +22,12 @@ def _make_backend(monkeypatch, windows):
     return backend
 
 
-class TestAppFilterRejectsTitle:
-    """--app should NOT match by window title alone."""
+class TestAppFilterProcessPriority:
+    """--app prefers process name matches; falls back to title (#465, #671)."""
 
-    def test_chrome_with_notepad_in_title_not_matched(self, monkeypatch):
-        """--app notepad must NOT match a Chrome window with 'notepad' in title."""
+    def test_chrome_with_notepad_in_title_matched_as_fallback(self, monkeypatch):
+        """--app notepad matches Chrome window with 'notepad' in title when
+        no notepad.exe is running (#671 title fallback)."""
         backend = _make_backend(monkeypatch, [
             WindowInfo(
                 handle=1000,
@@ -35,8 +38,8 @@ class TestAppFilterRejectsTitle:
                 is_visible=True, is_minimized=False,
             ),
         ])
-        with pytest.raises(WindowNotFoundError):
-            backend._resolve_hwnd(app="notepad")
+        result = backend._resolve_hwnd(app="notepad")
+        assert result == 1000, "Title fallback should match when no process matches"
 
     def test_notepad_process_still_matched(self, monkeypatch):
         """--app notepad should match notepad.exe process name."""
@@ -77,8 +80,8 @@ class TestAppFilterRejectsTitle:
         result = backend._resolve_hwnd(app="notepad")
         assert result == 1000, "Substring process name match should still work"
 
-    def test_exact_title_match_ignored_for_app(self, monkeypatch):
-        """Even exact title match should not trigger for --app."""
+    def test_exact_title_match_used_as_fallback(self, monkeypatch):
+        """Exact title match should work as fallback when no process matches (#671)."""
         backend = _make_backend(monkeypatch, [
             WindowInfo(
                 handle=1000,
@@ -89,9 +92,35 @@ class TestAppFilterRejectsTitle:
                 is_visible=True, is_minimized=False,
             ),
         ])
-        # Chrome window with exact title "Calculator" should NOT match --app calculator
-        with pytest.raises(WindowNotFoundError):
-            backend._resolve_hwnd(app="Calculator")
+        # Chrome window with exact title "Calculator" should match via title
+        # fallback when no "Calculator" process exists
+        result = backend._resolve_hwnd(app="Calculator")
+        assert result == 1000, "Exact title fallback should match"
+
+    def test_process_match_wins_over_title_match(self, monkeypatch):
+        """Process name match must always win over title-only match (#465)."""
+        backend = _make_backend(monkeypatch, [
+            WindowInfo(
+                handle=1000,
+                title="help with notepad",
+                process_name="chrome.exe",
+                pid=100,
+                x=0, y=0, width=1920, height=1080,
+                is_visible=True, is_minimized=False,
+            ),
+            WindowInfo(
+                handle=2000,
+                title="Untitled - Notepad",
+                process_name="notepad.exe",
+                pid=200,
+                x=0, y=0, width=800, height=600,
+                is_visible=True, is_minimized=False,
+            ),
+        ])
+        # When notepad.exe is running, --app notepad should match it,
+        # NOT the Chrome window with "notepad" in title
+        result = backend._resolve_hwnd(app="notepad")
+        assert result == 2000, "Process name match must beat title match"
 
     def test_alias_still_matches_process(self, monkeypatch):
         """Alias matching should still work for process names."""
@@ -126,11 +155,107 @@ class TestAppFilterRejectsTitle:
         assert result == 1000, "--window-title should still match by title"
 
 
-class TestResolveHwndsRejectsTitle:
-    """_resolve_hwnds with --app should also reject title-only matches."""
+class TestAppTitleFallback:
+    """--app falls back to window title matching when no process matches (#671)."""
 
-    def test_bulk_resolve_no_title_matches(self, monkeypatch):
-        """_resolve_hwnds should not include title-only matches for --app."""
+    def test_app_matches_terminal_by_window_title(self, monkeypatch):
+        """--app claude should find Terminal window titled 'claude' (#671)."""
+        backend = _make_backend(monkeypatch, [
+            WindowInfo(
+                handle=1000,
+                title="claude",
+                process_name="WindowsTerminal.exe",
+                pid=100,
+                x=0, y=0, width=800, height=600,
+                is_visible=True, is_minimized=False,
+            ),
+            WindowInfo(
+                handle=2000,
+                title="GitHub API investigation",
+                process_name="WindowsTerminal.exe",
+                pid=100,
+                x=0, y=0, width=800, height=600,
+                is_visible=True, is_minimized=False,
+            ),
+            WindowInfo(
+                handle=3000,
+                title="Review issue #500",
+                process_name="WindowsTerminal.exe",
+                pid=100,
+                x=0, y=0, width=800, height=600,
+                is_visible=True, is_minimized=False,
+            ),
+        ])
+        result = backend._resolve_hwnd(app="claude")
+        assert result == 1000, "--app claude should match Terminal window titled 'claude'"
+
+    def test_app_matches_partial_title(self, monkeypatch):
+        """--app GitHub should find Terminal window with 'GitHub' in title (#671)."""
+        backend = _make_backend(monkeypatch, [
+            WindowInfo(
+                handle=1000,
+                title="claude",
+                process_name="WindowsTerminal.exe",
+                pid=100,
+                x=0, y=0, width=800, height=600,
+                is_visible=True, is_minimized=False,
+            ),
+            WindowInfo(
+                handle=2000,
+                title="GitHub API investigation",
+                process_name="WindowsTerminal.exe",
+                pid=100,
+                x=0, y=0, width=800, height=600,
+                is_visible=True, is_minimized=False,
+            ),
+        ])
+        result = backend._resolve_hwnd(app="GitHub")
+        assert result == 2000, "--app GitHub should match window with 'GitHub' in title"
+
+    def test_resolve_hwnds_title_fallback(self, monkeypatch):
+        """_resolve_hwnds should also fall back to title matching (#671)."""
+        backend = _make_backend(monkeypatch, [
+            WindowInfo(
+                handle=1000,
+                title="claude - work session",
+                process_name="WindowsTerminal.exe",
+                pid=100,
+                x=0, y=0, width=800, height=600,
+                is_visible=True, is_minimized=False,
+            ),
+            WindowInfo(
+                handle=2000,
+                title="other task",
+                process_name="WindowsTerminal.exe",
+                pid=100,
+                x=0, y=0, width=800, height=600,
+                is_visible=True, is_minimized=False,
+            ),
+        ])
+        result = backend._resolve_hwnds(app="claude")
+        assert result == [1000], "_resolve_hwnds should find window by title fallback"
+
+    def test_no_match_still_raises(self, monkeypatch):
+        """When neither process nor title matches, should still raise."""
+        backend = _make_backend(monkeypatch, [
+            WindowInfo(
+                handle=1000,
+                title="Untitled - Notepad",
+                process_name="notepad.exe",
+                pid=100,
+                x=0, y=0, width=800, height=600,
+                is_visible=True, is_minimized=False,
+            ),
+        ])
+        with pytest.raises(WindowNotFoundError):
+            backend._resolve_hwnd(app="nonexistent_app_xyz")
+
+
+class TestResolveHwndsProcessPriority:
+    """_resolve_hwnds prefers process name matches; title is fallback."""
+
+    def test_bulk_resolve_process_over_title(self, monkeypatch):
+        """_resolve_hwnds should prefer process-name matches over title (#465)."""
         backend = _make_backend(monkeypatch, [
             WindowInfo(
                 handle=1000,
@@ -150,4 +275,4 @@ class TestResolveHwndsRejectsTitle:
             ),
         ])
         result = backend._resolve_hwnds(app="notepad")
-        assert result == [2000], "Only process-name matches should be included"
+        assert result == [2000], "Process-name matches should take priority"


### PR DESCRIPTION
## Changes
- `--app` now falls back to window title matching when no process name or alias matches
- Both `_resolve_hwnd` and `_resolve_hwnds` support the title fallback
- Process name matches (score 3-4) always take priority over title matches (score 2-4), preserving #465 safety against cross-process contamination
- Updated and added 8 new tests covering the title fallback behavior

## How It Works
1. First pass: match by process name and aliases (existing behavior)
2. If no match: try UWP AFH fallback (existing behavior)
3. If still no match: try window title matching (new #671 fallback)

This means `--app notepad` still matches `notepad.exe` (not a Chrome window titled "notepad"), but `--app claude` will find a Terminal window titled "claude" when no process named "claude" exists.

## Testing
- 3351 tests pass, 0 new failures
- 70 window resolution tests pass
- ruff lint clean
- Pre-existing failures in `test_mcp_snapshot.py` are unrelated

**[Dev-Sirius]**