### PR TITLE
fix: add pip cache to lint and publish CI jobs (fixes #712)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+          cache: "pip"
 
       - name: Install linting tools
         run: pip install ruff mypy
@@ -468,6 +469,7 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+          cache: "pip"
 
       - name: Download DLL
         uses: actions/download-artifact@v8


### PR DESCRIPTION
## Changes
- Added `cache: "pip"` to `setup-python` in the `lint` job (Ubuntu) and `publish` job
- Ubuntu test and macOS test jobs already had caching; only these two were missing it

## Testing
- YAML syntax verified
- No functional changes to test logic

**[Dev-Sirius]**