### PR TITLE
fix: Python 3.9 + Click 8.2+ test compatibility (fixes #730)

### DIFF
--- a/tests/test_cli_consistency.py
+++ b/tests/test_cli_consistency.py
@@ -95,8 +95,8 @@ def test_all_visible_commands_respond():
 )
 def test_no_visible_command_prints_not_implemented():
     """Invoking any visible leaf command (with no args) must not print 'Not implemented'."""
-    # Long-running server commands that take over stdio — skip bare invocation
-    SKIP_BARE_INVOKE = {("mcp", "start")}
+    # Commands that block on interactive prompts or take over stdio
+    SKIP_BARE_INVOKE = {("mcp", "start"), ("config", "setup", "anthropic")}
     for args, cmd in _visible_subcommands(main):
         # Skip groups — they just show help when invoked bare
         if hasattr(cmd, "commands"):

--- a/tests/test_excel.py
+++ b/tests/test_excel.py
@@ -352,9 +352,9 @@ class TestExcelMCP:
 
     def test_excel_mcp_tools_registered(self):
         """Excel MCP tools are registered in create_server."""
-        from naturo.mcp_server import create_server
+        pytest.importorskip("mcp")
 
-        mcp = pytest.importorskip("mcp")
+        from naturo.mcp_server import create_server
 
         server = create_server()
         # Check tool names include excel tools

--- a/tests/test_get_cmd.py
+++ b/tests/test_get_cmd.py
@@ -10,12 +10,20 @@ Covers:
 
 import json
 import platform
+import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
 
 from naturo.cli import main
+
+# Resolve the *module* (not the Click Command object that shadows it in
+# naturo.cli's namespace).  On Python 3.9 ``mock.patch()`` uses the old
+# ``_importer`` which walks ``getattr`` and finds the Command; on 3.11+
+# it uses ``pkgutil.resolve_name`` which finds the module.  Using
+# ``patch.object`` with the real module works on every Python version.
+_get_cmd_mod = sys.modules["naturo.cli.get_cmd"]
 
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
@@ -50,14 +58,6 @@ def _make_mock_backend(result=None, not_found=False, error=None):
 
 # ── CLI Tests ────────────────────────────────────────────────────────────────
 
-def _patch_get(mock_backend):
-    """Context manager to patch both backend and platform check for get_cmd."""
-    return (
-        patch("naturo.cli.get_cmd._get_backend", return_value=mock_backend),
-        patch("naturo.cli.get_cmd.platform") if platform.system() not in ("Windows",) else None,
-    )
-
-
 def _apply_patches(mock_backend):
     """Apply both backend and platform patches for get_cmd tests.
 
@@ -68,9 +68,9 @@ def _apply_patches(mock_backend):
 
     @contextlib.contextmanager
     def _ctx():
-        with patch("naturo.cli.get_cmd._get_backend", return_value=mock_backend):
+        with patch.object(_get_cmd_mod, "_get_backend", return_value=mock_backend):
             if platform.system() not in ("Windows",):
-                with patch("naturo.cli.get_cmd.platform") as mock_plat:
+                with patch.object(_get_cmd_mod, "platform") as mock_plat:
                     mock_plat.system.return_value = "Windows"
                     yield
             else:

--- a/tests/test_set_cmd.py
+++ b/tests/test_set_cmd.py
@@ -12,6 +12,7 @@ Covers:
 
 import json
 import platform
+import sys
 from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
@@ -19,6 +20,10 @@ import pytest
 from click.testing import CliRunner
 
 from naturo.cli import main
+
+# Resolve the *module* (not the Click Command object that shadows it in
+# naturo.cli's namespace).  See test_get_cmd.py for detailed explanation.
+_set_cmd_mod = sys.modules["naturo.cli.set_cmd"]
 
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
@@ -53,11 +58,11 @@ def _apply_patches(mock_backend, resolve_aid=None, resolve_role=None,
     resolver = _mock_resolve_identifiers(
         aid=resolve_aid, role=resolve_role, name=resolve_name,
     )
-    with patch("naturo.cli.set_cmd._get_backend", return_value=mock_backend), \
-         patch("naturo.cli.set_cmd._resolve_element_identifiers",
-               side_effect=resolver):
+    with patch.object(_set_cmd_mod, "_get_backend", return_value=mock_backend), \
+         patch.object(_set_cmd_mod, "_resolve_element_identifiers",
+                      side_effect=resolver):
         if platform.system() not in ("Windows",):
-            with patch("naturo.cli.set_cmd.platform") as mock_plat:
+            with patch.object(_set_cmd_mod, "platform") as mock_plat:
                 mock_plat.system.return_value = "Windows"
                 yield
         else:

--- a/tests/test_window_backward_compat.py
+++ b/tests/test_window_backward_compat.py
@@ -17,7 +17,16 @@ from naturo.cli import main
 
 @pytest.fixture
 def runner():
-    """Click CLI test runner."""
+    """Click CLI test runner with stderr captured separately.
+
+    Click 8.0 defaults mix_stderr=True which prevents accessing
+    result.stderr.  Click 8.2+ removed the parameter entirely and
+    always separates stderr.  Use inspect to stay compatible with both.
+    """
+    import inspect
+    sig = inspect.signature(CliRunner.__init__)
+    if "mix_stderr" in sig.parameters:
+        return CliRunner(mix_stderr=False)
     return CliRunner()
 
 


### PR DESCRIPTION
## Changes\n\nSupersedes #731 — includes all the same Python 3.9 fixes plus a Click version compatibility fix that #731 was missing.\n\n- **test_get_cmd.py / test_set_cmd.py** (62 failures on 3.9): `patch(\"naturo.cli.get_cmd._get_backend\")` resolves via `getattr` on Python 3.9 to the Click Command object (not the module). Switched to `patch.object(sys.modules[...])` which works on all Python versions.\n- **test_window_backward_compat.py** (6 failures on 3.9, **broke 3.13 in #731**): Click 8.0 defaults `mix_stderr=True`, making `result.stderr` raise. PR #731 used `CliRunner(mix_stderr=False)` but Click 8.2+ removed the `mix_stderr` parameter entirely, causing `TypeError` on Python 3.12/3.13. Fixed by using `inspect.signature` to detect whether the parameter exists.\n- **test_excel.py**: Moved `importorskip(\"mcp\")` before the module-level import.\n- **test_cli_consistency.py**: Added `config setup anthropic` to `SKIP_BARE_INVOKE` (hangs on interactive prompt).\n\n## Testing\n- 3896 tests pass, 504 skipped (Python 3.11, Click 8.3.1)\n- `ruff check` clean\n- The Click compat fix uses `inspect.signature` — works on Click 8.0 (has `mix_stderr`) and Click 8.2+ (removed it)\n\n**[Dev-Sirius]**