### PR TITLE
fix: MCP click resolves eN refs from see_ui_tree (fixes #682)

### DIFF
--- a/naturo/mcp/_input.py
+++ b/naturo/mcp/_input.py
@@ -1,7 +1,13 @@
 """MCP tools for mouse and keyboard input."""
 from __future__ import annotations
 
+import logging
+import re
 from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+_EN_REF_RE = re.compile(r"e\d+")
 
 
 def register_input_tools(server, _get_backend, _safe_tool):
@@ -20,12 +26,12 @@ def register_input_tools(server, _get_backend, _safe_tool):
     ) -> dict:
         """Click at coordinates or on a UI element.
 
-        Provide either (x, y) coordinates or an element_id from find_element/see_ui_tree.
+        Provide either (x, y) coordinates or an element_id from see_ui_tree/find_element.
 
         Args:
             x: X coordinate.
             y: Y coordinate.
-            element_id: Element ID to click (from find_element).
+            element_id: Element ID to click (eN ref from see_ui_tree, or selector from find_element).
             button: Mouse button — "left", "right", or "middle".
             double: Double-click if True.
             input_mode: Input method — "normal" (default) or "hardware" (Phys32, bypasses anti-cheat).
@@ -34,6 +40,26 @@ def register_input_tools(server, _get_backend, _safe_tool):
         Returns:
             Dict with success flag.
         """
+        # (#682) Resolve eN refs from see_ui_tree snapshots to coordinates.
+        if element_id and _EN_REF_RE.fullmatch(element_id):
+            from naturo.snapshot import get_snapshot_manager
+            mgr = get_snapshot_manager()
+            resolved = mgr.resolve_ref(element_id)
+            if resolved:
+                logger.debug("Resolved MCP ref %s → (%d, %d)", element_id, resolved[0], resolved[1])
+                x, y = resolved[0], resolved[1]
+                element_id = None
+            else:
+                return {
+                    "success": False,
+                    "error": {
+                        "code": "ELEMENT_NOT_FOUND",
+                        "message": f"Element ref '{element_id}' not found. "
+                        f"Call see_ui_tree first to capture a snapshot, "
+                        f"then use the eN ref from the response.",
+                    },
+                }
+
         backend = _get_backend()
         backend.click(x=x, y=y, element_id=element_id, button=button, double=double,
                       input_mode=input_mode)

