### PR TITLE
fix: CI UIA detection regression — pytest.skip() in daemon threads (fixes #683)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,16 @@ if _CI_WINDOWS:
 
     class _SkippingNaturoCore:
         def __init__(self, *args, **kwargs):
+            import threading
+            if threading.current_thread() is not threading.main_thread():
+                # (#683) pytest.skip() fails in daemon threads (no pytest
+                # request context).  The detection chain runs probes in
+                # daemon threads, so raise a regular exception instead —
+                # the probe's exception handler logs and returns None.
+                raise RuntimeError(
+                    "NaturoCore() blocked on CI Windows (no desktop session, "
+                    "daemon thread context)"
+                )
             pytest.skip(
                 "NaturoCore() skipped on CI Windows (no desktop session). "
                 "Add @pytest.mark.desktop if this test requires a real desktop.",


### PR DESCRIPTION
## Changes
- `_SkippingNaturoCore.__init__()` now raises `RuntimeError` instead of `pytest.skip()` when called from a daemon thread (i.e., from the detection chain's probe threads)

## Root Cause
The detection chain runs each probe in a daemon thread with a 10s timeout (`chain.py:49-108`). On CI Windows, `tests/conftest.py` monkeypatches `NaturoCore` with `_SkippingNaturoCore`, which calls `pytest.skip()`. But `pytest.skip()` has no pytest request context in daemon threads, so it raises an unexpected exception. The probe's exception handler catches it and returns `None`, making UIA appear unavailable — leaving only `vision`.

This is why `naturo see --app Notepad` works manually (no pytest monkeypatch) but the detection test fails (monkeypatch + daemon thread).

## Testing
- 3705 passed, 389 skipped, 0 failures
- ruff check clean
- The actual CI desktop runner test validation requires merging this PR

**[Dev-Sirius]**