### PR TITLE
fix: support Unicode file paths in capture (fixes #693)

### DIFF
--- a/core/src/capture.cpp
+++ b/core/src/capture.cpp
@@ -15,8 +15,21 @@
 #include <new>
 
 /**
+ * @brief Convert a UTF-8 string to a wide (UTF-16) string.
+ * @param utf8 Null-terminated UTF-8 string.
+ * @param wbuf Output buffer for wide characters.
+ * @param wbuf_len Size of wbuf in wchar_t units.
+ * @return Number of wide characters written (excluding null), or 0 on error.
+ */
+static int utf8_to_wide(const char* utf8, wchar_t* wbuf, int wbuf_len) {
+    if (!utf8 || !wbuf || wbuf_len <= 0) return 0;
+    int result = MultiByteToWideChar(CP_UTF8, 0, utf8, -1, wbuf, wbuf_len);
+    return result > 0 ? result - 1 : 0;  // Exclude null terminator from count
+}
+
+/**
  * @brief Write pixel data to a BMP file.
- * @param path Output file path.
+ * @param path Output file path (UTF-8 encoded).
  * @param pixels Pointer to raw pixel data (BGR, bottom-up).
  * @param width Image width in pixels.
  * @param height Image height in pixels.
@@ -40,7 +53,12 @@ static int write_bmp(const char* path, const void* pixels, int width, int height
     info_header.biCompression = BI_RGB;
     info_header.biSizeImage = data_size;
 
-    FILE* f = fopen(path, "wb");
+    // (#693) Use _wfopen with UTF-16 path to support Unicode file paths
+    // (Chinese characters, etc.). The path arrives as UTF-8 from Python.
+    wchar_t wpath[MAX_PATH];
+    if (utf8_to_wide(path, wpath, MAX_PATH) == 0) return -3;
+
+    FILE* f = _wfopen(wpath, L"wb");
     if (!f) return -3;
 
     fwrite(&file_header, sizeof(file_header), 1, f);

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -294,6 +294,48 @@ def test_capture_to_invalid_path_raises(core):
         core.capture_screen(0, invalid_path)
 
 
+@pytest.mark.desktop
+def test_capture_screen_unicode_path(core):
+    """T020: Capture should work with Chinese/Unicode characters in path (#693)."""
+    unicode_dir = os.path.join(tempfile.gettempdir(), "naturo_测试_中文路径")
+    os.makedirs(unicode_dir, exist_ok=True)
+    unicode_path = os.path.join(unicode_dir, "截图.bmp")
+
+    try:
+        result = core.capture_screen(0, unicode_path)
+        assert result == unicode_path
+        assert os.path.exists(unicode_path)
+        assert os.path.getsize(unicode_path) > 0
+    finally:
+        if os.path.exists(unicode_path):
+            os.unlink(unicode_path)
+        try:
+            os.rmdir(unicode_dir)
+        except OSError:
+            pass
+
+
+@pytest.mark.desktop
+def test_capture_window_unicode_path(core):
+    """T021: Window capture should work with Unicode characters in path (#693)."""
+    unicode_dir = os.path.join(tempfile.gettempdir(), "naturo_测试_中文路径")
+    os.makedirs(unicode_dir, exist_ok=True)
+    unicode_path = os.path.join(unicode_dir, "窗口截图.bmp")
+
+    try:
+        result = core.capture_window(0, unicode_path)
+        assert result == unicode_path
+        assert os.path.exists(unicode_path)
+        assert os.path.getsize(unicode_path) > 0
+    finally:
+        if os.path.exists(unicode_path):
+            os.unlink(unicode_path)
+        try:
+            os.rmdir(unicode_dir)
+        except OSError:
+            pass
+
+
 def test_backend_capture_screen(backend):
     """T019: WindowsBackend.capture_screen should return a CaptureResult."""
     with tempfile.NamedTemporaryFile(suffix=".bmp", delete=False) as f:

--- a/tests/test_cli_capture.py
+++ b/tests/test_cli_capture.py
@@ -55,6 +55,43 @@ def _patch_platform(supports=True):
 # to read the fake file path from FakeCaptureResult.
 
 
+class TestUnicodePathCapture:
+    """Verify capture accepts Chinese/Unicode output paths (#693)."""
+
+    def test_capture_unicode_output_path(self, runner, mock_backend):
+        unicode_path = "/tmp/中文路径/截图.png"
+        mock_backend.capture_screen.return_value = FakeCaptureResult(path=unicode_path)
+        with _patch_platform(), _patch_backend(mock_backend):
+            result = runner.invoke(capture, [
+                "-p", unicode_path, "--no-snapshot",
+            ], catch_exceptions=False)
+        assert result.exit_code == 0
+        mock_backend.capture_screen.assert_called_once_with(
+            screen_index=0, output_path=unicode_path,
+        )
+
+    def test_capture_unicode_json_output(self, runner, mock_backend):
+        unicode_path = "/tmp/テスト/スクリーンショット.png"
+        mock_backend.capture_screen.return_value = FakeCaptureResult(path=unicode_path)
+        with _patch_platform(), _patch_backend(mock_backend):
+            result = runner.invoke(capture, [
+                "-p", unicode_path, "--json", "--no-snapshot",
+            ], catch_exceptions=False)
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["success"] is True
+
+    def test_capture_window_unicode_path(self, runner, mock_backend):
+        unicode_path = "/tmp/中文/窗口.png"
+        mock_backend.capture_window.return_value = FakeCaptureResult(path=unicode_path)
+        with _patch_platform(), _patch_backend(mock_backend):
+            result = runner.invoke(capture, [
+                "--hwnd", "12345", "-p", unicode_path, "--no-snapshot",
+            ], catch_exceptions=False)
+        assert result.exit_code == 0
+        mock_backend.capture_window.assert_called_once()
+
+
 # ── Full screen capture ─────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Changes\n- Replace `fopen()` with `_wfopen()` in `write_bmp()` (capture.cpp) to handle UTF-8 paths with Chinese/Japanese/Korean characters\n- Add `utf8_to_wide()` helper using `MultiByteToWideChar(CP_UTF8)` for proper UTF-8 → UTF-16 conversion\n- 3 new CLI-level unit tests (mock-based, CI-safe) for Unicode output paths\n- 2 new desktop tests for end-to-end Unicode capture verification on Windows\n\n## Root Cause\nThe C++ DLL's `write_bmp()` used `fopen(path, \"wb\")` which interprets `const char*` as ANSI on Windows. Python passes paths as UTF-8, but `fopen()` can't handle non-ANSI characters (Chinese, Japanese, etc.), causing \"File I/O error\" for paths like `/tmp/中文路径/截图.png`.\n\n## Testing\n- 3819 non-desktop tests pass (including 3 new Unicode mock tests)\n- 2 new desktop-only tests for real capture with Unicode paths\n- ruff clean\n\n**[Dev-Sirius]**