### PR TITLE
refactor: extract shared Session ID and tasklist CSV parsing utilities (fixes #715)

### DIFF
--- a/naturo/backends/windows/_element.py
+++ b/naturo/backends/windows/_element.py
@@ -8,6 +8,7 @@ from typing import ClassVar, Optional
 from naturo.backends.base import (ElementInfo as BaseElementInfo, WindowInfo as BaseWindowInfo)
 from naturo.bridge import populate_hierarchy
 from naturo.errors import NaturoError
+from naturo.process import _get_console_session_id, _get_process_session_id
 
 logger = logging.getLogger(__name__)
 
@@ -103,51 +104,6 @@ class ElementMixin:
         "截图工具": {"snippingtool", "screensketch"},
     }
 
-    @staticmethod
-    def _get_console_session_id() -> int:
-        """Get the active console (interactive desktop) session ID.
-
-        Uses WTSGetActiveConsoleSessionId to determine which Windows session
-        owns the physical console.  Returns -1 if the call fails.
-
-        Returns:
-            Active console session ID, or -1 on failure.
-        """
-        try:
-            import ctypes
-            session_id = ctypes.windll.kernel32.WTSGetActiveConsoleSessionId()
-            # WTSGetActiveConsoleSessionId returns 0xFFFFFFFF on failure
-            if session_id == 0xFFFFFFFF:
-                return -1
-            return session_id
-        except Exception:
-            return -1
-
-    @staticmethod
-    def _get_process_session_id(pid: int) -> int:
-        """Get the Windows session ID for a given process.
-
-        Uses ProcessIdToSessionId to determine which session a process
-        belongs to.  Session 0 is the non-interactive services session;
-        session 1+ are interactive user sessions.
-
-        Args:
-            pid: Process ID.
-
-        Returns:
-            Session ID, or -1 on failure.
-        """
-        try:
-            import ctypes
-            session_id = ctypes.wintypes.DWORD()
-            success = ctypes.windll.kernel32.ProcessIdToSessionId(
-                pid, ctypes.byref(session_id)
-            )
-            if success:
-                return session_id.value
-            return -1
-        except Exception:
-            return -1
 
     @staticmethod
     def _get_foreground_hwnd() -> int:
@@ -280,7 +236,7 @@ class ElementMixin:
                 )
 
         # Get console session for session-aware ranking (#230)
-        console_session = self._get_console_session_id()
+        console_session = _get_console_session_id()
 
         # Get foreground HWND for deterministic tie-breaking (#449)
         fg_hwnd = self._get_foreground_hwnd()
@@ -359,7 +315,7 @@ class ElementMixin:
             # processes that exist in the non-interactive session.
             in_console = False
             if console_session >= 0:
-                w_session = self._get_process_session_id(w.pid)
+                w_session = _get_process_session_id(w.pid)
                 in_console = (w_session == console_session)
 
             # (#449) Check if this window is the foreground window
@@ -490,7 +446,7 @@ class ElementMixin:
 
                 in_console = False
                 if console_session >= 0:
-                    w_session = self._get_process_session_id(w.pid)
+                    w_session = _get_process_session_id(w.pid)
                     in_console = (w_session == console_session)
 
                 is_foreground = (fg_hwnd != 0 and w.handle == fg_hwnd)
@@ -566,7 +522,7 @@ class ElementMixin:
 
         search_lower = search.lower()
         windows = self.list_windows()
-        console_session = self._get_console_session_id()
+        console_session = _get_console_session_id()
         match_process = app is not None
 
         # Collect all matching windows with their scores
@@ -609,7 +565,7 @@ class ElementMixin:
             # Session-aware ranking
             in_console = False
             if console_session >= 0:
-                w_session = self._get_process_session_id(w.pid)
+                w_session = _get_process_session_id(w.pid)
                 in_console = (w_session == console_session)
 
             matches.append((score, in_console, len(w.title), w))
@@ -683,7 +639,7 @@ class ElementMixin:
         # (#569) UWP fallback: when no windows matched by process name,
         # probe AFH windows' content children for the real app process.
         if not result and match_process:
-            console_session = self._get_console_session_id()
+            console_session = _get_console_session_id()
             afh_match = self._uwp_afh_fallback(
                 search_lower, windows, console_session,
             )
