### PR TITLE
fix: add DLL artifact path flattening to publish.yml (fixes #713)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,12 +38,24 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+          cache: "pip"
 
       - name: Download DLL
         uses: actions/download-artifact@v8
         with:
           name: naturo-core-dll
           path: naturo/bin/
+
+      - name: Flatten DLL into naturo/bin
+        shell: bash
+        run: |
+          # download-artifact may preserve directory structure from upload
+          if [ -d "naturo/bin/bin/Release" ]; then
+            cp naturo/bin/bin/Release/*.dll naturo/bin/ 2>/dev/null || true
+          fi
+          # Verify DLL is in place
+          ls -la naturo/bin/
+          test -f naturo/bin/naturo_core.dll || { echo "ERROR: naturo_core.dll not found in naturo/bin/"; exit 1; }
 
       - name: Install build tools
         run: pip install build


### PR DESCRIPTION
## Changes\n\n`publish.yml` was missing the DLL artifact path flattening step that `build.yml` already has. When `download-artifact` preserves the upload directory structure, the DLL ends up at `naturo/bin/bin/Release/naturo_core.dll` instead of `naturo/bin/naturo_core.dll`, causing the wheel to ship without the DLL.\n\n- Added flatten step matching `build.yml`'s logic\n- Added verification check (`test -f naturo/bin/naturo_core.dll`)\n- Added `cache: \"pip\"` to the publish job's setup-python\n\n## Testing\n- YAML syntax verified\n- No functional changes to test logic\n- Will be exercised on next release publish\n\n**[Dev-Sirius]**