### PR TITLE
refactor: add return type annotations to CLI commands and helpers (fixes #716)

### DIFF
--- a/naturo/cli/__init__.py
+++ b/naturo/cli/__init__.py
@@ -97,7 +97,7 @@ def _patch_all_commands(group: click.Command) -> None:
     help="Log level",
 )
 @click.pass_context
-def main(ctx, json_output, verbose, log_level):
+def main(ctx, json_output, verbose, log_level) -> None:
     """Naturo — Windows desktop automation engine.
 
     See, click, type, automate. Built for AI agents.
@@ -158,7 +158,7 @@ main.add_command(excel)
 # Users naturally try `naturo help` (like git/docker). Redirect to --help.
 @main.command("help", hidden=True)
 @click.pass_context
-def help_cmd(ctx):
+def help_cmd(ctx) -> None:
     """Show help information (alias for --help)."""
     click.echo(ctx.parent.get_help())
 

--- a/naturo/cli/ai.py
+++ b/naturo/cli/ai.py
@@ -9,7 +9,7 @@ from naturo.cli.fuzzy_group import FuzzyGroup
 
 
 @click.group(cls=FuzzyGroup)
-def mcp():
+def mcp() -> None:
     """MCP (Model Context Protocol) server for AI agent integration."""
     pass
 
@@ -20,7 +20,7 @@ def mcp():
 @click.option("--host", default="localhost", help="Bind host (for sse/http)")
 @click.option("--port", type=int, default=3100, help="Bind port (for sse/http)")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def start(transport, host, port, json_output):
+def start(transport, host, port, json_output) -> None:
     """Start the MCP server.
 
     Default transport is stdio (for integration with AI agents like Claude, OpenClaw).
@@ -67,7 +67,7 @@ def start(transport, host, port, json_output):
 
 @mcp.command()
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def install(json_output):
+def install(json_output) -> None:
     """Install MCP server dependencies.
 
     Installs the required 'mcp' package for running the MCP server.
@@ -104,7 +104,7 @@ def install(json_output):
 
 @mcp.command()
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def tools(json_output):
+def tools(json_output) -> None:
     """List available MCP tools.
 
     Shows all tools that the MCP server exposes to AI agents.

--- a/naturo/cli/app_cmd.py
+++ b/naturo/cli/app_cmd.py
@@ -70,7 +70,7 @@ def _safe_echo(text: str, **kwargs) -> None:
 @click.option("--args", multiple=True, help="Arguments to pass to the application")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def app_launch(ctx, name, app_name, path, wait_until_ready, timeout, no_focus, args, json_output):
+def app_launch(ctx, name, app_name, path, wait_until_ready, timeout, no_focus, args, json_output) -> None:
     """Launch an application by name or path."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
     if not name and app_name:
@@ -126,7 +126,7 @@ def app_launch(ctx, name, app_name, path, wait_until_ready, timeout, no_focus, a
 @click.option("--timeout", type=float, default=10.0, help="Graceful shutdown timeout")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def app_quit(ctx, name, name_option, app_name, pid, force, timeout, json_output):
+def app_quit(ctx, name, name_option, app_name, pid, force, timeout, json_output) -> None:
     """Quit an application gracefully (or force kill).
 
     NAME is the application name to quit.
@@ -178,7 +178,7 @@ def app_quit(ctx, name, name_option, app_name, pid, force, timeout, json_output)
 @click.option("--timeout", type=float, default=30.0, help="Timeout in seconds")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def app_relaunch(ctx, name, app_name, wait_until_ready, timeout, json_output):
+def app_relaunch(ctx, name, app_name, wait_until_ready, timeout, json_output) -> None:
     """Quit and relaunch an application."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
     if not name and app_name:
@@ -222,7 +222,7 @@ def app_relaunch(ctx, name, app_name, wait_until_ready, timeout, json_output):
 @click.option("--all", "show_all", is_flag=True, help="Show all processes (not just apps with windows)")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def app_list(ctx, show_all, json_output):
+def app_list(ctx, show_all, json_output) -> None:
     """List running applications with visible windows.
 
     By default, shows user-facing applications with visible windows
@@ -362,7 +362,7 @@ def app_list(ctx, show_all, json_output):
 @click.option("--app", "app_name", default=None, help="Application name (alternative to positional NAME)")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def app_hide(ctx, name, app_name, json_output):
+def app_hide(ctx, name, app_name, json_output) -> None:
     """Hide (minimize) all windows of an application. Alias for minimize."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
     if not name and app_name:
@@ -410,7 +410,7 @@ def app_hide(ctx, name, app_name, json_output):
 @click.option("--app", "app_name", default=None, help="Application name (alternative to positional NAME)")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def app_unhide(ctx, name, app_name, json_output):
+def app_unhide(ctx, name, app_name, json_output) -> None:
     """Unhide (restore) all windows of an application. Alias for restore."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
     if not name and app_name:
@@ -458,7 +458,7 @@ def app_unhide(ctx, name, app_name, json_output):
 @click.option("--app", "app_name", default=None, help="Application name (alternative to positional NAME)")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def app_switch(ctx, name, app_name, json_output):
