### PR TITLE
fix(ci): add CodeQL gate job to satisfy branch protection required check

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,3 +36,20 @@ jobs:
         uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"
+
+  # Gate job whose name matches the branch-protection required check "CodeQL".
+  # Without this, the matrix jobs report as "Analyze (python)" / "Analyze (c-cpp)"
+  # which don't satisfy the required status check.
+  codeql-gate:
+    name: CodeQL
+    runs-on: ubuntu-latest
+    needs: [analyze]
+    if: ${{ always() }}
+    steps:
+      - name: Check analysis results
+        run: |
+          if [[ "${{ needs.analyze.result }}" != "success" ]]; then
+            echo "::error::CodeQL analysis did not succeed (${{ needs.analyze.result }})"
+            exit 1
+          fi
+          echo "✅ CodeQL analysis passed"


### PR DESCRIPTION
## Summary
- Branch protection on `develop` requires a status check named `"CodeQL"`, but `codeql.yml` only produces `"Analyze (python)"` and `"Analyze (c-cpp)"` — the required check always fails
- Added a `codeql-gate` job (named `CodeQL`) that aggregates the matrix results, matching the branch protection expectation
- This fixes the CodeQL FAILURE on PRs #793, #797, #802

## Test plan
- [ ] Verify the new `CodeQL` check appears and passes on this PR
- [ ] Verify existing PRs pass the CodeQL check after rebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)