### PR TITLE
test: add 49 tests for 4 CLI core modules (#660)

### DIFF
--- a/tests/test_cli_capture.py
+++ b/tests/test_cli_capture.py
@@ -1,0 +1,268 @@
+"""Tests for naturo.cli.core._capture — capture command.
+
+Tests cover full screen capture, window capture, --element crop,
+--region crop, --format, --screen validation, snapshot storage,
+JSON output, and error paths. All mock-based, CI-safe.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from naturo.cli.core._capture import capture
+
+
+@dataclass
+class FakeCaptureResult:
+    path: str = "/tmp/test.png"
+    width: int = 1920
+    height: int = 1080
+    format: str = "png"
+    scale_factor: float = 1.0
+    dpi: int = 96
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_backend():
+    backend = MagicMock()
+    backend.capture_screen.return_value = FakeCaptureResult()
+    backend.capture_window.return_value = FakeCaptureResult()
+    backend._resolve_hwnd.return_value = 12345
+    backend.list_monitors.return_value = [
+        MagicMock(index=0), MagicMock(index=1),
+    ]
+    return backend
+
+
+def _patch_backend(mock_backend):
+    return patch("naturo.cli.core._common._get_backend", return_value=mock_backend)
+
+
+def _patch_platform(supports=True):
+    return patch("naturo.cli.core._common._platform_supports_gui", return_value=supports)
+
+
+# Note: Most tests use --no-snapshot to avoid snapshot manager trying
+# to read the fake file path from FakeCaptureResult.
+
+
+# ── Full screen capture ─────────────────────────────────────────────
+
+
+class TestFullScreenCapture:
+
+    def test_basic_capture(self, runner, mock_backend):
+        with _patch_platform(), _patch_backend(mock_backend):
+            result = runner.invoke(capture, [
+                "-p", "/tmp/out.png", "--no-snapshot",
+            ], catch_exceptions=False)
+        assert result.exit_code == 0
+        mock_backend.capture_screen.assert_called_once_with(screen_index=0, output_path="/tmp/out.png")
+
+    def test_json_output(self, runner, mock_backend):
+        with _patch_platform(), _patch_backend(mock_backend):
+            result = runner.invoke(capture, [
+                "-p", "/tmp/out.png", "--json", "--no-snapshot",
+            ], catch_exceptions=False)
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["success"] is True
+        assert data["width"] == 1920
+        assert data["height"] == 1080
+        assert data["format"] == "png"
+
+    def test_default_path_generated(self, runner, mock_backend):
+        with _patch_platform(), _patch_backend(mock_backend):
+            result = runner.invoke(capture, ["--no-snapshot"], catch_exceptions=False)
+        assert result.exit_code == 0
+        call_args = mock_backend.capture_screen.call_args
+        assert call_args.kwargs["output_path"].startswith("naturo-screen-")
+        assert call_args.kwargs["output_path"].endswith(".png")
+
+    def test_plain_output_shows_path(self, runner, mock_backend):
+        with _patch_platform(), _patch_backend(mock_backend):
+            result = runner.invoke(capture, [
+                "-p", "/tmp/out.png", "--no-snapshot",
+            ], catch_exceptions=False)
+        assert result.exit_code == 0
+        assert "Saved:" in result.output
+        assert "1920x1080" in result.output
+
+
+# ── Screen index validation ──────────────────────────────────────────
+
+
+class TestScreenValidation:
+
+    def test_negative_screen_index_error(self, runner, mock_backend):
+        with _patch_platform(), _patch_backend(mock_backend):
+            result = runner.invoke(capture, [
+                "-s", "-1", "--json", "--no-snapshot",
+            ], catch_exceptions=False)
+        assert result.exit_code != 0
+        assert "INVALID_INPUT" in result.output
+
+    def test_screen_index_out_of_range(self, runner, mock_backend):
+        with _patch_platform(), _patch_backend(mock_backend):
+            result = runner.invoke(capture, [
+                "-s", "5", "--json", "--no-snapshot",
+            ], catch_exceptions=False)
+        assert result.exit_code != 0
+        assert "INVALID_INPUT" in result.output
+
+
+# ── Window capture ───────────────────────────────────────────────────
+
+
+class TestWindowCapture:
+
+    def test_capture_by_hwnd(self, runner, mock_backend):
+        with _patch_platform(), _patch_backend(mock_backend):
+            result = runner.invoke(capture, [
+                "--hwnd", "12345", "-p", "/tmp/out.png", "--no-snapshot",
+            ], catch_exceptions=False)
+        assert result.exit_code == 0
+        mock_backend.capture_window.assert_called_once()
+
+    def test_capture_by_app(self, runner, mock_backend):
+        with _patch_platform(), _patch_backend(mock_backend):
+            result = runner.invoke(capture, [
+                "--app", "notepad", "-p", "/tmp/out.png", "--no-snapshot",
+            ], catch_exceptions=False)
+        assert result.exit_code == 0
+        mock_backend._resolve_hwnd.assert_called()
+        mock_backend.capture_window.assert_called_once()
+
+
+# ── Region crop ──────────────────────────────────────────────────────
+
+
+class TestRegionCrop:
+
+    def test_invalid_region_format(self, runner, mock_backend):
+        with _patch_platform(), _patch_backend(mock_backend):
+            result = runner.invoke(capture, [
+                "-p", "/tmp/out.png", "--region", "bad", "--json", "--no-snapshot",
+            ], catch_exceptions=False)
+        assert result.exit_code != 0
+        assert "INVALID_INPUT" in result.output
+
+    def test_region_wrong_count(self, runner, mock_backend):
+        with _patch_platform(), _patch_backend(mock_backend):
+            result = runner.invoke(capture, [
+                "-p", "/tmp/out.png", "--region", "1,2,3", "--json", "--no-snapshot",
+            ], catch_exceptions=False)
+        assert result.exit_code != 0
+        assert "INVALID_INPUT" in result.output
+
+
+# ── Element crop ─────────────────────────────────────────────────────
+
+
+class TestElementCrop:
+
+    def test_element_ref_not_found(self, runner, mock_backend):
+        mock_mgr = MagicMock()
+        mock_mgr.resolve_ref.return_value = None
+
+        with _patch_platform(), _patch_backend(mock_backend), \
+             patch("naturo.snapshot.get_snapshot_manager", return_value=mock_mgr):
+            result = runner.invoke(capture, [
+                "-p", "/tmp/out.png", "--element", "e999", "--json", "--no-snapshot",
+            ], catch_exceptions=False)
+        assert result.exit_code != 0
+        assert "REF_NOT_FOUND" in result.output
+
+    def test_element_zero_size_error(self, runner, mock_backend):
+        mock_elem = MagicMock()
+        mock_elem.frame = (0, 0, 0, 0)
+        mock_elem.role = "Button"
+        mock_elem.name = "Hidden"
+        mock_mgr = MagicMock()
+        mock_mgr.resolve_ref.return_value = (0, 0, "snap1")
+        mock_mgr.resolve_ref_element.return_value = (mock_elem, "snap1")
+
+        with _patch_platform(), _patch_backend(mock_backend), \
+             patch("naturo.snapshot.get_snapshot_manager", return_value=mock_mgr):
+            result = runner.invoke(capture, [
+                "-p", "/tmp/out.png", "--element", "e5", "--json", "--no-snapshot",
+            ], catch_exceptions=False)
+        assert result.exit_code != 0
+        assert "ZERO_SIZE_ELEMENT" in result.output
+
+
+# ── Format option ────────────────────────────────────────────────────
+
+
+class TestFormatOption:
+
+    def test_jpg_format(self, runner, mock_backend):
+        with _patch_platform(), _patch_backend(mock_backend):
+            result = runner.invoke(capture, [
+                "--format", "jpg", "--no-snapshot",
+            ], catch_exceptions=False)
+        assert result.exit_code == 0
+        call_args = mock_backend.capture_screen.call_args
+        assert call_args.kwargs["output_path"].endswith(".jpg")
+
+
+# ── Platform check ───────────────────────────────────────────────────
+
+
+class TestPlatformCheck:
+
+    def test_unsupported_platform(self, runner):
+        with _patch_platform(supports=False):
+            result = runner.invoke(capture, ["--json"], catch_exceptions=False)
+        assert result.exit_code != 0
+        assert "PLATFORM_ERROR" in result.output
+
+    def test_unsupported_platform_plain(self, runner):
+        with _patch_platform(supports=False):
+            result = runner.invoke(capture, [], catch_exceptions=False)
+        assert result.exit_code != 0
+
+
+# ── Backend error ────────────────────────────────────────────────────
+
+
+class TestBackendError:
+
+    def test_capture_exception_json(self, runner, mock_backend):
+        mock_backend.capture_screen.side_effect = Exception("capture failed")
+        with _patch_platform(), _patch_backend(mock_backend):
+            result = runner.invoke(capture, [
+                "-p", "/tmp/out.png", "--json", "--no-snapshot",
+            ], catch_exceptions=False)
+        assert result.exit_code != 0
+        assert "CAPTURE_ERROR" in result.output
+
+
+# ── Snapshot storage ─────────────────────────────────────────────────
+
+
+class TestSnapshotStorage:
+
+    def test_json_includes_snapshot_id(self, runner, mock_backend):
+        mock_mgr = MagicMock()
+        mock_mgr.create_snapshot.return_value = "snap_abc"
+
+        with _patch_platform(), _patch_backend(mock_backend), \
+             patch("naturo.snapshot.get_snapshot_manager", return_value=mock_mgr):
+            result = runner.invoke(capture, [
+                "-p", "/tmp/out.png", "--json",
+            ], catch_exceptions=False)
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["snapshot_id"] == "snap_abc"
+        mock_mgr.create_snapshot.assert_called_once()
+        mock_mgr.store_screenshot.assert_called_once()

--- a/tests/test_cli_highlight.py
+++ b/tests/test_cli_highlight.py
@@ -1,0 +1,165 @@
+"""Tests for naturo.cli.core._highlight — highlight command.
+
+Tests cover UIA/win32 backends, ref filtering, annotate mode, JSON output,
+window resolution errors, and error paths. All mock-based, CI-safe.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from naturo.cli.core._highlight import highlight
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_backend():
+    backend = MagicMock()
+    backend._resolve_hwnd.return_value = 12345
+    backend.get_element_tree.return_value = MagicMock()
+    return backend
+
+
+def _patch_backend(mock_backend):
+    return patch("naturo.cli.core._common._get_backend", return_value=mock_backend)
+
+
+# ── UIA highlight (default) ─────────────────────────────────────────
+
+
+class TestUiaHighlight:
+
+    @patch("naturo.bridge.highlight_elements_uia")
+    def test_basic_highlight_json(self, mock_hl, runner, mock_backend):
+        with _patch_backend(mock_backend):
+            result = runner.invoke(highlight, [
+                "--app", "notepad", "--json", "--duration", "0.1",
+            ], catch_exceptions=False)
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["success"] is True
+        assert data["backend"] == "uia"
+        assert data["hwnd"] == 12345
+        mock_hl.assert_called_once()
+
+    @patch("naturo.bridge.highlight_elements_uia")
+    def test_highlight_with_refs(self, mock_hl, runner, mock_backend):
+        with _patch_backend(mock_backend):
+            result = runner.invoke(highlight, [
+                "e5", "e10", "--app", "notepad", "--json", "--duration", "0.1",
+            ], catch_exceptions=False)
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["refs"] == ["e5", "e10"]
+
+    @patch("naturo.bridge.highlight_elements_uia")
+    def test_highlight_on_ref(self, mock_hl, runner, mock_backend):
+        with _patch_backend(mock_backend):
+            result = runner.invoke(highlight, [
+                "--on", "e42", "--app", "notepad", "--json", "--duration", "0.1",
+            ], catch_exceptions=False)
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "e42" in data["refs"]
+
+    @patch("naturo.bridge.highlight_elements_uia")
+    def test_highlight_ref_option(self, mock_hl, runner, mock_backend):
+        with _patch_backend(mock_backend):
+            result = runner.invoke(highlight, [
+                "-r", "e5", "-r", "e10", "--app", "notepad", "--json", "--duration", "0.1",
+            ], catch_exceptions=False)
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "e5" in data["refs"]
+        assert "e10" in data["refs"]
+
+    @patch("naturo.bridge.highlight_elements_uia")
+    def test_highlight_all_flag(self, mock_hl, runner, mock_backend):
+        with _patch_backend(mock_backend):
+            result = runner.invoke(highlight, [
+                "--app", "notepad", "--all", "--json", "--duration", "0.1",
+            ], catch_exceptions=False)
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["show_all"] is True
+
+
+# ── Win32 highlight ──────────────────────────────────────────────────
+
+
+class TestWin32Highlight:
+
+    @patch("naturo.bridge.highlight_elements")
+    def test_win32_backend(self, mock_hl, runner, mock_backend):
+        with _patch_backend(mock_backend):
+            result = runner.invoke(highlight, [
+                "--app", "notepad", "--backend", "win32", "--json", "--duration", "0.1",
+            ], catch_exceptions=False)
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["backend"] == "win32"
+        mock_hl.assert_called_once()
+
+
+# ── Annotate mode ────────────────────────────────────────────────────
+
+
+class TestAnnotateMode:
+
+    @patch("naturo.bridge.highlight_elements_uia")
+    def test_annotate_saves_file(self, mock_hl, runner, mock_backend):
+        mock_hl.return_value = "/tmp/annotated.png"
+        with _patch_backend(mock_backend):
+            result = runner.invoke(highlight, [
+                "--app", "notepad", "-A", "/tmp/annotated.png", "--json",
+            ], catch_exceptions=False)
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["success"] is True
+        assert data["annotate_path"] == "/tmp/annotated.png"
+
+    @patch("naturo.bridge.highlight_elements_uia")
+    def test_annotate_no_snapshot(self, mock_hl, runner, mock_backend):
+        mock_hl.return_value = None
+        with _patch_backend(mock_backend):
+            result = runner.invoke(highlight, [
+                "--app", "notepad", "-A", "/tmp/out.png", "--json",
+            ], catch_exceptions=False)
+        assert result.exit_code != 0
+        assert "NO_SNAPSHOT" in result.output
+
+
+# ── Window resolution errors ────────────────────────────────────────
+
+
+class TestWindowResolution:
+
+    def test_window_not_found_json(self, runner, mock_backend):
+        mock_backend._resolve_hwnd.side_effect = Exception("window not found")
+        with _patch_backend(mock_backend):
+            result = runner.invoke(highlight, ["--app", "nonexistent", "--json"], catch_exceptions=False)
+        assert result.exit_code != 0
+        assert "WINDOW_NOT_FOUND" in result.output
+
+
+# ── Highlight error ──────────────────────────────────────────────────
+
+
+class TestHighlightError:
+
+    @patch("naturo.bridge.highlight_elements_uia")
+    def test_highlight_exception_json(self, mock_hl, runner, mock_backend):
+        mock_hl.side_effect = Exception("GDI error")
+        with _patch_backend(mock_backend):
+            result = runner.invoke(highlight, [
+                "--app", "notepad", "--json", "--duration", "0.1",
+            ], catch_exceptions=False)
+        assert result.exit_code != 0
+        assert "HIGHLIGHT_ERROR" in result.output

--- a/tests/test_cli_list.py
+++ b/tests/test_cli_list.py
@@ -1,0 +1,192 @@
+"""Tests for naturo.cli.core._list — list command group.
+
+Tests cover 'list windows', 'list screens', 'list permissions' subcommands
+with mocked backend. All mock-based, CI-safe.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from naturo.cli.core._list import list_cmd
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def _make_window(**overrides):
+    """Create a mock window info."""
+    w = MagicMock()
+    w.handle = overrides.get("handle", 12345)
+    w.title = overrides.get("title", "Untitled - Notepad")
+    w.process_name = overrides.get("process_name", "notepad.exe")
+    w.pid = overrides.get("pid", 5678)
+    w.x = overrides.get("x", 100)
+    w.y = overrides.get("y", 100)
+    w.width = overrides.get("width", 800)
+    w.height = overrides.get("height", 600)
+    w.is_visible = overrides.get("is_visible", True)
+    w.is_minimized = overrides.get("is_minimized", False)
+    return w
+
+
+def _make_monitor(**overrides):
+    """Create a mock monitor info."""
+    m = MagicMock()
+    m.index = overrides.get("index", 0)
+    m.name = overrides.get("name", "\\\\.\\DISPLAY1")
+    m.model_name = overrides.get("model_name", "DELL U2723QE")
+    m.device_path = overrides.get("device_path", "\\\\.\\DISPLAY1")
+    m.x = overrides.get("x", 0)
+    m.y = overrides.get("y", 0)
+    m.width = overrides.get("width", 3840)
+    m.height = overrides.get("height", 2160)
+    m.is_primary = overrides.get("is_primary", True)
+    m.scale_factor = overrides.get("scale_factor", 1.5)
+    m.dpi = overrides.get("dpi", 144)
+    m.work_area = overrides.get("work_area", {"x": 0, "y": 0, "width": 3840, "height": 2112})
+    return m
+
+
+@pytest.fixture
+def mock_backend():
+    backend = MagicMock()
+    backend.list_windows.return_value = [
+        _make_window(handle=1001, title="Notepad", process_name="notepad.exe", pid=100),
+        _make_window(handle=1002, title="Calculator", process_name="calc.exe", pid=200),
+    ]
+    backend.list_monitors.return_value = [
+        _make_monitor(index=0, is_primary=True),
+        _make_monitor(index=1, is_primary=False, model_name="LG 27UK850"),
+    ]
+    return backend
+
+
+def _patch_backend(mock_backend):
+    return patch("naturo.cli.core._common._get_backend", return_value=mock_backend)
+
+
+def _patch_platform(supports=True):
+    return patch("naturo.cli.core._common._platform_supports_gui", return_value=supports)
+
+
+# ── list windows ─────────────────────────────────────────────────────
+
+
+class TestListWindows:
+
+    def test_lists_windows_json(self, runner, mock_backend):
+        with _patch_platform(), _patch_backend(mock_backend), \
+             patch("os.getpid", return_value=99999), patch("os.getppid", return_value=99998):
+            result = runner.invoke(list_cmd, ["windows", "--json"], catch_exceptions=False)
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["success"] is True
+        assert len(data["windows"]) == 2
+        assert data["windows"][0]["title"] == "Notepad"
+        assert data["windows"][1]["title"] == "Calculator"
+
+    def test_lists_windows_plain(self, runner, mock_backend):
+        with _patch_platform(), _patch_backend(mock_backend), \
+             patch("os.getpid", return_value=99999), patch("os.getppid", return_value=99998):
+            result = runner.invoke(list_cmd, ["windows"], catch_exceptions=False)
+        assert result.exit_code == 0
+        assert "Notepad" in result.output
+        assert "2 windows found" in result.output
+
+    def test_filter_by_app(self, runner, mock_backend):
+        with _patch_platform(), _patch_backend(mock_backend), \
+             patch("os.getpid", return_value=99999), patch("os.getppid", return_value=99998):
+            result = runner.invoke(list_cmd, ["windows", "--app", "notepad", "--json"], catch_exceptions=False)
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert len(data["windows"]) == 1
+        assert data["windows"][0]["title"] == "Notepad"
+
+    def test_filter_by_pid(self, runner, mock_backend):
+        with _patch_platform(), _patch_backend(mock_backend), \
+             patch("os.getpid", return_value=99999), patch("os.getppid", return_value=99998):
+            result = runner.invoke(list_cmd, ["windows", "--pid", "200", "--json"], catch_exceptions=False)
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert len(data["windows"]) == 1
+        assert data["windows"][0]["title"] == "Calculator"
+
+    def test_no_windows_found(self, runner, mock_backend):
+        mock_backend.list_windows.return_value = []
+        with _patch_platform(), _patch_backend(mock_backend), \
+             patch("os.getpid", return_value=99999), patch("os.getppid", return_value=99998):
+            result = runner.invoke(list_cmd, ["windows"], catch_exceptions=False)
+        assert result.exit_code == 0
+        assert "No windows found" in result.output
+
+    def test_excludes_own_process(self, runner, mock_backend):
+        mock_backend.list_windows.return_value = [
+            _make_window(pid=42),  # own process
+            _make_window(pid=100, title="Other"),
+        ]
+        with _patch_platform(), _patch_backend(mock_backend), \
+             patch("os.getpid", return_value=42), patch("os.getppid", return_value=99998):
+            result = runner.invoke(list_cmd, ["windows", "--json"], catch_exceptions=False)
+        data = json.loads(result.output)
+        assert len(data["windows"]) == 1
+        assert data["windows"][0]["title"] == "Other"
+
+    def test_unsupported_platform(self, runner, mock_backend):
+        with _patch_platform(supports=False):
+            result = runner.invoke(list_cmd, ["windows", "--json"], catch_exceptions=False)
+        assert result.exit_code != 0
+        assert "PLATFORM_ERROR" in result.output
+
+
+# ── list screens ─────────────────────────────────────────────────────
+
+
+class TestListScreens:
+
+    def test_lists_monitors_json(self, runner, mock_backend):
+        with _patch_backend(mock_backend):
+            result = runner.invoke(list_cmd, ["screens", "--json"], catch_exceptions=False)
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["success"] is True
+        assert len(data["monitors"]) == 2
+        assert data["monitors"][0]["name"] == "DELL U2723QE"
+        assert data["monitors"][0]["is_primary"] is True
+        assert data["monitors"][0]["dpi"] == 144
+
+    def test_lists_monitors_plain(self, runner, mock_backend):
+        with _patch_backend(mock_backend):
+            result = runner.invoke(list_cmd, ["screens"], catch_exceptions=False)
+        assert result.exit_code == 0
+        assert "DELL U2723QE" in result.output
+
+    def test_not_implemented(self, runner, mock_backend):
+        mock_backend.list_monitors.side_effect = NotImplementedError
+        with _patch_backend(mock_backend):
+            result = runner.invoke(list_cmd, ["screens", "--json"], catch_exceptions=False)
+        assert result.exit_code != 0
+        assert "NOT_IMPLEMENTED" in result.output
+
+    def test_no_monitors(self, runner, mock_backend):
+        mock_backend.list_monitors.return_value = []
+        with _patch_backend(mock_backend):
+            result = runner.invoke(list_cmd, ["screens"], catch_exceptions=False)
+        assert result.exit_code == 0
+        assert "No monitors detected" in result.output
+
+
+# ── list permissions ─────────────────────────────────────────────────
+
+
+class TestListPermissions:
+
+    def test_not_implemented(self, runner, mock_backend):
+        result = runner.invoke(list_cmd, ["permissions", "--json"], catch_exceptions=False)
+        assert result.exit_code != 0
+        assert "NOT_IMPLEMENTED" in result.output

--- a/tests/test_cli_menu.py
+++ b/tests/test_cli_menu.py
@@ -1,0 +1,164 @@
+"""Tests for naturo.cli.core._menu — menu-inspect command.
+
+Tests cover menu tree display, flat mode, JSON output, app not found,
+no menu items, platform check, and error paths. All mock-based, CI-safe.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from naturo.cli.core._menu import menu_inspect
+
+
+def _make_menu_item(name="File", shortcut=None, enabled=True, checked=False, submenu=None):
+    """Create a mock menu item."""
+    item = MagicMock()
+    item.name = name
+    item.shortcut = shortcut
+    item.enabled = enabled
+    item.checked = checked
+    item.submenu = submenu or []
+    item.to_dict.return_value = {
+        "name": name,
+        "shortcut": shortcut,
+        "enabled": enabled,
+        "checked": checked,
+        "children": [s.to_dict() for s in (submenu or [])],
+    }
+    item.flatten.return_value = [
+        {"path": f"File > {name}" if name != "File" else name, "shortcut": shortcut},
+    ]
+    return item
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_backend():
+    backend = MagicMock()
+    sub_new = _make_menu_item(name="New", shortcut="Ctrl+N")
+    sub_open = _make_menu_item(name="Open", shortcut="Ctrl+O")
+    file_menu = _make_menu_item(name="File", submenu=[sub_new, sub_open])
+    file_menu.flatten.return_value = [
+        {"path": "File > New", "shortcut": "Ctrl+N"},
+        {"path": "File > Open", "shortcut": "Ctrl+O"},
+    ]
+    edit_menu = _make_menu_item(name="Edit")
+    edit_menu.flatten.return_value = [{"path": "Edit", "shortcut": None}]
+    backend.get_menu_items.return_value = [file_menu, edit_menu]
+    return backend
+
+
+def _patch_backend(mock_backend):
+    return patch("naturo.cli.core._common._get_backend", return_value=mock_backend)
+
+
+def _patch_platform(supports=True):
+    return patch("naturo.cli.core._common._platform_supports_gui", return_value=supports)
+
+
+# ── Menu tree display ────────────────────────────────────────────────
+
+
+class TestMenuTree:
+
+    def test_json_output(self, runner, mock_backend):
+        with _patch_platform(), _patch_backend(mock_backend):
+            result = runner.invoke(menu_inspect, ["--json"], catch_exceptions=False)
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["success"] is True
+        assert len(data["menu_items"]) == 2
+
+    def test_plain_output(self, runner, mock_backend):
+        with _patch_platform(), _patch_backend(mock_backend):
+            result = runner.invoke(menu_inspect, [], catch_exceptions=False)
+        assert result.exit_code == 0
+        assert "File" in result.output
+
+    def test_flat_json_output(self, runner, mock_backend):
+        with _patch_platform(), _patch_backend(mock_backend):
+            result = runner.invoke(menu_inspect, ["--flat", "--json"], catch_exceptions=False)
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["success"] is True
+        # Flattened entries from both menus
+        assert any("File > New" in str(item) for item in data["menu_items"])
+
+    def test_flat_plain_output(self, runner, mock_backend):
+        with _patch_platform(), _patch_backend(mock_backend):
+            result = runner.invoke(menu_inspect, ["--flat"], catch_exceptions=False)
+        assert result.exit_code == 0
+        assert "File > New" in result.output
+        assert "Ctrl+N" in result.output
+
+
+# ── No menu items ────────────────────────────────────────────────────
+
+
+class TestNoMenuItems:
+
+    def test_no_items_json(self, runner, mock_backend):
+        mock_backend.get_menu_items.return_value = []
+        with _patch_platform(), _patch_backend(mock_backend):
+            result = runner.invoke(menu_inspect, ["--json"], catch_exceptions=False)
+        assert result.exit_code != 0
+        assert "NO_MENU_ITEMS" in result.output
+
+    def test_no_items_plain(self, runner, mock_backend):
+        mock_backend.get_menu_items.return_value = []
+        with _patch_platform(), _patch_backend(mock_backend):
+            result = runner.invoke(menu_inspect, [], catch_exceptions=False)
+        assert result.exit_code != 0
+
+
+# ── App filter ───────────────────────────────────────────────────────
+
+
+class TestAppFilter:
+
+    def test_app_passed_to_backend(self, runner, mock_backend):
+        with _patch_platform(), _patch_backend(mock_backend), \
+             patch("naturo.process.find_process", return_value={"name": "notepad"}):
+            result = runner.invoke(menu_inspect, ["--app", "notepad"], catch_exceptions=False)
+        assert result.exit_code == 0
+        mock_backend.get_menu_items.assert_called_once_with(window_title="notepad", hwnd=None)
+
+
+# ── Platform check ───────────────────────────────────────────────────
+
+
+class TestPlatformCheck:
+
+    def test_unsupported_platform_json(self, runner):
+        with _patch_platform(supports=False):
+            result = runner.invoke(menu_inspect, ["--json"], catch_exceptions=False)
+        assert result.exit_code != 0
+        assert "PLATFORM_ERROR" in result.output
+
+
+# ── Backend errors ───────────────────────────────────────────────────
+
+
+class TestErrors:
+
+    def test_not_implemented_json(self, runner, mock_backend):
+        mock_backend.get_menu_items.side_effect = NotImplementedError
+        with _patch_platform(), _patch_backend(mock_backend):
+            result = runner.invoke(menu_inspect, ["--json"], catch_exceptions=False)
+        assert result.exit_code != 0
+        assert "NOT_SUPPORTED" in result.output
+
+    def test_generic_error_json(self, runner, mock_backend):
+        mock_backend.get_menu_items.side_effect = Exception("menu access denied")
+        with _patch_platform(), _patch_backend(mock_backend):
+            result = runner.invoke(menu_inspect, ["--json"], catch_exceptions=False)
+        assert result.exit_code != 0
+        assert "menu access denied" in result.output


### PR DESCRIPTION
## Changes

Adds test coverage for 4 previously untested CLI core modules (49 total tests), all mock-based and CI-safe.

### cli/core/_capture.py (17 tests)
- Full screen capture: basic, JSON output, default path generation, plain output
- Screen index validation: negative index, out of range
- Window capture: by hwnd, by app
- Region crop: invalid format, wrong count
- Element crop: ref not found, zero-size error
- Format option: jpg format
- Platform check: unsupported (JSON + plain)
- Backend error: capture exception
- Snapshot storage: JSON includes snapshot_id

### cli/core/_list.py (13 tests)
- `list windows`: JSON/plain output, --app filter, --pid filter, empty result, own-process exclusion, platform check
- `list screens`: JSON/plain output, not-implemented error, no monitors
- `list permissions`: not-implemented error

### cli/core/_menu.py (9 tests)
- Menu tree: JSON, plain, flat JSON, flat plain output
- No menu items: JSON + plain errors
- App filter: passes to backend with find_process check
- Platform check: unsupported platform
- Backend errors: not-implemented, generic exception

### cli/core/_highlight.py (10 tests)
- UIA highlight: basic JSON, positional refs, --on ref, -r option, --all flag
- Win32 backend: backend selection
- Annotate mode: save file, no snapshot error
- Window resolution: not found error
- Highlight error: GDI exception

## Testing
- All 49 new tests pass locally (`pytest -q`)
- Full suite: 3620 passed, 503 skipped
- `ruff check` → all clean

**[Dev-Sirius]**