@@ -707,7 +663,7 @@ class ElementMixin:
                 if score > 0:
                     in_console = False
                     if console_session >= 0:
-                        w_session = self._get_process_session_id(w.pid)
+                        w_session = _get_process_session_id(w.pid)
                         in_console = (w_session == console_session)
                     title_matches.append((score, in_console, len(w.title), w))
 
@@ -1040,7 +996,7 @@ class ElementMixin:
             # Session-aware ranking: prefer console session
             in_console = False
             if console_session >= 0:
-                w_session = self._get_process_session_id(w.pid)
+                w_session = _get_process_session_id(w.pid)
                 in_console = (w_session == console_session)
 
             if best_afh is None or (in_console and not best_in_console):

--- a/naturo/cli/interaction/_common.py
+++ b/naturo/cli/interaction/_common.py
@@ -586,16 +586,14 @@ def _is_current_session_interactive() -> bool:
     try:
         import ctypes
         import ctypes.wintypes
+        import os
+
+        from naturo.process import _get_process_session_id
 
         # --------------- session ID for current process ---------------
-        pid = ctypes.windll.kernel32.GetCurrentProcessId()  # type: ignore[attr-defined]
-        session_id = ctypes.wintypes.DWORD(0)
-        ok = ctypes.windll.kernel32.ProcessIdToSessionId(  # type: ignore[attr-defined]
-            pid, ctypes.byref(session_id),
-        )
-        if not ok:
+        sid = _get_process_session_id(os.getpid())
+        if sid == -1:
             return False
-        sid = session_id.value
 
         # Session 0 is always the non-interactive services session.
         if sid == 0:

--- a/naturo/detect/probes.py
+++ b/naturo/detect/probes.py
@@ -820,15 +820,17 @@ def _find_window_by_process_name(pid: int, exe: str) -> Optional[int]:
             proc_name = os.path.basename(exe).lower()
         if not proc_name:
             try:
+                from naturo.process import _parse_tasklist_csv_line
+
                 result = subprocess.run(
                     ["tasklist", "/FI", f"PID eq {pid}", "/FO", "CSV", "/NH"],
                     capture_output=True, text=True, encoding="utf-8",
                     errors="replace", timeout=5,
                 )
                 for line in result.stdout.strip().splitlines():
-                    parts = line.strip('"').split('","')
-                    if len(parts) >= 2:
-                        proc_name = parts[0].lower()
+                    parsed = _parse_tasklist_csv_line(line)
+                    if parsed:
+                        proc_name = parsed[0].lower()
                         break
             except Exception:
                 return None

--- a/naturo/process.py
+++ b/naturo/process.py
@@ -38,6 +38,30 @@ class ProcessInfo:
     window_count: int = 0
 
 
+def _parse_tasklist_csv_line(line: str) -> tuple[str, int] | None:
+    """Parse a single ``tasklist /FO CSV`` output line into (name, pid).
+
+    Args:
+        line: A single CSV line from ``tasklist /FO CSV /NH`` output.
+
+    Returns:
+        A ``(process_name, pid)`` tuple, or ``None`` if the line is
+        malformed or empty.
+    """
+    line = line.strip()
+    if not line:
+        return None
+    parts = line.strip('"').split('","')
+    if len(parts) >= 2:
+        name = parts[0]
+        try:
+            pid = int(parts[1])
+            return (name, pid)
+        except (ValueError, IndexError):
+            return None
+    return None
+
+
 def _list_processes() -> list[ProcessInfo]:
     """List running processes using platform-appropriate methods."""
     system = platform.system()
@@ -53,16 +77,9 @@ def _list_processes() -> list[ProcessInfo]:
                 errors="replace", timeout=10,
             )
             for line in result.stdout.strip().split("\n"):
-                line = line.strip()
-                if not line:
-                    continue
-                parts = line.split('","')
-                if len(parts) >= 2:
-                    name = parts[0].strip('"')
-                    try:
-                        pid = int(parts[1].strip('"'))
-                    except (ValueError, IndexError):
-                        continue
+                parsed = _parse_tasklist_csv_line(line)
+                if parsed:
+                    name, pid = parsed
                     processes.append(ProcessInfo(pid=pid, name=name, is_running=True))
         except Exception as exc:
             logger.debug("Failed to list processes on Windows: %s", exc)

