### PR TITLE
feat: add --ai-provider/--ai-model/--ai-api-key to see --cascade (fixes #754)

### DIFF
--- a/naturo/cascade/_providers.py
+++ b/naturo/cascade/_providers.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import logging
-from typing import List
+from typing import List, Optional
 
 from naturo.backends.base import ElementInfo
 
@@ -102,6 +102,8 @@ def _fetch_ai_elements(
     window_bounds: tuple[int, int, int, int],
     provider_name: str = "auto",
     scale_factor: float = 1.0,
+    model: Optional[str] = None,
+    api_key: Optional[str] = None,
 ) -> List[ElementInfo]:
     """Use AI vision to identify additional elements from a screenshot.
 
@@ -118,6 +120,12 @@ def _fetch_ai_elements(
         DPI scale factor of the captured monitor (e.g. 1.5 for 150% DPI).
         AI returns coords in screenshot pixels; UIA uses physical (scaled)
         pixels.  We multiply AI coords by scale_factor to align them.
+    model:
+        AI model override (e.g. ``"claude-opus-4-6"``, ``"gpt-4o"``).
+        When ``None``, uses the provider's default model.
+    api_key:
+        API key override.  When ``None``, uses the provider's default
+        credentials (env var or credentials file).
 
     Returns a flat list of elements identified by the AI provider.
     Falls back gracefully if the provider is unavailable.
@@ -127,7 +135,12 @@ def _fetch_ai_elements(
         from naturo.errors import AIProviderUnavailableError
 
         try:
-            provider = get_vision_provider(provider_name)
+            kwargs: dict[str, str] = {}
+            if model:
+                kwargs["model"] = model
+            if api_key:
+                kwargs["api_key"] = api_key
+            provider = get_vision_provider(provider_name, **kwargs)
         except AIProviderUnavailableError:
             return []
 

--- a/naturo/cascade/_run.py
+++ b/naturo/cascade/_run.py
@@ -167,6 +167,8 @@ def run_cascade(
     coverage_target: float = 0.0,
     fill_gaps_ai: bool = False,
     ai_provider: str = "auto",
+    ai_model: Optional[str] = None,
+    ai_api_key: Optional[str] = None,
     screenshot_path: Optional[str] = None,
     screenshot_scale_factor: float = 1.0,
 ) -> CascadeResult:
@@ -199,6 +201,12 @@ def run_cascade(
         When True, add AI vision as the final fallback provider.
     ai_provider:
         AI provider name (``"auto"`` | ``"anthropic"`` | ``"openai"`` | ``"ollama"``).
+    ai_model:
+        AI model override (e.g. ``"claude-opus-4-6"``, ``"gpt-4o"``).
+        When ``None``, uses the provider's default model.
+    ai_api_key:
+        API key override.  When ``None``, uses the provider's default
+        credentials (env var or credentials file).
     screenshot_path:
         Path to existing screenshot for AI vision (avoids re-capture).
     screenshot_scale_factor:
@@ -385,6 +393,8 @@ def run_cascade(
             ai_elements = _get_cascade_pkg()._fetch_ai_elements(
                 screenshot_path, bounds, ai_provider,
                 scale_factor=screenshot_scale_factor,
+                model=ai_model,
+                api_key=ai_api_key,
             )
             elapsed = (time.monotonic() - t0) * 1000
 

--- a/naturo/cli/core/_see.py
+++ b/naturo/cli/core/_see.py
@@ -48,11 +48,20 @@ import naturo.cli.core._common as _common
 )
 @click.option("--app-id", "app_id", default=None,
               help='Stable app/window ID from "naturo app list" output (e.g. a1)')
+@click.option("--ai-provider", "ai_provider",
+              type=click.Choice(["auto", "anthropic", "openai", "ollama"]),
+              default="auto",
+              help="AI vision provider for --cascade/--fill-gaps (default: auto)")
+@click.option("--ai-model", "ai_model", default=None, envvar="NATURO_AI_MODEL",
+              help="AI model override (e.g. claude-opus-4-6, gpt-4o)")
+@click.option("--ai-api-key", "ai_api_key", default=None,
+              help="AI provider API key (overrides env var / credentials file)")
 def see(app: str | None, window_title: str | None, hwnd: int | None, pid: int | None,
         mode: str, depth: int, path: str | None, annotate: bool, store_snapshot: bool,
         session: str | None, cascade: bool, fill_gaps: bool, show_stats: bool,
         coverage_target: float, visible_only: bool, show_selectors: bool,
-        json_output: bool, backend: str, app_id: str | None) -> None:
+        json_output: bool, backend: str, app_id: str | None,
+        ai_provider: str, ai_model: str | None, ai_api_key: str | None) -> None:
     """Capture screenshot and analyze UI elements.
 
     Inspects the UI element tree of the foreground window (or a specific
@@ -80,6 +89,7 @@ def see(app: str | None, window_title: str | None, hwnd: int | None, pid: int | 
     Examples:
         naturo see --app feishu --cascade      # UIA + CDP for Electron content
         naturo see --app feishu --cascade --fill-gaps  # Also use AI vision
+        naturo see --app feishu --cascade --fill-gaps --ai-model opus  # Use specific AI model
         naturo see --app feishu --cascade --stats      # Show provider breakdown
         naturo see --app feishu --backend auto         # Try all A11y backends
         naturo see --app feishu --backend hybrid       # Per-node backend selection
@@ -176,6 +186,9 @@ def see(app: str | None, window_title: str | None, hwnd: int | None, pid: int | 
                 backend_name=backend,
                 coverage_target=coverage_target,
                 fill_gaps_ai=fill_gaps,
+                ai_provider=ai_provider,
+                ai_model=ai_model,
+                ai_api_key=ai_api_key,
                 screenshot_path=cascade_screenshot,
                 screenshot_scale_factor=(
                     cascade_capture_result.scale_factor

--- a/tests/test_cascade.py
+++ b/tests/test_cascade.py
@@ -316,6 +316,49 @@ class TestRunCascade:
         assert vision_stat.elements == 1
         assert vision_stat.status == "ok"
 
+    def test_ai_model_and_api_key_threaded_to_fetch(self, tmp_path):
+        """ai_model and ai_api_key are forwarded to _fetch_ai_elements."""
+        tree = _make_el(id="root", w=1000, h=600)
+        be = _make_backend(tree)
+
+        fake_screenshot = str(tmp_path / "screen.png")
+        Path(fake_screenshot).write_bytes(b"fake")
+
+        with patch("naturo.cascade._fetch_ai_elements", return_value=[]) as mock_ai:
+            run_cascade(
+                be, backend_name="uia",
+                fill_gaps_ai=True,
+                ai_provider="anthropic",
+                ai_model="claude-opus-4-6",
+                ai_api_key="sk-test-key",
+                screenshot_path=fake_screenshot,
+            )
+
+        mock_ai.assert_called_once()
+        call_kwargs = mock_ai.call_args
+        assert call_kwargs.kwargs.get("model") == "claude-opus-4-6"
+        assert call_kwargs.kwargs.get("api_key") == "sk-test-key"
+
+    def test_ai_model_defaults_to_none(self, tmp_path):
+        """When ai_model is not specified, None is passed to _fetch_ai_elements."""
+        tree = _make_el(id="root", w=1000, h=600)
+        be = _make_backend(tree)
+
+        fake_screenshot = str(tmp_path / "screen.png")
+        Path(fake_screenshot).write_bytes(b"fake")
+
+        with patch("naturo.cascade._fetch_ai_elements", return_value=[]) as mock_ai:
+            run_cascade(
+                be, backend_name="uia",
+                fill_gaps_ai=True,
+                screenshot_path=fake_screenshot,
+            )
+
+        mock_ai.assert_called_once()
+        call_kwargs = mock_ai.call_args
+        assert call_kwargs.kwargs.get("model") is None
+        assert call_kwargs.kwargs.get("api_key") is None
+
 
 # ── CLI integration ───────────────────────────────────────────────────────────
 
@@ -349,6 +392,21 @@ class TestSeeCascadeCLI:
         runner = CliRunner()
         result = runner.invoke(main, ["see", "--help"])
         assert "--coverage" in result.output
+
+    def test_ai_provider_flag_exists(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["see", "--help"])
+        assert "--ai-provider" in result.output
+
+    def test_ai_model_flag_exists(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["see", "--help"])
+        assert "--ai-model" in result.output
+
+    def test_ai_api_key_flag_exists(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["see", "--help"])
+        assert "--ai-api-key" in result.output
 
     def test_cascade_invokes_run_cascade(self):
         """When --cascade is passed, run_cascade() is called."""


### PR DESCRIPTION
## Changes\n- Add `--ai-provider`, `--ai-model`, `--ai-api-key` CLI options to `naturo see` command\n- Thread these params through `run_cascade()` → `_fetch_ai_elements()` → `get_vision_provider()`\n- Previously, cascade AI vision had no way to control model/provider from CLI\n- `NATURO_AI_MODEL` env var also supported via `--ai-model` envvar binding\n\n## Testing\n- 5 new unit tests: param forwarding, defaults, CLI flag existence\n- All 4012 tests pass, ruff clean, mypy clean\n\n**[Dev-Sirius]**