### PR TITLE
test: add 22 tests for cli/interaction/_common.py (#660)

### DIFF
--- a/tests/test_interaction_common.py
+++ b/tests/test_interaction_common.py
@@ -160,3 +160,276 @@ class TestVerificationKeys:
 
     def test_is_frozen(self):
         assert isinstance(_VERIFICATION_KEYS, frozenset)
+
+
+# ── _find_element_by_text_fallback ──────────────
+
+
+class TestFindElementByTextFallback:
+    """Tests for _find_element_by_text_fallback() tree search."""
+
+    def _make_element(self, role="Button", name="OK", x=100, y=200, w=80, h=30, children=None):
+        el = MagicMock()
+        el.role = role
+        el.name = name
+        el.x = x
+        el.y = y
+        el.width = w
+        el.height = h
+        el.children = children or []
+        return el
+
+    def _make_match(self, element):
+        m = MagicMock()
+        m.element = element
+        return m
+
+    def test_no_get_element_tree_returns_none(self):
+        from naturo.cli.interaction._common import _find_element_by_text_fallback
+        backend = MagicMock(spec=[])  # no get_element_tree
+        assert _find_element_by_text_fallback(backend, "OK") is None
+
+    def test_empty_tree_returns_none(self):
+        from naturo.cli.interaction._common import _find_element_by_text_fallback
+        backend = MagicMock()
+        backend.get_element_tree.return_value = None
+        assert _find_element_by_text_fallback(backend, "OK") is None
+
+    def test_no_matches_returns_none(self):
+        from naturo.cli.interaction._common import _find_element_by_text_fallback
+        backend = MagicMock()
+        backend.get_element_tree.return_value = self._make_element()
+        with patch("naturo.search.search_elements", return_value=[]):
+            assert _find_element_by_text_fallback(backend, "OK") is None
+
+    def test_exact_actionable_match(self):
+        from naturo.cli.interaction._common import _find_element_by_text_fallback
+        backend = MagicMock()
+        btn = self._make_element(role="Button", name="OK", x=100, y=200, w=80, h=30)
+        backend.get_element_tree.return_value = btn
+        with patch("naturo.search.search_elements",
+                   return_value=[self._make_match(btn)]):
+            result = _find_element_by_text_fallback(backend, "OK")
+        assert result == (140, 215)  # center: 100+80//2, 200+30//2
+
+    def test_exact_any_match_when_no_actionable(self):
+        from naturo.cli.interaction._common import _find_element_by_text_fallback
+        backend = MagicMock()
+        text_el = self._make_element(role="Text", name="OK", x=50, y=60, w=40, h=20)
+        backend.get_element_tree.return_value = text_el
+        with patch("naturo.search.search_elements",
+                   return_value=[self._make_match(text_el)]):
+            result = _find_element_by_text_fallback(backend, "OK")
+        assert result == (70, 70)  # 50+40//2, 60+20//2
+
+    def test_zero_bounds_skipped(self):
+        from naturo.cli.interaction._common import _find_element_by_text_fallback
+        backend = MagicMock()
+        offscreen = self._make_element(role="Button", name="OK", x=0, y=0, w=0, h=0)
+        backend.get_element_tree.return_value = offscreen
+        with patch("naturo.search.search_elements",
+                   return_value=[self._make_match(offscreen)]):
+            result = _find_element_by_text_fallback(backend, "OK")
+        assert result is None
+
+    def test_case_insensitive_match(self):
+        from naturo.cli.interaction._common import _find_element_by_text_fallback
+        backend = MagicMock()
+        btn = self._make_element(role="Button", name="ok", x=10, y=20, w=60, h=40)
+        backend.get_element_tree.return_value = btn
+        with patch("naturo.search.search_elements",
+                   return_value=[self._make_match(btn)]):
+            result = _find_element_by_text_fallback(backend, "OK")
+        assert result == (40, 40)  # 10+60//2, 20+40//2
+
+    def test_tree_fetch_exception_returns_none(self):
+        from naturo.cli.interaction._common import _find_element_by_text_fallback
+        backend = MagicMock()
+        backend.get_element_tree.side_effect = RuntimeError("no tree")
+        assert _find_element_by_text_fallback(backend, "OK") is None
+
+
+# ── _resolve_app_id ─────────────────────────────
+
+
+class TestResolveAppId:
+    """Tests for _resolve_app_id() app-id resolution."""
+
+    def test_none_app_id_passthrough(self):
+        from naturo.cli.interaction._common import _resolve_app_id
+        result = _resolve_app_id(None, "notepad", 123, 456, False)
+        assert result == ("notepad", 123, 456)
+
+    def test_valid_app_id_returns_handle_and_pid(self):
+        from naturo.cli.interaction._common import _resolve_app_id
+        entry = MagicMock(handle=999, pid=111)
+        fake_map = MagicMock()
+        fake_map.resolve.return_value = entry
+        with patch("naturo.app_ids.get_app_id_map", return_value=fake_map):
+            result = _resolve_app_id("a1", "notepad", None, None, False)
+        assert result == (None, 999, 111)
+
+    def test_invalid_app_id_exits(self):
+        from naturo.cli.interaction._common import _resolve_app_id
+        fake_map = MagicMock()
+        fake_map.resolve.return_value = None
+        with patch("naturo.app_ids.get_app_id_map", return_value=fake_map):
+            with pytest.raises(SystemExit):
+                _resolve_app_id("a99", None, None, None, True)
+
+
+# ── _elementinfo_to_dict ────────────────────────
+
+
+class TestElementInfoToDict:
+    """Tests for _elementinfo_to_dict() conversion."""
+
+    def test_basic_conversion(self):
+        from naturo.cli.interaction._common import _elementinfo_to_dict
+        el = MagicMock()
+        el.role = "Button"
+        el.name = "OK"
+        el.id = "btn1"
+        el.value = ""
+        el.x = 10
+        el.y = 20
+        el.width = 80
+        el.height = 30
+        el.properties = {}
+        el.children = []
+        result = _elementinfo_to_dict(el)
+        assert result["role"] == "Button"
+        assert result["name"] == "OK"
+        assert result["automationid"] == "btn1"
+        assert result["children"] == []
+
+    def test_classname_from_properties(self):
+        from naturo.cli.interaction._common import _elementinfo_to_dict
+        el = MagicMock()
+        el.role = "Edit"
+        el.name = "Input"
+        el.id = "edit1"
+        el.value = "hello"
+        el.x = 0
+        el.y = 0
+        el.width = 200
+        el.height = 30
+        el.properties = {"className": "TextBox"}
+        el.children = []
+        result = _elementinfo_to_dict(el)
+        assert result["cls"] == "TextBox"
+
+    def test_recursive_children(self):
+        from naturo.cli.interaction._common import _elementinfo_to_dict
+        child = MagicMock()
+        child.role = "Text"
+        child.name = "Label"
+        child.id = "lbl"
+        child.value = ""
+        child.x = 5
+        child.y = 5
+        child.width = 50
+        child.height = 20
+        child.properties = {}
+        child.children = []
+
+        parent = MagicMock()
+        parent.role = "Group"
+        parent.name = "Panel"
+        parent.id = "grp"
+        parent.value = ""
+        parent.x = 0
+        parent.y = 0
+        parent.width = 100
+        parent.height = 100
+        parent.properties = {}
+        parent.children = [child]
+
+        result = _elementinfo_to_dict(parent)
+        assert len(result["children"]) == 1
+        assert result["children"][0]["role"] == "Text"
+
+
+# ── _auto_route ─────────────────────────────────
+
+
+class TestAutoRoute:
+    """Tests for _auto_route() auto-routing helper."""
+
+    def test_explicit_method_skips_routing(self):
+        from naturo.cli.interaction._common import _auto_route
+        result = _auto_route(app="notepad", pid=None, method="uia", json_output=False)
+        assert result == {}
+
+    def test_no_app_no_pid_skips_routing(self):
+        from naturo.cli.interaction._common import _auto_route
+        result = _auto_route(app=None, pid=None, method="auto", json_output=False)
+        assert result == {}
+
+    def test_auto_with_app_calls_resolve_method(self):
+        from naturo.cli.interaction._common import _auto_route
+        fake_result = MagicMock()
+        fake_result.pid = 123
+        fake_result.method = "uia"
+        fake_result.framework = "WPF"
+        fake_result.to_dict.return_value = {"method": "uia", "framework": "WPF"}
+        with patch("naturo.routing.resolve_method", return_value=fake_result):
+            result = _auto_route(app="notepad", pid=None, method="auto", json_output=False)
+        assert result["method"] == "uia"
+
+    def test_auto_with_app_not_found_exits(self):
+        from naturo.cli.interaction._common import _auto_route
+        fake_result = MagicMock()
+        fake_result.pid = None  # app not found
+        with patch("naturo.routing.resolve_method", return_value=fake_result):
+            with pytest.raises(SystemExit):
+                _auto_route(app="nonexistent", pid=None, method="auto", json_output=True)
+
+    def test_routing_exception_returns_empty(self):
+        from naturo.cli.interaction._common import _auto_route
+        with patch("naturo.routing.resolve_method", side_effect=RuntimeError("fail")):
+            result = _auto_route(app="notepad", pid=None, method="auto", json_output=False)
+        assert result == {}
+
+
+# ── _get_backend ────────────────────────────────
+
+
+class TestGetBackend:
+    """Tests for _get_backend() in interaction module."""
+
+    @patch("naturo.cli.interaction._common._check_desktop_session")
+    @patch("naturo.backends.base.get_backend")
+    def test_returns_backend(self, mock_get, mock_check):
+        from naturo.cli.interaction._common import _get_backend
+        mock_get.return_value = MagicMock()
+        backend = _get_backend(json_output=False)
+        mock_check.assert_called_once()
+        assert backend is mock_get.return_value
+
+    @patch("naturo.cli.interaction._common._check_desktop_session",
+           side_effect=Exception("no desktop"))
+    def test_no_desktop_json_exits(self, _mock):
+        from naturo.cli.interaction._common import _get_backend
+        with pytest.raises(SystemExit):
+            _get_backend(json_output=True)
+
+    @patch("naturo.cli.interaction._common._check_desktop_session",
+           side_effect=Exception("no desktop"))
+    def test_no_desktop_text_raises_usage_error(self, _mock):
+        from naturo.cli.interaction._common import _get_backend
+        with pytest.raises(click.UsageError, match="no desktop"):
+            _get_backend(json_output=False)
+
+
+# ── _validate_method ────────────────────────────
+
+
+class TestValidateMethod:
+    """Tests for _validate_method()."""
+
+    def test_always_returns_true(self):
+        from naturo.cli.interaction._common import _validate_method
+        assert _validate_method("auto", False) is True
+        assert _validate_method("uia", True) is True
+        assert _validate_method("cdp", False) is True


### PR DESCRIPTION
## Changes
- Add 22 new tests for untested functions in `cli/interaction/_common.py` (830 lines, previously only 17 tests covering 3 functions)
- Functions now covered: `_find_element_by_text_fallback` (priority matching, zero-bounds skip, case insensitivity, error paths), `_resolve_app_id` (passthrough, valid/invalid IDs), `_elementinfo_to_dict` (basic conversion, className property, recursive children), `_auto_route` (explicit method skip, app not found, routing exception), `_get_backend` (success, JSON exit, UsageError), `_validate_method`
- Total tests in file: 39 (17 existing + 22 new)

## Testing
- `pytest tests/test_interaction_common.py` — 39 passed
- `pytest tests/ -m "not desktop"` — 3692 passed, 390 skipped
- `ruff check` — clean
- `mypy` — clean

**[Dev-Sirius]**