### PR TITLE
feat: add visual regression testing — baseline/compare/diff/report (fixes #91)

### DIFF
--- a/naturo/cli/__init__.py
+++ b/naturo/cli/__init__.py
@@ -47,6 +47,7 @@ from naturo.cli.extensions import excel
 from naturo.cli.browser_cmd import browser
 
 from naturo.cli.selector_cmd import selector
+from naturo.cli.visual_cmd import visual
 from naturo.cli.config_cmd import config_cmd as _config_cmd_group
 
 
@@ -170,6 +171,7 @@ def help_cmd(ctx) -> None:
 
 # ── Config / Credentials ────────────────────────
 main.add_command(selector)
+main.add_command(visual)
 main.add_command(_config_cmd_group, "config")
 
 # Replace stub app subcommands with working implementations

--- a/naturo/cli/visual_cmd.py
+++ b/naturo/cli/visual_cmd.py
@@ -1,0 +1,296 @@
+"""Visual regression testing CLI commands.
+
+Provides `naturo visual baseline/compare/list/delete/report` commands
+for screenshot-based regression testing.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+import click
+
+from naturo.cli.fuzzy_group import FuzzyGroup
+from naturo.visual import (
+    save_baseline,
+    list_baselines,
+    delete_baseline,
+    compare_with_baseline,
+    compare_images,
+    generate_html_report,
+    VisualReport,
+)
+
+
+@click.group("visual", cls=FuzzyGroup)
+def visual():
+    """Visual regression testing — compare screenshots across runs.
+
+    \b
+    Examples:
+        naturo visual baseline login_screen --from screenshot.png
+        naturo visual compare login_screen --current screenshot2.png
+        naturo visual list
+        naturo visual report --name "Sprint 42" --output report.html
+    """
+
+
+@click.command("baseline")
+@click.argument("name")
+@click.option("--from", "from_path", required=True, type=click.Path(exists=True),
+              help="Path to screenshot to use as baseline.")
+@click.option("-j", "--json", "json_output", is_flag=True, help="Output JSON.")
+def visual_baseline(name: str, from_path: str, json_output: bool):
+    """Save a screenshot as a visual baseline.
+
+    \b
+    Examples:
+        naturo visual baseline login_screen --from screenshot.png
+        naturo visual baseline dashboard --from ~/captures/dash.png
+    """
+    try:
+        path = save_baseline(from_path, name)
+    except ImportError as e:
+        if json_output:
+            click.echo(json.dumps({"success": False, "error": str(e)}))
+        else:
+            click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
+
+    if json_output:
+        click.echo(json.dumps({"success": True, "name": name, "path": str(path)}))
+    else:
+        click.echo(f"Baseline saved: {name}")
+        click.echo(f"Path: {path}")
+
+
+@click.command("compare")
+@click.argument("name")
+@click.option("--current", required=True, type=click.Path(exists=True),
+              help="Path to current screenshot to compare.")
+@click.option("--threshold", type=float, default=0.95,
+              help="Similarity threshold (0.0-1.0, default 0.95).")
+@click.option("-j", "--json", "json_output", is_flag=True, help="Output JSON.")
+def visual_compare(name: str, current: str, threshold: float, json_output: bool):
+    """Compare a screenshot against its saved baseline.
+
+    \b
+    Examples:
+        naturo visual compare login_screen --current new_screenshot.png
+        naturo visual compare login_screen --current new.png --threshold 0.90
+    """
+    try:
+        result = compare_with_baseline(current, name, threshold=threshold)
+    except FileNotFoundError as e:
+        if json_output:
+            click.echo(json.dumps({"success": False, "error": str(e)}))
+        else:
+            click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
+    except ImportError as e:
+        if json_output:
+            click.echo(json.dumps({"success": False, "error": str(e)}))
+        else:
+            click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
+
+    if json_output:
+        click.echo(json.dumps(result.to_dict()))
+    else:
+        status = "PASS" if result.match else "FAIL"
+        color = "" if result.match else "! "
+        click.echo(f"{color}[{status}] {result.name}")
+        click.echo(f"  Similarity: {result.similarity:.1%} (threshold: {result.threshold:.1%})")
+        click.echo(f"  Diff pixels: {result.diff_pixels:,} / {result.total_pixels:,} "
+                    f"({result.to_dict()['diff_percentage']:.2f}%)")
+        if not result.dimensions_match:
+            click.echo(f"  Warning: dimensions differ — "
+                        f"baseline {result.baseline_size} vs current {result.current_size}")
+        if result.diff_path:
+            click.echo(f"  Diff image: {result.diff_path}")
+
+    if not result.match:
+        sys.exit(1)
+
+
+@click.command("diff")
+@click.argument("image1", type=click.Path(exists=True))
+@click.argument("image2", type=click.Path(exists=True))
+@click.option("--output", "-o", type=click.Path(), help="Save diff image to path.")
+@click.option("--threshold", type=float, default=0.95, help="Similarity threshold.")
+@click.option("-j", "--json", "json_output", is_flag=True, help="Output JSON.")
+def visual_diff(image1: str, image2: str, output: Optional[str],
+                threshold: float, json_output: bool):
+    """Compare any two images directly (without baseline).
+
+    \b
+    Examples:
+        naturo visual diff before.png after.png
+        naturo visual diff before.png after.png -o diff.png
+    """
+    try:
+        result = compare_images(
+            image1, image2, name="diff",
+            threshold=threshold, diff_output=output,
+        )
+    except ImportError as e:
+        if json_output:
+            click.echo(json.dumps({"success": False, "error": str(e)}))
+        else:
+            click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
+
+    if json_output:
+        click.echo(json.dumps(result.to_dict()))
+    else:
+        status = "MATCH" if result.match else "DIFFER"
+        click.echo(f"[{status}] Similarity: {result.similarity:.1%}")
+        click.echo(f"  Diff pixels: {result.diff_pixels:,} / {result.total_pixels:,}")
+        if output:
+            click.echo(f"  Diff image: {output}")
+
+
+@click.command("list")
+@click.option("-j", "--json", "json_output", is_flag=True, help="Output JSON.")
+def visual_list(json_output: bool):
+    """List all saved baselines.
+
+    \b
+    Examples:
+        naturo visual list
+    """
+    baselines = list_baselines()
+
+    if json_output:
+        click.echo(json.dumps({"baselines": baselines}))
+        return
+
+    if not baselines:
+        click.echo("No baselines saved.")
+        click.echo("Use 'naturo visual baseline <name> --from <image>' to create one.")
+        return
+
+    click.echo(f"{'Name':<25} {'Size':>12}  {'Created'}")
+    click.echo("-" * 60)
+    for b in baselines:
+        size = f"{b.get('size', [0, 0])[0]}x{b.get('size', [0, 0])[1]}"
+        created = b.get("created_at", "")[:19]
+        exists = "" if b.get("exists", True) else " [MISSING]"
+        click.echo(f"{b['name']:<25} {size:>12}  {created}{exists}")
+
+
+@click.command("delete")
+@click.argument("name")
+@click.option("--force", is_flag=True, help="Skip confirmation.")
+@click.option("-j", "--json", "json_output", is_flag=True, help="Output JSON.")
+def visual_delete(name: str, force: bool, json_output: bool):
+    """Delete a saved baseline.
+
+    \b
+    Examples:
+        naturo visual delete login_screen
+        naturo visual delete login_screen --force
+    """
+    if not force and not json_output:
+        click.confirm(f"Delete baseline '{name}'?", abort=True)
+
+    deleted = delete_baseline(name)
+    if json_output:
+        click.echo(json.dumps({"success": deleted, "name": name}))
+    else:
+        if deleted:
+            click.echo(f"Deleted baseline: {name}")
+        else:
+            click.echo(f"Baseline not found: {name}")
+
+
+@click.command("report")
+@click.argument("names", nargs=-1)
+@click.option("--current-dir", type=click.Path(exists=True),
+              help="Directory containing current screenshots (name.png).")
+@click.option("--threshold", type=float, default=0.95, help="Similarity threshold.")
+@click.option("--output", "-o", type=click.Path(), default=None,
+              help="Output HTML report path.")
+@click.option("--name", "report_name", default=None, help="Report name.")
+@click.option("-j", "--json", "json_output", is_flag=True, help="Output JSON.")
+def visual_report(names: tuple, current_dir: Optional[str], threshold: float,
+                  output: Optional[str], report_name: Optional[str],
+                  json_output: bool):
+    """Run visual regression tests and generate a report.
+
+    Compare multiple baselines against current screenshots at once.
+    If no names given, compares all baselines against screenshots in --current-dir.
+
+    \b
+    Examples:
+        naturo visual report login dashboard --current-dir ./screenshots/
+        naturo visual report --current-dir ./screenshots/ -o report.html
+        naturo visual report login dashboard --current-dir ./current/ --threshold 0.90
+    """
+    if not current_dir:
+        click.echo("Error: --current-dir is required.", err=True)
+        sys.exit(1)
+
+    current_path = Path(current_dir)
+    rname = report_name or f"Visual Regression {datetime.now().strftime('%Y-%m-%d %H:%M')}"
+    report = VisualReport(name=rname, created_at=datetime.now().isoformat())
+
+    # If no names given, compare all baselines
+    if not names:
+        baselines = list_baselines()
+        names = tuple(b["name"] for b in baselines)
+
+    if not names:
+        msg = "No baselines to compare."
+        if json_output:
+            click.echo(json.dumps({"success": False, "error": msg}))
+        else:
+            click.echo(msg)
+        return
+
+    for name in names:
+        current_img = current_path / f"{name}.png"
+        if not current_img.exists():
+            if not json_output:
+                click.echo(f"  [SKIP] {name} — no current screenshot at {current_img}")
+            continue
+
+        try:
+            result = compare_with_baseline(str(current_img), name, threshold=threshold)
+            report.add_result(result)
+            if not json_output:
+                status = "PASS" if result.match else "FAIL"
+                click.echo(f"  [{status}] {name} — {result.similarity:.1%}")
+        except (FileNotFoundError, ImportError) as e:
+            if not json_output:
+                click.echo(f"  [ERROR] {name} — {e}")
+
+    # Generate HTML report
+    if output:
+        try:
+            html_path = generate_html_report(report, output)
+            if not json_output:
+                click.echo(f"\nReport saved: {html_path}")
+        except Exception as e:
+            if not json_output:
+                click.echo(f"Error generating report: {e}", err=True)
+
+    if json_output:
+        click.echo(json.dumps(report.to_dict()))
+    else:
+        click.echo(f"\nResults: {report.passed} passed, {report.failed} failed")
+
+    if not report.all_passed:
+        sys.exit(1)
+
+
+# Register subcommands
+visual.add_command(visual_baseline, "baseline")
+visual.add_command(visual_compare, "compare")
+visual.add_command(visual_diff, "diff")
+visual.add_command(visual_list, "list")
+visual.add_command(visual_delete, "delete")
+visual.add_command(visual_report, "report")

--- a/naturo/visual.py
+++ b/naturo/visual.py
@@ -1,0 +1,458 @@
+"""Visual regression testing engine.
+
+Captures baseline screenshots, compares against current state,
+generates diff images and reports for detecting UI changes.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+try:
+    from PIL import Image, ImageChops, ImageDraw
+    _HAS_PIL = True
+except ImportError:
+    _HAS_PIL = False
+
+
+BASELINES_DIR = Path.home() / ".naturo" / "visual" / "baselines"
+REPORTS_DIR = Path.home() / ".naturo" / "visual" / "reports"
+
+
+def _require_pil() -> None:
+    if not _HAS_PIL:
+        raise ImportError(
+            "Pillow is required for visual regression testing. "
+            "Install with: pip install naturo[visual] or pip install Pillow"
+        )
+
+
+def _ensure_dir(d: Path) -> Path:
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+@dataclass
+class ComparisonResult:
+    """Result of comparing two images."""
+    name: str
+    match: bool
+    similarity: float  # 0.0 to 1.0
+    threshold: float
+    baseline_path: str
+    current_path: str
+    diff_path: Optional[str] = None
+    diff_pixels: int = 0
+    total_pixels: int = 0
+    dimensions_match: bool = True
+    baseline_size: tuple = (0, 0)
+    current_size: tuple = (0, 0)
+
+    def to_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "match": self.match,
+            "similarity": round(self.similarity, 4),
+            "threshold": self.threshold,
+            "baseline_path": self.baseline_path,
+            "current_path": self.current_path,
+            "diff_path": self.diff_path,
+            "diff_pixels": self.diff_pixels,
+            "total_pixels": self.total_pixels,
+            "diff_percentage": round(
+                (self.diff_pixels / self.total_pixels * 100) if self.total_pixels > 0 else 0, 2
+            ),
+            "dimensions_match": self.dimensions_match,
+            "baseline_size": list(self.baseline_size),
+            "current_size": list(self.current_size),
+        }
+
+
+@dataclass
+class VisualReport:
+    """A visual regression test report."""
+    name: str
+    created_at: str
+    results: list[ComparisonResult] = field(default_factory=list)
+    passed: int = 0
+    failed: int = 0
+
+    def add_result(self, result: ComparisonResult) -> None:
+        self.results.append(result)
+        if result.match:
+            self.passed += 1
+        else:
+            self.failed += 1
+
+    @property
+    def all_passed(self) -> bool:
+        return self.failed == 0
+
+    def to_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "created_at": self.created_at,
+            "passed": self.passed,
+            "failed": self.failed,
+            "all_passed": self.all_passed,
+            "results": [r.to_dict() for r in self.results],
+        }
+
+
+def save_baseline(
+    image_path: str | Path,
+    name: str,
+    directory: Optional[Path] = None,
+) -> Path:
+    """Save an image as a visual baseline.
+
+    Args:
+        image_path: Path to the screenshot to use as baseline.
+        name: Friendly name for the baseline (e.g., "login_screen").
+        directory: Custom baselines directory. Uses default if None.
+
+    Returns:
+        Path to the saved baseline image.
+    """
+    _require_pil()
+    src = Path(image_path)
+    if not src.exists():
+        raise FileNotFoundError(f"Image not found: {image_path}")
+
+    d = _ensure_dir(directory or BASELINES_DIR)
+    dest = d / f"{name}.png"
+
+    img = Image.open(src)
+    img.save(dest, "PNG")
+
+    # Save metadata
+    meta = {
+        "name": name,
+        "created_at": datetime.now().isoformat(),
+        "size": list(img.size),
+        "source": str(src),
+    }
+    meta_path = d / f"{name}.json"
+    with open(meta_path, "w", encoding="utf-8") as f:
+        json.dump(meta, f, indent=2)
+
+    return dest
+
+
+def list_baselines(directory: Optional[Path] = None) -> list[dict]:
+    """List all saved baselines.
+
+    Returns:
+        List of baseline metadata dictionaries.
+    """
+    d = directory or BASELINES_DIR
+    if not d.exists():
+        return []
+
+    results = []
+    for meta_path in sorted(d.glob("*.json")):
+        try:
+            with open(meta_path, "r", encoding="utf-8") as f:
+                meta = json.load(f)
+            img_path = d / f"{meta['name']}.png"
+            meta["exists"] = img_path.exists()
+            results.append(meta)
+        except (json.JSONDecodeError, KeyError):
+            continue
+    return results
+
+
+def delete_baseline(name: str, directory: Optional[Path] = None) -> bool:
+    """Delete a baseline image and its metadata."""
+    d = directory or BASELINES_DIR
+    img_path = d / f"{name}.png"
+    meta_path = d / f"{name}.json"
+    deleted = False
+    if img_path.exists():
+        img_path.unlink()
+        deleted = True
+    if meta_path.exists():
+        meta_path.unlink()
+        deleted = True
+    return deleted
+
+
+def compare_images(
+    baseline_path: str | Path,
+    current_path: str | Path,
+    name: str = "comparison",
+    threshold: float = 0.95,
+    diff_output: Optional[str | Path] = None,
+    highlight_color: tuple = (255, 0, 0),
+) -> ComparisonResult:
+    """Compare two images and generate a diff.
+
+    Args:
+        baseline_path: Path to the baseline image.
+        current_path: Path to the current screenshot.
+        name: Name for this comparison.
+        threshold: Similarity threshold (0.0-1.0). Above = pass, below = fail.
+        diff_output: Path to save the diff image. None = don't save.
+        highlight_color: RGB color for highlighting differences.
+
+    Returns:
+        ComparisonResult with similarity score and diff information.
+    """
+    _require_pil()
+
+    baseline = Image.open(baseline_path).convert("RGB")
+    current = Image.open(current_path).convert("RGB")
+
+    dimensions_match = baseline.size == current.size
+
+    if not dimensions_match:
+        # Resize current to baseline size for comparison
+        current_resized = current.resize(baseline.size, Image.LANCZOS)
+    else:
+        current_resized = current
+
+    # Pixel-level diff
+    diff = ImageChops.difference(baseline, current_resized)
+    diff_data = diff.get_flattened_data() if hasattr(diff, 'get_flattened_data') else diff.getdata()
+
+    # Count differing pixels (with tolerance for anti-aliasing)
+    tolerance = 10  # per-channel tolerance
+    diff_pixels = 0
+    for pixel in diff_data:
+        if any(c > tolerance for c in pixel):
+            diff_pixels += 1
+
+    total_pixels = baseline.size[0] * baseline.size[1]
+    similarity = 1.0 - (diff_pixels / total_pixels) if total_pixels > 0 else 1.0
+
+    # Generate diff image
+    diff_path = None
+    if diff_output:
+        diff_img = _generate_diff_image(baseline, current_resized, tolerance, highlight_color)
+        diff_path_obj = Path(diff_output)
+        _ensure_dir(diff_path_obj.parent)
+        diff_img.save(diff_path_obj, "PNG")
+        diff_path = str(diff_path_obj)
+
+    return ComparisonResult(
+        name=name,
+        match=similarity >= threshold,
+        similarity=similarity,
+        threshold=threshold,
+        baseline_path=str(baseline_path),
+        current_path=str(current_path),
+        diff_path=diff_path,
+        diff_pixels=diff_pixels,
+        total_pixels=total_pixels,
+        dimensions_match=dimensions_match,
+        baseline_size=baseline.size,
+        current_size=current.size,
+    )
+
+
+def compare_with_baseline(
+    current_path: str | Path,
+    name: str,
+    threshold: float = 0.95,
+    baselines_dir: Optional[Path] = None,
+    reports_dir: Optional[Path] = None,
+) -> ComparisonResult:
+    """Compare a screenshot against its saved baseline.
+
+    Args:
+        current_path: Path to the current screenshot.
+        name: Baseline name to compare against.
+        threshold: Similarity threshold (0.0-1.0).
+        baselines_dir: Custom baselines directory.
+        reports_dir: Custom reports directory for diff images.
+
+    Returns:
+        ComparisonResult with match/similarity data.
+
+    Raises:
+        FileNotFoundError: If baseline doesn't exist.
+    """
+    bd = baselines_dir or BASELINES_DIR
+    baseline_path = bd / f"{name}.png"
+    if not baseline_path.exists():
+        raise FileNotFoundError(f"Baseline not found: {name}")
+
+    rd = _ensure_dir(reports_dir or REPORTS_DIR)
+    diff_output = rd / f"{name}_diff.png"
+
+    return compare_images(
+        baseline_path=baseline_path,
+        current_path=current_path,
+        name=name,
+        threshold=threshold,
+        diff_output=diff_output,
+    )
+
+
+def _generate_diff_image(
+    baseline: "Image.Image",
+    current: "Image.Image",
+    tolerance: int = 10,
+    highlight_color: tuple = (255, 0, 0),
+) -> "Image.Image":
+    """Generate a side-by-side diff image with differences highlighted.
+
+    Layout: [baseline | diff overlay | current]
+    """
+    w, h = baseline.size
+    canvas = Image.new("RGB", (w * 3, h), (255, 255, 255))
+
+    # Left: baseline
+    canvas.paste(baseline, (0, 0))
+
+    # Middle: diff overlay on dimmed baseline
+    overlay = baseline.copy()
+    overlay = Image.blend(overlay, Image.new("RGB", (w, h), (200, 200, 200)), 0.5)
+    diff = ImageChops.difference(baseline, current)
+    draw = ImageDraw.Draw(overlay)
+
+    diff_data = diff.get_flattened_data() if hasattr(diff, 'get_flattened_data') else diff.getdata()
+    for i, pixel in enumerate(diff_data):
+        if any(c > tolerance for c in pixel):
+            x = i % w
+            y = i // w
+            draw.point((x, y), fill=highlight_color)
+
+    canvas.paste(overlay, (w, 0))
+
+    # Right: current
+    canvas.paste(current, (w * 2, 0))
+
+    return canvas
+
+
+def generate_html_report(report: VisualReport, output_path: str | Path) -> Path:
+    """Generate an HTML report for visual regression results.
+
+    Args:
+        report: VisualReport with comparison results.
+        output_path: Path to save the HTML file.
+
+    Returns:
+        Path to the generated HTML report.
+    """
+    path = Path(output_path)
+    _ensure_dir(path.parent)
+
+    status_color = "#2ecc71" if report.all_passed else "#e74c3c"
+    status_text = "PASSED" if report.all_passed else "FAILED"
+
+    rows = []
+    for r in report.results:
+        color = "#2ecc71" if r.match else "#e74c3c"
+        status = "PASS" if r.match else "FAIL"
+        diff_link = f'<a href="{r.diff_path}">View Diff</a>' if r.diff_path else "N/A"
+        rows.append(f"""
+        <tr>
+            <td>{r.name}</td>
+            <td style="color:{color};font-weight:bold">{status}</td>
+            <td>{r.similarity:.1%}</td>
+            <td>{r.threshold:.1%}</td>
+            <td>{r.diff_pixels:,} / {r.total_pixels:,} ({r.to_dict()['diff_percentage']:.2f}%)</td>
+            <td>{'Yes' if r.dimensions_match else f'No ({r.baseline_size} vs {r.current_size})'}</td>
+            <td>{diff_link}</td>
+        </tr>""")
+
+    html = f"""<!DOCTYPE html>
+<html>
+<head>
+    <title>Visual Regression Report — {report.name}</title>
+    <style>
+        body {{ font-family: -apple-system, BlinkMacSystemFont, sans-serif; margin: 2em; }}
+        h1 {{ color: #333; }}
+        .status {{ display: inline-block; padding: 4px 12px; border-radius: 4px;
+                   color: white; background: {status_color}; font-weight: bold; }}
+        table {{ border-collapse: collapse; width: 100%; margin-top: 1em; }}
+        th, td {{ border: 1px solid #ddd; padding: 8px 12px; text-align: left; }}
+        th {{ background: #f5f5f5; }}
+        tr:hover {{ background: #f9f9f9; }}
+        .summary {{ margin: 1em 0; color: #666; }}
+    </style>
+</head>
+<body>
+    <h1>Visual Regression Report</h1>
+    <p><strong>Name:</strong> {report.name}</p>
+    <p><strong>Date:</strong> {report.created_at}</p>
+    <p><strong>Status:</strong> <span class="status">{status_text}</span></p>
+    <p class="summary">{report.passed} passed, {report.failed} failed out of {len(report.results)} comparisons</p>
+    <table>
+        <tr>
+            <th>Name</th><th>Status</th><th>Similarity</th><th>Threshold</th>
+            <th>Diff Pixels</th><th>Dimensions</th><th>Diff Image</th>
+        </tr>
+        {''.join(rows)}
+    </table>
+</body>
+</html>"""
+
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(html)
+    return path
+
+
+def compute_ssim(
+    img1: "Image.Image",
+    img2: "Image.Image",
+    window_size: int = 8,
+) -> float:
+    """Compute Structural Similarity Index (SSIM) between two images.
+
+    Simplified SSIM implementation using only Pillow (no scipy/numpy dependency).
+    Computes mean SSIM over non-overlapping blocks.
+
+    Args:
+        img1: First image (PIL Image, RGB).
+        img2: Second image (PIL Image, RGB, same size as img1).
+        window_size: Block size for local SSIM computation.
+
+    Returns:
+        SSIM value between -1.0 and 1.0 (1.0 = identical).
+    """
+    if img1.size != img2.size:
+        img2 = img2.resize(img1.size, Image.LANCZOS)
+
+    # Convert to grayscale
+    g1 = img1.convert("L")
+    g2 = img2.convert("L")
+    w, h = g1.size
+    _gd = lambda img: img.get_flattened_data() if hasattr(img, 'get_flattened_data') else img.getdata()  # noqa: E731
+    d1 = list(_gd(g1))
+    d2 = list(_gd(g2))
+
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+
+    ssim_sum = 0.0
+    count = 0
+
+    for by in range(0, h - window_size + 1, window_size):
+        for bx in range(0, w - window_size + 1, window_size):
+            block1 = []
+            block2 = []
+            for dy in range(window_size):
+                for dx in range(window_size):
+                    idx = (by + dy) * w + (bx + dx)
+                    block1.append(d1[idx])
+                    block2.append(d2[idx])
+
+            n = len(block1)
+            mu1 = sum(block1) / n
+            mu2 = sum(block2) / n
+            var1 = sum((x - mu1) ** 2 for x in block1) / n
+            var2 = sum((x - mu2) ** 2 for x in block2) / n
+            cov = sum((block1[i] - mu1) * (block2[i] - mu2) for i in range(n)) / n
+
+            num = (2 * mu1 * mu2 + C1) * (2 * cov + C2)
+            den = (mu1 ** 2 + mu2 ** 2 + C1) * (var1 + var2 + C2)
+            ssim_sum += num / den if den != 0 else 1.0
+            count += 1
+
+    return ssim_sum / count if count > 0 else 1.0