--- a/naturo/mcp/_inspect.py
+++ b/naturo/mcp/_inspect.py
@@ -20,7 +20,8 @@ def register_inspect_tools(server, _get_backend, _safe_tool):
         """Inspect the UI accessibility tree of a window.
 
         Returns the hierarchical tree of UI elements (buttons, text fields, etc.)
-        with their roles, names, bounds, and properties.
+        with their roles, names, bounds, and properties. Element IDs (eN) can be
+        used in subsequent ``click``, ``type_text``, and other tool calls.
 
         Args:
             window_title: Target window (partial match). None = foreground window.
@@ -42,9 +43,48 @@ def register_inspect_tools(server, _get_backend, _safe_tool):
         if tree is None:
             return {"success": False, "error": {"code": "NO_WINDOW", "message": "No matching window found"}}
 
+        # (#682) Store element tree in the snapshot manager so eN refs can be
+        # resolved by subsequent click/type_text calls in the same session.
+        from naturo.refs import assign_stable_refs
+        from naturo.models.snapshot import UIElement
+        from naturo.snapshot import get_snapshot_manager
+
+        element_obj_to_ref: dict[int, str] = {}
+        ui_map, ref_map = assign_stable_refs(
+            tree, UIElement, element_obj_to_ref=element_obj_to_ref,
+        )
+
+        mgr = get_snapshot_manager()
+        snapshot_id = mgr.create_snapshot()
+        mgr.store_detection_result(snapshot_id, ui_map)
+        mgr.store_ref_map(snapshot_id, ref_map)
+
+        # Store window metadata in the snapshot for coordinate resolution.
+        try:
+            snap_obj = mgr.get_snapshot(snapshot_id)
+            snap_obj.window_bounds = (tree.x, tree.y, tree.width, tree.height)
+            snap_obj.application_name = window_title
+            snap_obj.window_title = window_title
+            mgr._write_json_atomic(
+                mgr._snap_dir(snapshot_id) / "snapshot.json",
+                snap_obj.to_dict(),
+            )
+        except Exception as exc:
+            logger.debug("Snapshot metadata write failed: %s", exc)
+
+        # Build display ref map: sequential e1,e2,… → stable hash-based refs.
+        # The serialized tree uses stable refs; this mapping lets click resolve
+        # both sequential and stable refs.
+        display_ref_map: dict[str, str] = {}
+        _counter = [1]
+
         def _serialize(el) -> dict:
+            stable_ref = element_obj_to_ref.get(id(el), el.id)
+            display_ref = f"e{_counter[0]}"
+            _counter[0] += 1
+            display_ref_map[display_ref] = stable_ref
             d = {
-                "id": el.id,
+                "id": stable_ref,
                 "role": el.role,
                 "name": el.name,
                 "value": el.value,
@@ -55,7 +95,14 @@ def register_inspect_tools(server, _get_backend, _safe_tool):
                 d["children"] = [_serialize(c) for c in el.children]
             return d
 
-        return {"success": True, "tree": _serialize(tree)}
+        result = {"success": True, "tree": _serialize(tree), "snapshot_id": snapshot_id}
+
+        # Store display ref mapping so sequential refs from tree output
+        # can be translated to stable refs during click resolution.
+        if display_ref_map:
+            mgr.store_display_ref_map(snapshot_id, display_ref_map)
+
+        return result
 
     @server.tool()
     @_safe_tool

--- a/tests/test_mcp_click_ref.py
+++ b/tests/test_mcp_click_ref.py
@@ -1,0 +1,180 @@
+"""Tests for MCP click eN ref resolution (fixes #682).
+
+Verifies that element refs (eN) returned by see_ui_tree can be used
+in subsequent click calls within the same MCP session. The snapshot
+manager bridges the two calls by persisting the element tree.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+mcp_available = True
+try:
+    from naturo.mcp_server import create_server
+except ImportError:
+    mcp_available = False
+
+pytestmark = pytest.mark.skipif(not mcp_available, reason="mcp package not installed")
+
+
+def _call_tool(server, tool_name: str, arguments: dict):
+    """Helper to call an MCP tool function by name."""
+    async def _run():
+        return await server.call_tool(tool_name, arguments)
+
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(_run())
+    finally:
+        loop.close()
+
+
+def _make_element(**overrides):
+    """Create a mock element with standard attributes."""
+    el = MagicMock()
+    el.id = overrides.get("id", "btn_ok")
+    el.role = overrides.get("role", "Button")
+    el.name = overrides.get("name", "OK")
+    el.value = overrides.get("value", None)
+    el.x = overrides.get("x", 100)
+    el.y = overrides.get("y", 200)
+    el.width = overrides.get("width", 80)
+    el.height = overrides.get("height", 30)
+    el.properties = overrides.get("properties", {})
+    el.children = overrides.get("children", [])
+    el.is_actionable = overrides.get("is_actionable", False)
+    return el
+
+
+@pytest.fixture
+def snapshot_mgr(tmp_path):
+    """Real SnapshotManager using a temp directory."""
+    from naturo.snapshot import SnapshotManager
+    return SnapshotManager(storage_root=tmp_path, session="test")
+
+
+@pytest.fixture
+def mock_backend():
+    backend = MagicMock()
+    backend.get_element_tree.return_value = _make_element()
+    return backend
+
+
+@pytest.fixture
+def server(mock_backend, snapshot_mgr):
+    with patch("naturo.mcp_server.get_backend", return_value=mock_backend), \
+         patch("naturo.snapshot.get_snapshot_manager", return_value=snapshot_mgr):
+        yield create_server()
+
+
+class TestClickWithEnRef:
+    """Test that click can resolve eN refs from see_ui_tree."""
+
+    def test_see_then_click_resolves_ref(self, server, mock_backend):
+        """Core workflow: see_ui_tree → click(element_id=eN) succeeds."""
+        # Step 1: Call see_ui_tree to capture the element tree
+        see_result = _call_tool(server, "see_ui_tree", {})
+        see_data = json.loads(see_result[0].text)
+        assert see_data["success"] is True
+
+        # Get the element ID from the tree
+        element_ref = see_data["tree"]["id"]
+        assert element_ref.startswith("e")
+
+        # Step 2: Click using the element ref
+        click_result = _call_tool(server, "click", {"element_id": element_ref})
+        click_data = json.loads(click_result[0].text)
+        assert click_data["success"] is True
+
+        # Verify backend.click was called with resolved coordinates (center of 100,200 80x30)
+        mock_backend.click.assert_called_once()
+        call_kwargs = mock_backend.click.call_args
+        assert call_kwargs.kwargs.get("x") == 140  # 100 + 80/2
+        assert call_kwargs.kwargs.get("y") == 215  # 200 + 30/2
+        assert call_kwargs.kwargs.get("element_id") is None  # ref resolved to coords
+
+    def test_see_then_click_child_element(self, server, mock_backend):
+        """Click on a child element ref from see_ui_tree."""
+        child = _make_element(id="save_btn", role="Button", name="Save",
+                              x=300, y=400, width=100, height=40)
+        parent = _make_element(id="toolbar", role="ToolBar", name="Main",
+                               x=0, y=0, width=800, height=50, children=[child])
+        mock_backend.get_element_tree.return_value = parent
+
+        # Capture tree
+        see_result = _call_tool(server, "see_ui_tree", {})
+        see_data = json.loads(see_result[0].text)
+        child_ref = see_data["tree"]["children"][0]["id"]
+
+        # Click child
+        click_result = _call_tool(server, "click", {"element_id": child_ref})
+        click_data = json.loads(click_result[0].text)
+        assert click_data["success"] is True
+
+        # Verify coordinates are center of child (300,400 100x40)
+        call_kwargs = mock_backend.click.call_args
+        assert call_kwargs.kwargs.get("x") == 350  # 300 + 100/2
+        assert call_kwargs.kwargs.get("y") == 420  # 400 + 40/2
+
+    def test_click_unknown_ref_returns_error(self, server, mock_backend):
+        """Click with an eN ref that doesn't exist returns ELEMENT_NOT_FOUND."""
+        click_result = _call_tool(server, "click", {"element_id": "e9999"})
+        click_data = json.loads(click_result[0].text)
+        assert click_data["success"] is False
+        assert click_data["error"]["code"] == "ELEMENT_NOT_FOUND"
+        assert "e9999" in click_data["error"]["message"]
+
+    def test_click_non_ref_passes_to_backend(self, server, mock_backend):
+        """Click with a non-eN element_id passes through to backend."""
+        _call_tool(server, "click", {"element_id": "Button:Save"})
+        call_kwargs = mock_backend.click.call_args
+        assert call_kwargs.kwargs.get("element_id") == "Button:Save"
+
+    def test_click_coordinates_bypass_ref_resolution(self, server, mock_backend):
+        """Click with explicit (x, y) coordinates doesn't touch snapshot manager."""
+        click_result = _call_tool(server, "click", {"x": 500, "y": 300})
+        click_data = json.loads(click_result[0].text)
+        assert click_data["success"] is True
+        call_kwargs = mock_backend.click.call_args
+        assert call_kwargs.kwargs.get("x") == 500
+        assert call_kwargs.kwargs.get("y") == 300
+
+    def test_see_stores_snapshot_id(self, server, mock_backend):
+        """see_ui_tree response includes a snapshot_id."""
+        result = _call_tool(server, "see_ui_tree", {})
+        data = json.loads(result[0].text)
+        assert "snapshot_id" in data
+        assert isinstance(data["snapshot_id"], str)
+        assert len(data["snapshot_id"]) > 0
+
+    def test_click_right_button_with_ref(self, server, mock_backend):
+        """Right-click using an eN ref."""
+        see_result = _call_tool(server, "see_ui_tree", {})
+        see_data = json.loads(see_result[0].text)
+        element_ref = see_data["tree"]["id"]
+
+        click_result = _call_tool(server, "click", {
+            "element_id": element_ref,
+            "button": "right",
+        })
+        click_data = json.loads(click_result[0].text)
+        assert click_data["success"] is True
+        assert mock_backend.click.call_args.kwargs.get("button") == "right"
+
+    def test_click_double_with_ref(self, server, mock_backend):
+        """Double-click using an eN ref."""
+        see_result = _call_tool(server, "see_ui_tree", {})
+        see_data = json.loads(see_result[0].text)
+        element_ref = see_data["tree"]["id"]
+
+        click_result = _call_tool(server, "click", {
+            "element_id": element_ref,
+            "double": True,
+        })
+        click_data = json.loads(click_result[0].text)
+        assert click_data["success"] is True
+        assert mock_backend.click.call_args.kwargs.get("double") is True

--- a/tests/test_mcp_inspect.py
+++ b/tests/test_mcp_inspect.py
@@ -46,6 +46,7 @@ def _make_element(**overrides):
     el.height = overrides.get("height", 30)
     el.properties = overrides.get("properties", {})
     el.children = overrides.get("children", [])
+    el.is_actionable = overrides.get("is_actionable", False)
     return el
 
 
@@ -74,8 +75,16 @@ def mock_backend():
 
 
 @pytest.fixture
-def server(mock_backend):
-    with patch("naturo.mcp_server.get_backend", return_value=mock_backend):
+def snapshot_mgr(tmp_path):
+    """Real SnapshotManager using a temp directory."""
+    from naturo.snapshot import SnapshotManager
+    return SnapshotManager(storage_root=tmp_path, session="test")
+
+
+@pytest.fixture
+def server(mock_backend, snapshot_mgr):
+    with patch("naturo.mcp_server.get_backend", return_value=mock_backend), \
+         patch("naturo.snapshot.get_snapshot_manager", return_value=snapshot_mgr):
         yield create_server()
 
 
@@ -89,8 +98,10 @@ class TestSeeUiTree:
         data = json.loads(result[0].text)
         assert data["success"] is True
         assert "tree" in data
+        assert "snapshot_id" in data
         tree = data["tree"]
-        assert tree["id"] == "btn_ok"
+        # IDs are now stable hash-based refs (e.g. "e1234")
+        assert tree["id"].startswith("e")
         assert tree["role"] == "Button"
         assert tree["name"] == "OK"
         assert tree["bounds"] == {"x": 100, "y": 200, "width": 80, "height": 30}
@@ -140,7 +151,8 @@ class TestSeeUiTree:
         data = json.loads(result[0].text)
         tree = data["tree"]
         assert len(tree["children"]) == 1
-        assert tree["children"][0]["id"] == "child1"
+        # IDs are now stable hash-based refs
+        assert tree["children"][0]["id"].startswith("e")
         assert tree["children"][0]["role"] == "Text"
 
     def test_valid_backend_values_accepted(self, server, mock_backend):


### PR DESCRIPTION
## Changes
- `see_ui_tree` now stores element tree in SnapshotManager with stable hash-based refs, making eN refs available for subsequent tool calls
- MCP `click` handler detects eN-pattern element_ids (e.g. "e1234") and resolves them to coordinates through the snapshot manager — matching how the CLI click command works
- Returns `snapshot_id` in `see_ui_tree` response for reference

## Root Cause
`see_ui_tree` generated ephemeral eN refs via `populate_hierarchy()` but never persisted them. MCP `click` passed `element_id` directly to `backend.click()`, which treated "e45" as a UIA selector (role:name format) and searched for a literal element named "e45" — which obviously doesn't exist.

The CLI `click` command correctly resolves eN refs through `mgr.resolve_ref()` before delegating to the backend. The MCP handler was missing this resolution step.

## Testing
- 8 new tests in `test_mcp_click_ref.py` covering the full see→click workflow, error cases, right-click, double-click
- Updated 3 existing tests in `test_mcp_inspect.py` for new stable ref format
- Full suite: 3705 passed, 390 skipped, 0 failures
- ruff check clean
- mypy clean

**[Dev-Sirius]**