### PR TITLE
fix: use identity-based UIA lookup for UWP eN click (fixes #681)

### DIFF
--- a/naturo/backends/windows/_input.py
+++ b/naturo/backends/windows/_input.py
@@ -68,19 +68,33 @@ class InputMixin:
         y: int,
         app: Optional[str] = None,
         hwnd: Optional[int] = None,
+        element_name: Optional[str] = None,
+        element_automation_id: Optional[str] = None,
+        element_role: Optional[str] = None,
     ) -> bool:
-        """Click a UI element at (x, y) using UIA patterns instead of SendInput.
+        """Click a UI element using UIA patterns instead of SendInput.
 
         For UWP apps hosted by ApplicationFrameHost.exe, SendInput clicks
-        don't reach the inner content.  This method uses UIA to find the
-        element at the given point and invokes it via InvokePattern,
+        don't reach the inner content.  This method finds the element via
+        UIA and invokes it via ExpandCollapsePattern, InvokePattern,
         TogglePattern, or SelectionItemPattern (#248).
+
+        When ``element_name`` or ``element_automation_id`` is provided (e.g.
+        from a cached snapshot), the element is located by identity via
+        ``_find_uia_element`` first — this is more reliable than
+        ``ElementFromPoint`` which can resolve to the wrong element when
+        coordinates are slightly stale or the window has repositioned (#681).
+        Falls back to ``ElementFromPoint(x, y)`` if the identity search
+        finds nothing.
 
         Args:
             x: Screen X coordinate of the target element center.
             y: Screen Y coordinate of the target element center.
             app: Application name (used to resolve window handle).
             hwnd: Direct window handle.
+            element_name: Accessible name from snapshot (e.g. "File").
+            element_automation_id: UIA AutomationId from snapshot.
+            element_role: UIA control type from snapshot (e.g. "MenuItem").
 
         Returns:
             True if UIA invoke succeeded, False otherwise.
@@ -95,15 +109,40 @@ class InputMixin:
             from ctypes import wintypes
             from comtypes import COMError  # type: ignore[import-untyped]
 
-            # Use UIA.ElementFromPoint to find the element at coordinates
-            point = wintypes.POINT(x, y)
-            element = uia.ElementFromPoint(point)
+            element = None
+
+            # (#681) Prefer identity-based lookup over coordinate-based when
+            # element metadata is available from the snapshot.  This avoids
+            # ElementFromPoint resolving to the wrong element when cached
+            # coordinates are slightly off (e.g. after window reposition).
+            if element_name or element_automation_id:
+                search_hwnd = hwnd or 0
+                if not search_hwnd and app:
+                    try:
+                        search_hwnd = self._resolve_hwnd(app=app)
+                    except Exception:
+                        search_hwnd = 0
+                element = self._find_uia_element(
+                    uia, mod, hwnd=search_hwnd,
+                    name=element_name,
+                    automation_id=element_automation_id,
+                )
+                if element is not None:
+                    logger.debug(
+                        "UIA click: found element by identity (name=%r, id=%r)",
+                        element_name, element_automation_id,
+                    )
+
+            # Fallback: locate element by screen coordinates
             if element is None:
-                logger.debug("UIA click: no element found at (%d, %d)", x, y)
-                return False
+                point = wintypes.POINT(x, y)
+                element = uia.ElementFromPoint(point)
+                if element is None:
+                    logger.debug("UIA click: no element found at (%d, %d)", x, y)
+                    return False
 
             elem_name = element.CurrentName or ""
-            logger.debug("UIA click: found element %r at (%d, %d)", elem_name, x, y)
+            logger.debug("UIA click: target element %r at (%d, %d)", elem_name, x, y)
 
             # (#672) Try ExpandCollapsePattern first (menu items, combo boxes,
             # tree items).  Top-level menu bar items (File, Edit, View…) support

--- a/naturo/cli/interaction/_click.py
+++ b/naturo/cli/interaction/_click.py
@@ -119,9 +119,11 @@ def click_cmd(query: str | None, on_text: str | None, ref_alias: str | None,
     _zero_bounds_element = None  # Track element for Invoke fallback (#137)
     _ref_resolved = False  # True when eN ref resolved to coordinates
     _snapshot_hwnd = None  # HWND from snapshot metadata for window focus
+    _ref_element = None  # (#681) Cached element metadata for UIA identity lookup
     if target_id and _re.fullmatch(r"e\d+", target_id):
         from naturo.snapshot import get_snapshot_manager
         mgr = get_snapshot_manager()
+        _original_ref = target_id  # Save before target_id is cleared
         resolved = mgr.resolve_ref(target_id)
         if resolved:
             x, y = resolved[0], resolved[1]
@@ -136,6 +138,16 @@ def click_cmd(query: str | None, on_text: str | None, ref_alias: str | None,
                     _snapshot_hwnd = snapshot.window_handle
             except Exception as exc:
                 logger.debug("Snapshot HWND retrieval failed: %s", exc)
+            # (#681) Retrieve element metadata (name, role, AutomationId)
+            # for identity-based UIA lookup — more reliable than
+            # ElementFromPoint for UWP apps where cached coordinates may
+            # resolve to the wrong element.
+            try:
+                el_result = mgr.resolve_ref_element(_original_ref)
+                if el_result is not None:
+                    _ref_element = el_result[0]  # UIElement
+            except Exception as exc:
+                logger.debug("Element metadata retrieval failed: %s", exc)
         else:
             # resolve_ref returns None for both "not found" and "zero-bounds".
             # Check resolve_ref_element to distinguish: if the element exists
@@ -276,14 +288,19 @@ def click_cmd(query: str | None, on_text: str | None, ref_alias: str | None,
             # (#248) UWP apps: SendInput clicks don't reach content inside
             # ApplicationFrameHost.  Try UIA InvokePattern first for
             # coordinate-based clicks on UWP apps.
+            # (#681) Pass element metadata from snapshot for identity-based
+            # lookup — avoids ElementFromPoint returning the wrong element.
             _used_uia_click = False
             if _is_uwp and x is not None and y is not None and button == "left" and not double:
                 if hasattr(backend, "click_element_uia"):
-                    _used_uia_click = backend.click_element_uia(
-                        x=x, y=y, app=app, hwnd=hwnd,
-                    )
+                    _uia_kwargs: dict[str, Any] = {"x": x, "y": y, "app": app, "hwnd": hwnd}
+                    if _ref_element is not None:
+                        _uia_kwargs["element_name"] = _ref_element.title
+                        _uia_kwargs["element_automation_id"] = _ref_element.identifier
+                        _uia_kwargs["element_role"] = _ref_element.role
+                    _used_uia_click = backend.click_element_uia(**_uia_kwargs)
                     if _used_uia_click:
-                        logger.info("UWP click: used UIA InvokePattern at (%d, %d)", x, y)
+                        logger.info("UWP click: used UIA pattern at (%d, %d)", x, y)
             if not _used_uia_click:
                 backend.click(x=x, y=y, button=button, double=double,
                               input_mode=input_mode)

--- a/tests/test_click_uwp_identity.py
+++ b/tests/test_click_uwp_identity.py
@@ -1,0 +1,200 @@
+"""Tests for UWP click identity-based element lookup (#681).
+
+When clicking an eN ref on a UWP app, click_element_uia should use the
+element's name and AutomationId from the snapshot to find the live UIA
+element — rather than relying solely on ElementFromPoint(x, y) which
+can resolve to the wrong element when cached coordinates are stale.
+"""
+from __future__ import annotations
+
+from typing import Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from naturo.models.snapshot import Snapshot, UIElement
+
+
+def _make_snapshot(
+    snapshot_id: str = "test-snap-uwp",
+    window_handle: Optional[int] = 0x12345,
+) -> Snapshot:
+    """Create a test snapshot with a MenuItem element (like UWP Notepad menu)."""
+    elements = {
+        "e13": UIElement(
+            id="e13",
+            element_id="element_13",
+            role="MenuItem",
+            title="File",
+            identifier="MenuItemFile",
+            frame=(100, 50, 60, 30),
+            is_actionable=True,
+        ),
+        "e5": UIElement(
+            id="e5",
+            element_id="element_5",
+            role="Button",
+            title="Bold",
+            identifier="BoldButton",
+            frame=(200, 100, 30, 30),
+            is_actionable=True,
+        ),
+    }
+    return Snapshot(
+        snapshot_id=snapshot_id,
+        ui_map=elements,
+        window_handle=window_handle,
+        application_name="Notepad",
+        application_pid=5678,
+        window_title="Untitled - Notepad",
+    )
+
+
+def _make_mock_snapshot_manager(snapshot: Snapshot) -> MagicMock:
+    """Create a mock SnapshotManager that resolves refs from the snapshot."""
+    mgr = MagicMock()
+
+    def resolve_ref(ref: str):
+        el = snapshot.ui_map.get(ref)
+        if el is None:
+            return None
+        ex, ey, ew, eh = el.frame
+        if ew == 0 and eh == 0:
+            return None
+        cx = ex + ew // 2
+        cy = ey + eh // 2
+        return (cx, cy, snapshot.snapshot_id)
+
+    def resolve_ref_element(ref: str):
+        el = snapshot.ui_map.get(ref)
+        if el is None:
+            return None
+        return (el, snapshot.snapshot_id)
+
+    mgr.resolve_ref.side_effect = resolve_ref
+    mgr.resolve_ref_element.side_effect = resolve_ref_element
+    mgr.get_snapshot.return_value = snapshot
+    return mgr
+
+
+class TestUwpClickIdentityLookup:
+    """Verify that UWP click passes element metadata for identity-based lookup (#681)."""
+
+    @patch("naturo.snapshot.get_snapshot_manager")
+    @patch("naturo.cli.interaction._common._get_backend")
+    def test_uwp_click_passes_element_metadata(
+        self, mock_get_backend, mock_get_mgr
+    ):
+        """When clicking eN on a UWP app, element name/id/role should be
+        passed to click_element_uia for identity-based lookup."""
+        from click.testing import CliRunner
+        from naturo.cli.interaction import click_cmd
+
+        snapshot = _make_snapshot(window_handle=0xABCDE)
+        mgr = _make_mock_snapshot_manager(snapshot)
+        mock_get_mgr.return_value = mgr
+
+        backend = MagicMock()
+        backend._is_afh_window.return_value = True  # UWP app
+        backend._resolve_hwnds.return_value = [0xABCDE]
+        backend.click_element_uia.return_value = True
+        mock_get_backend.return_value = backend
+
+        runner = CliRunner()
+        result = runner.invoke(click_cmd, ["e13", "--app", "notepad", "--no-verify"])
+
+        assert result.exit_code == 0, result.output
+
+        # Verify click_element_uia was called with element metadata
+        backend.click_element_uia.assert_called_once()
+        call_kwargs = backend.click_element_uia.call_args
+        # Check coordinates
+        assert call_kwargs.kwargs["x"] == 130  # 100 + 60//2
+        assert call_kwargs.kwargs["y"] == 65   # 50 + 30//2
+        # Check identity metadata from snapshot
+        assert call_kwargs.kwargs["element_name"] == "File"
+        assert call_kwargs.kwargs["element_automation_id"] == "MenuItemFile"
+        assert call_kwargs.kwargs["element_role"] == "MenuItem"
+
+    @patch("naturo.snapshot.get_snapshot_manager")
+    @patch("naturo.cli.interaction._common._get_backend")
+    def test_non_uwp_click_does_not_use_uia(
+        self, mock_get_backend, mock_get_mgr
+    ):
+        """Non-UWP apps should use regular coordinate click, not click_element_uia."""
+        from click.testing import CliRunner
+        from naturo.cli.interaction import click_cmd
+
+        snapshot = _make_snapshot(window_handle=0xABCDE)
+        mgr = _make_mock_snapshot_manager(snapshot)
+        mock_get_mgr.return_value = mgr
+
+        backend = MagicMock()
+        backend._is_afh_window.return_value = False  # NOT UWP
+        mock_get_backend.return_value = backend
+
+        runner = CliRunner()
+        result = runner.invoke(click_cmd, ["e13", "--no-verify"])
+
+        assert result.exit_code == 0, result.output
+
+        # click_element_uia should NOT be called for non-UWP
+        backend.click_element_uia.assert_not_called()
+        # Regular click should be called with coordinates
+        backend.click.assert_called_once()
+
+    @patch("naturo.cli.interaction._common._auto_route")
+    @patch("naturo.cli.interaction._common._get_backend")
+    def test_uwp_click_without_ref_no_element_metadata(
+        self, mock_get_backend, mock_auto_route
+    ):
+        """Coordinate-based click on UWP (no eN ref) should not pass element metadata."""
+        from click.testing import CliRunner
+        from naturo.cli.interaction import click_cmd
+
+        mock_auto_route.return_value = {}
+
+        backend = MagicMock()
+        backend._is_afh_window.return_value = True  # UWP
+        backend._resolve_hwnd.return_value = 0xABCDE
+        backend.click_element_uia.return_value = True
+        mock_get_backend.return_value = backend
+
+        runner = CliRunner()
+        result = runner.invoke(click_cmd, [
+            "--coords", "200", "300", "--app", "notepad", "--no-verify",
+        ])
+
+        assert result.exit_code == 0, result.output
+
+        # click_element_uia called but WITHOUT element metadata
+        backend.click_element_uia.assert_called_once()
+        call_kwargs = backend.click_element_uia.call_args
+        assert call_kwargs.kwargs.get("element_name") is None
+        assert call_kwargs.kwargs.get("element_automation_id") is None
+
+
+class TestClickElementUiaSignature:
+    """Verify click_element_uia accepts the new element identity parameters."""
+
+    def test_click_element_uia_accepts_element_metadata_params(self):
+        """click_element_uia signature should accept element_name,
+        element_automation_id, and element_role keyword arguments."""
+        from naturo.backends.windows._input import InputMixin
+        import inspect
+
+        sig = inspect.signature(InputMixin.click_element_uia)
+        param_names = list(sig.parameters.keys())
+        assert "element_name" in param_names
+        assert "element_automation_id" in param_names
+        assert "element_role" in param_names
+
+    def test_click_element_uia_defaults_to_none(self):
+        """New element identity params should default to None."""
+        from naturo.backends.windows._input import InputMixin
+        import inspect
+
+        sig = inspect.signature(InputMixin.click_element_uia)
+        assert sig.parameters["element_name"].default is None
+        assert sig.parameters["element_automation_id"].default is None
+        assert sig.parameters["element_role"].default is None


### PR DESCRIPTION
## Changes\n- When clicking an eN ref on a UWP app, `click_element_uia` now prefers identity-based element lookup (name + AutomationId via `_find_uia_element`) over `ElementFromPoint(x, y)`\n- Falls back to `ElementFromPoint` when identity lookup finds nothing — safe degradation\n- `_click.py` retrieves element metadata from snapshot and passes it through to `click_element_uia`\n\n## Root Cause\n`ElementFromPoint(x, y)` with cached snapshot coordinates can resolve to the wrong UIA element when coordinates are slightly stale or the window has repositioned. For UWP Notepad menu items, this caused clicks to land on unrelated elements (italic toggle, editor area) instead of the target MenuItem.\n\n## Testing\n- 5 new tests in `test_click_uwp_identity.py`\n- Full suite: 3519 passed, 681 skipped\n- ruff check clean\n\n**[Dev-Sirius]**