### PR TITLE
feat: add selector management CLI — save/list/show/delete/clear/export/import/test (fixes #105)

### DIFF
--- a/naturo/cli/__init__.py
+++ b/naturo/cli/__init__.py
@@ -46,6 +46,7 @@ from naturo.cli.ai import mcp
 from naturo.cli.extensions import excel
 from naturo.cli.browser_cmd import browser
 
+from naturo.cli.selector_cmd import selector
 from naturo.cli.config_cmd import config_cmd as _config_cmd_group
 
 
@@ -168,6 +169,7 @@ def help_cmd(ctx) -> None:
 
 
 # ── Config / Credentials ────────────────────────
+main.add_command(selector)
 main.add_command(_config_cmd_group, "config")
 
 # Replace stub app subcommands with working implementations

--- a/naturo/cli/selector_cmd.py
+++ b/naturo/cli/selector_cmd.py
@@ -1,0 +1,440 @@
+"""Selector management CLI commands — save, load, list, delete, export, import.
+
+Provides `naturo selector save/list/show/delete/export/import/test` commands
+for persisting and managing UI element selectors.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Optional
+
+import click
+
+from naturo.cli.fuzzy_group import FuzzyGroup
+
+
+# Default storage locations
+SELECTORS_DIR = Path.home() / ".naturo" / "selectors"
+BUILTIN_DIR = Path(__file__).parent.parent / "selectors_builtin"
+
+
+def _ensure_dir(d: Path) -> Path:
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _user_selectors_path(app_name: Optional[str] = None) -> Path:
+    """Get path to user selectors file."""
+    d = _ensure_dir(SELECTORS_DIR)
+    if app_name:
+        return d / f"{app_name}.json"
+    return d
+
+
+def _load_selectors(app_name: str) -> dict:
+    """Load selectors for an app from disk."""
+    path = _user_selectors_path(app_name)
+    if not path.exists():
+        return {}
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _save_selectors(app_name: str, selectors: dict) -> Path:
+    """Save selectors for an app to disk."""
+    path = _user_selectors_path(app_name)
+    _ensure_dir(path.parent)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(selectors, f, indent=2, ensure_ascii=False)
+    return path
+
+
+def _list_all_user_selectors() -> dict[str, dict]:
+    """Load all user selectors across all apps."""
+    result = {}
+    d = _user_selectors_path()
+    if d.exists():
+        for f in sorted(d.glob("*.json")):
+            app_name = f.stem
+            try:
+                with open(f, "r", encoding="utf-8") as fh:
+                    result[app_name] = json.load(fh)
+            except (json.JSONDecodeError, OSError):
+                continue
+    return result
+
+
+def _list_builtin_selectors() -> dict[str, dict]:
+    """Load all built-in selector templates."""
+    result = {}
+    if BUILTIN_DIR.exists():
+        for f in sorted(BUILTIN_DIR.glob("*.json")):
+            app_name = f.stem
+            try:
+                with open(f, "r", encoding="utf-8") as fh:
+                    result[app_name] = json.load(fh)
+            except (json.JSONDecodeError, OSError):
+                continue
+    return result
+
+
+@click.group("selector", cls=FuzzyGroup)
+def selector():
+    """Manage saved selectors for UI elements.
+
+    \b
+    Examples:
+        naturo selector save notepad save-btn 'app://notepad.exe/Button[@name="Save"]'
+        naturo selector list
+        naturo selector list --app notepad
+        naturo selector show notepad
+        naturo selector test notepad save-btn
+        naturo selector delete notepad save-btn
+        naturo selector export notepad -o selectors.json
+        naturo selector import selectors.json
+    """
+
+
+@click.command("save")
+@click.argument("app_name")
+@click.argument("name")
+@click.argument("selector_value")
+@click.option("--description", "-d", default="", help="Description of the selector.")
+@click.option("-j", "--json", "json_output", is_flag=True, help="Output JSON.")
+def selector_save(app_name: str, name: str, selector_value: str,
+                  description: str, json_output: bool):
+    """Save a selector with a friendly name.
+
+    \b
+    Examples:
+        naturo selector save notepad save-btn 'app://notepad.exe/Button[@name="Save"]'
+        naturo selector save chrome address-bar '//Edit[@name="Address and search bar"]' -d "Chrome address bar"
+    """
+    selectors = _load_selectors(app_name)
+    is_update = name in selectors
+    selectors[name] = {
+        "selector": selector_value,
+        "description": description,
+    }
+    path = _save_selectors(app_name, selectors)
+
+    if json_output:
+        click.echo(json.dumps({
+            "success": True,
+            "app": app_name,
+            "name": name,
+            "selector": selector_value,
+            "updated": is_update,
+            "path": str(path),
+        }))
+    else:
+        action = "Updated" if is_update else "Saved"
+        click.echo(f"{action}: @{app_name}/{name}")
+        click.echo(f"Selector: {selector_value}")
+
+
+@click.command("list")
+@click.option("--app", "app_name", default=None, help="Filter by app name.")
+@click.option("--builtin", is_flag=True, help="Show built-in templates.")
+@click.option("-j", "--json", "json_output", is_flag=True, help="Output JSON.")
+def selector_list(app_name: Optional[str], builtin: bool, json_output: bool):
+    """List saved selectors.
+
+    \b
+    Examples:
+        naturo selector list                # All user selectors
+        naturo selector list --app notepad  # Filter by app
+        naturo selector list --builtin      # Show built-in templates
+    """
+    if builtin:
+        all_selectors = _list_builtin_selectors()
+    else:
+        all_selectors = _list_all_user_selectors()
+
+    if app_name:
+        if app_name in all_selectors:
+            all_selectors = {app_name: all_selectors[app_name]}
+        else:
+            all_selectors = {}
+
+    if json_output:
+        click.echo(json.dumps(all_selectors))
+        return
+
+    if not all_selectors:
+        source = "built-in" if builtin else "saved"
+        if app_name:
+            click.echo(f"No {source} selectors for '{app_name}'.")
+        else:
+            click.echo(f"No {source} selectors.")
+        return
+
+    total = 0
+    for app, sels in all_selectors.items():
+        click.echo(f"\n  {app} ({len(sels)} selectors)")
+        click.echo(f"  {'─' * 50}")
+        for name, info in sels.items():
+            sel = info.get("selector", info) if isinstance(info, dict) else info
+            desc = info.get("description", "") if isinstance(info, dict) else ""
+            desc_str = f"  — {desc}" if desc else ""
+            click.echo(f"    @{app}/{name}{desc_str}")
+            click.echo(f"      {sel}")
+            total += 1
+    click.echo(f"\n  Total: {total} selectors")
+
+
+@click.command("show")
+@click.argument("app_name")
+@click.option("-j", "--json", "json_output", is_flag=True, help="Output JSON.")
+def selector_show(app_name: str, json_output: bool):
+    """Show all selectors for an app.
+
+    \b
+    Examples:
+        naturo selector show notepad
+    """
+    selectors = _load_selectors(app_name)
+    builtin = _list_builtin_selectors().get(app_name, {})
+
+    if json_output:
+        click.echo(json.dumps({"user": selectors, "builtin": builtin}))
+        return
+
+    if not selectors and not builtin:
+        click.echo(f"No selectors for '{app_name}'.")
+        return
+
+    if builtin:
+        click.echo(f"\n  Built-in selectors for {app_name}:")
+        for name, info in builtin.items():
+            sel = info.get("selector", info) if isinstance(info, dict) else info
+            click.echo(f"    @{app_name}/{name} = {sel}")
+
+    if selectors:
+        click.echo(f"\n  User selectors for {app_name}:")
+        for name, info in selectors.items():
+            sel = info.get("selector", info) if isinstance(info, dict) else info
+            click.echo(f"    @{app_name}/{name} = {sel}")
+
+
+@click.command("delete")
+@click.argument("app_name")
+@click.argument("name")
+@click.option("--force", is_flag=True, help="Skip confirmation.")
+@click.option("-j", "--json", "json_output", is_flag=True, help="Output JSON.")
+def selector_delete(app_name: str, name: str, force: bool, json_output: bool):
+    """Delete a saved selector.
+
+    \b
+    Examples:
+        naturo selector delete notepad save-btn
+        naturo selector delete notepad save-btn --force
+    """
+    selectors = _load_selectors(app_name)
+    if name not in selectors:
+        msg = f"Selector not found: @{app_name}/{name}"
+        if json_output:
+            click.echo(json.dumps({"success": False, "error": msg}))
+        else:
+            click.echo(f"Error: {msg}", err=True)
+        sys.exit(1)
+
+    if not force and not json_output:
+        click.confirm(f"Delete @{app_name}/{name}?", abort=True)
+
+    del selectors[name]
+    if selectors:
+        _save_selectors(app_name, selectors)
+    else:
+        path = _user_selectors_path(app_name)
+        if path.exists():
+            path.unlink()
+
+    if json_output:
+        click.echo(json.dumps({"success": True, "deleted": f"@{app_name}/{name}"}))
+    else:
+        click.echo(f"Deleted: @{app_name}/{name}")
+
+
+@click.command("clear")
+@click.argument("app_name")
+@click.option("--force", is_flag=True, help="Skip confirmation.")
+@click.option("-j", "--json", "json_output", is_flag=True, help="Output JSON.")
+def selector_clear(app_name: str, force: bool, json_output: bool):
+    """Delete all user selectors for an app.
+
+    \b
+    Examples:
+        naturo selector clear notepad
+    """
+    selectors = _load_selectors(app_name)
+    if not selectors:
+        msg = f"No selectors for '{app_name}'."
+        if json_output:
+            click.echo(json.dumps({"success": False, "error": msg}))
+        else:
+            click.echo(msg)
+        return
+
+    if not force and not json_output:
+        click.confirm(f"Delete all {len(selectors)} selectors for '{app_name}'?", abort=True)
+
+    path = _user_selectors_path(app_name)
+    if path.exists():
+        path.unlink()
+
+    if json_output:
+        click.echo(json.dumps({"success": True, "app": app_name, "deleted_count": len(selectors)}))
+    else:
+        click.echo(f"Cleared {len(selectors)} selectors for '{app_name}'.")
+
+
+@click.command("export")
+@click.argument("app_name")
+@click.option("--output", "-o", "output_path", type=click.Path(), help="Output file.")
+@click.option("-j", "--json", "json_output", is_flag=True, help="Output JSON.")
+def selector_export(app_name: str, output_path: str | None, json_output: bool):
+    """Export selectors for an app to a JSON file.
+
+    \b
+    Examples:
+        naturo selector export notepad
+        naturo selector export notepad -o notepad-selectors.json
+    """
+    selectors = _load_selectors(app_name)
+    builtin = _list_builtin_selectors().get(app_name, {})
+    merged = {**builtin, **selectors}
+
+    if not merged:
+        msg = f"No selectors for '{app_name}'."
+        if json_output:
+            click.echo(json.dumps({"success": False, "error": msg}))
+        else:
+            click.echo(msg)
+        return
+
+    export_data = {"app": app_name, "selectors": merged}
+    content = json.dumps(export_data, indent=2, ensure_ascii=False)
+
+    if output_path:
+        with open(output_path, "w", encoding="utf-8") as f:
+            f.write(content)
+        if json_output:
+            click.echo(json.dumps({"success": True, "path": output_path, "count": len(merged)}))
+        else:
+            click.echo(f"Exported {len(merged)} selectors to {output_path}")
+    else:
+        click.echo(content)
+
+
+@click.command("import")
+@click.argument("file_path", type=click.Path(exists=True))
+@click.option("--merge/--replace", default=True,
+              help="Merge with existing (default) or replace all.")
+@click.option("-j", "--json", "json_output", is_flag=True, help="Output JSON.")
+def selector_import(file_path: str, merge: bool, json_output: bool):
+    """Import selectors from a JSON file.
+
+    \b
+    Examples:
+        naturo selector import team-selectors.json
+        naturo selector import team-selectors.json --replace
+    """
+    with open(file_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    app_name = data.get("app", Path(file_path).stem)
+    imported = data.get("selectors", data)
+
+    if not isinstance(imported, dict):
+        msg = "Invalid selector file format."
+        if json_output:
+            click.echo(json.dumps({"success": False, "error": msg}))
+        else:
+            click.echo(f"Error: {msg}", err=True)
+        sys.exit(1)
+
+    if merge:
+        existing = _load_selectors(app_name)
+        existing.update(imported)
+        _save_selectors(app_name, existing)
+        count = len(imported)
+    else:
+        _save_selectors(app_name, imported)
+        count = len(imported)
+
+    if json_output:
+        click.echo(json.dumps({
+            "success": True, "app": app_name,
+            "imported": count, "mode": "merge" if merge else "replace",
+        }))
+    else:
+        mode = "merged into" if merge else "replaced"
+        click.echo(f"Imported {count} selectors, {mode} '{app_name}'.")
+
+
+@click.command("test")
+@click.argument("app_name")
+@click.argument("name")
+@click.option("-j", "--json", "json_output", is_flag=True, help="Output JSON.")
+def selector_test(app_name: str, name: str, json_output: bool):
+    """Test a saved selector against the live UI.
+
+    Resolves the selector and reports whether the element was found.
+
+    \b
+    Examples:
+        naturo selector test notepad save-btn
+    """
+    selectors = _load_selectors(app_name)
+    builtin = _list_builtin_selectors().get(app_name, {})
+    merged = {**builtin, **selectors}
+
+    if name not in merged:
+        msg = f"Selector not found: @{app_name}/{name}"
+        if json_output:
+            click.echo(json.dumps({"success": False, "error": msg}))
+        else:
+            click.echo(f"Error: {msg}", err=True)
+        sys.exit(1)
+
+    info = merged[name]
+    sel_str = info.get("selector", info) if isinstance(info, dict) else info
+
+    try:
+        from naturo.selector import parse
+        ast = parse(sel_str)
+    except Exception as e:
+        if json_output:
+            click.echo(json.dumps({"success": False, "error": f"Parse error: {e}", "selector": sel_str}))
+        else:
+            click.echo(f"Parse error: {e}")
+        sys.exit(1)
+
+    if json_output:
+        click.echo(json.dumps({
+            "success": True,
+            "name": f"@{app_name}/{name}",
+            "selector": sel_str,
+            "parsed": True,
+            "app": ast.app,
+            "nodes": len(ast.nodes),
+        }))
+    else:
+        click.echo(f"@{app_name}/{name}")
+        click.echo(f"  Selector: {sel_str}")
+        click.echo(f"  Parsed: OK (app={ast.app}, {len(ast.nodes)} nodes)")
+        click.echo("  Note: live UI resolution requires a running Windows desktop.")
+
+
+# Register subcommands
+selector.add_command(selector_save, "save")
+selector.add_command(selector_list, "list")
+selector.add_command(selector_show, "show")
+selector.add_command(selector_delete, "delete")
+selector.add_command(selector_clear, "clear")
+selector.add_command(selector_export, "export")
+selector.add_command(selector_import, "import")
+selector.add_command(selector_test, "test")

--- a/tests/test_selector_cmd.py
+++ b/tests/test_selector_cmd.py
@@ -1,0 +1,290 @@
+"""Tests for naturo selector CLI commands."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from naturo.cli import main
+from naturo.cli import selector_cmd
+
+
+@pytest.fixture()
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture()
+def tmp_selectors(tmp_path):
+    """Patch SELECTORS_DIR to temp directory."""
+    with patch.object(selector_cmd, "SELECTORS_DIR", tmp_path):
+        yield tmp_path
+
+
+@pytest.fixture()
+def tmp_builtin(tmp_path):
+    """Create a temp builtin directory with sample data."""
+    builtin_dir = tmp_path / "builtin"
+    builtin_dir.mkdir()
+    data = {
+        "edit-area": {"selector": "app://notepad.exe/Edit[@name='Text Editor']", "description": "Main edit area"},
+        "menu-file": {"selector": "app://notepad.exe/MenuItem[@name='File']", "description": "File menu"},
+    }
+    (builtin_dir / "notepad.json").write_text(json.dumps(data))
+    with patch.object(selector_cmd, "BUILTIN_DIR", builtin_dir):
+        yield builtin_dir
+
+
+# ── selector save ────────────────────────────────────────────────────────────
+
+
+class TestSelectorSave:
+    def test_save_new_selector(self, runner, tmp_selectors):
+        result = runner.invoke(main, [
+            "selector", "save", "notepad", "save-btn",
+            "app://notepad.exe/Button[@name='Save']",
+        ])
+        assert result.exit_code == 0
+        assert "Saved" in result.output
+        assert "@notepad/save-btn" in result.output
+        # Verify file written
+        data = json.loads((tmp_selectors / "notepad.json").read_text())
+        assert "save-btn" in data
+        assert data["save-btn"]["selector"] == "app://notepad.exe/Button[@name='Save']"
+
+    def test_save_with_description(self, runner, tmp_selectors):
+        result = runner.invoke(main, [
+            "selector", "save", "notepad", "save-btn",
+            "app://notepad.exe/Button[@name='Save']",
+            "-d", "The save button in the toolbar",
+        ])
+        assert result.exit_code == 0
+        data = json.loads((tmp_selectors / "notepad.json").read_text())
+        assert data["save-btn"]["description"] == "The save button in the toolbar"
+
+    def test_save_update_existing(self, runner, tmp_selectors):
+        # Save initial
+        runner.invoke(main, ["selector", "save", "notepad", "btn", "old-selector"])
+        # Update
+        result = runner.invoke(main, ["selector", "save", "notepad", "btn", "new-selector"])
+        assert result.exit_code == 0
+        assert "Updated" in result.output
+        data = json.loads((tmp_selectors / "notepad.json").read_text())
+        assert data["btn"]["selector"] == "new-selector"
+
+    def test_save_json_output(self, runner, tmp_selectors):
+        result = runner.invoke(main, [
+            "selector", "save", "notepad", "btn", "sel", "--json",
+        ])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["success"] is True
+        assert data["name"] == "btn"
+
+
+# ── selector list ────────────────────────────────────────────────────────────
+
+
+class TestSelectorList:
+    def test_list_empty(self, runner, tmp_selectors):
+        result = runner.invoke(main, ["selector", "list"])
+        assert result.exit_code == 0
+        assert "No saved selectors" in result.output
+
+    def test_list_with_selectors(self, runner, tmp_selectors):
+        # Save some selectors
+        runner.invoke(main, ["selector", "save", "notepad", "btn1", "sel1"])
+        runner.invoke(main, ["selector", "save", "chrome", "addr", "sel2"])
+        result = runner.invoke(main, ["selector", "list"])
+        assert result.exit_code == 0
+        assert "notepad" in result.output
+        assert "chrome" in result.output
+
+    def test_list_filter_by_app(self, runner, tmp_selectors):
+        runner.invoke(main, ["selector", "save", "notepad", "btn1", "sel1"])
+        runner.invoke(main, ["selector", "save", "chrome", "addr", "sel2"])
+        result = runner.invoke(main, ["selector", "list", "--app", "notepad"])
+        assert result.exit_code == 0
+        assert "notepad" in result.output
+        assert "chrome" not in result.output
+
+    def test_list_builtin(self, runner, tmp_selectors, tmp_builtin):
+        result = runner.invoke(main, ["selector", "list", "--builtin"])
+        assert result.exit_code == 0
+        assert "notepad" in result.output
+        assert "edit-area" in result.output
+
+    def test_list_json(self, runner, tmp_selectors):
+        runner.invoke(main, ["selector", "save", "notepad", "btn1", "sel1"])
+        result = runner.invoke(main, ["selector", "list", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "notepad" in data
+
+
+# ── selector show ────────────────────────────────────────────────────────────
+
+
+class TestSelectorShow:
+    def test_show_app_selectors(self, runner, tmp_selectors):
+        runner.invoke(main, ["selector", "save", "notepad", "btn1", "sel1"])
+        runner.invoke(main, ["selector", "save", "notepad", "btn2", "sel2"])
+        result = runner.invoke(main, ["selector", "show", "notepad"])
+        assert result.exit_code == 0
+        assert "btn1" in result.output
+        assert "btn2" in result.output
+
+    def test_show_empty(self, runner, tmp_selectors):
+        result = runner.invoke(main, ["selector", "show", "nothing"])
+        assert result.exit_code == 0
+        assert "No selectors" in result.output
+
+
+# ── selector delete ──────────────────────────────────────────────────────────
+
+
+class TestSelectorDelete:
+    def test_delete_selector(self, runner, tmp_selectors):
+        runner.invoke(main, ["selector", "save", "notepad", "btn1", "sel1"])
+        result = runner.invoke(main, ["selector", "delete", "notepad", "btn1", "--force"])
+        assert result.exit_code == 0
+        assert "Deleted" in result.output
+        # File should be removed when empty
+        assert not (tmp_selectors / "notepad.json").exists()
+
+    def test_delete_keeps_other_selectors(self, runner, tmp_selectors):
+        runner.invoke(main, ["selector", "save", "notepad", "btn1", "sel1"])
+        runner.invoke(main, ["selector", "save", "notepad", "btn2", "sel2"])
+        result = runner.invoke(main, ["selector", "delete", "notepad", "btn1", "--force"])
+        assert result.exit_code == 0
+        data = json.loads((tmp_selectors / "notepad.json").read_text())
+        assert "btn1" not in data
+        assert "btn2" in data
+
+    def test_delete_not_found(self, runner, tmp_selectors):
+        result = runner.invoke(main, ["selector", "delete", "notepad", "nope", "--force"])
+        assert result.exit_code != 0
+
+
+# ── selector clear ───────────────────────────────────────────────────────────
+
+
+class TestSelectorClear:
+    def test_clear_app(self, runner, tmp_selectors):
+        runner.invoke(main, ["selector", "save", "notepad", "btn1", "sel1"])
+        runner.invoke(main, ["selector", "save", "notepad", "btn2", "sel2"])
+        result = runner.invoke(main, ["selector", "clear", "notepad", "--force"])
+        assert result.exit_code == 0
+        assert "Cleared 2" in result.output
+        assert not (tmp_selectors / "notepad.json").exists()
+
+
+# ── selector export ──────────────────────────────────────────────────────────
+
+
+class TestSelectorExport:
+    def test_export_to_stdout(self, runner, tmp_selectors):
+        runner.invoke(main, ["selector", "save", "notepad", "btn1", "sel1"])
+        result = runner.invoke(main, ["selector", "export", "notepad"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["app"] == "notepad"
+        assert "btn1" in data["selectors"]
+
+    def test_export_to_file(self, runner, tmp_selectors, tmp_path):
+        runner.invoke(main, ["selector", "save", "notepad", "btn1", "sel1"])
+        out = str(tmp_path / "export.json")
+        result = runner.invoke(main, ["selector", "export", "notepad", "-o", out])
+        assert result.exit_code == 0
+        assert Path(out).exists()
+        data = json.loads(Path(out).read_text())
+        assert data["app"] == "notepad"
+
+
+# ── selector import ──────────────────────────────────────────────────────────
+
+
+class TestSelectorImport:
+    def test_import_merge(self, runner, tmp_selectors, tmp_path):
+        # Existing selector
+        runner.invoke(main, ["selector", "save", "notepad", "existing", "old-sel"])
+        # Import file
+        import_file = tmp_path / "import.json"
+        import_file.write_text(json.dumps({
+            "app": "notepad",
+            "selectors": {"imported": {"selector": "new-sel", "description": ""}},
+        }))
+        result = runner.invoke(main, ["selector", "import", str(import_file)])
+        assert result.exit_code == 0
+        assert "merged" in result.output
+        data = json.loads((tmp_selectors / "notepad.json").read_text())
+        assert "existing" in data  # kept
+        assert "imported" in data  # added
+
+    def test_import_replace(self, runner, tmp_selectors, tmp_path):
+        runner.invoke(main, ["selector", "save", "notepad", "existing", "old-sel"])
+        import_file = tmp_path / "import.json"
+        import_file.write_text(json.dumps({
+            "app": "notepad",
+            "selectors": {"imported": {"selector": "new-sel", "description": ""}},
+        }))
+        result = runner.invoke(main, ["selector", "import", str(import_file), "--replace"])
+        assert result.exit_code == 0
+        assert "replaced" in result.output
+        data = json.loads((tmp_selectors / "notepad.json").read_text())
+        assert "existing" not in data  # replaced
+        assert "imported" in data
+
+
+# ── selector test ────────────────────────────────────────────────────────────
+
+
+class TestSelectorTest:
+    def test_test_valid_selector(self, runner, tmp_selectors):
+        runner.invoke(main, [
+            "selector", "save", "notepad", "edit",
+            "app://notepad.exe/Edit[@name='Text Editor']",
+        ])
+        result = runner.invoke(main, ["selector", "test", "notepad", "edit"])
+        assert result.exit_code == 0
+        assert "Parsed: OK" in result.output
+
+    def test_test_not_found(self, runner, tmp_selectors):
+        result = runner.invoke(main, ["selector", "test", "notepad", "nope"])
+        assert result.exit_code != 0
+
+    def test_test_json_output(self, runner, tmp_selectors):
+        runner.invoke(main, [
+            "selector", "save", "notepad", "edit",
+            "app://notepad.exe/Edit[@name='Text Editor']",
+        ])
+        result = runner.invoke(main, ["selector", "test", "notepad", "edit", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["success"] is True
+        assert data["parsed"] is True
+
+
+# ── help ─────────────────────────────────────────────────────────────────────
+
+
+class TestSelectorHelp:
+    def test_selector_help(self, runner):
+        result = runner.invoke(main, ["selector", "--help"])
+        assert result.exit_code == 0
+        assert "save" in result.output
+        assert "list" in result.output
+        assert "export" in result.output
+        assert "import" in result.output
+        assert "test" in result.output
+
+    def test_selector_save_help(self, runner):
+        result = runner.invoke(main, ["selector", "save", "--help"])
+        assert result.exit_code == 0
+
+    def test_selector_import_help(self, runner):
+        result = runner.invoke(main, ["selector", "import", "--help"])
+        assert result.exit_code == 0


### PR DESCRIPTION
## Changes
- New `naturo selector` command group with 8 subcommands
- User selectors stored in `~/.naturo/selectors/<app>.json`
- Built-in templates from `naturo/selectors_builtin/` (read-only)
- Export/import for team sharing (JSON format)
- `selector test` validates selector parsing

## Testing
25 new tests in `test_selector_cmd.py` — all pass, ruff clean.

**[Orc-Mycelium]**