### PR TITLE
fix: click snapshot filtering, feedback output, highlight options parity

### DIFF
--- a/agents/orchestrator/review-prompt.md
+++ b/agents/orchestrator/review-prompt.md
@@ -117,10 +117,10 @@ git push origin main
 
 ## Phase 5 — Write Daily Report
 
-Write to `.work/reviews/YYYY-MM-DD-daily-review.md`:
+Write to `.work/reviews/YYYY-MM-DD-HHmm-daily-review.md`:
 
 ```markdown
-# Daily Review — YYYY-MM-DD
+# Daily Review — YYYY-MM-DD HH:mm
 
 ## Summary
 - <1-line: what happened>
@@ -149,7 +149,7 @@ Write to `.work/reviews/YYYY-MM-DD-daily-review.md`:
 Commit the report:
 ```bash
 git add .work/reviews/
-git commit -m "orc: daily review $(date +%Y-%m-%d) [skip ci]"
+git commit -m "orc: daily review $(date +%Y-%m-%d-%H%M) [skip ci]"
 git push origin main
 ```
 

--- a/naturo/cli/core/_capture.py
+++ b/naturo/cli/core/_capture.py
@@ -124,7 +124,7 @@ def capture(app: str | None, pid: int | None, window_title: str | None, hwnd: in
             # Resolve eN ref → bounds from most recent snapshot
             from naturo.snapshot import get_snapshot_manager
             _mgr = get_snapshot_manager(session=session)
-            resolved = _mgr.resolve_ref(element_ref)
+            resolved = _mgr.resolve_ref(element_ref, app_name=app)
             if resolved is None:
                 msg = (
                     f"Element ref '{element_ref}' not found in recent snapshots. "
@@ -136,7 +136,7 @@ def capture(app: str | None, pid: int | None, window_title: str | None, hwnd: in
                     click.echo(f"Error: {msg}", err=True)
                 raise SystemExit(1)
             cx, cy, _snap_id = resolved
-            el_result = _mgr.resolve_ref_element(element_ref)
+            el_result = _mgr.resolve_ref_element(element_ref, app_name=app)
             if el_result:
                 element, snap_id = el_result
                 ex, ey, ew, eh = element.frame

--- a/naturo/cli/core/_highlight.py
+++ b/naturo/cli/core/_highlight.py
@@ -24,17 +24,25 @@ logger = logging.getLogger(__name__)
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.option(
     "--backend", "-b",
-    type=click.Choice(["uia", "win32", "win32hybrid"]),
+    type=click.Choice(["uia", "win32", "win32hybrid", "msaa", "ia2", "jab", "auto", "hybrid"]),
     default="uia",
-    help="Highlight backend: uia (default), win32 (HWND-only), win32hybrid (HWND + UIA drill-down)",
+    help="Accessibility backend (same as 'naturo see --backend')",
 )
 @click.option("--all", "show_all", is_flag=True, help="Show all elements, not just actionable ones")
 @click.option("--annotate", "-A", "annotate_path", type=click.Path(), default=None,
               help="Save annotated screenshot to file instead of live overlay (requires Pillow)")
 @click.option("--filter", "role_filter", default=None,
               help="Filter elements by role (e.g. --filter Button)")
+@click.option("--visible-only", is_flag=True,
+              help="Only highlight visible (non-zero-bounds) elements")
+@click.option("--cascade", is_flag=True,
+              help="Progressive recognition: UIA → CDP → AI vision (same as 'naturo see --cascade')")
+@click.option("--fill-gaps", "fill_gaps", is_flag=True,
+              help="Use AI vision to fill uncovered regions (requires --cascade)")
+@click.option("--pid", type=int, default=None, help="Process ID")
 def highlight(positional_refs, on_ref, ref_option, app, hwnd, app_id, depth, duration,
-              json_output, backend, show_all, annotate_path, role_filter):
+              json_output, backend, show_all, annotate_path, role_filter,
+              visible_only, cascade, fill_gaps, pid):
     """Highlight UI elements on screen with colored borders and labels.
 
     By default highlights only actionable elements (Button, Edit, ComboBox,
@@ -43,6 +51,9 @@ def highlight(positional_refs, on_ref, ref_option, app, hwnd, app_id, depth, dur
 
     Elements at the same tree depth share a color for visual grouping.
     Labels are positioned to avoid overlapping each other.
+
+    Uses the same element discovery as 'naturo see', supporting --depth,
+    --backend, --cascade, --visible-only, and --fill-gaps.
 
     Use --annotate to save an annotated screenshot instead of live overlay.
     Use --backend win32 for VB6/ActiveX apps where UIA fails.
@@ -53,6 +64,8 @@ def highlight(positional_refs, on_ref, ref_option, app, hwnd, app_id, depth, dur
       naturo highlight --app notepad --all       # All elements
       naturo highlight e11 --app notepad         # Specific ref
       naturo highlight --app notepad --filter Button
+      naturo highlight --app notepad --visible-only
+      naturo highlight --app feishu --cascade -d 10
       naturo highlight --app notepad -A out.png  # Annotated screenshot
       naturo highlight --hwnd 10697004 -r e69 -r e77
       naturo highlight --app notepad --duration 10
@@ -74,7 +87,7 @@ def highlight(positional_refs, on_ref, ref_option, app, hwnd, app_id, depth, dur
 
     be = _common._get_backend(json_output)
     try:
-        handle = be._resolve_hwnd(app=app, hwnd=hwnd)
+        handle = be._resolve_hwnd(app=app, hwnd=hwnd, pid=pid)
     except Exception as exc:
         if json_output:
             click.echo(_common._json_error_str("WINDOW_NOT_FOUND", str(exc)))
@@ -88,17 +101,31 @@ def highlight(positional_refs, on_ref, ref_option, app, hwnd, app_id, depth, dur
     refs_list = all_refs if all_refs else None
 
     try:
-        # (#662) Fetch element tree via backend first — same path as `see`,
+        # (#662) Fetch element tree via backend — same path as `see`,
         # guaranteeing DPI-correct coordinates for all highlight modes.
+        # Supports --cascade for progressive recognition (UIA → CDP → AI).
         element_tree = None
         try:
-            element_tree = be.get_element_tree(
-                hwnd=handle, depth=depth, backend=backend,
-            )
+            if cascade:
+                from naturo.cascade import run_cascade
+                cascade_result = run_cascade(
+                    be, app=app, hwnd=handle, depth=depth,
+                    backend_name=backend,
+                    fill_gaps_ai=fill_gaps,
+                )
+                element_tree = cascade_result.tree
+            else:
+                element_tree = be.get_element_tree(
+                    hwnd=handle, depth=depth, backend=backend,
+                )
         except Exception:
             logger.debug("Pre-fetch element tree failed, highlight will fallback", exc_info=True)
 
-        if backend == "win32":
+        # (#662) Filter out zero-bounds (offscreen) elements when --visible-only
+        if visible_only and element_tree is not None:
+            _filter_zero_bounds(element_tree)
+
+        if backend in ("win32",):
             from naturo.bridge import highlight_elements
             if not json_output:
                 click.echo(f"Highlighting elements (win32) for {duration}s... (switch to the target window)")
@@ -138,7 +165,7 @@ def highlight(positional_refs, on_ref, ref_option, app, hwnd, app_id, depth, dur
                     raise SystemExit(1)
             else:
                 if not json_output:
-                    click.echo(f"Highlighting elements (uia) for {duration}s... (switch to the target window)")
+                    click.echo(f"Highlighting elements ({backend}) for {duration}s... (switch to the target window)")
                 import time
                 time.sleep(1.5)
                 highlight_elements_uia(
@@ -167,3 +194,13 @@ def highlight(positional_refs, on_ref, ref_option, app, hwnd, app_id, depth, dur
         click.echo(_json.dumps(result))
     else:
         click.echo("Done.")
+
+
+def _filter_zero_bounds(el) -> None:
+    """Recursively remove zero-bounds children from element tree (in-place)."""
+    el.children = [
+        c for c in el.children
+        if not (c.x == 0 and c.y == 0 and c.width == 0 and c.height == 0)
+    ]
+    for c in el.children:
+        _filter_zero_bounds(c)

--- a/naturo/cli/interaction/_click.py
+++ b/naturo/cli/interaction/_click.py
@@ -124,7 +124,7 @@ def click_cmd(query: str | None, on_text: str | None, ref_alias: str | None,
         from naturo.snapshot import get_snapshot_manager
         mgr = get_snapshot_manager()
         _original_ref = target_id  # Save before target_id is cleared
-        resolved = mgr.resolve_ref(target_id)
+        resolved = mgr.resolve_ref(target_id, app_name=app)
         if resolved:
             x, y = resolved[0], resolved[1]
             _snap_id = resolved[2]
@@ -143,16 +143,21 @@ def click_cmd(query: str | None, on_text: str | None, ref_alias: str | None,
             # ElementFromPoint for UWP apps where cached coordinates may
             # resolve to the wrong element.
             try:
-                el_result = mgr.resolve_ref_element(_original_ref)
+                el_result = mgr.resolve_ref_element(_original_ref, app_name=app)
                 if el_result is not None:
                     _ref_element = el_result[0]  # UIElement
+                    # (#662) Show what we're about to click for user verification
+                    if not json_output:
+                        _el = _ref_element
+                        _el_desc = f"{_el.role} \"{_el.title}\"" if _el.title else _el.role
+                        click.echo(f"Clicking {_original_ref} ({_el_desc}) at ({x}, {y})")
             except Exception as exc:
                 logger.debug("Element metadata retrieval failed: %s", exc)
         else:
             # resolve_ref returns None for both "not found" and "zero-bounds".
             # Check resolve_ref_element to distinguish: if the element exists
             # but has zero-bounds, try UIA Invoke pattern (#137/#135).
-            el_result = mgr.resolve_ref_element(target_id)
+            el_result = mgr.resolve_ref_element(target_id, app_name=app)
             if el_result is not None:
                 element, _snap_id = el_result
                 ex, ey, ew, eh = element.frame

--- a/naturo/cli/interaction/_mouse.py
+++ b/naturo/cli/interaction/_mouse.py
@@ -96,7 +96,7 @@ def scroll(direction_arg, direction_option, amount, on_text, ref_alias, element_
             # Resolve eN ref from most recent `see` snapshot
             from naturo.snapshot import get_snapshot_manager
             mgr = get_snapshot_manager()
-            resolved = mgr.resolve_ref(target_id)
+            resolved = mgr.resolve_ref(target_id, app_name=app)
             if resolved:
                 x, y = resolved[0], resolved[1]
                 target_label = target_id
@@ -243,7 +243,7 @@ def drag(from_text, from_coords, from_selector, to_text, to_coords, to_selector,
         fx, fy = from_coords
     elif from_text and _re.fullmatch(r"e\d+", from_text):
         mgr = get_snapshot_manager()
-        resolved = mgr.resolve_ref(from_text)
+        resolved = mgr.resolve_ref(from_text, app_name=app)
         if resolved:
             fx, fy = resolved[0], resolved[1]
             from_label = from_text
@@ -277,7 +277,7 @@ def drag(from_text, from_coords, from_selector, to_text, to_coords, to_selector,
         tx, ty = to_coords
     elif to_text and _re.fullmatch(r"e\d+", to_text):
         mgr = get_snapshot_manager()
-        resolved = mgr.resolve_ref(to_text)
+        resolved = mgr.resolve_ref(to_text, app_name=app)
         if resolved:
             tx, ty = resolved[0], resolved[1]
             to_label = to_text

--- a/naturo/cli/interaction/_press.py
+++ b/naturo/cli/interaction/_press.py
@@ -105,9 +105,18 @@ def press(keys: tuple[str, ...], count: int, delay: float, hold_duration: float 
         if _re.fullmatch(r"e\d+", on_element):
             from naturo.snapshot import get_snapshot_manager
             mgr = get_snapshot_manager()
-            resolved = mgr.resolve_ref(on_element)
+            resolved = mgr.resolve_ref(on_element, app_name=app)
             if resolved:
                 click_x, click_y = resolved[0], resolved[1]
+                if not json_output:
+                    try:
+                        _el_info = mgr.resolve_ref_element(on_element, app_name=app)
+                        if _el_info and len(_el_info) >= 2:
+                            _el = _el_info[0]
+                            _el_desc = f"{_el.role} \"{_el.title}\"" if _el.title else _el.role
+                            click.echo(f"Pressing on {on_element} ({_el_desc}) at ({click_x}, {click_y})")
+                    except Exception:
+                        pass
             else:
                 _common._json_err(
                     f"Element ref '{on_element}' not found. Run 'naturo see' first to "

--- a/naturo/cli/interaction/_type.py
+++ b/naturo/cli/interaction/_type.py
@@ -206,9 +206,18 @@ def type_cmd(text, delay, profile, wpm, press_return, tab_count, escape,
         if _re.fullmatch(r"e\d+", on_element):
             from naturo.snapshot import get_snapshot_manager
             mgr = get_snapshot_manager()
-            resolved = mgr.resolve_ref(on_element)
+            resolved = mgr.resolve_ref(on_element, app_name=app)
             if resolved:
                 click_x, click_y = resolved[0], resolved[1]
+                if not json_output:
+                    try:
+                        _el_info = mgr.resolve_ref_element(on_element, app_name=app)
+                        if _el_info and len(_el_info) >= 2:
+                            _el = _el_info[0]
+                            _el_desc = f"{_el.role} \"{_el.title}\"" if _el.title else _el.role
+                            click.echo(f"Typing on {on_element} ({_el_desc}) at ({click_x}, {click_y})")
+                    except Exception:
+                        pass
             else:
                 _common._json_err(
                     f"Element ref '{on_element}' not found. Run 'naturo see' first to "
@@ -319,7 +328,7 @@ def type_cmd(text, delay, profile, wpm, press_return, tab_count, escape,
                 if _re.fullmatch(r"e\d+", on_element):
                     from naturo.snapshot import get_snapshot_manager
                     mgr = get_snapshot_manager()
-                    el_result = mgr.resolve_ref_element(on_element)
+                    el_result = mgr.resolve_ref_element(on_element, app_name=app)
                     if el_result:
                         elem, _snap = el_result
                         _target_name = elem.title or elem.label

--- a/naturo/snapshot.py
+++ b/naturo/snapshot.py
@@ -353,7 +353,7 @@ class SnapshotManager:
                 return ref
         return display_map.get(ref, ref)
 
-    def resolve_ref(self, ref: str) -> Optional[tuple]:
+    def resolve_ref(self, ref: str, app_name: Optional[str] = None) -> Optional[tuple]:
         """Resolve a short element ref (e.g. ``e3``) to center coordinates.
 
         Searches the most recent valid snapshot for the ref, looks up the
@@ -364,6 +364,10 @@ class SnapshotManager:
         ----------
         ref:
             Short ref string (e.g. ``"e3"``).
+        app_name:
+            If provided, only consider snapshots for this application.
+            Prevents cross-app snapshot confusion when multiple apps have
+            recent snapshots (#662).
 
         Returns
         -------
@@ -371,7 +375,9 @@ class SnapshotManager:
             ``(x, y, snapshot_id)`` — center coordinates and the snapshot ID
             used; or ``None`` if no matching ref was found.
         """
-        recent_id = self.get_most_recent_snapshot(require_refs=True)
+        recent_id = self.get_most_recent_snapshot(
+            require_refs=True, app_name=app_name,
+        )
         if not recent_id:
             return None
 
@@ -431,7 +437,7 @@ class SnapshotManager:
         cy = ey + eh // 2
         return (cx, cy, recent_id)
 
-    def resolve_ref_element(self, ref: str) -> Optional[tuple]:
+    def resolve_ref_element(self, ref: str, app_name: Optional[str] = None) -> Optional[tuple]:
         """Resolve a short element ref (e.g. ``e3``) to full element info.
 
         Searches the most recent valid snapshot for the ref and returns
@@ -441,13 +447,17 @@ class SnapshotManager:
         ----------
         ref:
             Short ref string (e.g. ``"e3"``).
+        app_name:
+            If provided, only consider snapshots for this application (#662).
 
         Returns
         -------
         tuple | None
             ``(UIElement, snapshot_id)`` or ``None`` if not found.
         """
-        recent_id = self.get_most_recent_snapshot(require_refs=True)
+        recent_id = self.get_most_recent_snapshot(
+            require_refs=True, app_name=app_name,
+        )
         if not recent_id:
             return None
 

--- a/tests/test_cli_press.py
+++ b/tests/test_cli_press.py
@@ -238,7 +238,7 @@ class TestPressOnElement:
                 catch_exceptions=False,
             )
             assert result.exit_code == 0
-            mgr.resolve_ref.assert_called_once_with("e5")
+            mgr.resolve_ref.assert_called_once_with("e5", app_name=None)
             # Should click at resolved coords then press key
             backend.click.assert_called_once()
             backend.press_key.assert_called_once()

--- a/tests/test_click_app_foreground.py
+++ b/tests/test_click_app_foreground.py
@@ -45,7 +45,7 @@ def _make_mock_snapshot_manager(snapshot: Snapshot) -> MagicMock:
     """Create a mock SnapshotManager that resolves refs from the snapshot."""
     mgr = MagicMock()
 
-    def resolve_ref(ref: str):
+    def resolve_ref(ref: str, app_name=None):
         el = snapshot.ui_map.get(ref)
         if el is None:
             return None
@@ -56,7 +56,7 @@ def _make_mock_snapshot_manager(snapshot: Snapshot) -> MagicMock:
         cy = ey + eh // 2
         return (cx, cy, snapshot.snapshot_id)
 
-    def resolve_ref_element(ref: str):
+    def resolve_ref_element(ref: str, app_name=None):
         el = snapshot.ui_map.get(ref)
         if el is None:
             return None

--- a/tests/test_click_app_validation.py
+++ b/tests/test_click_app_validation.py
@@ -43,7 +43,7 @@ def _make_mock_snapshot_manager(snapshot: Snapshot) -> MagicMock:
     """Create a mock SnapshotManager that resolves refs from the snapshot."""
     mgr = MagicMock()
 
-    def resolve_ref(ref: str):
+    def resolve_ref(ref: str, app_name=None):
         el = snapshot.ui_map.get(ref)
         if el is None:
             return None
@@ -54,7 +54,7 @@ def _make_mock_snapshot_manager(snapshot: Snapshot) -> MagicMock:
         cy = ey + eh // 2
         return (cx, cy, snapshot.snapshot_id)
 
-    def resolve_ref_element(ref: str):
+    def resolve_ref_element(ref: str, app_name=None):
         el = snapshot.ui_map.get(ref)
         if el is None:
             return None

--- a/tests/test_click_ref_skip_routing.py
+++ b/tests/test_click_ref_skip_routing.py
@@ -54,7 +54,7 @@ def _make_mock_snapshot_manager(snapshot: Snapshot) -> MagicMock:
     """Create a mock SnapshotManager that resolves refs from the snapshot."""
     mgr = MagicMock()
 
-    def resolve_ref(ref: str):
+    def resolve_ref(ref: str, app_name=None):
         el = snapshot.ui_map.get(ref)
         if el is None:
             return None
@@ -65,7 +65,7 @@ def _make_mock_snapshot_manager(snapshot: Snapshot) -> MagicMock:
         cy = ey + eh // 2
         return (cx, cy, snapshot.snapshot_id)
 
-    def resolve_ref_element(ref: str):
+    def resolve_ref_element(ref: str, app_name=None):
         el = snapshot.ui_map.get(ref)
         if el is None:
             return None

--- a/tests/test_click_uwp_identity.py
+++ b/tests/test_click_uwp_identity.py
@@ -54,7 +54,7 @@ def _make_mock_snapshot_manager(snapshot: Snapshot) -> MagicMock:
     """Create a mock SnapshotManager that resolves refs from the snapshot."""
     mgr = MagicMock()
 
-    def resolve_ref(ref: str):
+    def resolve_ref(ref: str, app_name=None):
         el = snapshot.ui_map.get(ref)
         if el is None:
             return None
@@ -65,7 +65,7 @@ def _make_mock_snapshot_manager(snapshot: Snapshot) -> MagicMock:
         cy = ey + eh // 2
         return (cx, cy, snapshot.snapshot_id)
 
-    def resolve_ref_element(ref: str):
+    def resolve_ref_element(ref: str, app_name=None):
         el = snapshot.ui_map.get(ref)
         if el is None:
             return None


### PR DESCRIPTION
## Summary
- **click/type/press snapshot filtering**: pass `--app` to `resolve_ref` to prevent cross-app snapshot confusion
- **click feedback output**: show `Clicking e5 (Button "OK") at (120, 220)` before clicking
- **highlight options**: add `--visible-only`, `--cascade`, `--fill-gaps`, `--pid`, expand `--backend` choices to match `see`
- **review prompt**: add hour/minute to daily review report filename

## Test plan
- [x] 3697 tests pass, 0 regressions
- [x] Merged conflict with #681 (UIA identity lookup) — both features preserved
- [ ] Manual: `naturo click e5 --app notepad` shows feedback output
- [ ] Manual: `naturo highlight --app feishu --cascade -d 10 --visible-only`

**[Orc-Mycelium]**

https://claude.ai/code/session_01WLVqPqx66dA25A4McKoCtJ