### PR TITLE
fix: detect app ID pattern in --app flag for seamless resolution (fixes #752)

### DIFF
--- a/naturo/cli/core/_capture.py
+++ b/naturo/cli/core/_capture.py
@@ -53,6 +53,10 @@ def capture(app: str | None, pid: int | None, window_title: str | None, hwnd: in
         naturo capture --app-id a1 --element e12        # element by app ID
         naturo capture -o output.png                    # save to output.png
     """
+    # (#752) Auto-detect app ID pattern (a1, a2, ...) in --app flag
+    from naturo.cli.options import maybe_promote_app_to_app_id
+    app, app_id = maybe_promote_app_to_app_id(app, app_id)
+
     # (#361) Resolve --app-id to app/hwnd before any other logic
     if app_id is not None:
         from naturo.app_ids import get_app_id_map

--- a/naturo/cli/core/_find.py
+++ b/naturo/cli/core/_find.py
@@ -63,6 +63,10 @@ def find_cmd(query: str | None, query_opt: str | None, find_all: bool, role: str
         naturo find "search field" --ai --app "Chrome"  # AI + specific app
         naturo find "OK" --backend msaa          # MSAA for legacy apps
     """
+    # (#752) Auto-detect app ID pattern (a1, a2, ...) in --app flag
+    from naturo.cli.options import maybe_promote_app_to_app_id
+    app, app_id = maybe_promote_app_to_app_id(app, app_id)
+
     # (#593) Resolve --app-id to hwnd before any other logic
     hwnd = None
     if app_id is not None:

--- a/naturo/cli/core/_highlight.py
+++ b/naturo/cli/core/_highlight.py
@@ -71,6 +71,10 @@ def highlight(positional_refs, on_ref, ref_option, app, hwnd, app_id, depth, dur
       naturo highlight --app notepad --duration 10
       naturo highlight --app legacy --backend win32
     """
+    # (#752) Auto-detect app ID pattern (a1, a2, ...) in --app flag
+    from naturo.cli.options import maybe_promote_app_to_app_id
+    app, app_id = maybe_promote_app_to_app_id(app, app_id)
+
     # (#593) Resolve --app-id to hwnd before any other logic
     if app_id is not None:
         from naturo.app_ids import get_app_id_map

--- a/naturo/cli/core/_menu.py
+++ b/naturo/cli/core/_menu.py
@@ -27,6 +27,10 @@ def menu_inspect(app, app_id, flat, json_output) -> None:
       naturo menu-inspect --flat              # Flat path list
       naturo menu-inspect --app notepad --json # JSON output
     """
+    # (#752) Auto-detect app ID pattern (a1, a2, ...) in --app flag
+    from naturo.cli.options import maybe_promote_app_to_app_id
+    app, app_id = maybe_promote_app_to_app_id(app, app_id)
+
     # (#593) Resolve --app-id to hwnd before any other logic
     hwnd = None
     if app_id is not None:

--- a/naturo/cli/core/_see.py
+++ b/naturo/cli/core/_see.py
@@ -84,6 +84,10 @@ def see(app: str | None, window_title: str | None, hwnd: int | None, pid: int | 
         naturo see --app feishu --backend auto         # Try all A11y backends
         naturo see --app feishu --backend hybrid       # Per-node backend selection
     """
+    # (#752) Auto-detect app ID pattern (a1, a2, ...) in --app flag
+    from naturo.cli.options import maybe_promote_app_to_app_id
+    app, app_id = maybe_promote_app_to_app_id(app, app_id)
+
     # (#361) Resolve --app-id to app/hwnd/pid before any other logic
     if app_id is not None:
         from naturo.app_ids import get_app_id_map

--- a/naturo/cli/diff_cmd.py
+++ b/naturo/cli/diff_cmd.py
@@ -38,6 +38,10 @@ def diff(ctx: click.Context, snapshots: tuple[str, ...], window_title: str | Non
     """
     json_output = json_output or (ctx.obj or {}).get("json", False)
 
+    # (#752) Auto-detect app ID pattern (a1, a2, ...) in --app flag
+    from naturo.cli.options import maybe_promote_app_to_app_id
+    app, app_id = maybe_promote_app_to_app_id(app, app_id)
+
     # Resolve --app-id to hwnd (#595)
     resolved_hwnd = resolve_app_id_to_hwnd(app_id, hwnd, json_output)
     if app_id is not None and resolved_hwnd is None:

--- a/naturo/cli/get_cmd.py
+++ b/naturo/cli/get_cmd.py
@@ -104,6 +104,10 @@ def get_cmd(ctx, target, ref, automation_id, role, name, get_all, prop, app,
     if json_output is None:
         json_output = ctx.obj.get("json", False) if ctx.obj else False
 
+    # (#752) Auto-detect app ID pattern (a1, a2, ...) in --app flag
+    from naturo.cli.options import maybe_promote_app_to_app_id
+    app, app_id = maybe_promote_app_to_app_id(app, app_id)
+
     # (#522) Resolve --app-id to hwnd override (consistent with
     # see/click/capture/type which all accept --app-id).
     # (#582) Do NOT leak process_name as app — it may be a full path

--- a/naturo/cli/interaction/_common.py
+++ b/naturo/cli/interaction/_common.py
@@ -395,6 +395,11 @@ def _resolve_app_id(
         Tuple of (app, hwnd, pid) — possibly overridden from the ID map.
         Returns (None, None, None) with error emitted if ID is invalid.
     """
+    # (#752) Auto-detect app ID pattern (a1, a2, ...) in --app flag
+    if app_id is None and app is not None:
+        from naturo.cli.options import maybe_promote_app_to_app_id
+        app, app_id = maybe_promote_app_to_app_id(app, app_id)
+
     if app_id is None:
         return app, hwnd, pid
 

--- a/naturo/cli/options.py
+++ b/naturo/cli/options.py
@@ -19,19 +19,23 @@ Usage::
 """
 from __future__ import annotations
 
+import re as _re
 from typing import Optional
 
 import click
 
 
+_APP_ID_PATTERN = _re.compile(r"a\d+$")
+
+
 # ── Primary options (visible in --help) ──────────────────────────────────────
 
 def app_option(func):
-    """``--app`` — target application (partial name match)."""
+    """``--app`` — target application (partial name match or app ID)."""
     return click.option(
         "--app",
         default=None,
-        help="Target application (name or partial match)",
+        help='Target application (name, partial match, or app ID like "a1")',
     )(func)
 
 
@@ -130,6 +134,31 @@ def resolve_app_id_to_hwnd(
             click.echo(f"Error: {msg}", err=True)
         return None
     return entry.handle
+
+
+def maybe_promote_app_to_app_id(
+    app: str | None,
+    app_id: str | None,
+) -> tuple[str | None, str | None]:
+    """Detect app ID pattern in ``--app`` and promote to ``--app-id``.
+
+    When a user passes ``--app a1`` (an app ID from ``naturo app list``),
+    this function detects the ``a<N>`` pattern and returns it as the
+    ``app_id`` parameter instead, so the caller resolves it via the app
+    ID map rather than fuzzy process-name matching.
+
+    Args:
+        app: The ``--app`` value (process name or possible app ID).
+        app_id: The ``--app-id`` value (explicit app ID).
+
+    Returns:
+        Tuple of ``(app, app_id)`` — if ``app`` matched the app ID
+        pattern and ``app_id`` was not already set, ``app`` is cleared
+        and ``app_id`` is set to the detected value.
+    """
+    if app_id is None and app is not None and _APP_ID_PATTERN.fullmatch(app):
+        return None, app
+    return app, app_id
 
 
 def json_option(func):

--- a/naturo/cli/set_cmd.py
+++ b/naturo/cli/set_cmd.py
@@ -121,6 +121,10 @@ def set_cmd(ctx, target, value, ref, automation_id, role, name, toggle,
     if json_output is None:
         json_output = ctx.obj.get("json", False) if ctx.obj else False
 
+    # (#752) Auto-detect app ID pattern (a1, a2, ...) in --app flag
+    from naturo.cli.options import maybe_promote_app_to_app_id
+    app, app_id = maybe_promote_app_to_app_id(app, app_id)
+
     # (#582) Resolve --app-id to hwnd override.
     # Use hwnd only, not process_name (avoids #576 full-path bug).
     if app_id is not None:

--- a/naturo/cli/wait_cmd.py
+++ b/naturo/cli/wait_cmd.py
@@ -44,6 +44,10 @@ def wait(ctx, duration, element, window_title, gone, timeout, interval,
     """
     json_output = json_output or (ctx.obj or {}).get("json", False)
 
+    # (#752) Auto-detect app ID pattern (a1, a2, ...) in --app flag
+    from naturo.cli.options import maybe_promote_app_to_app_id
+    app, app_id = maybe_promote_app_to_app_id(app, app_id)
+
     # Resolve --app-id to hwnd (#595)
     resolved_hwnd = resolve_app_id_to_hwnd(app_id, hwnd, json_output)
     if app_id is not None and resolved_hwnd is None:

--- a/tests/test_cli_options.py
+++ b/tests/test_cli_options.py
@@ -20,6 +20,7 @@ from naturo.cli.options import (
     app_option,
     hwnd_option,
     json_option,
+    maybe_promote_app_to_app_id,
     on_option,
     pid_option,
     process_name_option,
@@ -86,6 +87,61 @@ class TestResolveAppIdToHwnd:
         runner = CliRunner()
         res = runner.invoke(_test_cmd)
         assert res.exit_code != 0 or "APP_ID_NOT_FOUND" in res.output
+
+
+# ── maybe_promote_app_to_app_id (#752) ───────────────────────────────────
+
+
+class TestMaybePromoteAppToAppId:
+    """Tests for app ID pattern detection in --app flag."""
+
+    def test_app_id_pattern_promoted(self):
+        """'a1' in --app is promoted to --app-id."""
+        app, app_id = maybe_promote_app_to_app_id("a1", None)
+        assert app is None
+        assert app_id == "a1"
+
+    def test_multi_digit_app_id_promoted(self):
+        """'a123' in --app is promoted to --app-id."""
+        app, app_id = maybe_promote_app_to_app_id("a123", None)
+        assert app is None
+        assert app_id == "a123"
+
+    def test_process_name_not_promoted(self):
+        """Normal process names are not promoted."""
+        app, app_id = maybe_promote_app_to_app_id("notepad", None)
+        assert app == "notepad"
+        assert app_id is None
+
+    def test_explicit_app_id_takes_precedence(self):
+        """When --app-id is already set, --app is not promoted."""
+        app, app_id = maybe_promote_app_to_app_id("a2", "a1")
+        assert app == "a2"
+        assert app_id == "a1"
+
+    def test_none_app_unchanged(self):
+        """None --app is returned unchanged."""
+        app, app_id = maybe_promote_app_to_app_id(None, None)
+        assert app is None
+        assert app_id is None
+
+    def test_partial_match_not_promoted(self):
+        """Strings like 'app1' or 'abc' are not promoted."""
+        app, app_id = maybe_promote_app_to_app_id("app1", None)
+        assert app == "app1"
+        assert app_id is None
+
+    def test_uppercase_not_promoted(self):
+        """'A1' (uppercase) is not promoted — app IDs are lowercase."""
+        app, app_id = maybe_promote_app_to_app_id("A1", None)
+        assert app == "A1"
+        assert app_id is None
+
+    def test_bare_a_not_promoted(self):
+        """'a' alone (no digits) is not promoted."""
+        app, app_id = maybe_promote_app_to_app_id("a", None)
+        assert app == "a"
+        assert app_id is None
 
 
 # ── Option decorators ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Changes
- Added `maybe_promote_app_to_app_id()` helper in `options.py` that detects `a<N>` pattern (e.g. a1, a23) in `--app` values
- Applied auto-detection across all 10 commands that support both `--app` and `--app-id`: see, find, capture, highlight, menu-inspect, click/type/press (via _common.py), get, set, wait, diff
- Updated `--app` help text to mention app ID support
- Added 8 unit tests for pattern detection

## Testing
- All 3,726 tests pass (782 skipped)
- ruff and mypy clean
- Tested edge cases: multi-digit IDs (a123), non-matching strings (notepad, app1, A1, a), explicit --app-id precedence

**[Dev-Sirius]**