### PR TITLE
fix: Python 3.9 test compatibility — mock resolution, CliRunner stderr, MCP import (fixes #730)

### DIFF
--- a/tests/test_cli_consistency.py
+++ b/tests/test_cli_consistency.py
@@ -95,8 +95,8 @@ def test_all_visible_commands_respond():
 )
 def test_no_visible_command_prints_not_implemented():
     """Invoking any visible leaf command (with no args) must not print 'Not implemented'."""
-    # Long-running server commands that take over stdio — skip bare invocation
-    SKIP_BARE_INVOKE = {("mcp", "start")}
+    # Commands that block on interactive prompts or take over stdio
+    SKIP_BARE_INVOKE = {("mcp", "start"), ("config", "setup", "anthropic")}
     for args, cmd in _visible_subcommands(main):
         # Skip groups — they just show help when invoked bare
         if hasattr(cmd, "commands"):

--- a/tests/test_excel.py
+++ b/tests/test_excel.py
@@ -352,9 +352,9 @@ class TestExcelMCP:
 
     def test_excel_mcp_tools_registered(self):
         """Excel MCP tools are registered in create_server."""
-        from naturo.mcp_server import create_server
+        pytest.importorskip("mcp")
 
-        mcp = pytest.importorskip("mcp")
+        from naturo.mcp_server import create_server
 
         server = create_server()
         # Check tool names include excel tools

--- a/tests/test_get_cmd.py
+++ b/tests/test_get_cmd.py
@@ -10,12 +10,20 @@ Covers:
 
 import json
 import platform
+import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
 
 from naturo.cli import main
+
+# Resolve the *module* (not the Click Command object that shadows it in
+# naturo.cli's namespace).  On Python 3.9 ``mock.patch()`` uses the old
+# ``_importer`` which walks ``getattr`` and finds the Command; on 3.11+
+# it uses ``pkgutil.resolve_name`` which finds the module.  Using
+# ``patch.object`` with the real module works on every Python version.
+_get_cmd_mod = sys.modules["naturo.cli.get_cmd"]
 
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
@@ -50,14 +58,6 @@ def _make_mock_backend(result=None, not_found=False, error=None):
 
 # ── CLI Tests ────────────────────────────────────────────────────────────────
 
-def _patch_get(mock_backend):
-    """Context manager to patch both backend and platform check for get_cmd."""
-    return (
-        patch("naturo.cli.get_cmd._get_backend", return_value=mock_backend),
-        patch("naturo.cli.get_cmd.platform") if platform.system() not in ("Windows",) else None,
-    )
-
-
 def _apply_patches(mock_backend):
     """Apply both backend and platform patches for get_cmd tests.
 
@@ -68,9 +68,9 @@ def _apply_patches(mock_backend):
 
     @contextlib.contextmanager
     def _ctx():
-        with patch("naturo.cli.get_cmd._get_backend", return_value=mock_backend):
+        with patch.object(_get_cmd_mod, "_get_backend", return_value=mock_backend):
             if platform.system() not in ("Windows",):
-                with patch("naturo.cli.get_cmd.platform") as mock_plat:
+                with patch.object(_get_cmd_mod, "platform") as mock_plat:
                     mock_plat.system.return_value = "Windows"
                     yield
             else:

--- a/tests/test_set_cmd.py
+++ b/tests/test_set_cmd.py
@@ -12,6 +12,7 @@ Covers:
 
 import json
 import platform
+import sys
 from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
@@ -19,6 +20,10 @@ import pytest
 from click.testing import CliRunner
 
 from naturo.cli import main
+
+# Resolve the *module* (not the Click Command object that shadows it in
+# naturo.cli's namespace).  See test_get_cmd.py for detailed explanation.
+_set_cmd_mod = sys.modules["naturo.cli.set_cmd"]
 
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
@@ -53,11 +58,11 @@ def _apply_patches(mock_backend, resolve_aid=None, resolve_role=None,
     resolver = _mock_resolve_identifiers(
         aid=resolve_aid, role=resolve_role, name=resolve_name,
     )
-    with patch("naturo.cli.set_cmd._get_backend", return_value=mock_backend), \
-         patch("naturo.cli.set_cmd._resolve_element_identifiers",
-               side_effect=resolver):
+    with patch.object(_set_cmd_mod, "_get_backend", return_value=mock_backend), \
+         patch.object(_set_cmd_mod, "_resolve_element_identifiers",
+                      side_effect=resolver):
         if platform.system() not in ("Windows",):
-            with patch("naturo.cli.set_cmd.platform") as mock_plat:
+            with patch.object(_set_cmd_mod, "platform") as mock_plat:
                 mock_plat.system.return_value = "Windows"
                 yield
         else:

--- a/tests/test_window_backward_compat.py
+++ b/tests/test_window_backward_compat.py
@@ -17,8 +17,12 @@ from naturo.cli import main
 
 @pytest.fixture
 def runner():
-    """Click CLI test runner."""
-    return CliRunner()
+    """Click CLI test runner with stderr captured separately.
+
+    Click 8.0 defaults mix_stderr=True which prevents accessing
+    result.stderr.  Explicitly set False for all Click 8.x versions.
+    """
+    return CliRunner(mix_stderr=False)
 
 
 # ── #277: Positional argument on window subcommands ──────────────────────


### PR DESCRIPTION
## Changes

- **test_get_cmd.py / test_set_cmd.py (62 failures)**: `naturo.cli.__init__` imports `get_cmd` and `set_cmd` functions that shadow the submodule names. On Python 3.9, `mock.patch("naturo.cli.get_cmd._get_backend")` resolves via `getattr` to the Click Command (not the module), causing `AttributeError`. Switched to `patch.object(sys.modules["naturo.cli.get_cmd"], ...)` which works on all Python versions.

- **test_window_backward_compat.py (6 failures)**: Click 8.0 defaults `mix_stderr=True`, making `result.stderr` raise `ValueError`. Fixed by passing `CliRunner(mix_stderr=False)` explicitly.

- **test_excel.py**: `from naturo.mcp_server import create_server` triggers `from mcp.server.fastmcp import FastMCP` at module level, failing before `pytest.importorskip("mcp")` runs. Moved `importorskip` before the import.

- **test_cli_consistency.py**: `config setup anthropic` prompts for interactive input, hanging the bare-invoke test. Added to `SKIP_BARE_INVOKE` set.

## Testing
- All 3896 tests pass on Python 3.11
- Verified with Click 8.0.4 (oldest supported) — all previously failing patterns now pass
- `ruff check` clean on all changed files

**[Dev-Sirius]**