--- a/tests/test_app_alias_localized.py
+++ b/tests/test_app_alias_localized.py
@@ -16,8 +16,8 @@ def _make_backend(monkeypatch, windows):
     """Create a WindowsBackend with mocked window list."""
     backend = WindowsBackend()
     monkeypatch.setattr(backend, "list_windows", lambda: windows)
-    monkeypatch.setattr(backend, "_get_console_session_id", lambda: 1)
-    monkeypatch.setattr(backend, "_get_process_session_id", lambda pid: 1)
+    monkeypatch.setattr("naturo.backends.windows._element._get_console_session_id", lambda: 1)
+    monkeypatch.setattr("naturo.backends.windows._element._get_process_session_id", lambda pid: 1)
     return backend
 
 

--- a/tests/test_app_filter_process_priority.py
+++ b/tests/test_app_filter_process_priority.py
@@ -17,8 +17,8 @@ def _make_backend(monkeypatch, windows):
     """Create a WindowsBackend with mocked window list."""
     backend = WindowsBackend()
     monkeypatch.setattr(backend, "list_windows", lambda: windows)
-    monkeypatch.setattr(backend, "_get_console_session_id", lambda: 1)
-    monkeypatch.setattr(backend, "_get_process_session_id", lambda pid: 1)
+    monkeypatch.setattr("naturo.backends.windows._element._get_console_session_id", lambda: 1)
+    monkeypatch.setattr("naturo.backends.windows._element._get_process_session_id", lambda pid: 1)
     return backend
 
 

--- a/tests/test_cmd_window_exclusion.py
+++ b/tests/test_cmd_window_exclusion.py
@@ -42,8 +42,8 @@ class TestCmdWindowExclusion:
             return 1
 
         monkeypatch.setattr(backend, "list_windows", mock_list_windows)
-        monkeypatch.setattr(backend, "_get_console_session_id", mock_console_session)
-        monkeypatch.setattr(backend, "_get_process_session_id", mock_process_session)
+        monkeypatch.setattr("naturo.backends.windows._element._get_console_session_id", mock_console_session)
+        monkeypatch.setattr("naturo.backends.windows._element._get_process_session_id", mock_process_session)
 
         # _resolve_hwnd with --app "MyApp" should match the real MyApp, NOT cmd
         result = backend._resolve_hwnd(app="MyApp")
@@ -82,8 +82,8 @@ class TestCmdWindowExclusion:
             return 1
 
         monkeypatch.setattr(backend, "list_windows", mock_list_windows)
-        monkeypatch.setattr(backend, "_get_console_session_id", mock_console_session)
-        monkeypatch.setattr(backend, "_get_process_session_id", mock_process_session)
+        monkeypatch.setattr("naturo.backends.windows._element._get_console_session_id", mock_console_session)
+        monkeypatch.setattr("naturo.backends.windows._element._get_process_session_id", mock_process_session)
 
         result = backend._resolve_hwnd(app="Calculator")
         assert result == 4000, "Should match Calculator.exe, not powershell.exe"
@@ -121,8 +121,8 @@ class TestCmdWindowExclusion:
             return 1
 
         monkeypatch.setattr(backend, "list_windows", mock_list_windows)
-        monkeypatch.setattr(backend, "_get_console_session_id", mock_console_session)
-        monkeypatch.setattr(backend, "_get_process_session_id", mock_process_session)
+        monkeypatch.setattr("naturo.backends.windows._element._get_console_session_id", mock_console_session)
+        monkeypatch.setattr("naturo.backends.windows._element._get_process_session_id", mock_process_session)
 
         result = backend._resolve_hwnd(app="Notepad")
         assert result == 6000, "Should match notepad.exe, not conhost.exe"
@@ -151,8 +151,8 @@ class TestCmdWindowExclusion:
             return 1
 
         monkeypatch.setattr(backend, "list_windows", mock_list_windows)
-        monkeypatch.setattr(backend, "_get_console_session_id", mock_console_session)
-        monkeypatch.setattr(backend, "_get_process_session_id", mock_process_session)
+        monkeypatch.setattr("naturo.backends.windows._element._get_console_session_id", mock_console_session)
+        monkeypatch.setattr("naturo.backends.windows._element._get_process_session_id", mock_process_session)
 
         # --app "cmd" should still match cmd.exe by process name
         result = backend._resolve_hwnd(app="cmd")