+def app_switch(ctx, name, app_name, json_output) -> None:
     """Switch to (focus) the most recent window of an application. Alias for focus."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
     if not name and app_name:
@@ -494,7 +494,7 @@ def app_switch(ctx, name, app_name, json_output):
 @click.option("--pid", type=int, help="Search by PID instead of name")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def app_find(ctx, name, pid, json_output):
+def app_find(ctx, name, pid, json_output) -> None:
     """Find a running application by name or PID."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
 
@@ -548,7 +548,7 @@ def app_find(ctx, name, pid, json_output):
 @click.option("--quick", is_flag=True, help="Fast probe — stop at first available method")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def app_inspect(ctx, name, app_name, pid, scan_all, quick, json_output):
+def app_inspect(ctx, name, app_name, pid, scan_all, quick, json_output) -> None:
     """Probe an application and report available interaction methods.
 
     Detects which UI framework the app uses (Electron, WPF, Qt, etc.)
@@ -854,7 +854,7 @@ def _require_target(name, window_title, hwnd, json_output):
     return True
 
 
-def _handle_naturo_error(exc, json_output):
+def _handle_naturo_error(exc, json_output) -> None:
     """Emit a NaturoError and exit."""
     if json_output:
         click.echo(json.dumps(exc.to_json_response()))
@@ -863,7 +863,7 @@ def _handle_naturo_error(exc, json_output):
     sys.exit(1)
 
 
-def _handle_generic_error(exc, json_output):
+def _handle_generic_error(exc, json_output) -> None:
     """Emit a generic exception and exit."""
     if json_output:
         click.echo(_json_error_str("UNKNOWN_ERROR", str(exc)))
@@ -879,7 +879,7 @@ def _handle_generic_error(exc, json_output):
 @click.option("--hwnd", type=int, default=None, help="Window handle (HWND)")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def app_focus(ctx, name, app_name, window_title, hwnd, json_output):
+def app_focus(ctx, name, app_name, window_title, hwnd, json_output) -> None:
     """Focus an application window (bring to foreground).
 
     \b
@@ -921,7 +921,7 @@ def app_focus(ctx, name, app_name, window_title, hwnd, json_output):
 @click.option("--force", is_flag=True, help="Force terminate the process")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def app_close(ctx, name, app_name, window_title, hwnd, force, json_output):
+def app_close(ctx, name, app_name, window_title, hwnd, force, json_output) -> None:
     """Close an application window (graceful or forced).
 
     \b
@@ -961,7 +961,7 @@ def app_close(ctx, name, app_name, window_title, hwnd, force, json_output):
 @click.option("--hwnd", type=int, default=None, help="Window handle (HWND)")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def app_minimize(ctx, name, window_title, hwnd, json_output):
+def app_minimize(ctx, name, window_title, hwnd, json_output) -> None:
     """Minimize an application window.
 
     \b
@@ -995,7 +995,7 @@ def app_minimize(ctx, name, window_title, hwnd, json_output):
 @click.option("--hwnd", type=int, default=None, help="Window handle (HWND)")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def app_maximize(ctx, name, window_title, hwnd, json_output):
+def app_maximize(ctx, name, window_title, hwnd, json_output) -> None:
     """Maximize an application window.
 
     \b
@@ -1029,7 +1029,7 @@ def app_maximize(ctx, name, window_title, hwnd, json_output):
 @click.option("--hwnd", type=int, default=None, help="Window handle (HWND)")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def app_restore(ctx, name, window_title, hwnd, json_output):
+def app_restore(ctx, name, window_title, hwnd, json_output) -> None:
     """Restore a minimized or maximized window to normal state.
 
     \b
@@ -1067,7 +1067,7 @@ def app_restore(ctx, name, window_title, hwnd, json_output):
 @click.option("--height", type=int, default=None, help="New height in pixels (optional)")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def app_move(ctx, name, window_title, hwnd, x, y, width, height, json_output):
+def app_move(ctx, name, window_title, hwnd, x, y, width, height, json_output) -> None:
     """Move and/or resize an application window.
 
     Combines move, resize, and set-bounds into one command.
@@ -1162,7 +1162,7 @@ def app_move(ctx, name, window_title, hwnd, x, y, width, height, json_output):
 @click.option("--pid", type=int, help="Process ID")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def app_windows(ctx, name, pid, json_output):
+def app_windows(ctx, name, pid, json_output) -> None:
     """List open windows (optionally filtered by app name or PID).
 
     \b

--- a/naturo/cli/clipboard_cmd.py
+++ b/naturo/cli/clipboard_cmd.py
@@ -38,7 +38,7 @@ def _get_backend(json_output: bool = False):
 
 
 @click.group(cls=FuzzyGroup)
-def clipboard():
+def clipboard() -> None:
     """Read, write, and manage clipboard contents.
 
     Data management for the system clipboard. Supports reading and writing

--- a/naturo/cli/core/_find.py
+++ b/naturo/cli/core/_find.py
@@ -239,7 +239,7 @@ def _find_with_ai(
     *,
     model: str | None = None,
     api_key: str | None = None,
-):
+) -> None:
     """AI-powered element finding via naturo find --ai.
 
     Args:

