### PR TITLE
feat: add browser download --dir/--wait for file downloads (fixes #759)

### DIFF
--- a/naturo/browser/_download.py
+++ b/naturo/browser/_download.py
@@ -1,0 +1,157 @@
+"""File download management for browser automation.
+
+Configures Chrome to download files to a specific directory and
+provides a polling-based mechanism to wait for downloads to complete.
+
+Usage (programmatic)::
+
+    from naturo.browser import BrowserPage
+    from naturo.browser._download import set_download_dir, wait_for_download
+
+    page = BrowserPage(port=9222)
+    set_download_dir(page, "/tmp/downloads")
+    page.find("a.download-link").click()
+    path = wait_for_download("/tmp/downloads", timeout=60)
+    print(f"Downloaded: {path}")
+
+Usage (CLI)::
+
+    naturo browser download --dir /tmp/downloads
+    naturo browser download --dir /tmp/downloads --wait --timeout 60
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+logger = logging.getLogger(__name__)
+
+# Chrome uses these extensions for partial downloads
+_PARTIAL_EXTENSIONS = frozenset({".crdownload", ".tmp", ".download", ".part"})
+
+
+def set_download_dir(page, directory: str) -> None:
+    """Configure the browser to save downloads to a specific directory.
+
+    Uses ``Browser.setDownloadBehavior`` CDP command to tell Chrome
+    where to save files and to allow downloads without prompts.
+
+    Args:
+        page: A :class:`~naturo.browser.BrowserPage` instance.
+        directory: Absolute path to the download directory.
+
+    Raises:
+        ValueError: If directory does not exist.
+        CDPError: If the CDP command fails.
+    """
+    abs_dir = os.path.abspath(directory)
+    if not os.path.isdir(abs_dir):
+        raise ValueError(f"Download directory does not exist: {abs_dir}")
+
+    page._cdp.send(
+        "Browser.setDownloadBehavior",
+        {
+            "behavior": "allow",
+            "downloadPath": abs_dir,
+        },
+    )
+    logger.info("Download directory set to: %s", abs_dir)
+
+
+def wait_for_download(
+    directory: str,
+    timeout: float = 60.0,
+    poll_interval: float = 0.5,
+) -> str:
+    """Wait for a file download to complete in the given directory.
+
+    Monitors the directory for new files and waits until no partial
+    download files (``.crdownload``, ``.tmp``, ``.part``) remain.
+    Returns the path to the most recently completed download.
+
+    Args:
+        directory: Directory where Chrome saves downloads.
+        timeout: Maximum seconds to wait (default 60).
+        poll_interval: Seconds between directory polls (default 0.5).
+
+    Returns:
+        Absolute path to the downloaded file.
+
+    Raises:
+        TimeoutError: If download does not complete within timeout.
+        ValueError: If directory does not exist.
+    """
+    abs_dir = os.path.abspath(directory)
+    if not os.path.isdir(abs_dir):
+        raise ValueError(f"Download directory does not exist: {abs_dir}")
+
+    # Snapshot existing files to detect new ones
+    before = _list_files(abs_dir)
+    deadline = time.monotonic() + timeout
+
+    # Phase 1: wait for a new file to appear (partial or complete)
+    while time.monotonic() < deadline:
+        current = _list_files(abs_dir)
+        new_files = current - before
+        if new_files:
+            break
+        time.sleep(poll_interval)
+    else:
+        raise TimeoutError(
+            f"No new file appeared in {abs_dir} within {timeout}s"
+        )
+
+    # Phase 2: wait for partial downloads to finish
+    while time.monotonic() < deadline:
+        current = _list_files(abs_dir)
+        partials = {f for f in current if _is_partial(f)}
+        if not partials:
+            # Find the newest completed file
+            completed = current - before
+            # Remove partials from completed set
+            completed = {f for f in completed if not _is_partial(f)}
+            if completed:
+                newest = max(
+                    completed,
+                    key=lambda f: os.path.getmtime(os.path.join(abs_dir, f)),
+                )
+                result = os.path.join(abs_dir, newest)
+                logger.info("Download complete: %s", result)
+                return result
+        time.sleep(poll_interval)
+
+    raise TimeoutError(
+        f"Download did not complete in {abs_dir} within {timeout}s"
+    )
+
+
+def _list_files(directory: str) -> set:
+    """List files (not directories) in a directory.
+
+    Args:
+        directory: Path to scan.
+
+    Returns:
+        Set of filenames.
+    """
+    try:
+        return {
+            f for f in os.listdir(directory)
+            if os.path.isfile(os.path.join(directory, f))
+        }
+    except OSError:
+        return set()
+
+
+def _is_partial(filename: str) -> bool:
+    """Check if a filename looks like a partial download.
+
+    Args:
+        filename: The filename to check.
+
+    Returns:
+        True if the file has a partial-download extension.
+    """
+    _, ext = os.path.splitext(filename)
+    return ext.lower() in _PARTIAL_EXTENSIONS

--- a/naturo/cli/browser_cmd.py
+++ b/naturo/cli/browser_cmd.py
@@ -974,6 +974,97 @@ def profiles_cmd(user_data_dir: Optional[str], json_output: bool) -> None:
             click.echo(f"  {p['name']:<20} [{p['directory']}]  {p['path']}")
 
 
+# ── Download management (#759) ───────────────────────────────────────────────
+
+
+@browser.command("download")
+@click.option("--dir", "directory", required=True,
+              help="Directory to save downloaded files to")
+@click.option("--wait", "wait", is_flag=True,
+              help="Wait for a download to complete after setting the directory")
+@click.option("--timeout", type=float, default=60.0,
+              help="Seconds to wait for download completion (default: 60)")
+@click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
+@click.pass_context
+def download_cmd(
+    ctx: click.Context,
+    directory: str,
+    wait: bool,
+    timeout: float,
+    json_output: bool,
+) -> None:
+    """Configure file downloads and optionally wait for completion.
+
+    Sets the browser download directory so files are saved without
+    prompts. With ``--wait``, blocks until a new file finishes
+    downloading (partial files like .crdownload are detected).
+
+    \b
+    Examples:
+        naturo browser download --dir /tmp/downloads
+        naturo browser download --dir /tmp/downloads --wait
+        naturo browser download --dir ./out --wait --timeout 120 --json
+    """
+    import os
+
+    from naturo.browser._download import set_download_dir, wait_for_download
+
+    # Ensure directory exists
+    abs_dir = os.path.abspath(directory)
+    os.makedirs(abs_dir, exist_ok=True)
+
+    page = _get_page(ctx)
+    try:
+        set_download_dir(page, abs_dir)
+
+        if not wait:
+            if json_output:
+                click.echo(json_module.dumps({
+                    "success": True,
+                    "download_dir": abs_dir,
+                }))
+            else:
+                click.echo(f"Download directory set to: {abs_dir}")
+            return
+
+        # Wait mode: block until a download completes
+        if not json_output:
+            click.echo(f"Waiting for download in {abs_dir} (timeout: {timeout}s)...")
+
+        try:
+            path = wait_for_download(abs_dir, timeout=timeout)
+        except TimeoutError as exc:
+            if json_output:
+                click.echo(json_module.dumps({
+                    "success": False,
+                    "error": str(exc),
+                    "download_dir": abs_dir,
+                }))
+            else:
+                click.echo(f"Error: {exc}", err=True)
+            raise SystemExit(1)
+
+        if json_output:
+            click.echo(json_module.dumps({
+                "success": True,
+                "download_dir": abs_dir,
+                "file": path,
+                "filename": os.path.basename(path),
+            }))
+        else:
+            click.echo(f"Downloaded: {path}")
+    except SystemExit:
+        raise
+    except Exception as exc:
+        if json_output:
+            click.echo(json_module.dumps({"success": False, "error": str(exc)}))
+        else:
+            click.echo(f"Error: {exc}", err=True)
+        raise SystemExit(1)
+    finally:
+        page.close()
+
+
 # ── Stealth / anti-detection (#760) ──────────────────────────────────────────
 
 

--- a/tests/test_browser_download.py
+++ b/tests/test_browser_download.py
@@ -1,0 +1,284 @@
+"""Tests for naturo.browser._download — file download management."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from naturo.browser._download import (
+    set_download_dir,
+    wait_for_download,
+    _is_partial,
+    _list_files,
+)
+from naturo.cli.browser_cmd import browser
+
+
+# ---------------------------------------------------------------------------
+# set_download_dir
+# ---------------------------------------------------------------------------
+
+
+class TestSetDownloadDir:
+    """Test download directory configuration."""
+
+    def test_sets_download_behavior(self, tmp_path):
+        """Sends Browser.setDownloadBehavior with correct path."""
+        mock_page = MagicMock()
+        mock_page._cdp = MagicMock()
+
+        set_download_dir(mock_page, str(tmp_path))
+
+        mock_page._cdp.send.assert_called_once_with(
+            "Browser.setDownloadBehavior",
+            {
+                "behavior": "allow",
+                "downloadPath": str(tmp_path),
+            },
+        )
+
+    def test_rejects_nonexistent_directory(self):
+        """Raises ValueError for missing directory."""
+        mock_page = MagicMock()
+        with pytest.raises(ValueError, match="does not exist"):
+            set_download_dir(mock_page, "/nonexistent/path/xyz")
+
+    def test_resolves_relative_path(self, tmp_path, monkeypatch):
+        """Resolves relative paths to absolute."""
+        mock_page = MagicMock()
+        mock_page._cdp = MagicMock()
+        monkeypatch.chdir(tmp_path)
+        subdir = tmp_path / "downloads"
+        subdir.mkdir()
+
+        set_download_dir(mock_page, "downloads")
+
+        call_args = mock_page._cdp.send.call_args[0]
+        assert os.path.isabs(call_args[1]["downloadPath"])
+
+
+# ---------------------------------------------------------------------------
+# wait_for_download
+# ---------------------------------------------------------------------------
+
+
+class TestWaitForDownload:
+    """Test download wait logic."""
+
+    def test_detects_new_file(self, tmp_path):
+        """Returns path when a new file appears."""
+        # Simulate file appearing after short delay
+        def create_file():
+            time.sleep(0.2)
+            (tmp_path / "report.pdf").write_bytes(b"PDF content")
+
+        import threading
+        t = threading.Thread(target=create_file)
+        t.start()
+
+        result = wait_for_download(str(tmp_path), timeout=5, poll_interval=0.1)
+        t.join()
+
+        assert result.endswith("report.pdf")
+        assert os.path.isabs(result)
+
+    def test_waits_for_partial_to_complete(self, tmp_path):
+        """Waits for .crdownload file to become the final file."""
+        # Create partial file first
+        partial = tmp_path / "file.zip.crdownload"
+        partial.write_bytes(b"partial")
+
+        def finish_download():
+            time.sleep(0.3)
+            partial.unlink()
+            (tmp_path / "file.zip").write_bytes(b"complete")
+
+        import threading
+        t = threading.Thread(target=finish_download)
+        t.start()
+
+        result = wait_for_download(str(tmp_path), timeout=5, poll_interval=0.1)
+        t.join()
+
+        assert result.endswith("file.zip")
+
+    def test_timeout_no_new_file(self, tmp_path):
+        """Raises TimeoutError when no file appears."""
+        with pytest.raises(TimeoutError, match="No new file appeared"):
+            wait_for_download(str(tmp_path), timeout=0.3, poll_interval=0.1)
+
+    def test_timeout_stuck_partial(self, tmp_path):
+        """Raises TimeoutError when partial never completes."""
+        # Create a partial that never finishes
+        def create_partial():
+            time.sleep(0.1)
+            (tmp_path / "stuck.zip.crdownload").write_bytes(b"partial")
+
+        import threading
+        t = threading.Thread(target=create_partial)
+        t.start()
+
+        with pytest.raises(TimeoutError, match="did not complete"):
+            wait_for_download(str(tmp_path), timeout=0.5, poll_interval=0.1)
+        t.join()
+
+    def test_rejects_nonexistent_directory(self):
+        """Raises ValueError for missing directory."""
+        with pytest.raises(ValueError, match="does not exist"):
+            wait_for_download("/nonexistent/xyz", timeout=1)
+
+    def test_ignores_preexisting_files(self, tmp_path):
+        """Does not return files that existed before the call."""
+        (tmp_path / "old.txt").write_bytes(b"existing")
+
+        def create_new():
+            time.sleep(0.2)
+            (tmp_path / "new.txt").write_bytes(b"new")
+
+        import threading
+        t = threading.Thread(target=create_new)
+        t.start()
+
+        result = wait_for_download(str(tmp_path), timeout=5, poll_interval=0.1)
+        t.join()
+
+        assert result.endswith("new.txt")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class TestHelpers:
+    """Test helper functions."""
+
+    def test_is_partial_crdownload(self):
+        assert _is_partial("file.zip.crdownload") is True
+
+    def test_is_partial_tmp(self):
+        assert _is_partial("data.tmp") is True
+
+    def test_is_partial_part(self):
+        assert _is_partial("file.part") is True
+
+    def test_is_not_partial(self):
+        assert _is_partial("report.pdf") is False
+        assert _is_partial("data.csv") is False
+
+    def test_list_files_empty(self, tmp_path):
+        assert _list_files(str(tmp_path)) == set()
+
+    def test_list_files_ignores_dirs(self, tmp_path):
+        (tmp_path / "subdir").mkdir()
+        (tmp_path / "file.txt").write_bytes(b"data")
+        result = _list_files(str(tmp_path))
+        assert result == {"file.txt"}
+
+    def test_list_files_nonexistent(self):
+        assert _list_files("/nonexistent/xyz") == set()
+
+
+# ---------------------------------------------------------------------------
+# CLI command
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadCLI:
+    """Test browser download CLI command."""
+
+    @pytest.fixture
+    def runner(self):
+        return CliRunner()
+
+    def test_download_set_dir(self, runner, tmp_path):
+        """browser download --dir sets the directory."""
+        mock_page = MagicMock()
+        with patch("naturo.cli.browser_cmd._get_page", return_value=mock_page), \
+             patch("naturo.browser._download.set_download_dir") as mock_set:
+            result = runner.invoke(
+                browser, ["download", "--dir", str(tmp_path)]
+            )
+        assert result.exit_code == 0
+        assert "Download directory set" in result.output
+        mock_set.assert_called_once()
+        mock_page.close.assert_called_once()
+
+    def test_download_set_dir_json(self, runner, tmp_path):
+        """browser download --dir --json outputs JSON."""
+        mock_page = MagicMock()
+        with patch("naturo.cli.browser_cmd._get_page", return_value=mock_page), \
+             patch("naturo.browser._download.set_download_dir"):
+            result = runner.invoke(
+                browser, ["download", "--dir", str(tmp_path), "--json"]
+            )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["success"] is True
+        assert "download_dir" in data
+
+    def test_download_wait_success(self, runner, tmp_path):
+        """browser download --dir --wait reports downloaded file."""
+        mock_page = MagicMock()
+        fake_path = str(tmp_path / "report.pdf")
+        with patch("naturo.cli.browser_cmd._get_page", return_value=mock_page), \
+             patch("naturo.browser._download.set_download_dir"), \
+             patch("naturo.browser._download.wait_for_download", return_value=fake_path):
+            result = runner.invoke(
+                browser, ["download", "--dir", str(tmp_path), "--wait"]
+            )
+        assert result.exit_code == 0
+        assert "report.pdf" in result.output
+
+    def test_download_wait_json(self, runner, tmp_path):
+        """browser download --dir --wait --json returns file info."""
+        mock_page = MagicMock()
+        fake_path = str(tmp_path / "data.csv")
+        with patch("naturo.cli.browser_cmd._get_page", return_value=mock_page), \
+             patch("naturo.browser._download.set_download_dir"), \
+             patch("naturo.browser._download.wait_for_download", return_value=fake_path):
+            result = runner.invoke(
+                browser, ["download", "--dir", str(tmp_path), "--wait", "--json"]
+            )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["success"] is True
+        assert data["filename"] == "data.csv"
+
+    def test_download_wait_timeout(self, runner, tmp_path):
+        """browser download --wait exits 1 on timeout."""
+        mock_page = MagicMock()
+        with patch("naturo.cli.browser_cmd._get_page", return_value=mock_page), \
+             patch("naturo.browser._download.set_download_dir"), \
+             patch("naturo.browser._download.wait_for_download",
+                   side_effect=TimeoutError("No new file")):
+            result = runner.invoke(
+                browser, ["download", "--dir", str(tmp_path), "--wait"]
+            )
+        assert result.exit_code != 0
+
+    def test_download_wait_timeout_json(self, runner, tmp_path):
+        """browser download --wait --json reports timeout in JSON."""
+        mock_page = MagicMock()
+        with patch("naturo.cli.browser_cmd._get_page", return_value=mock_page), \
+             patch("naturo.browser._download.set_download_dir"), \
+             patch("naturo.browser._download.wait_for_download",
+                   side_effect=TimeoutError("No new file")):
+            result = runner.invoke(
+                browser, ["download", "--dir", str(tmp_path), "--wait", "--json"]
+            )
+        assert result.exit_code != 0
+        data = json.loads(result.output)
+        assert data["success"] is False
+
+    def test_download_help(self, runner):
+        """browser download --help shows usage."""
+        result = runner.invoke(browser, ["download", "--help"])
+        assert result.exit_code == 0
+        assert "--dir" in result.output
+        assert "--wait" in result.output


### PR DESCRIPTION
## Summary
- Adds `naturo browser download --dir <path> [--wait] [--timeout]` CLI command
- Adds `naturo/browser/_download.py` with `set_download_dir()` and `wait_for_download()` functions
- Uses CDP `Browser.setDownloadBehavior` to configure download directory
- Polls for `.crdownload`/`.tmp`/`.part` files to detect download completion
- 284-line test suite covering all paths

## Test plan
- [ ] CI passes (unit tests)
- [ ] Integration: `naturo browser download --dir /tmp/test` sets dir without error
- [ ] Integration: `--wait` blocks and returns completed file path

🤖 Generated with [Claude Code](https://claude.com/claude-code)