--- a/tests/test_explorer_program_manager.py
+++ b/tests/test_explorer_program_manager.py
@@ -22,8 +22,17 @@ def _make_backend():
         pytest.skip("WindowsBackend not available on this platform")
 
 
+_SESSION_PATCH_BASE = "naturo.backends.windows._element"
+
+
 class TestExplorerProgramManager:
     """Verify --app explorer prefers File Explorer over Program Manager (#524)."""
+
+    @pytest.fixture(autouse=True)
+    def _patch_session(self):
+        with patch(f"{_SESSION_PATCH_BASE}._get_console_session_id", return_value=-1), \
+             patch(f"{_SESSION_PATCH_BASE}._get_process_session_id", return_value=1):
+            yield
 
     def _make_explorer_windows(self):
         """Program Manager (desktop) + File Explorer window."""
@@ -57,8 +66,6 @@ class TestExplorerProgramManager:
         backend = MagicMock(spec=BackendClass)
         backend.list_windows = MagicMock(return_value=windows)
         backend._resolve_hwnd = BackendClass._resolve_hwnd.__get__(backend)
-        backend._get_console_session_id = MagicMock(return_value=-1)
-        backend._get_process_session_id = MagicMock(return_value=1)
         backend._get_foreground_hwnd = MagicMock(return_value=0)
         backend._APP_ALIASES = BackendClass._APP_ALIASES
         backend._DESKTOP_SHELL_CLASSES = BackendClass._DESKTOP_SHELL_CLASSES

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -7,6 +7,7 @@ from naturo.process import (
     relaunch_app, list_apps, _list_processes, _verify_quit,
     _close_all_windows_for_app, _app_has_visible_windows,
     _get_console_session_id, _get_process_session_id,
+    _parse_tasklist_csv_line,
     _resolve_launch_name, _resolve_pid_from_backend, _LAUNCH_ALIASES,
     _matches_app_by_process_name,
 )
@@ -238,6 +239,27 @@ class TestFindProcessAliasResolution:
         result = find_process(name="记事本")
         assert result is not None
         assert result.pid == 200, "Alias match should prefer interactive session"
+
+
+class TestParseTasklistCsvLine:
+    """Tests for _parse_tasklist_csv_line utility."""
+
+    def test_normal_line(self):
+        assert _parse_tasklist_csv_line('"notepad.exe","1234","Console","1","12,345 K"') == ("notepad.exe", 1234)
+
+    def test_empty_line(self):
+        assert _parse_tasklist_csv_line("") is None
+        assert _parse_tasklist_csv_line("   ") is None
+
+    def test_malformed_line(self):
+        assert _parse_tasklist_csv_line("garbage") is None
+
+    def test_non_numeric_pid(self):
+        assert _parse_tasklist_csv_line('"notepad.exe","abc"') is None
+
+    def test_unicode_process_name(self):
+        result = _parse_tasklist_csv_line('"记事本.exe","5678","Console","1","8,192 K"')
+        assert result == ("记事本.exe", 5678)
 
 
 class TestSessionHelpers:

--- a/tests/test_resolve_all_windows.py
+++ b/tests/test_resolve_all_windows.py
@@ -58,8 +58,8 @@ class TestResolveAllWindows:
             return 1
 
         monkeypatch.setattr(backend, "list_windows", mock_list_windows)
-        monkeypatch.setattr(backend, "_get_console_session_id", mock_console_session)
-        monkeypatch.setattr(backend, "_get_process_session_id", mock_process_session)
+        monkeypatch.setattr("naturo.backends.windows._element._get_console_session_id", mock_console_session)
+        monkeypatch.setattr("naturo.backends.windows._element._get_process_session_id", mock_process_session)
 
         # --app "Lark" should return all 3 Feishu windows
         result = backend._resolve_hwnds(app="Lark")
@@ -90,8 +90,8 @@ class TestResolveAllWindows:
             return 1
 
         monkeypatch.setattr(backend, "list_windows", mock_list_windows)
