### PR TITLE
fix: Notepad test polling — drop is_visible filter, increase timeout (fixes #729)

### DIFF
--- a/tests/test_app_control.py
+++ b/tests/test_app_control.py
@@ -450,17 +450,18 @@ class TestAppLifecycleE2EWindows:
         return False
 
     @staticmethod
-    def _poll_for_notepad(backend, is_notepad_fn, timeout=15.0, interval=0.5):
-        """Poll for a visible Notepad window with retry (#560, #697).
+    def _poll_for_notepad(backend, is_notepad_fn, timeout=20.0, interval=0.5):
+        """Poll for a Notepad window with retry (#560, #697, #729).
 
         UWP Notepad on Windows 11 launches through a broker process;
         the actual window may take several seconds to appear.
 
-        Timeout reduced from 30s to 15s (#697) to prevent hanging the
-        CI pipeline when --timeout-method=thread is used with ctypes.
+        Does NOT filter by ``is_visible`` during polling — UWP windows
+        may not report ``is_visible=True`` immediately after launch,
+        causing the poll to time out on CI (#729).
 
         Returns:
-            List of matching visible WindowInfo objects.
+            List of matching WindowInfo objects.
         """
         import time
         deadline = time.monotonic() + timeout
@@ -468,7 +469,7 @@ class TestAppLifecycleE2EWindows:
             windows = backend.list_windows()
             notepad_wins = [
                 w for w in windows
-                if is_notepad_fn(w) and w.is_visible
+                if is_notepad_fn(w)
             ]
             if notepad_wins:
                 return notepad_wins

--- a/tests/test_cli_phase2.py
+++ b/tests/test_cli_phase2.py
@@ -550,13 +550,15 @@ class TestNotepadAutomation:
                     return True
                 return False
 
-            # (#560, #729) Poll for Notepad window — UWP launch is slow
-            deadline = time.monotonic() + 15.0
+            # (#560, #729) Poll for Notepad window — UWP launch is slow.
+            # Do NOT filter by is_visible during polling: UWP windows may
+            # not report visibility immediately after launch (#729).
+            deadline = time.monotonic() + 20.0
             notepad = None
             while notepad is None and time.monotonic() < deadline:
                 windows = core.list_windows()
                 notepad = next(
-                    (w for w in windows if _is_notepad(w) and w.is_visible),
+                    (w for w in windows if _is_notepad(w)),
                     None
                 )
                 if notepad is None:


### PR DESCRIPTION
## Changes
- Remove `is_visible` filter from Notepad window polling in `test_app_control.py` and `test_cli_phase2.py`
- Increase polling timeout from 15s to 20s for UWP Notepad process model

## Root Cause
UWP Notepad on Windows 11 launches through ApplicationFrameHost.exe and may not report `is_visible=True` immediately after process creation. The failing tests filtered by `w.is_visible` during polling, causing timeout before the window became visible. The passing tests in `test_e2e_notepad.py` use `visible_only=False` (default) and don't filter by visibility during polling.

## Testing
- Aligns with the approach in `test_e2e_notepad.py` which passes on CI desktop runner
- Requires desktop CI verification to confirm fix

**[Dev-Sirius]**