### PR TITLE
fix: Notepad test timing — poll instead of fixed sleep for UWP launch (fixes #729)

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -242,15 +242,17 @@ def notepad_app(has_desktop) -> Generator[int, None, None]:
     if proc is None:
         pytest.skip("Could not launch Notepad")
 
-    # (#534, #697) Find the PID that owns the visible Notepad window.
+    # (#534, #697, #729) Find the PID that owns the visible Notepad window.
     # This handles UWP Notepad where the launcher PID differs from
     # the actual window-owning process.
-    # Wait extra time for UWP Notepad on Win11 — the UIA tree takes
-    # several seconds to initialize after the window appears.
-    time.sleep(2)
-    actual_pid = _find_notepad_window_pid()
+    # Poll instead of fixed sleep — UWP Notepad on Win11 can take 5-10s.
+    actual_pid = None
+    deadline = time.monotonic() + 15.0
+    while actual_pid is None and time.monotonic() < deadline:
+        actual_pid = _find_notepad_window_pid()
+        if actual_pid is None:
+            time.sleep(1.0)
     if actual_pid is None:
-        # Fallback: try tasklist
         actual_pid = _find_process_by_name("Notepad.exe")
     if actual_pid is None:
         actual_pid = proc.pid

--- a/tests/test_cli_phase2.py
+++ b/tests/test_cli_phase2.py
@@ -550,8 +550,8 @@ class TestNotepadAutomation:
                     return True
                 return False
 
-            # (#560) Poll for Notepad window — UWP launch is slow
-            deadline = time.monotonic() + 10.0
+            # (#560, #729) Poll for Notepad window — UWP launch is slow
+            deadline = time.monotonic() + 15.0
             notepad = None
             while notepad is None and time.monotonic() < deadline:
                 windows = core.list_windows()

--- a/tests/test_e2e_notepad.py
+++ b/tests/test_e2e_notepad.py
@@ -73,6 +73,31 @@ def _kill_process(proc):
             pass
 
 
+def _poll_for_notepad(core, count: int = 1, *, timeout: float = 15.0,
+                      interval: float = 0.5, visible_only: bool = False):
+    """Poll for Notepad windows until *count* are found or *timeout* expires.
+
+    UWP Notepad on Windows 11 launches via ApplicationFrameHost.exe and
+    may take several seconds before the real window appears (#729).
+
+    Returns:
+        List of matching window objects.
+    """
+    deadline = time.monotonic() + timeout
+    matches = []
+    while time.monotonic() < deadline:
+        windows = core.list_windows()
+        matches = [
+            w for w in windows
+            if _is_notepad_window(w)
+            and (not visible_only or (w.is_visible and not w.is_minimized))
+        ]
+        if len(matches) >= count:
+            return matches
+        time.sleep(interval)
+    return matches
+
+
 class TestMultiWindowChaos:
     """R-QA-001 to R-QA-003: Multi-window chaos tests."""
 
@@ -86,18 +111,12 @@ class TestMultiWindowChaos:
         try:
             for _ in range(3):
                 procs.append(_launch_notepad())
-                time.sleep(1.0)  # CI runners can be slow; 0.5s was flaky
+                time.sleep(1.0)
 
-            # Give windows time to fully initialize
-            time.sleep(2.0)
+            # (#729) Poll until all 3 windows appear — UWP Notepad's process
+            # model (ApplicationFrameHost → Notepad) can take 5-10 seconds.
+            notepad_windows = _poll_for_notepad(core, count=3, timeout=20.0)
 
-            windows = core.list_windows()
-            notepad_windows = [
-                w for w in windows
-                if _is_notepad_window(w)
-            ]
-
-            # Should find at least our 3 notepad windows
             assert len(notepad_windows) >= 3, (
                 f"Expected >=3 Notepad windows, found {len(notepad_windows)}"
             )
@@ -129,16 +148,12 @@ class TestMultiWindowChaos:
         try:
             for _ in range(2):
                 procs.append(_launch_notepad())
-                time.sleep(0.5)
-            time.sleep(1.0)
+                time.sleep(1.0)
 
-            windows = core.list_windows()
-            notepad_windows = [
-                w for w in windows
-                if _is_notepad_window(w)
-                and w.is_visible
-                and not w.is_minimized
-            ]
+            # (#729) Poll for windows instead of fixed sleep
+            notepad_windows = _poll_for_notepad(
+                core, count=2, timeout=15.0, visible_only=True,
+            )
 
             if len(notepad_windows) < 2:
                 pytest.skip("Could not find 2 visible Notepad windows")
@@ -169,16 +184,12 @@ class TestMultiWindowChaos:
         try:
             for _ in range(2):
                 procs.append(_launch_notepad())
-                time.sleep(0.5)
-            time.sleep(1.0)
+                time.sleep(1.0)
 
-            windows = core.list_windows()
-            notepad_windows = [
-                w for w in windows
-                if _is_notepad_window(w)
-                and w.is_visible
-                and not w.is_minimized
-            ]
+            # (#729) Poll for windows instead of fixed sleep
+            notepad_windows = _poll_for_notepad(
+                core, count=2, timeout=15.0, visible_only=True,
+            )
 
             if len(notepad_windows) < 2:
                 pytest.skip("Could not find 2 visible Notepad windows")
@@ -203,14 +214,10 @@ class TestNotepadElements:
         """
         proc = _launch_notepad()
         try:
-            time.sleep(1.5)
-
-            windows = core.list_windows()
-            notepad_windows = [
-                w for w in windows
-                if _is_notepad_window(w)
-                and w.is_visible
-            ]
+            # (#729) Poll for UWP Notepad window
+            notepad_windows = _poll_for_notepad(
+                core, count=1, timeout=15.0, visible_only=True,
+            )
             if not notepad_windows:
                 pytest.skip("Notepad window not found")
 
@@ -243,14 +250,10 @@ class TestNotepadElements:
         """
         proc = _launch_notepad()
         try:
-            time.sleep(1.5)
-
-            windows = core.list_windows()
-            notepad_windows = [
-                w for w in windows
-                if _is_notepad_window(w)
-                and w.is_visible
-            ]
+            # (#729) Poll for UWP Notepad window
+            notepad_windows = _poll_for_notepad(
+                core, count=1, timeout=15.0, visible_only=True,
+            )
             if not notepad_windows:
                 pytest.skip("Notepad window not found")
 
@@ -290,14 +293,10 @@ class TestAIAgentPerspective:
 
         proc = _launch_notepad()
         try:
-            time.sleep(1.5)
-
-            windows = core.list_windows()
-            notepad_windows = [
-                w for w in windows
-                if _is_notepad_window(w)
-                and w.is_visible
-            ]
+            # (#729) Poll for UWP Notepad window
+            notepad_windows = _poll_for_notepad(
+                core, count=1, timeout=15.0, visible_only=True,
+            )
             if not notepad_windows:
                 pytest.skip("Notepad window not found")
 


### PR DESCRIPTION
## Changes\n\n6 desktop/integration tests and 3 E2E tests were failing because Notepad windows couldn't be found after launch. Root cause: UWP Notepad on Windows 11 launches via ApplicationFrameHost.exe and the real window takes 5-10 seconds to appear. Tests used fixed `time.sleep()` waits that were too short.\n\n**Fix:** Replace all fixed sleep waits with polling loops that retry `list_windows()` until the expected windows appear or a generous timeout (15-20s) expires.\n\n- Added `_poll_for_notepad()` shared helper in `test_e2e_notepad.py`\n- Updated 6 tests in `test_e2e_notepad.py` to use polling\n- Increased `test_notepad_open_type_close` timeout from 10s to 15s\n- Replaced fixed 2s sleep in `notepad_app` fixture with 15s polling loop\n\n## Testing\n- 3928 tests pass on Python 3.11 (Linux, desktop tests skipped)\n- `ruff check` clean\n- Desktop verification needed on Windows CI runner\n\n**[Dev-Sirius]**