--- a/naturo/cli/core/_highlight.py
+++ b/naturo/cli/core/_highlight.py
@@ -42,7 +42,7 @@ logger = logging.getLogger(__name__)
 @click.option("--pid", type=int, default=None, help="Process ID")
 def highlight(positional_refs, on_ref, ref_option, app, hwnd, app_id, depth, duration,
               json_output, backend, show_all, annotate_path, role_filter,
-              visible_only, cascade, fill_gaps, pid):
+              visible_only, cascade, fill_gaps, pid) -> None:
     """Highlight UI elements on screen with colored borders and labels.
 
     By default highlights only actionable elements (Button, Edit, ComboBox,

--- a/naturo/cli/core/_list.py
+++ b/naturo/cli/core/_list.py
@@ -10,7 +10,7 @@ import naturo.cli.core._common as _common
 
 
 @click.group("list", cls=_common.FuzzyGroup)
-def list_cmd():
+def list_cmd() -> None:
     """List apps, windows, and screens."""
     pass
 
@@ -19,7 +19,7 @@ def list_cmd():
 @click.option("--all", "show_all", is_flag=True, help="Show all processes (not just apps with windows)")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def apps(ctx, show_all, json_output):
+def apps(ctx, show_all, json_output) -> None:
     """List running applications (delegates to 'app list')."""
     from naturo.cli.app_cmd import app_list
     ctx.invoke(app_list, show_all=show_all, json_output=json_output)
@@ -30,7 +30,7 @@ def apps(ctx, show_all, json_output):
 @click.option("--process-name", "app", default=None, hidden=True, help="")
 @click.option("--pid", type=int, help="Process ID")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def windows(app, pid, json_output):
+def windows(app, pid, json_output) -> None:
     """List open windows.
 
     Shows all visible top-level windows with their handles, titles,
@@ -111,7 +111,7 @@ def windows(app, pid, json_output):
 
 @list_cmd.command()
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def screens(json_output):
+def screens(json_output) -> None:
     """List connected screens/monitors.
 
     Shows monitor index, resolution, position, DPI scale factor, and
@@ -181,7 +181,7 @@ def screens(json_output):
 
 @list_cmd.command(hidden=True)
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def permissions(json_output):
+def permissions(json_output) -> None:
     """List automation permissions status (UIAccess, admin, etc.)."""
     msg = "Permission listing is not implemented yet — coming in a future release."
     if json_output:

--- a/naturo/cli/core/_menu.py
+++ b/naturo/cli/core/_menu.py
@@ -14,7 +14,7 @@ import naturo.cli.core._common as _common
               help='Stable app/window ID from "naturo app list" output (e.g. a1)')
 @click.option("--flat", is_flag=True, help="Flatten menu tree into paths")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def menu_inspect(app, app_id, flat, json_output):
+def menu_inspect(app, app_id, flat, json_output) -> None:
     """List the menu bar structure of the foreground application.
 
     Traverses the application's MenuBar via UIAutomation and displays
@@ -97,7 +97,7 @@ def menu_inspect(app, app_id, flat, json_output):
                         shortcut = f"  [{entry['shortcut']}]" if entry.get("shortcut") else ""
                         click.echo(f"  {entry['path']}{shortcut}")
             else:
-                def print_menu(item, indent=0):
+                def print_menu(item, indent=0) -> None:
                     """Recursively print a menu item and its submenus with indentation."""
                     prefix = "  " * indent
                     shortcut = f" [{item.shortcut}]" if item.shortcut else ""

