### PR TITLE
fix: stabilize CI Notepad UIA detection tests (fixes #697)

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -238,14 +238,16 @@ def notepad_app(has_desktop) -> Generator[int, None, None]:
     from the window-owning process.  We resolve the actual PID by finding
     the visible Notepad window (#534).
     """
-    proc = _launch_app("notepad.exe", wait_seconds=2.0)
+    proc = _launch_app("notepad.exe", wait_seconds=3.0)
     if proc is None:
         pytest.skip("Could not launch Notepad")
 
-    # (#534) Find the PID that owns the visible Notepad window.
+    # (#534, #697) Find the PID that owns the visible Notepad window.
     # This handles UWP Notepad where the launcher PID differs from
     # the actual window-owning process.
-    time.sleep(1)
+    # Wait extra time for UWP Notepad on Win11 — the UIA tree takes
+    # several seconds to initialize after the window appears.
+    time.sleep(2)
     actual_pid = _find_notepad_window_pid()
     if actual_pid is None:
         # Fallback: try tasklist

--- a/tests/integration/test_unified_app_model.py
+++ b/tests/integration/test_unified_app_model.py
@@ -18,17 +18,47 @@ Test matrix:
 import json
 import platform
 import subprocess
+import time
 from typing import Any, Dict
 
 import pytest
 
 pytestmark = [
     pytest.mark.integration,
+    pytest.mark.desktop,
     pytest.mark.skipif(
         platform.system() != "Windows",
         reason="Integration tests require Windows desktop",
     ),
 ]
+
+
+def _detect_with_retry(detect_chain, *, retries: int = 3, delay: float = 2.0,
+                        **kwargs) -> Any:
+    """Run detection chain with retries for UIA readiness (#697).
+
+    UWP Notepad on Win11 may need several seconds after window creation
+    before its UIA tree is fully initialized. The first detection attempt
+    may fall back to vision-only; retrying gives UIA time to become ready.
+
+    Args:
+        detect_chain: The detect function from naturo.detect.chain.
+        retries: Number of attempts.
+        delay: Seconds to wait between retries.
+        **kwargs: Arguments forwarded to detect_chain.
+
+    Returns:
+        DetectionResult from the last attempt.
+    """
+    result = None
+    for attempt in range(retries):
+        result = detect_chain(**kwargs)
+        method_names = [m.method.value for m in result.methods]
+        if "uia" in method_names or "msaa" in method_names:
+            return result
+        if attempt < retries - 1:
+            time.sleep(delay)
+    return result
 
 
 def _run_naturo(*args: str, timeout: int = 15) -> Dict[str, Any]:
@@ -71,8 +101,12 @@ class TestDetectionChainNotepad:
 
     def test_detect_notepad_has_uia(self, notepad_app, detect_chain):
         """Notepad should support UIA interaction method."""
-        result = detect_chain(pid=notepad_app, exe="notepad.exe",
-                              app_name="Notepad")
+        # (#697) Retry detection — UWP Notepad UIA tree may not be ready
+        # immediately after window creation.
+        result = _detect_with_retry(
+            detect_chain, pid=notepad_app, exe="notepad.exe",
+            app_name="Notepad",
+        )
 
         method_names = [m.method.value for m in result.methods]
         assert "uia" in method_names, (
@@ -81,8 +115,11 @@ class TestDetectionChainNotepad:
 
     def test_detect_notepad_best_method(self, notepad_app, detect_chain):
         """Notepad's best method should be UIA (native Win32 app)."""
-        result = detect_chain(pid=notepad_app, exe="notepad.exe",
-                              app_name="Notepad")
+        # (#697) Retry detection — UIA tree may need extra init time.
+        result = _detect_with_retry(
+            detect_chain, pid=notepad_app, exe="notepad.exe",
+            app_name="Notepad",
+        )
 
         best = result.best_method()
         assert best is not None, "Should have a best method"

--- a/tests/test_app_control.py
+++ b/tests/test_app_control.py
@@ -450,11 +450,14 @@ class TestAppLifecycleE2EWindows:
         return False
 
     @staticmethod
-    def _poll_for_notepad(backend, is_notepad_fn, timeout=30.0, interval=0.5):
-        """Poll for a visible Notepad window with retry (#560).
+    def _poll_for_notepad(backend, is_notepad_fn, timeout=15.0, interval=0.5):
+        """Poll for a visible Notepad window with retry (#560, #697).
 
         UWP Notepad on Windows 11 launches through a broker process;
         the actual window may take several seconds to appear.
+
+        Timeout reduced from 30s to 15s (#697) to prevent hanging the
+        CI pipeline when --timeout-method=thread is used with ctypes.
 
         Returns:
             List of matching visible WindowInfo objects.


### PR DESCRIPTION
## Changes\n- Add `@pytest.mark.desktop` to integration test module for proper CI categorization\n- Increase Notepad fixture wait time (3s launch + 2s UIA init) for UWP Win11\n- Add `_detect_with_retry()` helper for flaky UIA detection (retries 3x with 2s delay)\n- Reduce `_poll_for_notepad` timeout from 30s to 15s to prevent CI pipeline hangs\n\n## Root Cause\nUWP Notepad on Windows 11 needs several seconds after window creation before its UIA accessibility tree is fully initialized. The integration test fixture only waited 3s total, causing detection to fall back to vision-only. Additionally, `_poll_for_notepad` had a 30s timeout matching the pytest `--timeout=30`, which with `--timeout-method=thread` could hang the CI runner.\n\n## Testing\n- All 3546 non-desktop tests pass\n- ruff clean\n- Changes are in test fixtures only — no production code modified\n\n**[Dev-Sirius]**