### PR TITLE
refactor: extract input strategy pattern (fixes #412)

### DIFF
--- a/naturo/backends/windows/__init__.py
+++ b/naturo/backends/windows/__init__.py
@@ -13,6 +13,12 @@ from naturo.backends.windows._core import CoreMixin
 from naturo.backends.windows._element import ElementMixin
 from naturo.backends.windows._input import InputMixin
 from naturo.backends.windows._shell import ShellMixin
+from naturo.backends.windows._strategies import (
+    InputStrategy,
+    Phys32Strategy,
+    SendInputStrategy,
+    get_input_strategy,
+)
 from naturo.backends.windows._window import WindowMixin
 
 # Re-export names that were previously importable from the monolithic module.
@@ -40,4 +46,10 @@ class WindowsBackend(
     """
 
 
-__all__ = ["WindowsBackend"]
+__all__ = [
+    "WindowsBackend",
+    "InputStrategy",
+    "SendInputStrategy",
+    "Phys32Strategy",
+    "get_input_strategy",
+]

--- a/naturo/backends/windows/_input.py
+++ b/naturo/backends/windows/_input.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Optional
 
+from naturo.backends.windows._strategies import get_input_strategy
 from naturo.errors import NaturoError
 
 logger = logging.getLogger(__name__)
@@ -42,6 +43,7 @@ class InputMixin:
             NaturoCoreError: On system error.
         """
         core = self._ensure_core()
+        strategy = get_input_strategy(core, input_mode)
 
         BUTTON_MAP = {"left": 0, "right": 1, "middle": 2}
         btn = BUTTON_MAP.get(button.lower(), 0)
@@ -54,13 +56,11 @@ class InputMixin:
                 raise ElementNotFoundError(element_id)
             cx = el.x + el.width // 2
             cy = el.y + el.height // 2
-            core.mouse_move(cx, cy)
+            strategy.click(cx, cy, btn, double)
         elif x is not None and y is not None:
-            core.mouse_move(x, y)
+            strategy.click(x, y, btn, double)
         else:
             raise ValueError("click: provide either (x, y) or element_id")
-
-        core.mouse_click(btn, double)
 
     def click_element_uia(
         self,
@@ -673,6 +673,7 @@ class InputMixin:
             NaturoCoreError: On system error.
         """
         core = self._ensure_core()
+        strategy = get_input_strategy(core, input_mode)
 
         actual_delay = delay_ms
         if profile == "human" and wpm > 0:
@@ -680,10 +681,7 @@ class InputMixin:
             ms_per_char = int(60_000 / (wpm * 5))
             actual_delay = max(1, ms_per_char)
 
-        if input_mode == "hardware":
-            core.phys_key_type(text, actual_delay)
-        else:
-            core.key_type(text, actual_delay)
+        strategy.type_text(text, actual_delay)
 
     def press_key(self, key: str = "", input_mode: str = "normal") -> None:
         """Press and release a named key.
@@ -697,10 +695,8 @@ class InputMixin:
             NaturoCoreError: If key name is unrecognized or on system error.
         """
         core = self._ensure_core()
-        if input_mode == "hardware":
-            core.phys_key_press(key)
-        else:
-            core.key_press(key)
+        strategy = get_input_strategy(core, input_mode)
+        strategy.press_key(key)
 
     def hotkey(self, *keys: str, hold_duration_ms: int = 50,
               input_mode: str = "normal") -> None:
@@ -721,10 +717,8 @@ class InputMixin:
             NaturoCoreError: On invalid argument or system error.
         """
         core = self._ensure_core()
-        if input_mode == "hardware":
-            core.phys_key_hotkey(*keys)
-        else:
-            core.key_hotkey(*keys)
+        strategy = get_input_strategy(core, input_mode)
+        strategy.hotkey(*keys)
 
     def scroll(self, direction: str = "down", amount: int = 3,
                x: Optional[int] = None, y: Optional[int] = None,
@@ -742,6 +736,7 @@ class InputMixin:
             NaturoCoreError: On system error.
         """
         core = self._ensure_core()
+        strategy = get_input_strategy(core)
 
         if x is not None and y is not None:
             core.mouse_move(x, y)
@@ -752,7 +747,7 @@ class InputMixin:
         sign = 1 if direction in ("up", "right") else -1
         delta = sign * amount * WHEEL_DELTA
 
-        core.mouse_scroll(delta, horizontal)
+        strategy.scroll(delta, horizontal)
 
     def drag(self, from_x: int = 0, from_y: int = 0, to_x: int = 0, to_y: int = 0,
              duration_ms: int = 500, steps: int = 10) -> None:

--- a/naturo/backends/windows/_strategies.py
+++ b/naturo/backends/windows/_strategies.py
@@ -1,0 +1,165 @@
+"""Pluggable input strategies for Windows backend.
+
+Each strategy encapsulates a different mechanism for delivering keyboard
+and mouse input to the OS.  The ``get_input_strategy`` factory selects
+the appropriate strategy based on ``input_mode``.
+
+Adding a new input method (e.g. MinHook injection) requires only:
+1. Subclass ``InputStrategy``
+2. Add the mode string to ``get_input_strategy``
+
+No changes to ``InputMixin`` or CLI code are needed.
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from naturo.bridge._core import NaturoCore
+
+logger = logging.getLogger(__name__)
+
+
+class InputStrategy(ABC):
+    """Abstract base for input delivery mechanisms.
+
+    Every concrete strategy must implement the five primitives that the
+    ``InputMixin`` delegates to.  Strategies are stateless with respect
+    to the input they deliver -- the ``NaturoCore`` handle is injected
+    at construction time.
+    """
+
+    @abstractmethod
+    def type_text(self, text: str, delay_ms: int = 5) -> None:
+        """Type a UTF-8 string.
+
+        Args:
+            text: Text to type.
+            delay_ms: Delay between keystrokes in milliseconds.
+        """
+
+    @abstractmethod
+    def press_key(self, key: str) -> None:
+        """Press and release a named key.
+
+        Args:
+            key: Key name (e.g. ``"enter"``, ``"tab"``, ``"f5"``).
+        """
+
+    @abstractmethod
+    def hotkey(self, *keys: str) -> None:
+        """Press a hotkey combination.
+
+        Args:
+            *keys: Key names.  Modifiers (ctrl, alt, shift, win) are
+                detected automatically; one non-modifier key is the
+                base key.
+        """
+
+    @abstractmethod
+    def click(self, x: int, y: int, button: int = 0,
+              double: bool = False) -> None:
+        """Move the cursor and click.
+
+        Args:
+            x: Screen X coordinate.
+            y: Screen Y coordinate.
+            button: 0 = left, 1 = right, 2 = middle.
+            double: ``True`` for double-click.
+        """
+
+    @abstractmethod
+    def scroll(self, delta: int, horizontal: bool = False) -> None:
+        """Scroll the mouse wheel.
+
+        Args:
+            delta: Scroll amount (positive = up/right, negative = down/left).
+            horizontal: ``True`` for horizontal scrolling.
+        """
+
+
+class SendInputStrategy(InputStrategy):
+    """Default virtual-key / Unicode input via Win32 ``SendInput``.
+
+    This is the standard strategy for most applications.
+    """
+
+    def __init__(self, core: NaturoCore) -> None:
+        self._core = core
+
+    def type_text(self, text: str, delay_ms: int = 5) -> None:
+        self._core.key_type(text, delay_ms)
+
+    def press_key(self, key: str) -> None:
+        self._core.key_press(key)
+
+    def hotkey(self, *keys: str) -> None:
+        self._core.key_hotkey(*keys)
+
+    def click(self, x: int, y: int, button: int = 0,
+              double: bool = False) -> None:
+        self._core.mouse_move(x, y)
+        self._core.mouse_click(button, double)
+
+    def scroll(self, delta: int, horizontal: bool = False) -> None:
+        self._core.mouse_scroll(delta, horizontal)
+
+
+class Phys32Strategy(InputStrategy):
+    """Hardware scan-code input via the Phys32 driver.
+
+    Uses ``KEYEVENTF_SCANCODE`` to send raw PS/2 scan codes, which are
+    harder for games and anti-cheat software to detect as synthetic
+    input.  Mouse operations fall through to ``SendInput`` because
+    Phys32 only covers the keyboard.
+    """
+
+    def __init__(self, core: NaturoCore) -> None:
+        self._core = core
+
+    def type_text(self, text: str, delay_ms: int = 5) -> None:
+        self._core.phys_key_type(text, delay_ms)
+
+    def press_key(self, key: str) -> None:
+        self._core.phys_key_press(key)
+
+    def hotkey(self, *keys: str) -> None:
+        self._core.phys_key_hotkey(*keys)
+
+    def click(self, x: int, y: int, button: int = 0,
+              double: bool = False) -> None:
+        # Phys32 only covers keyboard; mouse is always SendInput.
+        self._core.mouse_move(x, y)
+        self._core.mouse_click(button, double)
+
+    def scroll(self, delta: int, horizontal: bool = False) -> None:
+        self._core.mouse_scroll(delta, horizontal)
+
+
+def get_input_strategy(
+    core: NaturoCore,
+    input_mode: str = "normal",
+) -> InputStrategy:
+    """Select the appropriate input strategy.
+
+    Args:
+        core: Loaded ``NaturoCore`` instance.
+        input_mode: ``"normal"`` for SendInput, ``"hardware"`` for Phys32.
+
+    Returns:
+        An ``InputStrategy`` implementation.
+
+    Raises:
+        ValueError: If ``input_mode`` is not recognized.
+    """
+    if input_mode == "hardware":
+        return Phys32Strategy(core)
+    if input_mode == "normal":
+        return SendInputStrategy(core)
+    raise ValueError(
+        f"Unknown input_mode {input_mode!r}. "
+        f"Supported modes: 'normal', 'hardware'."
+    )

--- a/tests/test_input_strategies.py
+++ b/tests/test_input_strategies.py
@@ -1,0 +1,330 @@
+"""Tests for the pluggable input strategy pattern (issue #412).
+
+Validates:
+  - InputStrategy ABC cannot be instantiated directly
+  - SendInputStrategy delegates to NaturoCore virtual-key methods
+  - Phys32Strategy delegates to NaturoCore scan-code methods
+  - get_input_strategy factory returns correct strategy for each mode
+  - InputMixin.type_text/press_key/hotkey dispatch through strategies
+  - Unknown input_mode raises ValueError
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from naturo.backends.windows._strategies import (
+    InputStrategy,
+    Phys32Strategy,
+    SendInputStrategy,
+    get_input_strategy,
+)
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _make_core() -> MagicMock:
+    """Create a mock NaturoCore with all input methods."""
+    core = MagicMock()
+    core.key_type.return_value = None
+    core.key_press.return_value = None
+    core.key_hotkey.return_value = None
+    core.mouse_move.return_value = None
+    core.mouse_click.return_value = None
+    core.mouse_scroll.return_value = None
+    core.phys_key_type.return_value = None
+    core.phys_key_press.return_value = None
+    core.phys_key_hotkey.return_value = None
+    return core
+
+
+# ── ABC Tests ────────────────────────────────────────────────────────────────
+
+
+class TestInputStrategyABC:
+    """InputStrategy is abstract and cannot be instantiated."""
+
+    def test_cannot_instantiate(self):
+        """Attempting to create InputStrategy directly raises TypeError."""
+        with pytest.raises(TypeError):
+            InputStrategy()  # type: ignore[abstract]
+
+    def test_has_required_methods(self):
+        """InputStrategy declares all five abstract methods."""
+        abstracts = InputStrategy.__abstractmethods__
+        assert "type_text" in abstracts
+        assert "press_key" in abstracts
+        assert "hotkey" in abstracts
+        assert "click" in abstracts
+        assert "scroll" in abstracts
+
+
+# ── SendInputStrategy Tests ──────────────────────────────────────────────────
+
+
+class TestSendInputStrategy:
+    """SendInputStrategy delegates to NaturoCore virtual-key methods."""
+
+    def test_type_text(self):
+        core = _make_core()
+        s = SendInputStrategy(core)
+        s.type_text("hello", 10)
+        core.key_type.assert_called_once_with("hello", 10)
+
+    def test_type_text_default_delay(self):
+        core = _make_core()
+        s = SendInputStrategy(core)
+        s.type_text("x")
+        core.key_type.assert_called_once_with("x", 5)
+
+    def test_press_key(self):
+        core = _make_core()
+        s = SendInputStrategy(core)
+        s.press_key("enter")
+        core.key_press.assert_called_once_with("enter")
+
+    def test_hotkey(self):
+        core = _make_core()
+        s = SendInputStrategy(core)
+        s.hotkey("ctrl", "c")
+        core.key_hotkey.assert_called_once_with("ctrl", "c")
+
+    def test_click(self):
+        core = _make_core()
+        s = SendInputStrategy(core)
+        s.click(100, 200, button=1, double=True)
+        core.mouse_move.assert_called_once_with(100, 200)
+        core.mouse_click.assert_called_once_with(1, True)
+
+    def test_click_defaults(self):
+        core = _make_core()
+        s = SendInputStrategy(core)
+        s.click(50, 60)
+        core.mouse_move.assert_called_once_with(50, 60)
+        core.mouse_click.assert_called_once_with(0, False)
+
+    def test_scroll(self):
+        core = _make_core()
+        s = SendInputStrategy(core)
+        s.scroll(360, horizontal=True)
+        core.mouse_scroll.assert_called_once_with(360, True)
+
+
+# ── Phys32Strategy Tests ────────────────────────────────────────────────────
+
+
+class TestPhys32Strategy:
+    """Phys32Strategy delegates keyboard to scan-code methods, mouse to SendInput."""
+
+    def test_type_text(self):
+        core = _make_core()
+        s = Phys32Strategy(core)
+        s.type_text("world", 20)
+        core.phys_key_type.assert_called_once_with("world", 20)
+        core.key_type.assert_not_called()
+
+    def test_press_key(self):
+        core = _make_core()
+        s = Phys32Strategy(core)
+        s.press_key("tab")
+        core.phys_key_press.assert_called_once_with("tab")
+        core.key_press.assert_not_called()
+
+    def test_hotkey(self):
+        core = _make_core()
+        s = Phys32Strategy(core)
+        s.hotkey("ctrl", "a")
+        core.phys_key_hotkey.assert_called_once_with("ctrl", "a")
+        core.key_hotkey.assert_not_called()
+
+    def test_click_uses_sendinput(self):
+        """Phys32 only covers keyboard; mouse is still SendInput."""
+        core = _make_core()
+        s = Phys32Strategy(core)
+        s.click(300, 400)
+        core.mouse_move.assert_called_once_with(300, 400)
+        core.mouse_click.assert_called_once_with(0, False)
+
+    def test_scroll_uses_sendinput(self):
+        """Phys32 only covers keyboard; scroll is still SendInput."""
+        core = _make_core()
+        s = Phys32Strategy(core)
+        s.scroll(-240)
+        core.mouse_scroll.assert_called_once_with(-240, False)
+
+
+# ── Factory Tests ────────────────────────────────────────────────────────────
+
+
+class TestGetInputStrategy:
+    """get_input_strategy returns the correct strategy for each mode."""
+
+    def test_normal_returns_sendinput(self):
+        core = _make_core()
+        s = get_input_strategy(core, "normal")
+        assert isinstance(s, SendInputStrategy)
+
+    def test_hardware_returns_phys32(self):
+        core = _make_core()
+        s = get_input_strategy(core, "hardware")
+        assert isinstance(s, Phys32Strategy)
+
+    def test_default_is_normal(self):
+        core = _make_core()
+        s = get_input_strategy(core)
+        assert isinstance(s, SendInputStrategy)
+
+    def test_unknown_mode_raises(self):
+        core = _make_core()
+        with pytest.raises(ValueError, match="Unknown input_mode"):
+            get_input_strategy(core, "telekinesis")
+
+
+# ── InputMixin Integration Tests ─────────────────────────────────────────────
+
+
+class TestInputMixinUsesStrategy:
+    """InputMixin methods dispatch through get_input_strategy."""
+
+    def _make_backend(self) -> MagicMock:
+        """Create a mock backend with _ensure_core returning a mock core."""
+        from naturo.backends.windows._input import InputMixin
+        backend = MagicMock(spec=InputMixin)
+        backend._ensure_core = MagicMock(return_value=_make_core())
+        return backend
+
+    def test_type_text_normal_delegates_to_sendinput(self):
+        core = _make_core()
+        with patch(
+            "naturo.backends.windows._input.get_input_strategy"
+        ) as mock_factory:
+            mock_strategy = MagicMock()
+            mock_factory.return_value = mock_strategy
+
+            from naturo.backends.windows._input import InputMixin
+            mixin = InputMixin.__new__(InputMixin)
+            mixin._ensure_core = MagicMock(return_value=core)
+
+            mixin.type_text("test", input_mode="normal")
+
+            mock_factory.assert_called_once_with(core, "normal")
+            mock_strategy.type_text.assert_called_once_with("test", 5)
+
+    def test_type_text_hardware_delegates_to_phys32(self):
+        core = _make_core()
+        with patch(
+            "naturo.backends.windows._input.get_input_strategy"
+        ) as mock_factory:
+            mock_strategy = MagicMock()
+            mock_factory.return_value = mock_strategy
+
+            from naturo.backends.windows._input import InputMixin
+            mixin = InputMixin.__new__(InputMixin)
+            mixin._ensure_core = MagicMock(return_value=core)
+
+            mixin.type_text("test", input_mode="hardware")
+
+            mock_factory.assert_called_once_with(core, "hardware")
+            mock_strategy.type_text.assert_called_once()
+
+    def test_press_key_delegates_through_strategy(self):
+        core = _make_core()
+        with patch(
+            "naturo.backends.windows._input.get_input_strategy"
+        ) as mock_factory:
+            mock_strategy = MagicMock()
+            mock_factory.return_value = mock_strategy
+
+            from naturo.backends.windows._input import InputMixin
+            mixin = InputMixin.__new__(InputMixin)
+            mixin._ensure_core = MagicMock(return_value=core)
+
+            mixin.press_key("enter", input_mode="normal")
+
+            mock_factory.assert_called_once_with(core, "normal")
+            mock_strategy.press_key.assert_called_once_with("enter")
+
+    def test_hotkey_delegates_through_strategy(self):
+        core = _make_core()
+        with patch(
+            "naturo.backends.windows._input.get_input_strategy"
+        ) as mock_factory:
+            mock_strategy = MagicMock()
+            mock_factory.return_value = mock_strategy
+
+            from naturo.backends.windows._input import InputMixin
+            mixin = InputMixin.__new__(InputMixin)
+            mixin._ensure_core = MagicMock(return_value=core)
+
+            mixin.hotkey("ctrl", "z", input_mode="hardware")
+
+            mock_factory.assert_called_once_with(core, "hardware")
+            mock_strategy.hotkey.assert_called_once_with("ctrl", "z")
+
+    def test_type_text_human_profile_calculates_delay(self):
+        """Human typing profile converts WPM to ms-per-char before delegating."""
+        core = _make_core()
+        with patch(
+            "naturo.backends.windows._input.get_input_strategy"
+        ) as mock_factory:
+            mock_strategy = MagicMock()
+            mock_factory.return_value = mock_strategy
+
+            from naturo.backends.windows._input import InputMixin
+            mixin = InputMixin.__new__(InputMixin)
+            mixin._ensure_core = MagicMock(return_value=core)
+
+            # 60 WPM = 60000 / (60*5) = 200ms per char
+            mixin.type_text("abc", profile="human", wpm=60)
+
+            mock_strategy.type_text.assert_called_once_with("abc", 200)
+
+
+# ── Extensibility Tests ──────────────────────────────────────────────────────
+
+
+class TestStrategyExtensibility:
+    """New strategies can be created by subclassing InputStrategy."""
+
+    def test_custom_strategy_subclass(self):
+        """A third-party input strategy can be created."""
+
+        class HookStrategy(InputStrategy):
+            """Hypothetical MinHook injection strategy."""
+
+            def __init__(self) -> None:
+                self.calls: list[str] = []
+
+            def type_text(self, text: str, delay_ms: int = 5) -> None:
+                self.calls.append(f"type:{text}")
+
+            def press_key(self, key: str) -> None:
+                self.calls.append(f"press:{key}")
+
+            def hotkey(self, *keys: str) -> None:
+                self.calls.append(f"hotkey:{'+'.join(keys)}")
+
+            def click(self, x: int, y: int, button: int = 0,
+                      double: bool = False) -> None:
+                self.calls.append(f"click:{x},{y}")
+
+            def scroll(self, delta: int, horizontal: bool = False) -> None:
+                self.calls.append(f"scroll:{delta}")
+
+        s = HookStrategy()
+        s.type_text("hi")
+        s.press_key("enter")
+        s.hotkey("ctrl", "s")
+        s.click(10, 20)
+        s.scroll(-120)
+
+        assert s.calls == [
+            "type:hi",
+            "press:enter",
+            "hotkey:ctrl+s",
+            "click:10,20",
+            "scroll:-120",
+        ]


### PR DESCRIPTION
## Changes
- Add `naturo/backends/windows/_strategies.py` with `InputStrategy` ABC and two concrete implementations:
  - `SendInputStrategy` — default virtual-key / Unicode input via Win32 SendInput
  - `Phys32Strategy` — hardware scan-code input via Phys32 driver (keyboard only; mouse falls through to SendInput)
- Add `get_input_strategy(core, input_mode)` factory function for strategy selection
- Refactor `InputMixin.type_text()`, `press_key()`, `hotkey()`, `click()`, `scroll()` to delegate through strategies instead of inline if/else branching
- Re-export strategy types from `naturo.backends.windows` for public API access
- 24 new tests covering strategy dispatch, factory, mixin integration, and extensibility

## Design
New input methods (e.g. MinHook injection) can now be added by:
1. Subclassing `InputStrategy`
2. Adding the mode string to `get_input_strategy()`

No changes to `InputMixin` or CLI code required.

## Testing
- 3732 tests pass, 0 failures
- ruff check clean
- mypy clean (strategies module)
- All existing keyboard/mouse/phys32 tests unchanged and passing

**[Dev-Sirius]**