--- a/naturo/cli/core/_see.py
+++ b/naturo/cli/core/_see.py
@@ -445,7 +445,7 @@ def see(app: str | None, window_title: str | None, hwnd: int | None, pid: int | 
             # passed to ``naturo click e3`` for quick interaction.
             _ref_counter = [0]
 
-            def print_tree(el, indent=0, ancestors_dicts=None):
+            def print_tree(el, indent=0, ancestors_dicts=None) -> None:
                 """Print element tree with short element refs."""
                 if ancestors_dicts is None:
                     ancestors_dicts = []

--- a/naturo/cli/core/_tools.py
+++ b/naturo/cli/core/_tools.py
@@ -8,7 +8,7 @@ import naturo.cli.core._common as _common
 
 @click.command(hidden=True)
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def tools(json_output):
+def tools(json_output) -> None:
     """List available automation tools and backends.
 
     Shows which native backends are available (UIA, MSAA, Java Bridge, etc.).

--- a/naturo/cli/desktop_cmd.py
+++ b/naturo/cli/desktop_cmd.py
@@ -33,7 +33,7 @@ def _ensure_pyvda() -> None:
 
 
 @_click.group(cls=FuzzyGroup)
-def desktop():
+def desktop() -> None:
     """Virtual desktop management (Windows 10/11).
 
     List, switch, create, and close virtual desktops.

--- a/naturo/cli/dialog_cmd.py
+++ b/naturo/cli/dialog_cmd.py
@@ -27,7 +27,7 @@ from naturo.cli.options import app_id_option, resolve_app_id_to_hwnd
 
 
 @click.group(cls=FuzzyGroup)
-def dialog():
+def dialog() -> None:
     """Detect and interact with system dialogs.
 
     Handles message boxes, file pickers, confirmation prompts, and other
@@ -51,7 +51,7 @@ def dialog():
 @click.option("--hwnd", type=int, help="Filter by dialog window handle")
 @app_id_option
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def detect(app, hwnd, app_id, json_output):
+def detect(app, hwnd, app_id, json_output) -> None:
     """Detect active dialog windows.
 
     Scans for system dialogs including message boxes, file pickers,
@@ -117,7 +117,7 @@ def detect(app, hwnd, app_id, json_output):
 @click.option("--hwnd", type=int, help="Specific dialog window handle")
 @app_id_option
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def accept(app, hwnd, app_id, json_output):
+def accept(app, hwnd, app_id, json_output) -> None:
     """Accept (confirm) the active dialog.
 
     Clicks the first accept-type button found: OK, Yes, Open, Save,
@@ -189,7 +189,7 @@ def accept(app, hwnd, app_id, json_output):
 @click.option("--hwnd", type=int, help="Specific dialog window handle")
 @app_id_option
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def dismiss(app, hwnd, app_id, json_output):
+def dismiss(app, hwnd, app_id, json_output) -> None:
     """Dismiss (cancel) the active dialog.
 
     Clicks the first dismiss-type button found: Cancel, No, Close,
@@ -262,7 +262,7 @@ def dismiss(app, hwnd, app_id, json_output):
 @click.option("--hwnd", type=int, help="Specific dialog window handle")
 @app_id_option
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def click_button(button, app, hwnd, app_id, json_output):
+def click_button(button, app, hwnd, app_id, json_output) -> None:
     """Click a specific button in the active dialog.
 
     Finds a button by name (case-insensitive, supports partial match)
@@ -312,7 +312,7 @@ def click_button(button, app, hwnd, app_id, json_output):
 @click.option("--hwnd", type=int, help="Specific dialog window handle")
 @app_id_option
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def dialog_type(text, do_accept, app, hwnd, app_id, json_output):
+def dialog_type(text, do_accept, app, hwnd, app_id, json_output) -> None:
     """Type text into a dialog's input field.
 
     Finds the dialog's input/edit control, clears it, and types

--- a/naturo/cli/extensions.py
+++ b/naturo/cli/extensions.py
@@ -11,7 +11,7 @@ from naturo.cli.fuzzy_group import FuzzyGroup
 
 
 @click.group(hidden=True, cls=FuzzyGroup)
-def excel():
+def excel() -> None:
     """Excel COM automation (Windows-specific).
 
     Automate Excel workbooks via COM interface — read/write cells, run macros,
@@ -27,7 +27,7 @@ def excel():
 @click.option("--visible", is_flag=True, help="Show Excel window")
 @click.option("--read-only", is_flag=True, help="Open in read-only mode")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def excel_open_cmd(path, visible, read_only, json_output):
+def excel_open_cmd(path, visible, read_only, json_output) -> None:
     """Open an Excel workbook and show its info.
 
     PATH is the workbook file (.xlsx, .xls, .xlsm).
@@ -62,7 +62,7 @@ def excel_open_cmd(path, visible, read_only, json_output):
 @click.argument("cell")
 @click.option("--sheet", help="Sheet name (default: active sheet)")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def read(path, cell, sheet, json_output):
+def read(path, cell, sheet, json_output) -> None:
     """Read a cell or range value from a workbook.
 
     PATH is the workbook file. CELL is a cell reference (A1) or range (A1:C10).
@@ -145,7 +145,7 @@ def write(path: str, cell: str, value: str, sheet: str | None, create: bool, jso
 @excel.command("list-sheets")
 @click.argument("path", type=click.Path())
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def list_sheets(path, json_output):
+def list_sheets(path, json_output) -> None:
     """List all sheets in a workbook.
 
     \b
@@ -179,7 +179,7 @@ def list_sheets(path, json_output):
 @click.argument("macro_name")
 @click.option("--arg", "macro_args", multiple=True, help="Macro argument (repeatable)")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def run_macro(path, macro_name, macro_args, json_output):
+def run_macro(path, macro_name, macro_args, json_output) -> None:
     """Run a VBA macro in a workbook.
 
     PATH is the workbook file (.xlsm). MACRO_NAME is the macro to run.
@@ -213,7 +213,7 @@ def run_macro(path, macro_name, macro_args, json_output):
 @click.argument("path", type=click.Path())
 @click.option("--sheet", help="Sheet name (default: active sheet)")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def excel_info(path, sheet, json_output):
+def excel_info(path, sheet, json_output) -> None:
     """Get used range info for a worksheet.
 
     Shows the dimensions of the data area in the sheet.

--- a/naturo/cli/get_cmd.py
+++ b/naturo/cli/get_cmd.py
@@ -40,7 +40,7 @@ def _collect_matching_elements(tree, role=None, name=None):
     """
     matches = []
 
-    def _walk(el, depth=0):
+    def _walk(el, depth=0) -> None:
         role_match = role is None or el.role.lower() == role.lower()
         name_match = name is None or (
             el.name and name.lower() in el.name.lower()
@@ -81,7 +81,7 @@ def _collect_matching_elements(tree, role=None, name=None):
               help="JSON output")
 @click.pass_context
 def get_cmd(ctx, target, ref, automation_id, role, name, get_all, prop, app,
-            app_id, window_title, hwnd, json_output):
+            app_id, window_title, hwnd, json_output) -> None:
     """Read element text/value.
 
     Read the current value of a UI element. Accepts an element ref (e47),

--- a/naturo/cli/interaction/_common.py
+++ b/naturo/cli/interaction/_common.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import json
 import logging
 import sys
-from typing import Optional
+from typing import Callable, Optional
 
 import click
 
@@ -18,7 +18,7 @@ def _find_element_by_text_fallback(
     hwnd: Optional[int] = None,
     window_title: Optional[str] = None,
     pid: Optional[int] = None,
-):
+) -> tuple[int, int] | None:
     """Fallback element search when C++ exact UIA Name match fails.
 
     Searches the target app's element tree for elements whose name matches
@@ -116,7 +116,7 @@ def _find_element_by_text_fallback(
 # ── --see flag (post-action UI snapshot) ─────────────────────────────────────
 
 
-def _see_options(func):
+def _see_options(func: Callable) -> Callable:
     """Shared Click decorator that adds --see and --settle to action commands.
 
     When ``--see`` is passed, the command re-captures the UI element tree