--- a/tests/test_visual.py
+++ b/tests/test_visual.py
@@ -1,0 +1,296 @@
+"""Tests for visual regression testing engine and CLI."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+try:
+    from PIL import Image
+    _HAS_PIL = True
+except ImportError:
+    _HAS_PIL = False
+
+from naturo.cli import main
+from naturo import visual as visual_mod
+
+
+pytestmark = pytest.mark.skipif(not _HAS_PIL, reason="Pillow not installed")
+
+
+@pytest.fixture()
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture()
+def tmp_dirs(tmp_path):
+    """Patch baseline and report dirs."""
+    bd = tmp_path / "baselines"
+    rd = tmp_path / "reports"
+    bd.mkdir()
+    rd.mkdir()
+    with patch.object(visual_mod, "BASELINES_DIR", bd), \
+         patch.object(visual_mod, "REPORTS_DIR", rd):
+        yield bd, rd
+
+
+@pytest.fixture()
+def red_image(tmp_path) -> Path:
+    """Create a solid red 100x100 PNG."""
+    p = tmp_path / "red.png"
+    Image.new("RGB", (100, 100), (255, 0, 0)).save(p)
+    return p
+
+
+@pytest.fixture()
+def blue_image(tmp_path) -> Path:
+    """Create a solid blue 100x100 PNG."""
+    p = tmp_path / "blue.png"
+    Image.new("RGB", (100, 100), (0, 0, 255)).save(p)
+    return p
+
+
+@pytest.fixture()
+def red_copy(tmp_path) -> Path:
+    """Create another solid red 100x100 PNG (identical to red_image)."""
+    p = tmp_path / "red_copy.png"
+    Image.new("RGB", (100, 100), (255, 0, 0)).save(p)
+    return p
+
+
+@pytest.fixture()
+def slightly_different(tmp_path) -> Path:
+    """Create a mostly-red image with a few different pixels."""
+    img = Image.new("RGB", (100, 100), (255, 0, 0))
+    for x in range(5):
+        for y in range(5):
+            img.putpixel((x, y), (0, 255, 0))  # 25 green pixels out of 10000
+    p = tmp_path / "slight.png"
+    img.save(p)
+    return p
+
+
+# ── Engine tests ─────────────────────────────────────────────────────────────
+
+
+class TestSaveBaseline:
+    def test_save_creates_files(self, tmp_dirs, red_image):
+        bd, _ = tmp_dirs
+        path = visual_mod.save_baseline(red_image, "test_screen", bd)
+        assert path.exists()
+        assert (bd / "test_screen.png").exists()
+        assert (bd / "test_screen.json").exists()
+
+    def test_save_metadata(self, tmp_dirs, red_image):
+        bd, _ = tmp_dirs
+        visual_mod.save_baseline(red_image, "test_screen", bd)
+        meta = json.loads((bd / "test_screen.json").read_text())
+        assert meta["name"] == "test_screen"
+        assert meta["size"] == [100, 100]
+
+    def test_save_not_found(self, tmp_dirs):
+        bd, _ = tmp_dirs
+        with pytest.raises(FileNotFoundError):
+            visual_mod.save_baseline("/nonexistent.png", "test", bd)
+
+
+class TestListBaselines:
+    def test_list_empty(self, tmp_dirs):
+        bd, _ = tmp_dirs
+        assert visual_mod.list_baselines(bd) == []
+
+    def test_list_returns_saved(self, tmp_dirs, red_image):
+        bd, _ = tmp_dirs
+        visual_mod.save_baseline(red_image, "screen1", bd)
+        visual_mod.save_baseline(red_image, "screen2", bd)
+        result = visual_mod.list_baselines(bd)
+        assert len(result) == 2
+        names = {r["name"] for r in result}
+        assert names == {"screen1", "screen2"}
+
+
+class TestDeleteBaseline:
+    def test_delete_existing(self, tmp_dirs, red_image):
+        bd, _ = tmp_dirs
+        visual_mod.save_baseline(red_image, "test", bd)
+        assert visual_mod.delete_baseline("test", bd) is True
+        assert not (bd / "test.png").exists()
+        assert not (bd / "test.json").exists()
+
+    def test_delete_nonexistent(self, tmp_dirs):
+        bd, _ = tmp_dirs
+        assert visual_mod.delete_baseline("nope", bd) is False
+
+
+class TestCompareImages:
+    def test_identical_images(self, red_image, red_copy):
+        result = visual_mod.compare_images(red_image, red_copy, threshold=0.95)
+        assert result.match is True
+        assert result.similarity == 1.0
+        assert result.diff_pixels == 0
+
+    def test_completely_different(self, red_image, blue_image):
+        result = visual_mod.compare_images(red_image, blue_image, threshold=0.95)
+        assert result.match is False
+        assert result.similarity < 0.1
+        assert result.diff_pixels == 10000
+
+    def test_slightly_different_passes(self, red_image, slightly_different):
+        result = visual_mod.compare_images(red_image, slightly_different, threshold=0.95)
+        assert result.match is True  # 25/10000 = 0.25% diff
+        assert result.similarity > 0.99
+
+    def test_diff_image_generated(self, red_image, blue_image, tmp_path):
+        diff_out = tmp_path / "diff.png"
+        result = visual_mod.compare_images(
+            red_image, blue_image, diff_output=str(diff_out),
+        )
+        assert diff_out.exists()
+        assert result.diff_path == str(diff_out)
+        # Diff image is 3x wide (side-by-side)
+        diff_img = Image.open(diff_out)
+        assert diff_img.size == (300, 100)
+
+    def test_different_dimensions(self, red_image, tmp_path):
+        small = tmp_path / "small.png"
+        Image.new("RGB", (50, 50), (255, 0, 0)).save(small)
+        result = visual_mod.compare_images(red_image, small)
+        assert result.dimensions_match is False
+        assert result.match is True  # same color, just resized
+
+    def test_threshold_configurable(self, red_image, slightly_different):
+        # Very strict threshold — 25/10000 diff = 99.75% similar, fails at 99.9%
+        result = visual_mod.compare_images(
+            red_image, slightly_different, threshold=0.999,
+        )
+        assert result.match is False
+        assert result.similarity > 0.99
+        # Relaxed threshold — passes
+        result2 = visual_mod.compare_images(
+            red_image, slightly_different, threshold=0.99,
+        )
+        assert result2.match is True
+
+
+class TestCompareWithBaseline:
+    def test_compare_against_baseline(self, tmp_dirs, red_image, red_copy):
+        bd, rd = tmp_dirs
+        visual_mod.save_baseline(red_image, "test", bd)
+        result = visual_mod.compare_with_baseline(
+            red_copy, "test", baselines_dir=bd, reports_dir=rd,
+        )
+        assert result.match is True
+
+    def test_baseline_not_found(self, tmp_dirs, red_image):
+        bd, rd = tmp_dirs
+        with pytest.raises(FileNotFoundError):
+            visual_mod.compare_with_baseline(
+                red_image, "nonexistent", baselines_dir=bd, reports_dir=rd,
+            )
+
+
+class TestSSIM:
+    def test_identical_ssim(self, red_image, red_copy):
+        img1 = Image.open(red_image)
+        img2 = Image.open(red_copy)
+        ssim = visual_mod.compute_ssim(img1, img2)
+        assert ssim > 0.99
+
+    def test_different_ssim(self, red_image, blue_image):
+        img1 = Image.open(red_image)
+        img2 = Image.open(blue_image)
+        ssim = visual_mod.compute_ssim(img1, img2)
+        assert ssim < 0.99  # different images have lower SSIM
+
+
+class TestHTMLReport:
+    def test_generate_report(self, tmp_dirs, red_image, blue_image):
+        bd, rd = tmp_dirs
+        result = visual_mod.compare_images(red_image, blue_image, name="test")
+        report = visual_mod.VisualReport(
+            name="Test Report",
+            created_at="2026-04-01T12:00:00",
+        )
+        report.add_result(result)
+        html_path = visual_mod.generate_html_report(report, rd / "report.html")
+        assert html_path.exists()
+        content = html_path.read_text()
+        assert "Test Report" in content
+        assert "FAILED" in content
+        assert "test" in content
+
+
+# ── CLI tests ────────────────────────────────────────────────────────────────
+
+
+class TestVisualCLI:
+    def test_baseline_command(self, runner, tmp_dirs, red_image):
+        result = runner.invoke(main, [
+            "visual", "baseline", "screen1", "--from", str(red_image),
+        ])
+        assert result.exit_code == 0
+        assert "Baseline saved" in result.output
+
+    def test_list_command(self, runner, tmp_dirs, red_image):
+        runner.invoke(main, ["visual", "baseline", "s1", "--from", str(red_image)])
+        result = runner.invoke(main, ["visual", "list"])
+        assert result.exit_code == 0
+        assert "s1" in result.output
+
+    def test_list_empty(self, runner, tmp_dirs):
+        result = runner.invoke(main, ["visual", "list"])
+        assert result.exit_code == 0
+        assert "No baselines" in result.output
+
+    def test_compare_pass(self, runner, tmp_dirs, red_image, red_copy):
+        runner.invoke(main, ["visual", "baseline", "s1", "--from", str(red_image)])
+        result = runner.invoke(main, [
+            "visual", "compare", "s1", "--current", str(red_copy),
+        ])
+        assert result.exit_code == 0
+        assert "PASS" in result.output
+
+    def test_compare_fail(self, runner, tmp_dirs, red_image, blue_image):
+        runner.invoke(main, ["visual", "baseline", "s1", "--from", str(red_image)])
+        result = runner.invoke(main, [
+            "visual", "compare", "s1", "--current", str(blue_image),
+        ])
+        assert result.exit_code != 0
+        assert "FAIL" in result.output
+
+    def test_compare_json(self, runner, tmp_dirs, red_image, red_copy):
+        runner.invoke(main, ["visual", "baseline", "s1", "--from", str(red_image)])
+        result = runner.invoke(main, [
+            "visual", "compare", "s1", "--current", str(red_copy), "--json",
+        ])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["match"] is True
+        assert data["similarity"] == 1.0
+
+    def test_diff_command(self, runner, red_image, blue_image, tmp_path):
+        diff_out = str(tmp_path / "diff.png")
+        result = runner.invoke(main, [
+            "visual", "diff", str(red_image), str(blue_image), "-o", diff_out,
+        ])
+        assert result.exit_code == 0
+        assert "DIFFER" in result.output
+        assert Path(diff_out).exists()
+
+    def test_delete_command(self, runner, tmp_dirs, red_image):
+        runner.invoke(main, ["visual", "baseline", "s1", "--from", str(red_image)])
+        result = runner.invoke(main, ["visual", "delete", "s1", "--force"])
+        assert result.exit_code == 0
+        assert "Deleted" in result.output
+
+    def test_help(self, runner):
+        result = runner.invoke(main, ["visual", "--help"])
+        assert result.exit_code == 0
+        assert "baseline" in result.output
+        assert "compare" in result.output
+        assert "diff" in result.output
+        assert "report" in result.output


### PR DESCRIPTION
## Changes
- New `naturo/visual.py` engine: pixel diff, SSIM, diff image generation, HTML reports
- New `naturo visual` CLI group: baseline, compare, diff, list, delete, report
- Pure Pillow implementation (no scipy/numpy/opencv dependency)
- Graceful import error when Pillow not installed

## Testing
27 new tests — all pass, ruff clean.

**[Orc-Mycelium]**