-        monkeypatch.setattr(backend, "_get_console_session_id", mock_console_session)
-        monkeypatch.setattr(backend, "_get_process_session_id", mock_process_session)
+        monkeypatch.setattr("naturo.backends.windows._element._get_console_session_id", mock_console_session)
+        monkeypatch.setattr("naturo.backends.windows._element._get_process_session_id", mock_process_session)
 
         result = backend._resolve_hwnds(app="Feishu")
         assert result == []
@@ -138,8 +138,8 @@ class TestResolveAllWindows:
             return 1
 
         monkeypatch.setattr(backend, "list_windows", mock_list_windows)
-        monkeypatch.setattr(backend, "_get_console_session_id", mock_console_session)
-        monkeypatch.setattr(backend, "_get_process_session_id", mock_process_session)
+        monkeypatch.setattr("naturo.backends.windows._element._get_console_session_id", mock_console_session)
+        monkeypatch.setattr("naturo.backends.windows._element._get_process_session_id", mock_process_session)
 
         result = backend._resolve_hwnds(app="myapp")
         # Exact process name match (score 4) should come first
@@ -209,8 +209,8 @@ class TestResolveAllWindows:
 
         monkeypatch.setattr(backend, "list_windows",
                             lambda: [calculator_app, afh_calculator, notepad_window])
-        monkeypatch.setattr(backend, "_get_console_session_id", lambda: 1)
-        monkeypatch.setattr(backend, "_get_process_session_id", lambda pid: 1)
+        monkeypatch.setattr("naturo.backends.windows._element._get_console_session_id", lambda: 1)
+        monkeypatch.setattr("naturo.backends.windows._element._get_process_session_id", lambda pid: 1)
         # AFH window has a content child (CoreWindow)
         monkeypatch.setattr(WindowsBackend, "_afh_has_content_window",
                             staticmethod(lambda hwnd: hwnd == 2000))
@@ -254,8 +254,8 @@ class TestResolveAllWindows:
 
         monkeypatch.setattr(backend, "list_windows",
                             lambda: [calculator_app, stale_afh, live_afh])
-        monkeypatch.setattr(backend, "_get_console_session_id", lambda: 1)
-        monkeypatch.setattr(backend, "_get_process_session_id", lambda pid: 1)
+        monkeypatch.setattr("naturo.backends.windows._element._get_console_session_id", lambda: 1)
+        monkeypatch.setattr("naturo.backends.windows._element._get_process_session_id", lambda pid: 1)
         # Only live_afh (3000) has content child
         monkeypatch.setattr(WindowsBackend, "_afh_has_content_window",
                             staticmethod(lambda hwnd: hwnd == 3000))

--- a/tests/test_resolve_hwnd_session.py
+++ b/tests/test_resolve_hwnd_session.py
@@ -13,6 +13,8 @@ from unittest.mock import patch, MagicMock, PropertyMock
 
 from naturo.backends.base import WindowInfo
 