@@ -139,7 +139,7 @@ def _see_options(func):
     return func
 
 
-def _verify_options(func):
+def _verify_options(func: Callable) -> Callable:
     """Shared Click decorator that adds --verify/--no-verify to action commands.
 
     Post-action verification checks whether the action actually had effect.
@@ -275,7 +275,7 @@ def _post_action_see(
         # Print tree with refs
         _ref_counter = [0]
 
-        def _print_tree(el, indent=0):
+        def _print_tree(el, indent=0) -> None:
             _ref_counter[0] += 1
             ref = f"e{_ref_counter[0]}"
             prefix = "  " * indent
@@ -306,7 +306,7 @@ def _record_action(command: str, args: dict, duration_ms: float = 0.0) -> None:
 VALID_METHODS = ("auto", "cdp", "uia", "msaa", "ia2", "jab", "vision")
 
 
-def _method_option(func):
+def _method_option(func: Callable) -> Callable:
     """Shared Click decorator that adds --method to an action command.
 
     The flag lets users bypass auto-detection and force a specific
@@ -339,7 +339,7 @@ def _validate_method(method: str, json_output: bool) -> bool:
 # ── Selector support (#103) ──────────────────────────────────────────────────
 
 
-def _selector_option(func):
+def _selector_option(func: Callable) -> Callable:
     """Shared Click decorator that adds --selector to action commands."""
     return click.option(
         "--selector",
@@ -353,7 +353,7 @@ def _selector_option(func):
     )(func)
 
 
-def _app_id_option(func):
+def _app_id_option(func: Callable) -> Callable:
     """Shared Click decorator that adds --app-id to action commands.
 
     Accepts a stable app/window ID (e.g. ``a1``) assigned by ``naturo app list``.

--- a/naturo/cli/interaction/_mouse.py
+++ b/naturo/cli/interaction/_mouse.py
@@ -42,7 +42,7 @@ logger = logging.getLogger(__name__)
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 def scroll(direction_arg, direction_option, amount, on_text, ref_alias, element_id, coords,
            smooth, delay, app, pid, window_title, hwnd, selector, method, app_id, see_after, settle,
-           json_output):
+           json_output) -> None:
     """Scroll in a direction.
 
     DIRECTION can be: up, down, left, right (default: down)
@@ -204,7 +204,7 @@ def scroll(direction_arg, direction_option, amount, on_text, ref_alias, element_
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 def drag(from_text, from_coords, from_selector, to_text, to_coords, to_selector,
          duration, steps, modifiers, profile, app, pid, window_title, hwnd, method,
-         app_id, json_output):
+         app_id, json_output) -> None:
     """Drag from one element/position to another.
 
     \b
@@ -351,7 +351,7 @@ def drag(from_text, from_coords, from_selector, to_text, to_coords, to_selector,
 @_common._app_id_option
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 def move(to_text, coords, element_id, duration, app, pid, window_title, hwnd,
-         selector, method, app_id, json_output):
+         selector, method, app_id, json_output) -> None:
     """Move the mouse cursor to a target element or coordinates.
 
     \b

