### PR TITLE
feat: add browser select command and BrowserPage profile integration (#759)

### DIFF
--- a/naturo/browser/_element.py
+++ b/naturo/browser/_element.py
@@ -166,6 +166,41 @@ class BrowserElement:
             cdp.send("Input.dispatchKeyEvent", {"type": "keyUp", "text": char})
         return self
 
+    def select(self, value: str) -> BrowserElement:
+        """Select an option in a ``<select>`` dropdown.
+
+        Sets the value and dispatches ``change`` + ``input`` events so
+        frameworks (React, Vue, etc.) detect the change.
+
+        Args:
+            value: The ``value`` attribute of the ``<option>`` to select.
+
+        Returns:
+            self (for method chaining).
+
+        Raises:
+            RuntimeError: If no matching option is found.
+        """
+        escaped = value.replace("\\", "\\\\").replace("'", "\\'")
+        result = self._call_function(f"""function() {{
+            var opt = Array.from(this.options).find(o => o.value === '{escaped}');
+            if (!opt) {{
+                opt = Array.from(this.options).find(
+                    o => o.textContent.trim() === '{escaped}'
+                );
+            }}
+            if (!opt) return 'NOT_FOUND';
+            this.value = opt.value;
+            this.dispatchEvent(new Event('change', {{bubbles: true}}));
+            this.dispatchEvent(new Event('input', {{bubbles: true}}));
+            return opt.value;
+        }}""")
+        if result == "NOT_FOUND":
+            raise RuntimeError(
+                f"No <option> with value or text '{value}' found in <select>"
+            )
+        return self
+
     def scroll_into_view(self) -> BrowserElement:
         """Scroll this element into the viewport.
 

--- a/naturo/browser/_page.py
+++ b/naturo/browser/_page.py
@@ -39,6 +39,11 @@ class BrowserPage:
         host: CDP host (default ``localhost``).
         tab_index: Which tab to connect to (default 0 = first tab).
         timeout: Default timeout in seconds for operations.
+        profile: Chrome profile name. When provided, automatically
+            launches Chrome with this profile via :func:`launch_chrome`.
+        headless: Run Chrome in headless mode (only when *profile* is set).
+        stealth: Apply anti-detection flags (only when *profile* is set).
+        chrome_path: Explicit Chrome binary path (only when *profile* is set).
 
     Example::
 
@@ -48,6 +53,11 @@ class BrowserPage:
         page.find("button.submit").click()
         print(page.title)
         page.close()
+
+    Auto-launch example::
+
+        page = BrowserPage(profile="xhs-account1")
+        page.navigate("https://www.xiaohongshu.com/explore")
     """
 
     def __init__(
@@ -56,9 +66,31 @@ class BrowserPage:
         host: str = "localhost",
         tab_index: int = 0,
         timeout: float = 30.0,
+        profile: Optional[str] = None,
+        headless: bool = False,
+        stealth: bool = False,
+        chrome_path: Optional[str] = None,
     ) -> None:
-        self._cdp = CDPClient(host=host, port=port, timeout=timeout)
+        self._chrome_process = None
         self._timeout = timeout
+
+        if profile is not None:
+            from naturo.browser._launcher import launch_chrome
+            extra_args = None
+            if stealth:
+                from naturo.browser._stealth import STEALTH_FLAGS
+                extra_args = list(STEALTH_FLAGS)
+            self._chrome_process = launch_chrome(
+                port=port,
+                headless=headless,
+                profile=profile,
+                extra_args=extra_args,
+                chrome_path=chrome_path,
+                timeout=timeout,
+            )
+            port = self._chrome_process.port
+
+        self._cdp = CDPClient(host=host, port=port, timeout=timeout)
         self._connect(tab_index)
 
     def _connect(self, tab_index: int = 0) -> None:
@@ -596,8 +628,11 @@ class BrowserPage:
     # ── Lifecycle ─────────────────────────────────────────────────────────
 
     def close(self) -> None:
-        """Close the CDP connection."""
+        """Close the CDP connection and terminate auto-launched Chrome."""
         self._cdp.close()
+        if self._chrome_process is not None:
+            self._chrome_process.terminate()
+            self._chrome_process = None
 
     # ── Internal ──────────────────────────────────────────────────────────
 

--- a/naturo/cli/browser_cmd.py
+++ b/naturo/cli/browser_cmd.py
@@ -256,6 +256,50 @@ def type_cmd(ctx: click.Context, selector: str, text: str, by: Optional[str],
         page.close()
 
 
+# ── Select ───────────────────────────────────────────────────────────────────
+
+
+@browser.command("select")
+@click.argument("selector")
+@click.argument("value")
+@click.option("--by", type=click.Choice(["css", "xpath", "text"]),
+              default=None, help="Force selector type")
+@click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
+@click.pass_context
+def select_cmd(ctx: click.Context, selector: str, value: str,
+               by: Optional[str], json_output: bool) -> None:
+    """Select an option from a <select> dropdown.
+
+    VALUE matches against option value attributes first, then text content.
+
+    \b
+    Examples:
+        naturo browser select "#country" "US"
+        naturo browser select "select[name=lang]" "English"
+    """
+    if by:
+        selector = f"{by}:{selector}"
+
+    page = _get_page(ctx)
+    try:
+        el = page.find(selector)
+        el.select(value)
+        if json_output:
+            click.echo(json_module.dumps({
+                "status": "ok", "selector": selector, "value": value,
+            }))
+        else:
+            click.echo(f"Selected '{value}' in: {selector}")
+    except RuntimeError as exc:
+        if json_output:
+            click.echo(json_module.dumps({"error": str(exc)}))
+        else:
+            click.echo(f"Error: {exc}", err=True)
+        raise SystemExit(1)
+    finally:
+        page.close()
+
+
 # ── Text / Attr / HTML ────────────────────────────────────────────────────────
 
 

--- a/tests/test_browser_select_profile.py
+++ b/tests/test_browser_select_profile.py
@@ -1,0 +1,191 @@
+"""Tests for browser select command and BrowserPage profile integration."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from naturo.cli.browser_cmd import browser
+
+
+@pytest.fixture()
+def runner():
+    return CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# BrowserElement.select
+# ---------------------------------------------------------------------------
+
+
+class TestBrowserElementSelect:
+    """Tests for the select() method on BrowserElement."""
+
+    def test_select_by_value(self):
+        from naturo.browser._element import BrowserElement
+
+        page = MagicMock()
+        el = BrowserElement(page, "obj123")
+
+        # Mock _call_function to return the selected value
+        el._call_function = MagicMock(return_value="US")
+        result = el.select("US")
+        assert result is el  # chainable
+        el._call_function.assert_called_once()
+        call_js = el._call_function.call_args[0][0]
+        assert "'US'" in call_js
+
+    def test_select_not_found_raises(self):
+        from naturo.browser._element import BrowserElement
+
+        page = MagicMock()
+        el = BrowserElement(page, "obj123")
+        el._call_function = MagicMock(return_value="NOT_FOUND")
+
+        with pytest.raises(RuntimeError, match="No <option>"):
+            el.select("nonexistent")
+
+    def test_select_escapes_quotes(self):
+        from naturo.browser._element import BrowserElement
+
+        page = MagicMock()
+        el = BrowserElement(page, "obj123")
+        el._call_function = MagicMock(return_value="it's")
+
+        el.select("it's")
+        call_js = el._call_function.call_args[0][0]
+        assert "it\\'s" in call_js
+
+
+# ---------------------------------------------------------------------------
+# CLI: browser select
+# ---------------------------------------------------------------------------
+
+
+class TestSelectCli:
+    """Tests for 'naturo browser select' command."""
+
+    @patch("naturo.cli.browser_cmd._get_page")
+    def test_select_basic(self, mock_get_page, runner):
+        mock_page = MagicMock()
+        mock_el = MagicMock()
+        mock_page.find.return_value = mock_el
+        mock_get_page.return_value = mock_page
+
+        result = runner.invoke(browser, ["select", "#country", "US"])
+        assert result.exit_code == 0
+        assert "Selected" in result.output
+        mock_el.select.assert_called_once_with("US")
+
+    @patch("naturo.cli.browser_cmd._get_page")
+    def test_select_json(self, mock_get_page, runner):
+        mock_page = MagicMock()
+        mock_el = MagicMock()
+        mock_page.find.return_value = mock_el
+        mock_get_page.return_value = mock_page
+
+        result = runner.invoke(browser, ["select", "#lang", "en", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["status"] == "ok"
+        assert data["value"] == "en"
+
+    @patch("naturo.cli.browser_cmd._get_page")
+    def test_select_not_found(self, mock_get_page, runner):
+        mock_page = MagicMock()
+        mock_page.find.side_effect = RuntimeError("No element found")
+        mock_get_page.return_value = mock_page
+
+        result = runner.invoke(browser, ["select", "#missing", "val"])
+        assert result.exit_code != 0
+
+    def test_select_help(self, runner):
+        result = runner.invoke(browser, ["select", "--help"])
+        assert result.exit_code == 0
+        assert "--by" in result.output
+        assert "VALUE" in result.output
+
+
+# ---------------------------------------------------------------------------
+# BrowserPage profile integration
+# ---------------------------------------------------------------------------
+
+
+class TestBrowserPageProfile:
+    """Tests for BrowserPage auto-launch via profile parameter."""
+
+    @patch("naturo.browser._page.CDPClient")
+    @patch("naturo.browser._launcher.launch_chrome")
+    def test_profile_launches_chrome(self, mock_launch, mock_cdp_cls):
+        from naturo.browser._page import BrowserPage
+
+        mock_proc = MagicMock()
+        mock_proc.port = 19200
+        mock_launch.return_value = mock_proc
+
+        mock_cdp = MagicMock()
+        mock_cdp.list_tabs.return_value = [{"id": "tab1", "title": "New Tab"}]
+        mock_cdp_cls.return_value = mock_cdp
+
+        page = BrowserPage(profile="test-profile")
+
+        mock_launch.assert_called_once()
+        call_kwargs = mock_launch.call_args[1]
+        assert call_kwargs["profile"] == "test-profile"
+        assert page._chrome_process is mock_proc
+        # CDPClient should connect to the launched port
+        mock_cdp_cls.assert_called_once_with(
+            host="localhost", port=19200, timeout=30.0
+        )
+
+    @patch("naturo.browser._page.CDPClient")
+    @patch("naturo.browser._launcher.launch_chrome")
+    def test_profile_with_stealth(self, mock_launch, mock_cdp_cls):
+        from naturo.browser._page import BrowserPage
+
+        mock_proc = MagicMock()
+        mock_proc.port = 9222
+        mock_launch.return_value = mock_proc
+
+        mock_cdp = MagicMock()
+        mock_cdp.list_tabs.return_value = [{"id": "t1", "title": ""}]
+        mock_cdp_cls.return_value = mock_cdp
+
+        BrowserPage(profile="stealth-test", stealth=True)
+
+        call_kwargs = mock_launch.call_args[1]
+        assert call_kwargs["extra_args"] is not None
+        assert len(call_kwargs["extra_args"]) > 0
+
+    @patch("naturo.browser._page.CDPClient")
+    @patch("naturo.browser._launcher.launch_chrome")
+    def test_close_terminates_chrome(self, mock_launch, mock_cdp_cls):
+        from naturo.browser._page import BrowserPage
+
+        mock_proc = MagicMock()
+        mock_proc.port = 9222
+        mock_launch.return_value = mock_proc
+
+        mock_cdp = MagicMock()
+        mock_cdp.list_tabs.return_value = [{"id": "t1", "title": ""}]
+        mock_cdp_cls.return_value = mock_cdp
+
+        page = BrowserPage(profile="temp")
+        page.close()
+
+        mock_proc.terminate.assert_called_once()
+        assert page._chrome_process is None
+
+    @patch("naturo.browser._page.CDPClient")
+    def test_no_profile_no_launch(self, mock_cdp_cls):
+        from naturo.browser._page import BrowserPage
+
+        mock_cdp = MagicMock()
+        mock_cdp.list_tabs.return_value = [{"id": "t1", "title": ""}]
+        mock_cdp_cls.return_value = mock_cdp
+
+        page = BrowserPage(port=9222)
+        assert page._chrome_process is None


### PR DESCRIPTION
## Summary
- Add `naturo browser select <selector> <value>` — interacts with HTML `<select>` dropdowns
- Add `BrowserElement.select(value)` — matches option by value then text, dispatches change/input events
- Add `profile`, `headless`, `stealth`, `chrome_path` params to `BrowserPage` constructor — auto-launches Chrome when profile is specified
- `BrowserPage.close()` now terminates auto-launched Chrome process
- 11 unit tests

This completes the remaining #759 scope (along with PR #812 for download).

## Test plan
- [ ] CI passes
- [ ] `naturo browser select --help` shows usage
- [ ] `BrowserPage(profile="Default")` launches Chrome and connects

🤖 Generated with [Claude Code](https://claude.com/claude-code)