+_SESSION_PATCH_BASE = "naturo.backends.windows._element"
+
 
 def _make_backend():
     """Create a WindowsBackend-like object for testing _resolve_hwnd.
@@ -56,14 +58,13 @@ class TestResolveHwndSessionAwareness:
 
         # Bind the real method to our mock
         backend._resolve_hwnd = BackendClass._resolve_hwnd.__get__(backend)
-        backend._get_console_session_id = MagicMock(return_value=1)
-        backend._get_process_session_id = MagicMock(
-            side_effect=lambda pid: 0 if pid == 100 else 1
-        )
         backend._get_foreground_hwnd = MagicMock(return_value=0)
         backend._APP_ALIASES = BackendClass._APP_ALIASES
 
-        result = backend._resolve_hwnd(app="notepad")
+        with patch(f"{_SESSION_PATCH_BASE}._get_console_session_id", return_value=1), \
+             patch(f"{_SESSION_PATCH_BASE}._get_process_session_id",
+                   side_effect=lambda pid: 0 if pid == 100 else 1):
+            result = backend._resolve_hwnd(app="notepad")
         # Should pick handle 2002 (PID 200, Session 1) not 1001 (PID 100, Session 0)
         assert result == 2002
 
@@ -88,12 +89,12 @@ class TestResolveHwndSessionAwareness:
         ]
         backend.list_windows = MagicMock(return_value=windows)
         backend._resolve_hwnd = BackendClass._resolve_hwnd.__get__(backend)
-        backend._get_console_session_id = MagicMock(return_value=-1)
-        backend._get_process_session_id = MagicMock(return_value=-1)
         backend._get_foreground_hwnd = MagicMock(return_value=0)
         backend._APP_ALIASES = BackendClass._APP_ALIASES
 
-        result = backend._resolve_hwnd(app="notepad")
+        with patch(f"{_SESSION_PATCH_BASE}._get_console_session_id", return_value=-1), \
+             patch(f"{_SESSION_PATCH_BASE}._get_process_session_id", return_value=-1):
+            result = backend._resolve_hwnd(app="notepad")
         # Both match equally on process name; PID 200 has larger area
         assert result == 2002
 
@@ -118,12 +119,12 @@ class TestResolveHwndSessionAwareness:
         ]
         backend.list_windows = MagicMock(return_value=windows)
         backend._resolve_hwnd = BackendClass._resolve_hwnd.__get__(backend)
-        backend._get_console_session_id = MagicMock(return_value=1)
-        backend._get_process_session_id = MagicMock(return_value=1)
         backend._get_foreground_hwnd = MagicMock(return_value=0)
         backend._APP_ALIASES = BackendClass._APP_ALIASES
 
-        result = backend._resolve_hwnd(app="notepad")
+        with patch(f"{_SESSION_PATCH_BASE}._get_console_session_id", return_value=1), \
+             patch(f"{_SESSION_PATCH_BASE}._get_process_session_id", return_value=1):
+            result = backend._resolve_hwnd(app="notepad")
         # Main window (3001) has much larger area than popup (3002)
         assert result == 3001
 
@@ -148,15 +149,13 @@ class TestResolveHwndSessionAwareness:
         ]
         backend.list_windows = MagicMock(return_value=windows)
         backend._resolve_hwnd = BackendClass._resolve_hwnd.__get__(backend)
-        backend._get_console_session_id = MagicMock(return_value=1)
-        # PID 100 in console, PID 200 in Session 0
-        backend._get_process_session_id = MagicMock(
-            side_effect=lambda pid: 1 if pid == 100 else 0
-        )
         backend._get_foreground_hwnd = MagicMock(return_value=0)
         backend._APP_ALIASES = BackendClass._APP_ALIASES
 
-        result = backend._resolve_hwnd(app="notepad")
+        with patch(f"{_SESSION_PATCH_BASE}._get_console_session_id", return_value=1), \
+             patch(f"{_SESSION_PATCH_BASE}._get_process_session_id",
+                   side_effect=lambda pid: 1 if pid == 100 else 0):
+            result = backend._resolve_hwnd(app="notepad")
         # PID 200 has exact process name match (score 4),
         # PID 100 only has title substring (score 1).
         # Higher score wins regardless of session.
@@ -187,13 +186,13 @@ class TestResolveHwndForegroundPreference:
         ]
         backend.list_windows = MagicMock(return_value=windows)
         backend._resolve_hwnd = BackendClass._resolve_hwnd.__get__(backend)
-        backend._get_console_session_id = MagicMock(return_value=1)
-        backend._get_process_session_id = MagicMock(return_value=1)
         # Window 2002 is the foreground window
         backend._get_foreground_hwnd = MagicMock(return_value=2002)
         backend._APP_ALIASES = BackendClass._APP_ALIASES
 
-        result = backend._resolve_hwnd(app="notepad")
+        with patch(f"{_SESSION_PATCH_BASE}._get_console_session_id", return_value=1), \
+             patch(f"{_SESSION_PATCH_BASE}._get_process_session_id", return_value=1):
+            result = backend._resolve_hwnd(app="notepad")
         # Both match on process name (score 4), same session, same area.
         # Foreground window (2002) should win.
         assert result == 2002
@@ -219,13 +218,13 @@ class TestResolveHwndForegroundPreference:
         ]
         backend.list_windows = MagicMock(return_value=windows)
         backend._resolve_hwnd = BackendClass._resolve_hwnd.__get__(backend)
-        backend._get_console_session_id = MagicMock(return_value=1)
-        backend._get_process_session_id = MagicMock(return_value=1)
         # Window 1001 is the foreground window (listed second)
         backend._get_foreground_hwnd = MagicMock(return_value=1001)
         backend._APP_ALIASES = BackendClass._APP_ALIASES
 
-        result = backend._resolve_hwnd(app="notepad")
+        with patch(f"{_SESSION_PATCH_BASE}._get_console_session_id", return_value=1), \
+             patch(f"{_SESSION_PATCH_BASE}._get_process_session_id", return_value=1):
+            result = backend._resolve_hwnd(app="notepad")
         # Foreground window 1001 should win even though it's listed second
         assert result == 1001
 
@@ -250,13 +249,13 @@ class TestResolveHwndForegroundPreference:
         ]
         backend.list_windows = MagicMock(return_value=windows)
         backend._resolve_hwnd = BackendClass._resolve_hwnd.__get__(backend)
-        backend._get_console_session_id = MagicMock(return_value=1)
-        backend._get_process_session_id = MagicMock(return_value=1)
         # Foreground is some unrelated window
         backend._get_foreground_hwnd = MagicMock(return_value=9999)
         backend._APP_ALIASES = BackendClass._APP_ALIASES
 
-        result = backend._resolve_hwnd(app="notepad")
+        with patch(f"{_SESSION_PATCH_BASE}._get_console_session_id", return_value=1), \
+             patch(f"{_SESSION_PATCH_BASE}._get_process_session_id", return_value=1):
+            result = backend._resolve_hwnd(app="notepad")
         # Neither is foreground, so larger area (2002) wins
         assert result == 2002
 
@@ -293,8 +292,6 @@ class TestResolveHwndPid:
         backend = MagicMock(spec=BackendClass)
         backend.list_windows = MagicMock(return_value=windows)
         backend._resolve_hwnd = BackendClass._resolve_hwnd.__get__(backend)
-        backend._get_console_session_id = MagicMock(return_value=1)
-        backend._get_process_session_id = MagicMock(return_value=1)
         backend._get_foreground_hwnd = MagicMock(return_value=fg_hwnd)
         backend._APP_ALIASES = BackendClass._APP_ALIASES
         return backend
@@ -304,8 +301,10 @@ class TestResolveHwndPid:
         backend = self._setup_backend(
             self._make_multi_app_windows(), fg_hwnd=3003,
         )
-        # Paint (3003) is foreground, but --pid 200 should target Calculator
-        result = backend._resolve_hwnd(pid=200)
+        with patch(f"{_SESSION_PATCH_BASE}._get_console_session_id", return_value=1), \
+             patch(f"{_SESSION_PATCH_BASE}._get_process_session_id", return_value=1):
+            # Paint (3003) is foreground, but --pid 200 should target Calculator
+            result = backend._resolve_hwnd(pid=200)
         assert result == 2002
 
     def test_pid_alone_targets_notepad_not_foreground(self):
@@ -313,14 +312,18 @@ class TestResolveHwndPid:
         backend = self._setup_backend(
             self._make_multi_app_windows(), fg_hwnd=3003,
         )
-        result = backend._resolve_hwnd(pid=100)
+        with patch(f"{_SESSION_PATCH_BASE}._get_console_session_id", return_value=1), \
+             patch(f"{_SESSION_PATCH_BASE}._get_process_session_id", return_value=1):
+            result = backend._resolve_hwnd(pid=100)
         assert result == 1001
 
     def test_pid_with_app_filters_both(self):
         """--pid combined with --app should filter by both."""
         backend = self._setup_backend(self._make_multi_app_windows())
-        # PID 200 is Calculator, --app calculator should also match
-        result = backend._resolve_hwnd(app="calculator", pid=200)
+        with patch(f"{_SESSION_PATCH_BASE}._get_console_session_id", return_value=1), \
+             patch(f"{_SESSION_PATCH_BASE}._get_process_session_id", return_value=1):
+            # PID 200 is Calculator, --app calculator should also match
+            result = backend._resolve_hwnd(app="calculator", pid=200)
         assert result == 2002
 
     def test_pid_selects_largest_window_among_process(self):
@@ -340,7 +343,9 @@ class TestResolveHwndPid:
             ),
         ]
         backend = self._setup_backend(windows)
-        result = backend._resolve_hwnd(pid=100)
+        with patch(f"{_SESSION_PATCH_BASE}._get_console_session_id", return_value=1), \
+             patch(f"{_SESSION_PATCH_BASE}._get_process_session_id", return_value=1):
+            result = backend._resolve_hwnd(pid=100)
         # Main window (1001) is larger → should be selected
         assert result == 1001
 
@@ -348,19 +353,25 @@ class TestResolveHwndPid:
         """--pid with no matching windows should raise WindowNotFoundError."""
         backend = self._setup_backend(self._make_multi_app_windows())
         from naturo.errors import WindowNotFoundError
-        with pytest.raises(WindowNotFoundError, match="PID 999"):
-            backend._resolve_hwnd(pid=999)
+        with patch(f"{_SESSION_PATCH_BASE}._get_console_session_id", return_value=1), \
+             patch(f"{_SESSION_PATCH_BASE}._get_process_session_id", return_value=1):
+            with pytest.raises(WindowNotFoundError, match="PID 999"):
+                backend._resolve_hwnd(pid=999)
 
     def test_pid_none_without_search_returns_foreground(self):
         """When pid=None and no search term, return 0 (foreground)."""
         backend = self._setup_backend(self._make_multi_app_windows())
-        result = backend._resolve_hwnd()
+        with patch(f"{_SESSION_PATCH_BASE}._get_console_session_id", return_value=1), \
+             patch(f"{_SESSION_PATCH_BASE}._get_process_session_id", return_value=1):
+            result = backend._resolve_hwnd()
         assert result == 0
 
     def test_pid_with_hwnd_prefers_hwnd(self):
         """Direct hwnd takes priority over pid."""
         backend = self._setup_backend(self._make_multi_app_windows())
-        result = backend._resolve_hwnd(hwnd=9999, pid=200)
+        with patch(f"{_SESSION_PATCH_BASE}._get_console_session_id", return_value=1), \
+             patch(f"{_SESSION_PATCH_BASE}._get_process_session_id", return_value=1):
+            result = backend._resolve_hwnd(hwnd=9999, pid=200)
         assert result == 9999
 
     def test_pid_prefers_foreground_among_same_process(self):
@@ -381,5 +392,7 @@ class TestResolveHwndPid:
         ]
         # Window 1002 is foreground
         backend = self._setup_backend(windows, fg_hwnd=1002)
-        result = backend._resolve_hwnd(pid=100)
+        with patch(f"{_SESSION_PATCH_BASE}._get_console_session_id", return_value=1), \
+             patch(f"{_SESSION_PATCH_BASE}._get_process_session_id", return_value=1):
+            result = backend._resolve_hwnd(pid=100)
         assert result == 1002

--- a/tests/test_uwp_afh_resolve.py
+++ b/tests/test_uwp_afh_resolve.py
@@ -17,8 +17,8 @@ def _make_backend(monkeypatch, windows):
     """Create a WindowsBackend with mocked window list and session helpers."""
     backend = WindowsBackend()
     monkeypatch.setattr(backend, "list_windows", lambda: windows)
-    monkeypatch.setattr(backend, "_get_console_session_id", lambda: 1)
-    monkeypatch.setattr(backend, "_get_process_session_id", lambda pid: 1)
+    monkeypatch.setattr("naturo.backends.windows._element._get_console_session_id", lambda: 1)
+    monkeypatch.setattr("naturo.backends.windows._element._get_process_session_id", lambda pid: 1)
     monkeypatch.setattr(backend, "_get_foreground_hwnd", lambda: 0)
     monkeypatch.setattr(backend, "_get_window_class_name", lambda h: "")
     return backend


### PR DESCRIPTION
## Changes
- Extract `_parse_tasklist_csv_line()` in `process.py` for shared tasklist CSV parsing
- Consolidate `_get_console_session_id()` and `_get_process_session_id()` in `process.py` as the single source of truth
- Remove 45-line duplicate static methods from `backends/windows/_element.py` (now imports from `process.py`)
- Replace inline `ProcessIdToSessionId` ctypes call in `cli/interaction/_common.py` with `_get_process_session_id(os.getpid())`
- Use `_parse_tasklist_csv_line()` in `detect/probes.py` instead of inline parsing
- Update 7 test files to patch module-level functions instead of instance methods
- Add 5 tests for `_parse_tasklist_csv_line()`

## Testing
- All 3961 tests pass (`pytest -m "not ui and not integration and not desktop and not windows"`)
- `ruff check naturo/` — all checks passed
- `mypy naturo/` — no issues found in 118 source files

**[Dev-Sirius]**