### PR TITLE
feat: add recording CLI commands — start/stop/play/list/show/delete/export (fixes #90)

### DIFF
--- a/naturo/cli/__init__.py
+++ b/naturo/cli/__init__.py
@@ -48,6 +48,7 @@ from naturo.cli.browser_cmd import browser
 
 from naturo.cli.selector_cmd import selector
 from naturo.cli.visual_cmd import visual
+from naturo.cli.recording_cmd import record
 from naturo.cli.config_cmd import config_cmd as _config_cmd_group
 
 
@@ -172,6 +173,7 @@ def help_cmd(ctx) -> None:
 # ── Config / Credentials ────────────────────────
 main.add_command(selector)
 main.add_command(visual)
+main.add_command(record)
 main.add_command(_config_cmd_group, "config")
 
 # Replace stub app subcommands with working implementations

--- a/naturo/cli/interaction/_common.py
+++ b/naturo/cli/interaction/_common.py
@@ -295,8 +295,9 @@ def _post_action_see(
 
 
 def _record_action(command: str, args: dict, duration_ms: float = 0.0) -> None:
-    """No-op stub — recording command removed."""
-    pass
+    """Append action to active recording (if any)."""
+    from naturo.recording import append_step_to_active
+    append_step_to_active(command, args, duration_ms)
 
 
 # ── Method override ──────────────────────────────────────────────────────────

--- a/naturo/cli/recording_cmd.py
+++ b/naturo/cli/recording_cmd.py
@@ -196,14 +196,14 @@ def record_list(json_output: bool):
     active = get_active_recording()
 
     if json_output:
-        result = {"recordings": recordings}
+        output: dict = {"recordings": recordings}
         if active:
-            result["active"] = {
+            output["active"] = {
                 "recording_id": active.recording_id,
                 "name": active.name,
                 "step_count": len(active.steps),
             }
-        click.echo(json.dumps(result))
+        click.echo(json.dumps(output))
     else:
         if active:
             click.echo(f"[RECORDING] {active.recording_id} — {active.name} "

--- a/naturo/cli/recording_cmd.py
+++ b/naturo/cli/recording_cmd.py
@@ -1,0 +1,455 @@
+"""Recording CLI commands — record, replay, and manage automation recordings.
+
+Provides `naturo record start/stop/play/list/show/delete/export` commands
+that wrap the recording engine in naturo/recording.py.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime
+
+import click
+
+from naturo.cli.fuzzy_group import FuzzyGroup
+from naturo.recording import (
+    Recording,
+    generate_recording_id,
+    get_active_recording,
+    set_active_recording,
+    save_recording,
+    load_recording,
+    list_recordings,
+    delete_recording,
+    replay_recording,
+)
+
+
+@click.group("record", cls=FuzzyGroup)
+def record():
+    """Record and replay automation actions.
+
+    \b
+    Examples:
+        naturo record start "Login flow"      # Start recording
+        naturo record stop                     # Stop and save
+        naturo record list                     # List recordings
+        naturo record play rec_20260401_120000 # Replay a recording
+        naturo record show rec_20260401_120000 # Show recording details
+        naturo record delete rec_20260401_120000
+        naturo record export rec_20260401_120000 --format python
+    """
+
+
+@click.command("start")
+@click.argument("name", default="")
+@click.option("-j", "--json", "json_output", is_flag=True, help="Output JSON.")
+def record_start(name: str, json_output: bool):
+    """Start recording user actions.
+
+    All subsequent naturo commands (click, type, press, etc.) will be
+    captured until `naturo record stop` is called.
+
+    \b
+    Examples:
+        naturo record start                    # Auto-named recording
+        naturo record start "Login automation"  # Named recording
+    """
+    active = get_active_recording()
+    if active is not None:
+        msg = f"Recording already in progress: {active.recording_id} ({active.name})"
+        if json_output:
+            click.echo(json.dumps({"success": False, "error": msg}))
+        else:
+            click.echo(f"Error: {msg}", err=True)
+            click.echo("Run 'naturo record stop' to finish the current recording first.")
+        sys.exit(1)
+
+    rec_id = generate_recording_id()
+    rec_name = name or f"Recording {datetime.now().strftime('%Y-%m-%d %H:%M')}"
+    rec = Recording(
+        name=rec_name,
+        recording_id=rec_id,
+        created_at=datetime.now().isoformat(),
+    )
+    set_active_recording(rec)
+
+    if json_output:
+        click.echo(json.dumps({
+            "success": True,
+            "recording_id": rec_id,
+            "name": rec_name,
+            "message": "Recording started",
+        }))
+    else:
+        click.echo(f"Recording started: {rec_id}")
+        click.echo(f"Name: {rec_name}")
+        click.echo("All naturo actions will be recorded. Run 'naturo record stop' to finish.")
+
+
+@click.command("stop")
+@click.option("-j", "--json", "json_output", is_flag=True, help="Output JSON.")
+def record_stop(json_output: bool):
+    """Stop recording and save.
+
+    Saves the recorded actions to ~/.naturo/recordings/ as a JSON file.
+
+    \b
+    Examples:
+        naturo record stop
+    """
+    active = get_active_recording()
+    if active is None:
+        msg = "No active recording to stop."
+        if json_output:
+            click.echo(json.dumps({"success": False, "error": msg}))
+        else:
+            click.echo(f"Error: {msg}", err=True)
+        sys.exit(1)
+
+    path = save_recording(active)
+    set_active_recording(None)
+
+    if json_output:
+        click.echo(json.dumps({
+            "success": True,
+            "recording_id": active.recording_id,
+            "name": active.name,
+            "step_count": len(active.steps),
+            "path": str(path),
+        }))
+    else:
+        click.echo(f"Recording stopped: {active.recording_id}")
+        click.echo(f"Name: {active.name}")
+        click.echo(f"Steps: {len(active.steps)}")
+        click.echo(f"Saved: {path}")
+
+
+@click.command("play")
+@click.argument("recording_id")
+@click.option("--speed", type=float, default=1.0,
+              help="Playback speed multiplier (2.0 = twice as fast).")
+@click.option("--dry-run", is_flag=True, help="Print actions without executing.")
+@click.option("-j", "--json", "json_output", is_flag=True, help="Output JSON.")
+def record_play(recording_id: str, speed: float, dry_run: bool, json_output: bool):
+    """Replay a saved recording.
+
+    \b
+    Examples:
+        naturo record play rec_20260401_120000
+        naturo record play rec_20260401_120000 --speed 2.0
+        naturo record play rec_20260401_120000 --dry-run
+    """
+    try:
+        rec = load_recording(recording_id)
+    except FileNotFoundError:
+        msg = f"Recording not found: {recording_id}"
+        if json_output:
+            click.echo(json.dumps({"success": False, "error": msg}))
+        else:
+            click.echo(f"Error: {msg}", err=True)
+        sys.exit(1)
+
+    if not json_output and not dry_run:
+        click.echo(f"Replaying: {rec.name} ({len(rec.steps)} steps, speed={speed}x)")
+
+    def _on_step(idx, step, result):
+        if not json_output:
+            status = result.get("status", "unknown")
+            symbol = "+" if status == "success" else ("~" if status == "skipped" else "!")
+            click.echo(f"  [{symbol}] Step {idx + 1}: {step.command} {step.args}")
+
+    results = replay_recording(rec, speed=speed, dry_run=dry_run, step_callback=_on_step)
+
+    success_count = sum(1 for r in results if r["status"] == "success")
+    error_count = sum(1 for r in results if r["status"] == "error")
+    skipped_count = sum(1 for r in results if r["status"] == "skipped")
+
+    if json_output:
+        click.echo(json.dumps({
+            "success": error_count == 0,
+            "recording_id": recording_id,
+            "total_steps": len(results),
+            "succeeded": success_count,
+            "failed": error_count,
+            "skipped": skipped_count,
+            "results": results,
+        }))
+    else:
+        click.echo(f"Replay complete: {success_count} succeeded, "
+                    f"{error_count} failed, {skipped_count} skipped")
+
+
+@click.command("list")
+@click.option("-j", "--json", "json_output", is_flag=True, help="Output JSON.")
+def record_list(json_output: bool):
+    """List all saved recordings.
+
+    \b
+    Examples:
+        naturo record list
+        naturo record list --json
+    """
+    recordings = list_recordings()
+
+    # Check for active recording
+    active = get_active_recording()
+
+    if json_output:
+        result = {"recordings": recordings}
+        if active:
+            result["active"] = {
+                "recording_id": active.recording_id,
+                "name": active.name,
+                "step_count": len(active.steps),
+            }
+        click.echo(json.dumps(result))
+    else:
+        if active:
+            click.echo(f"[RECORDING] {active.recording_id} — {active.name} "
+                        f"({len(active.steps)} steps so far)")
+            click.echo()
+
+        if not recordings:
+            click.echo("No saved recordings.")
+            return
+
+        click.echo(f"{'ID':<25} {'Name':<30} {'Steps':>6}  {'Created'}")
+        click.echo("-" * 80)
+        for r in recordings:
+            click.echo(
+                f"{r['recording_id']:<25} {r['name']:<30} "
+                f"{r['step_count']:>6}  {r['created_at'][:19]}"
+            )
+
+
+@click.command("show")
+@click.argument("recording_id")
+@click.option("-j", "--json", "json_output", is_flag=True, help="Output JSON.")
+def record_show(recording_id: str, json_output: bool):
+    """Show details of a recording including all steps.
+
+    \b
+    Examples:
+        naturo record show rec_20260401_120000
+    """
+    try:
+        rec = load_recording(recording_id)
+    except FileNotFoundError:
+        msg = f"Recording not found: {recording_id}"
+        if json_output:
+            click.echo(json.dumps({"success": False, "error": msg}))
+        else:
+            click.echo(f"Error: {msg}", err=True)
+        sys.exit(1)
+
+    if json_output:
+        click.echo(json.dumps(rec.to_dict()))
+    else:
+        click.echo(f"Recording: {rec.recording_id}")
+        click.echo(f"Name:      {rec.name}")
+        click.echo(f"Created:   {rec.created_at[:19]}")
+        click.echo(f"Steps:     {len(rec.steps)}")
+        duration = rec.total_duration_ms()
+        if duration > 0:
+            click.echo(f"Duration:  {duration / 1000:.1f}s")
+        click.echo()
+        if rec.steps:
+            click.echo("Steps:")
+            for i, step in enumerate(rec.steps, 1):
+                args_str = " ".join(f"{k}={v}" for k, v in step.args.items())
+                click.echo(f"  {i:3d}. {step.command} {args_str}")
+
+
+@click.command("delete")
+@click.argument("recording_id")
+@click.option("--force", is_flag=True, help="Skip confirmation.")
+@click.option("-j", "--json", "json_output", is_flag=True, help="Output JSON.")
+def record_delete(recording_id: str, force: bool, json_output: bool):
+    """Delete a saved recording.
+
+    \b
+    Examples:
+        naturo record delete rec_20260401_120000
+        naturo record delete rec_20260401_120000 --force
+    """
+    try:
+        rec = load_recording(recording_id)
+    except FileNotFoundError:
+        msg = f"Recording not found: {recording_id}"
+        if json_output:
+            click.echo(json.dumps({"success": False, "error": msg}))
+        else:
+            click.echo(f"Error: {msg}", err=True)
+        sys.exit(1)
+
+    if not force and not json_output:
+        click.confirm(
+            f"Delete recording '{rec.name}' ({len(rec.steps)} steps)?",
+            abort=True,
+        )
+
+    deleted = delete_recording(recording_id)
+    if json_output:
+        click.echo(json.dumps({"success": deleted, "recording_id": recording_id}))
+    else:
+        click.echo(f"Deleted: {recording_id}")
+
+
+@click.command("export")
+@click.argument("recording_id")
+@click.option("--format", "fmt", type=click.Choice(["json", "python", "bash"]),
+              default="json", help="Export format.")
+@click.option("--output", "-o", "output_path", type=click.Path(),
+              help="Output file path. Prints to stdout if omitted.")
+@click.option("-j", "--json", "json_output", is_flag=True, help="Output JSON.")
+def record_export(recording_id: str, fmt: str, output_path: str | None,
+                  json_output: bool):
+    """Export a recording to a script.
+
+    \b
+    Formats:
+        json    — Raw recording JSON (default)
+        python  — Python script using naturo CLI subprocess calls
+        bash    — Bash script with naturo commands
+
+    \b
+    Examples:
+        naturo record export rec_20260401_120000 --format python
+        naturo record export rec_20260401_120000 --format bash -o script.sh
+    """
+    try:
+        rec = load_recording(recording_id)
+    except FileNotFoundError:
+        msg = f"Recording not found: {recording_id}"
+        if json_output:
+            click.echo(json.dumps({"success": False, "error": msg}))
+        else:
+            click.echo(f"Error: {msg}", err=True)
+        sys.exit(1)
+
+    content = _export_recording(rec, fmt)
+
+    if output_path:
+        with open(output_path, "w", encoding="utf-8") as f:
+            f.write(content)
+        if json_output:
+            click.echo(json.dumps({
+                "success": True, "path": output_path, "format": fmt,
+            }))
+        else:
+            click.echo(f"Exported to {output_path} ({fmt})")
+    else:
+        if json_output:
+            click.echo(json.dumps({"success": True, "format": fmt, "content": content}))
+        else:
+            click.echo(content)
+
+
+def _export_recording(rec: Recording, fmt: str) -> str:
+    """Generate export content for a recording."""
+    if fmt == "json":
+        return json.dumps(rec.to_dict(), indent=2, ensure_ascii=False)
+
+    if fmt == "python":
+        lines = [
+            "#!/usr/bin/env python3",
+            f'"""Recorded automation: {rec.name}"""',
+            "import subprocess",
+            "import time",
+            "",
+            "",
+            "def run(cmd: str) -> None:",
+            '    subprocess.run(cmd, shell=True, check=True)',
+            "",
+            "",
+            f"# Recording: {rec.name} ({rec.recording_id})",
+            f"# Created: {rec.created_at[:19]}",
+            f"# Steps: {len(rec.steps)}",
+            "",
+        ]
+        prev_ts = None
+        for step in rec.steps:
+            if prev_ts is not None:
+                delay = step.timestamp - prev_ts
+                if delay > 0.1:
+                    lines.append(f"time.sleep({delay:.2f})")
+            lines.append(f"run({_step_to_naturo_cmd(step)!r})")
+            prev_ts = step.timestamp
+        return "\n".join(lines) + "\n"
+
+    if fmt == "bash":
+        lines = [
+            "#!/bin/bash",
+            f"# Recording: {rec.name} ({rec.recording_id})",
+            f"# Created: {rec.created_at[:19]}",
+            f"# Steps: {len(rec.steps)}",
+            "set -e",
+            "",
+        ]
+        prev_ts = None
+        for step in rec.steps:
+            if prev_ts is not None:
+                delay = step.timestamp - prev_ts
+                if delay > 0.1:
+                    lines.append(f"sleep {delay:.2f}")
+            lines.append(_step_to_naturo_cmd(step))
+            prev_ts = step.timestamp
+        return "\n".join(lines) + "\n"
+
+    return ""
+
+
+def _step_to_naturo_cmd(step) -> str:
+    """Convert an ActionStep to a naturo CLI command string."""
+    cmd = step.command
+    args = step.args
+
+    if cmd == "click":
+        parts = ["naturo click"]
+        if "x" in args and "y" in args:
+            parts.append(f"{args['x']} {args['y']}")
+        if args.get("button", "left") != "left":
+            parts.append(f"--button {args['button']}")
+        if args.get("double_click"):
+            parts.append("--double")
+        return " ".join(parts)
+
+    if cmd == "type":
+        text = args.get("text", "")
+        return f'naturo type "{text}"'
+
+    if cmd == "press":
+        key = args.get("key", "")
+        return f"naturo press {key}"
+
+    if cmd == "hotkey":
+        keys = args.get("keys", [])
+        return f"naturo hotkey {'+'.join(keys)}"
+
+    if cmd == "scroll":
+        direction = args.get("direction", "down")
+        amount = args.get("amount", 3)
+        return f"naturo scroll {direction} --amount {amount}"
+
+    if cmd == "drag":
+        return (f"naturo drag --from {args.get('from_x', 0)} {args.get('from_y', 0)} "
+                f"--to {args.get('to_x', 0)} {args.get('to_y', 0)}")
+
+    if cmd == "move":
+        return f"naturo move {args.get('x', 0)} {args.get('y', 0)}"
+
+    if cmd == "wait":
+        return f"naturo wait --duration {args.get('seconds', 1)}"
+
+    return f"# Unknown: {cmd} {args}"
+
+
+# Register subcommands
+record.add_command(record_start, "start")
+record.add_command(record_stop, "stop")
+record.add_command(record_play, "play")
+record.add_command(record_list, "list")
+record.add_command(record_show, "show")
+record.add_command(record_delete, "delete")
+record.add_command(record_export, "export")

--- a/tests/test_recording_cli.py
+++ b/tests/test_recording_cli.py
@@ -1,0 +1,326 @@
+"""Tests for naturo record CLI commands."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from naturo.cli import main
+from naturo.recording import (
+    Recording,
+    ActionStep,
+    save_recording,
+    set_active_recording,
+    get_active_recording,
+    RECORDINGS_DIR,
+)
+
+
+@pytest.fixture()
+def tmp_recordings(tmp_path):
+    """Patch RECORDINGS_DIR to use a temp directory."""
+    with patch("naturo.recording.RECORDINGS_DIR", tmp_path):
+        with patch("naturo.cli.recording_cmd.get_active_recording",
+                    side_effect=lambda: get_active_recording(tmp_path)):
+            yield tmp_path
+
+
+@pytest.fixture()
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture()
+def sample_recording(tmp_path) -> Recording:
+    """Create and save a sample recording."""
+    rec = Recording(
+        name="Test Recording",
+        recording_id="rec_20260401_120000",
+        created_at="2026-04-01T12:00:00",
+        steps=[
+            ActionStep(command="click", args={"x": 100, "y": 200}, timestamp=1000.0),
+            ActionStep(command="type", args={"text": "hello"}, timestamp=1001.0),
+            ActionStep(command="press", args={"key": "enter"}, timestamp=1002.0),
+        ],
+    )
+    with patch("naturo.recording.RECORDINGS_DIR", tmp_path):
+        save_recording(rec, tmp_path)
+    return rec
+
+
+# ── record start ─────────────────────────────────────────────────────────────
+
+
+class TestRecordStart:
+    def test_start_creates_active_recording(self, runner, tmp_path):
+        with patch("naturo.recording.RECORDINGS_DIR", tmp_path), \
+             patch("naturo.cli.recording_cmd.get_active_recording", return_value=None), \
+             patch("naturo.cli.recording_cmd.set_active_recording") as mock_set:
+            result = runner.invoke(main, ["record", "start", "My Flow"])
+            assert result.exit_code == 0
+            assert "Recording started" in result.output
+            assert "My Flow" in result.output
+            mock_set.assert_called_once()
+            rec = mock_set.call_args[0][0]
+            assert rec.name == "My Flow"
+            assert rec.recording_id.startswith("rec_")
+
+    def test_start_json_output(self, runner, tmp_path):
+        with patch("naturo.recording.RECORDINGS_DIR", tmp_path), \
+             patch("naturo.cli.recording_cmd.get_active_recording", return_value=None), \
+             patch("naturo.cli.recording_cmd.set_active_recording"):
+            result = runner.invoke(main, ["record", "start", "My Flow", "--json"])
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert data["success"] is True
+            assert data["name"] == "My Flow"
+
+    def test_start_fails_if_already_recording(self, runner):
+        active = Recording(name="existing", recording_id="rec_old",
+                           created_at="2026-01-01T00:00:00")
+        with patch("naturo.cli.recording_cmd.get_active_recording", return_value=active):
+            result = runner.invoke(main, ["record", "start", "New"])
+            assert result.exit_code != 0
+            assert "already in progress" in result.output
+
+
+# ── record stop ──────────────────────────────────────────────────────────────
+
+
+class TestRecordStop:
+    def test_stop_saves_and_clears_active(self, runner, tmp_path):
+        active = Recording(name="Test", recording_id="rec_test",
+                           created_at="2026-01-01T00:00:00",
+                           steps=[ActionStep("click", {"x": 1, "y": 2}, 1000.0)])
+        with patch("naturo.cli.recording_cmd.get_active_recording", return_value=active), \
+             patch("naturo.cli.recording_cmd.save_recording", return_value=tmp_path / "rec_test.json") as mock_save, \
+             patch("naturo.cli.recording_cmd.set_active_recording") as mock_clear:
+            result = runner.invoke(main, ["record", "stop"])
+            assert result.exit_code == 0
+            assert "rec_test" in result.output
+            assert "1" in result.output  # step count
+            mock_save.assert_called_once_with(active)
+            mock_clear.assert_called_once_with(None)
+
+    def test_stop_fails_if_not_recording(self, runner):
+        with patch("naturo.cli.recording_cmd.get_active_recording", return_value=None):
+            result = runner.invoke(main, ["record", "stop"])
+            assert result.exit_code != 0
+            assert "No active recording" in result.output
+
+
+# ── record list ──────────────────────────────────────────────────────────────
+
+
+class TestRecordList:
+    def test_list_empty(self, runner):
+        with patch("naturo.cli.recording_cmd.list_recordings", return_value=[]), \
+             patch("naturo.cli.recording_cmd.get_active_recording", return_value=None):
+            result = runner.invoke(main, ["record", "list"])
+            assert result.exit_code == 0
+            assert "No saved recordings" in result.output
+
+    def test_list_shows_recordings(self, runner):
+        recs = [
+            {"recording_id": "rec_001", "name": "Flow A", "created_at": "2026-04-01T12:00:00", "step_count": 5},
+            {"recording_id": "rec_002", "name": "Flow B", "created_at": "2026-04-01T13:00:00", "step_count": 3},
+        ]
+        with patch("naturo.cli.recording_cmd.list_recordings", return_value=recs), \
+             patch("naturo.cli.recording_cmd.get_active_recording", return_value=None):
+            result = runner.invoke(main, ["record", "list"])
+            assert result.exit_code == 0
+            assert "rec_001" in result.output
+            assert "Flow A" in result.output
+            assert "rec_002" in result.output
+
+    def test_list_json(self, runner):
+        recs = [{"recording_id": "rec_001", "name": "Flow A", "created_at": "2026-04-01", "step_count": 5}]
+        with patch("naturo.cli.recording_cmd.list_recordings", return_value=recs), \
+             patch("naturo.cli.recording_cmd.get_active_recording", return_value=None):
+            result = runner.invoke(main, ["record", "list", "--json"])
+            data = json.loads(result.output)
+            assert len(data["recordings"]) == 1
+
+    def test_list_shows_active_recording(self, runner):
+        active = Recording(name="In progress", recording_id="rec_active",
+                           created_at="2026-04-01T00:00:00",
+                           steps=[ActionStep("click", {"x": 1, "y": 2}, 1000.0)])
+        with patch("naturo.cli.recording_cmd.list_recordings", return_value=[]), \
+             patch("naturo.cli.recording_cmd.get_active_recording", return_value=active):
+            result = runner.invoke(main, ["record", "list"])
+            assert "RECORDING" in result.output
+            assert "rec_active" in result.output
+
+
+# ── record show ──────────────────────────────────────────────────────────────
+
+
+class TestRecordShow:
+    def test_show_recording(self, runner):
+        rec = Recording(
+            name="Test", recording_id="rec_test", created_at="2026-04-01T12:00:00",
+            steps=[
+                ActionStep("click", {"x": 100, "y": 200}, 1000.0),
+                ActionStep("type", {"text": "hello"}, 1001.0),
+            ],
+        )
+        with patch("naturo.cli.recording_cmd.load_recording", return_value=rec):
+            result = runner.invoke(main, ["record", "show", "rec_test"])
+            assert result.exit_code == 0
+            assert "rec_test" in result.output
+            assert "click" in result.output
+            assert "type" in result.output
+
+    def test_show_not_found(self, runner):
+        with patch("naturo.cli.recording_cmd.load_recording",
+                    side_effect=FileNotFoundError("not found")):
+            result = runner.invoke(main, ["record", "show", "rec_nope"])
+            assert result.exit_code != 0
+
+
+# ── record play ──────────────────────────────────────────────────────────────
+
+
+class TestRecordPlay:
+    def test_play_dry_run(self, runner):
+        rec = Recording(
+            name="Test", recording_id="rec_test", created_at="2026-04-01T12:00:00",
+            steps=[ActionStep("click", {"x": 100, "y": 200}, 1000.0)],
+        )
+        with patch("naturo.cli.recording_cmd.load_recording", return_value=rec), \
+             patch("naturo.cli.recording_cmd.replay_recording") as mock_replay:
+            mock_replay.return_value = [{"step": 1, "command": "click", "args": {}, "status": "skipped"}]
+            result = runner.invoke(main, ["record", "play", "rec_test", "--dry-run"])
+            assert result.exit_code == 0
+            mock_replay.assert_called_once()
+            assert mock_replay.call_args[1]["dry_run"] is True
+
+    def test_play_not_found(self, runner):
+        with patch("naturo.cli.recording_cmd.load_recording",
+                    side_effect=FileNotFoundError("not found")):
+            result = runner.invoke(main, ["record", "play", "rec_nope"])
+            assert result.exit_code != 0
+
+
+# ── record delete ────────────────────────────────────────────────────────────
+
+
+class TestRecordDelete:
+    def test_delete_with_force(self, runner):
+        rec = Recording(name="Test", recording_id="rec_test",
+                        created_at="2026-04-01T12:00:00")
+        with patch("naturo.cli.recording_cmd.load_recording", return_value=rec), \
+             patch("naturo.cli.recording_cmd.delete_recording", return_value=True):
+            result = runner.invoke(main, ["record", "delete", "rec_test", "--force"])
+            assert result.exit_code == 0
+            assert "Deleted" in result.output
+
+
+# ── record export ────────────────────────────────────────────────────────────
+
+
+class TestRecordExport:
+    def test_export_json(self, runner):
+        rec = Recording(
+            name="Test", recording_id="rec_test", created_at="2026-04-01T12:00:00",
+            steps=[ActionStep("click", {"x": 100, "y": 200}, 1000.0)],
+        )
+        with patch("naturo.cli.recording_cmd.load_recording", return_value=rec):
+            result = runner.invoke(main, ["record", "export", "rec_test"])
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert data["recording_id"] == "rec_test"
+
+    def test_export_python(self, runner):
+        rec = Recording(
+            name="Test", recording_id="rec_test", created_at="2026-04-01T12:00:00",
+            steps=[
+                ActionStep("click", {"x": 100, "y": 200}, 1000.0),
+                ActionStep("type", {"text": "hello"}, 1001.5),
+            ],
+        )
+        with patch("naturo.cli.recording_cmd.load_recording", return_value=rec):
+            result = runner.invoke(main, ["record", "export", "rec_test", "--format", "python"])
+            assert result.exit_code == 0
+            assert "#!/usr/bin/env python3" in result.output
+            assert 'naturo click 100 200' in result.output
+            assert 'naturo type "hello"' in result.output
+            assert "time.sleep" in result.output
+
+    def test_export_bash(self, runner):
+        rec = Recording(
+            name="Test", recording_id="rec_test", created_at="2026-04-01T12:00:00",
+            steps=[ActionStep("press", {"key": "enter"}, 1000.0)],
+        )
+        with patch("naturo.cli.recording_cmd.load_recording", return_value=rec):
+            result = runner.invoke(main, ["record", "export", "rec_test", "--format", "bash"])
+            assert result.exit_code == 0
+            assert "#!/bin/bash" in result.output
+            assert "naturo press enter" in result.output
+
+    def test_export_to_file(self, runner, tmp_path):
+        rec = Recording(
+            name="Test", recording_id="rec_test", created_at="2026-04-01T12:00:00",
+            steps=[ActionStep("click", {"x": 1, "y": 2}, 1000.0)],
+        )
+        out = str(tmp_path / "export.json")
+        with patch("naturo.cli.recording_cmd.load_recording", return_value=rec):
+            result = runner.invoke(main, ["record", "export", "rec_test", "-o", out])
+            assert result.exit_code == 0
+            assert Path(out).exists()
+
+
+# ── record_action hook ───────────────────────────────────────────────────────
+
+
+class TestRecordActionHook:
+    def test_record_action_appends_to_active(self, tmp_path):
+        """Verify _record_action hooks into the recording engine."""
+        from naturo.cli.interaction._common import _record_action
+
+        rec = Recording(name="Hook test", recording_id="rec_hook",
+                        created_at="2026-04-01T12:00:00")
+        with patch("naturo.recording.RECORDINGS_DIR", tmp_path):
+            set_active_recording(rec, tmp_path)
+            _record_action("click", {"x": 50, "y": 60})
+            active = get_active_recording(tmp_path)
+            assert active is not None
+            assert len(active.steps) == 1
+            assert active.steps[0].command == "click"
+
+    def test_record_action_noop_without_active(self, tmp_path):
+        """Verify _record_action is silent when no recording is active."""
+        from naturo.cli.interaction._common import _record_action
+
+        with patch("naturo.recording.RECORDINGS_DIR", tmp_path):
+            set_active_recording(None, tmp_path)
+            _record_action("click", {"x": 50, "y": 60})  # should not raise
+
+
+# ── help text ────────────────────────────────────────────────────────────────
+
+
+class TestRecordHelp:
+    def test_record_help(self, runner):
+        result = runner.invoke(main, ["record", "--help"])
+        assert result.exit_code == 0
+        assert "start" in result.output
+        assert "stop" in result.output
+        assert "play" in result.output
+        assert "list" in result.output
+        assert "export" in result.output
+
+    def test_record_start_help(self, runner):
+        result = runner.invoke(main, ["record", "start", "--help"])
+        assert result.exit_code == 0
+
+    def test_record_play_help(self, runner):
+        result = runner.invoke(main, ["record", "play", "--help"])
+        assert result.exit_code == 0
+
+    def test_record_export_help(self, runner):
+        result = runner.invoke(main, ["record", "export", "--help"])
+        assert result.exit_code == 0


### PR DESCRIPTION
## Changes
- New `naturo record` command group with 7 subcommands: start, stop, play, list, show, delete, export
- Wired `_record_action()` into the real recording engine (was a no-op stub)
- Export supports JSON, Python script, and Bash script formats
- All commands support `--json` output

## Testing
24 new tests in `test_recording_cli.py` — all pass, ruff clean.

**[Orc-Mycelium]**