--- a/naturo/cli/interaction/_press.py
+++ b/naturo/cli/interaction/_press.py
@@ -362,7 +362,7 @@ def press(keys: tuple[str, ...], count: int, delay: float, hold_duration: float 
 @_common._see_options
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 def hotkey(keys, keys_option, hold_duration, app, window_title, hwnd,
-           input_mode, method, app_id, verify, see_after, settle, json_output):
+           input_mode, method, app_id, verify, see_after, settle, json_output) -> None:
     """Press a hotkey combination (alias for 'press').
 
     \b

--- a/naturo/cli/interaction/_type.py
+++ b/naturo/cli/interaction/_type.py
@@ -59,7 +59,7 @@ logger = logging.getLogger(__name__)
 def type_cmd(text, delay, profile, wpm, press_return, tab_count, escape,
              delete, clear, paste_mode, file_path, restore, on_element, ref_alias, app, pid,
              window_title, hwnd, input_mode, method, selector, app_id, verify, see_after,
-             settle, raw, interpret_escapes, json_output):
+             settle, raw, interpret_escapes, json_output) -> None:
     """Type text with configurable speed and profile.
 
     TEXT is the string to type. Supports human-like variable-speed typing
@@ -159,7 +159,7 @@ def type_cmd(text, delay, profile, wpm, press_return, tab_count, escape,
                     import ctypes
                     import ctypes.wintypes
                     _focused_pid = ctypes.wintypes.DWORD()
-                    ctypes.windll.user32.GetWindowThreadProcessId(
+                    ctypes.windll.user32.GetWindowThreadProcessId(  # type: ignore[attr-defined]
                         _target_hwnd, ctypes.byref(_focused_pid)
                     )
                     if route_info and _focused_pid.value:

--- a/naturo/cli/set_cmd.py
+++ b/naturo/cli/set_cmd.py
@@ -101,7 +101,7 @@ def _resolve_element_identifiers(ref, automation_id, role, name):
 @click.pass_context
 def set_cmd(ctx, target, value, ref, automation_id, role, name, toggle,
             select, expand, collapse, app, app_id, window_title, hwnd,
-            json_output):
+            json_output) -> None:
     """Set element value/state.
 
     Write a value to a UI element, toggle a checkbox, select a list item,
@@ -262,7 +262,7 @@ def _resolve_hwnd(backend, app, window_title):
 
 
 def _do_set_value(backend, hwnd, automation_id, role, name, ref, value,
-                  json_output):
+                  json_output) -> None:
     """Set text value via UIA ValuePattern.
 
     Args:
@@ -309,7 +309,7 @@ def _do_set_value(backend, hwnd, automation_id, role, name, ref, value,
         click.echo(f"Set value on {target_str}: {value!r}")
 
 
-def _do_toggle(backend, hwnd, automation_id, role, name, ref, json_output):
+def _do_toggle(backend, hwnd, automation_id, role, name, ref, json_output) -> None:
     """Toggle element via UIA TogglePattern.
 
     Args:
@@ -353,7 +353,7 @@ def _do_toggle(backend, hwnd, automation_id, role, name, ref, json_output):
         click.echo(f"Toggled {target_str} → {result}")
 
 
-def _do_select(backend, hwnd, automation_id, role, name, ref, json_output):
+def _do_select(backend, hwnd, automation_id, role, name, ref, json_output) -> None:
     """Select element via UIA SelectionItemPattern.
 
     Args:
@@ -398,7 +398,7 @@ def _do_select(backend, hwnd, automation_id, role, name, ref, json_output):
 
 
 def _do_expand_collapse(backend, hwnd, automation_id, role, name, ref,
-                        json_output, expanding):
+                        json_output, expanding) -> None:
     """Expand or collapse element via UIA ExpandCollapsePattern.
 
     Args:

--- a/naturo/cli/system.py
+++ b/naturo/cli/system.py
@@ -10,7 +10,7 @@ from naturo.cli.fuzzy_group import FuzzyGroup
 
 
 @click.group(cls=FuzzyGroup)
-def app():
+def app() -> None:
     """Manage applications and windows: launch, quit, focus, close, minimize, maximize, restore, move, and more."""
     pass
 
@@ -20,7 +20,7 @@ def app():
 @click.option("--args", multiple=True, help="Launch arguments")
 @click.option("--wait", is_flag=True, help="Wait for app to start")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def launch(name, args, wait, json_output):
+def launch(name, args, wait, json_output) -> None:
     """Launch an application by name or path."""
     click.echo("Not implemented yet. See 'naturo app --help' for available commands.")
 
@@ -30,7 +30,7 @@ def launch(name, args, wait, json_output):
 @click.option("--pid", type=int, help="Process ID")
 @click.option("--force", is_flag=True, help="Force kill")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def quit(name, pid, force, json_output):
+def quit(name, pid, force, json_output) -> None:
     """Quit an application gracefully (or force kill)."""
     click.echo("Not implemented yet. See 'naturo app --help' for available commands.")
 
@@ -38,14 +38,14 @@ def quit(name, pid, force, json_output):
 @app.command(hidden=True)
 @click.argument("name")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def relaunch(name, json_output):
+def relaunch(name, json_output) -> None:
     """Quit and relaunch an application."""
     click.echo("Not implemented yet. See 'naturo app --help' for available commands.")
 
 
 @app.command(name="list", hidden=True)
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def app_list(json_output):
+def app_list(json_output) -> None:
     """List running applications."""
     click.echo("Not implemented yet. See 'naturo app --help' for available commands.")
 
@@ -54,7 +54,7 @@ def app_list(json_output):
 
 
 @click.group(cls=FuzzyGroup)
-def menu():
+def menu() -> None:
     """Interact with application menu bars."""
     pass
 
@@ -66,7 +66,7 @@ def menu():
 @click.option("--window-title", "window_title", default=None, hidden=True, help="")
 @click.option("--hwnd", type=int, default=None, help="Window handle (HWND)")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def menu_click(path, app, window_title, hwnd, json_output):
+def menu_click(path, app, window_title, hwnd, json_output) -> None:
     """Click a menu item by path (e.g. 'File > Save As')."""
     click.echo("Not implemented yet. This feature is planned for a future release.")
 
@@ -78,7 +78,7 @@ def menu_click(path, app, window_title, hwnd, json_output):
 @click.option("--hwnd", type=int, default=None, help="Window handle (HWND)")
 @click.option("--depth", type=int, default=3, help="Menu tree depth")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def menu_list(app, window_title, hwnd, depth, json_output):
+def menu_list(app, window_title, hwnd, depth, json_output) -> None:
     """List menu items of an application."""
     click.echo("Not implemented yet. This feature is planned for a future release.")
 
@@ -87,7 +87,7 @@ def menu_list(app, window_title, hwnd, depth, json_output):
 
 
 @click.group(cls=FuzzyGroup)
-def taskbar():
+def taskbar() -> None:
     """Windows taskbar management (pin, unpin, list).
 
     Windows equivalent of Peekaboo's dock commands.
@@ -98,7 +98,7 @@ def taskbar():
 @taskbar.command()
 @click.argument("name")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def pin(name, json_output):
+def pin(name, json_output) -> None:
     """Pin an application to the taskbar."""
     click.echo("Not implemented yet. This feature is planned for a future release.")
 
@@ -106,14 +106,14 @@ def pin(name, json_output):
 @taskbar.command()
 @click.argument("name")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def unpin(name, json_output):
+def unpin(name, json_output) -> None:
     """Unpin an application from the taskbar."""
     click.echo("Not implemented yet. This feature is planned for a future release.")
 
 
 @taskbar.command(name="list")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def taskbar_list(json_output):
+def taskbar_list(json_output) -> None:
     """List taskbar pinned items."""
     click.echo("Not implemented yet. This feature is planned for a future release.")
 
@@ -122,7 +122,7 @@ def taskbar_list(json_output):
 
 
 @click.group(cls=FuzzyGroup)
-def tray():
+def tray() -> None:
     """System tray icon interaction.
 
     Windows equivalent of Peekaboo's menubar commands.
@@ -132,7 +132,7 @@ def tray():
 
 @tray.command(name="list")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def tray_list(json_output):
+def tray_list(json_output) -> None:
     """List system tray icons."""
     click.echo("Not implemented yet. This feature is planned for a future release.")
 
@@ -142,7 +142,7 @@ def tray_list(json_output):
 @click.option("--double", is_flag=True, help="Double-click")
 @click.option("--right", is_flag=True, help="Right-click")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def tray_click(name, double, right, json_output):
+def tray_click(name, double, right, json_output) -> None:
     """Click a system tray icon by name."""
     click.echo("Not implemented yet. This feature is planned for a future release.")
 

--- a/naturo/cli/taskbar_cmd.py
+++ b/naturo/cli/taskbar_cmd.py
@@ -22,7 +22,7 @@ from naturo.cli.error_helpers import emit_error, emit_exception_error
 
 
 @_click.group()
-def taskbar():
+def taskbar() -> None:
     """Interact with the Windows taskbar.
 
     List running applications and pinned shortcuts on the taskbar,
@@ -39,7 +39,7 @@ def taskbar():
 
 @taskbar.command("list")
 @_click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def taskbar_list(json_output):
+def taskbar_list(json_output) -> None:
     """List items on the taskbar.
 
     Shows running applications and pinned shortcuts visible on the
@@ -81,7 +81,7 @@ def taskbar_list(json_output):
 @taskbar.command("click")
 @_click.argument("name")
 @_click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def taskbar_click(name, json_output):
+def taskbar_click(name, json_output) -> None:
     """Click a taskbar item to activate its window.
 
     Finds a taskbar button matching NAME (case-insensitive, partial match)

--- a/naturo/cli/tray_cmd.py
+++ b/naturo/cli/tray_cmd.py
@@ -23,7 +23,7 @@ from naturo.cli.error_helpers import emit_error, emit_exception_error
 
 
 @_click.group()
-def tray():
+def tray() -> None:
     """Interact with the system tray (notification area).
 
     List icons in the Windows notification area and click them to
@@ -40,7 +40,7 @@ def tray():
 
 @tray.command("list")
 @_click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def tray_list(json_output):
+def tray_list(json_output) -> None:
     """List system tray icons.
 
     Shows icons in the Windows notification area (system tray), including
@@ -84,7 +84,7 @@ def tray_list(json_output):
 @_click.option("--right", "right_click", is_flag=True, help="Right-click (context menu)")
 @_click.option("--double", "double_click", is_flag=True, help="Double-click (open)")
 @_click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def tray_click(name, right_click, double_click, json_output):
+def tray_click(name, right_click, double_click, json_output) -> None:
     """Click a system tray icon.
 
     Finds a tray icon matching NAME (case-insensitive, partial match)

--- a/naturo/cli/wait_cmd.py
+++ b/naturo/cli/wait_cmd.py
@@ -22,7 +22,7 @@ import click
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
 def wait(ctx, duration, element, window_title, gone, timeout, interval,
-         app, hwnd, pid, app_id, json_output):
+         app, hwnd, pid, app_id, json_output) -> None:
     """Wait for a duration, or for a UI element/window to appear or disappear.
 
     \b

--- a/naturo/cli/window_cmd.py
+++ b/naturo/cli/window_cmd.py
@@ -74,7 +74,7 @@ def _emit_deprecation(json_output: bool) -> None:
 
 
 @click.group(cls=FuzzyGroup, hidden=True)
-def window():
+def window() -> None:
     """Manage windows (deprecated — use 'naturo app' instead)."""
     pass
 
@@ -87,7 +87,7 @@ def window():
 @app_id_option
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def focus(ctx, name, app, title, hwnd, app_id, json_output):
+def focus(ctx, name, app, title, hwnd, app_id, json_output) -> None:
     """Focus a window (bring to foreground)."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
     _emit_deprecation(json_output)
@@ -140,7 +140,7 @@ def focus(ctx, name, app, title, hwnd, app_id, json_output):
 @app_id_option
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def close(ctx, name, app, title, hwnd, force, app_id, json_output):
+def close(ctx, name, app, title, hwnd, force, app_id, json_output) -> None:
     """Close a window (graceful or forced)."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
     _emit_deprecation(json_output)
@@ -193,7 +193,7 @@ def close(ctx, name, app, title, hwnd, force, app_id, json_output):
 @app_id_option
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def minimize(ctx, name, app, title, hwnd, app_id, json_output):
+def minimize(ctx, name, app, title, hwnd, app_id, json_output) -> None:
     """Minimize a window."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
     _emit_deprecation(json_output)
@@ -243,7 +243,7 @@ def minimize(ctx, name, app, title, hwnd, app_id, json_output):
 @app_id_option
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def maximize(ctx, name, app, title, hwnd, app_id, json_output):
+def maximize(ctx, name, app, title, hwnd, app_id, json_output) -> None:
     """Maximize a window."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
     _emit_deprecation(json_output)
@@ -293,7 +293,7 @@ def maximize(ctx, name, app, title, hwnd, app_id, json_output):
 @app_id_option
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def restore(ctx, name, app, title, hwnd, app_id, json_output):
+def restore(ctx, name, app, title, hwnd, app_id, json_output) -> None:
     """Restore a minimized or maximized window to normal state."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
     _emit_deprecation(json_output)
@@ -344,7 +344,7 @@ def restore(ctx, name, app, title, hwnd, app_id, json_output):
 @click.option("--y", type=int, default=None, help="Target Y position")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def window_move(ctx, app, title, hwnd, app_id, x, y, json_output):
+def window_move(ctx, app, title, hwnd, app_id, x, y, json_output) -> None:
     """Move a window to a position (keeps current size)."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
     _emit_deprecation(json_output)
@@ -402,7 +402,7 @@ def window_move(ctx, app, title, hwnd, app_id, x, y, json_output):
 @click.option("--height", type=int, default=None, help="New height in pixels")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def resize(ctx, app, title, hwnd, app_id, width, height, json_output):
+def resize(ctx, app, title, hwnd, app_id, width, height, json_output) -> None:
     """Resize a window (keeps current position)."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
     _emit_deprecation(json_output)
@@ -471,7 +471,7 @@ def resize(ctx, app, title, hwnd, app_id, width, height, json_output):
 @click.option("--height", type=int, default=None, help="Height in pixels")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def set_bounds(ctx, app, title, hwnd, app_id, x, y, width, height, json_output):
+def set_bounds(ctx, app, title, hwnd, app_id, x, y, width, height, json_output) -> None:
     """Set window position and size at once."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
     _emit_deprecation(json_output)
@@ -544,7 +544,7 @@ def set_bounds(ctx, app, title, hwnd, app_id, x, y, width, height, json_output):
 @click.option("--pid", type=int, help="Process ID")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def window_list(ctx, app, pid, json_output):
+def window_list(ctx, app, pid, json_output) -> None:
     """List open windows."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
     _emit_deprecation(json_output)


### PR DESCRIPTION
## Changes
- Add `-> None` to 93 CLI command/callback functions across 24 files
- Add proper return types to 7 helpers in `_common.py`: `Callable` for decorators, `tuple[int, int] | None` for `_find_element_by_text_fallback`
- Add `# type: ignore[attr-defined]` for Windows-only `ctypes.windll` access in `_type.py` (exposed by stricter mypy checking of newly-typed functions)
- Covers Phase 1 of #716: all CLI command functions and `_common.py` helpers

## Testing
- All 3961 tests pass
- `ruff check naturo/` — all checks passed
- `mypy naturo/` — no issues found in 118 source files

**[Dev-Sirius]**