### PR TITLE
fix: detect UIA for standalone WinUI 3 apps like Calculator (fixes #785)

### DIFF
--- a/naturo/detect/probes.py
+++ b/naturo/detect/probes.py
@@ -438,6 +438,51 @@ def _find_afh_content_children(parent_hwnd: int) -> List[int]:
         return []
 
 
+def _find_winui_content_children(parent_hwnd: int) -> List[int]:
+    """Enumerate DesktopWindowXamlSource children of any window.
+
+    Standalone WinUI 3 apps (Win11 Calculator, Paint) are NOT hosted by
+    ApplicationFrameHost — they run as their own process with a regular
+    top-level window.  When the main HWND returns an empty UIA tree, we
+    check for DesktopWindowXamlSource children which host the actual
+    XAML content (#785).
+
+    Unlike ``_find_afh_content_children``, this does NOT require the
+    parent to be an ApplicationFrameWindow.
+
+    Args:
+        parent_hwnd: Top-level window handle to inspect.
+
+    Returns:
+        List of DesktopWindowXamlSource child HWNDs.
+    """
+    if platform.system() != "Windows":
+        return []
+
+    try:
+        import ctypes
+
+        user32 = ctypes.WinDLL("user32", use_last_error=True)
+
+        winui_children: List[int] = []
+        child = user32.FindWindowExW(parent_hwnd, None, None, None)
+        while child:
+            child_cls = ctypes.create_unicode_buffer(256)
+            user32.GetClassNameW(child, child_cls, 256)
+            if child_cls.value.lower() == "desktopwindowxamlsource":
+                winui_children.append(child)
+            child = user32.FindWindowExW(parent_hwnd, child, None, None)
+
+        return winui_children
+
+    except Exception as exc:
+        logger.debug(
+            "Failed to enumerate WinUI children for HWND %s: %s",
+            parent_hwnd, exc,
+        )
+        return []
+
+
 def probe_uia(pid: int, exe: str, hwnd: Optional[int] = None) -> Optional[InteractionMethod]:
     """Probe for UI Automation availability.
 
@@ -500,6 +545,29 @@ def probe_uia(pid: int, exe: str, hwnd: Optional[int] = None) -> Optional[Intera
                     capabilities=capabilities,
                     confidence=0.95,
                 )
+
+        # (#785) Standalone WinUI 3 apps (Win11 Calculator, Paint) are
+        # NOT hosted by ApplicationFrameHost.  When the AFH child search
+        # returns empty, check for DesktopWindowXamlSource children
+        # directly — these host the actual XAML content.
+        if not child_hwnds:
+            winui_hwnds = _find_winui_content_children(target_hwnd)
+            for child_hwnd in winui_hwnds:
+                tree = core.get_element_tree(hwnd=child_hwnd, depth=1)
+                if tree is not None:
+                    logger.debug(
+                        "UIA probe succeeded via WinUI child HWND %s "
+                        "(parent %s)",
+                        child_hwnd, target_hwnd,
+                    )
+                    capabilities = ["click", "type", "find", "tree", "screenshot"]
+                    return InteractionMethod(
+                        method=InteractionMethodType.UIA,
+                        priority=METHOD_PRIORITY[InteractionMethodType.UIA],
+                        status=ProbeStatus.AVAILABLE,
+                        capabilities=capabilities,
+                        confidence=0.95,
+                    )
 
         logger.debug(
             "UIA probe via native DLL returned empty tree for PID %d (hwnd=%s)",

--- a/tests/test_winui3_uia_probe_785.py
+++ b/tests/test_winui3_uia_probe_785.py
@@ -1,0 +1,87 @@
+"""Tests for #785: UIA probe must detect standalone WinUI 3 apps.
+
+Win11 Calculator and Paint are standalone WinUI 3 apps not hosted by
+ApplicationFrameHost. The UIA probe only checked AFH child windows when
+the main HWND returned an empty tree, so these apps fell through to
+vision-only detection.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from naturo.detect.probes import _find_winui_content_children, probe_uia
+
+
+class TestFindWinuiContentChildren:
+    """Tests for the _find_winui_content_children helper."""
+
+    def test_returns_empty_on_non_windows(self):
+        with patch("naturo.detect.probes.platform") as mock_platform:
+            mock_platform.system.return_value = "Linux"
+            assert _find_winui_content_children(12345) == []
+
+    @pytest.mark.desktop
+    def test_returns_empty_for_normal_window(self):
+        """A normal window with no WinUI children returns empty."""
+        # This would need a real desktop to test — skip on CI
+        pass
+
+
+class TestProbeUiaWinuiFallback:
+    """probe_uia must try WinUI children when AFH children are empty."""
+
+    @patch("naturo.detect.probes.platform")
+    @patch("naturo.detect.probes._find_main_window", return_value=1001)
+    @patch("naturo.detect.probes._find_afh_content_children", return_value=[])
+    @patch("naturo.detect.probes._find_winui_content_children", return_value=[2001])
+    def test_winui_fallback_succeeds(
+        self, mock_winui, mock_afh, mock_main, mock_platform
+    ):
+        """When AFH search returns empty but WinUI children exist, probe succeeds."""
+        mock_platform.system.return_value = "Windows"
+
+        mock_core = MagicMock()
+        # Main HWND returns None (empty tree), WinUI child returns tree
+        mock_core.get_element_tree.side_effect = [None, {"role": "Window"}]
+
+        with patch("naturo.detect.probes._get_native_core", return_value=mock_core):
+            result = probe_uia(pid=100, exe="CalculatorApp.exe", hwnd=None)
+
+        assert result is not None
+        assert result.method.value == "uia"
+        assert mock_core.get_element_tree.call_count == 2
+
+    @patch("naturo.detect.probes.platform")
+    @patch("naturo.detect.probes._find_main_window", return_value=1001)
+    @patch("naturo.detect.probes._find_afh_content_children", return_value=[])
+    @patch("naturo.detect.probes._find_winui_content_children", return_value=[])
+    def test_winui_fallback_no_children(
+        self, mock_winui, mock_afh, mock_main, mock_platform
+    ):
+        """When both AFH and WinUI searches find nothing, probe returns None."""
+        mock_platform.system.return_value = "Windows"
+
+        mock_core = MagicMock()
+        mock_core.get_element_tree.return_value = None
+
+        with patch("naturo.detect.probes._get_native_core", return_value=mock_core):
+            result = probe_uia(pid=100, exe="CalculatorApp.exe", hwnd=None)
+
+        assert result is None
+
+    @patch("naturo.detect.probes.platform")
+    @patch("naturo.detect.probes._find_main_window", return_value=1001)
+    def test_direct_tree_success_skips_fallbacks(self, mock_main, mock_platform):
+        """When main HWND has a tree, no fallback probing needed."""
+        mock_platform.system.return_value = "Windows"
+
+        mock_core = MagicMock()
+        mock_core.get_element_tree.return_value = {"role": "Window"}
+
+        with patch("naturo.detect.probes._get_native_core", return_value=mock_core):
+            result = probe_uia(pid=100, exe="notepad.exe", hwnd=None)
+
+        assert result is not None
+        mock_core.get_element_tree.assert_called_once()


### PR DESCRIPTION
Win11 Calculator and Paint are standalone WinUI 3 apps not hosted by ApplicationFrameHost. The UIA probe only checked AFH child windows when the main HWND returned an empty tree. Added `_find_winui_content_children()` that enumerates DesktopWindowXamlSource children regardless of parent class, used as fallback when AFH child search returns empty.

**Tests**: 4 new tests. Ruff clean.

**[Orc-Mycelium]** Created on behalf of Dev-Sirius from session 2026-04-04.