### PR TITLE
fix: detect WinUI 3 apps for UIA click path (fixes #786)

### DIFF
--- a/naturo/backends/windows/_element.py
+++ b/naturo/backends/windows/_element.py
@@ -1030,6 +1030,32 @@ class ElementMixin:
         return False
 
     @staticmethod
+    def _is_winui_window(handle: int) -> bool:
+        """Check if a window has DesktopWindowXamlSource children (WinUI 3).
+
+        Standalone WinUI 3 apps (Win11 Notepad, Paint) are NOT hosted by
+        ApplicationFrameHost.exe — they run as regular processes but use
+        XAML rendering via DesktopWindowXamlSource child windows.  Detecting
+        this enables UIA click path for menu items (#786).
+
+        Args:
+            handle: Window handle to check.
+
+        Returns:
+            True if the window has at least one DesktopWindowXamlSource child.
+        """
+        import sys as _sys
+        if _sys.platform != "win32":
+            return False
+        try:
+            import ctypes
+            user32 = ctypes.WinDLL("user32", use_last_error=True)
+            child = user32.FindWindowExW(handle, None, "DesktopWindowXamlSource", None)
+            return child != 0
+        except Exception:
+            return False
+
+    @staticmethod
     def _is_shallow_tree(element) -> bool:
         """Check if an element tree is too shallow (VB6/ActiveX fallback signal).
 

--- a/naturo/cli/interaction/_click.py
+++ b/naturo/cli/interaction/_click.py
@@ -221,12 +221,19 @@ def click_cmd(query: str | None, on_text: str | None, ref_alias: str | None,
         except Exception as exc:
             logger.debug("HWND resolution for focus failed: %s", exc)
     if _focus_hwnd:
-        # Detect UWP apps for UIA click fallback (#248)
+        # Detect UWP/WinUI apps for UIA click fallback (#248, #786)
         if hasattr(backend, "_is_afh_window"):
             try:
                 _is_uwp = backend._is_afh_window(_focus_hwnd)
             except Exception as exc:
                 logger.debug("UWP detection failed (hwnd=%s): %s", _focus_hwnd, exc)
+        # (#786) Standalone WinUI 3 apps (Win11 Notepad, Paint) also need
+        # UIA click path but are not hosted by ApplicationFrameHost.
+        if not _is_uwp and hasattr(backend, "_is_winui_window"):
+            try:
+                _is_uwp = backend._is_winui_window(_focus_hwnd)
+            except Exception as exc:
+                logger.debug("WinUI detection failed (hwnd=%s): %s", _focus_hwnd, exc)
         try:
             backend.focus_window(hwnd=_focus_hwnd)
         except Exception as exc:

--- a/tests/test_click_app_foreground.py
+++ b/tests/test_click_app_foreground.py
@@ -218,6 +218,7 @@ class TestClickAppForeground:
         backend = MagicMock()
         backend.focus_window.side_effect = OSError("focus failed")
         backend._is_afh_window.return_value = False
+        backend._is_winui_window.return_value = False
         mock_get_backend.return_value = backend
 
         runner = CliRunner()

--- a/tests/test_click_uwp_identity.py
+++ b/tests/test_click_uwp_identity.py
@@ -131,6 +131,7 @@ class TestUwpClickIdentityLookup:
 
         backend = MagicMock()
         backend._is_afh_window.return_value = False  # NOT UWP
+        backend._is_winui_window.return_value = False  # NOT WinUI 3
         mock_get_backend.return_value = backend
 
         runner = CliRunner()

--- a/tests/test_winui_menu_click_786.py
+++ b/tests/test_winui_menu_click_786.py
@@ -1,0 +1,118 @@
+"""Tests for #786: WinUI 3 apps must use UIA click path for menu items.
+
+WinUI 3 apps (Win11 Notepad, Paint) run as standalone processes, not under
+ApplicationFrameHost. The UIA click path was only triggered for AFH-hosted
+apps, so menu items in WinUI 3 apps were clicked via SendInput which doesn't
+reliably reach XAML content.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from naturo.cli.interaction._click import click_cmd
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_backend():
+    backend = MagicMock()
+    backend.click.return_value = None
+    backend.focus_window.return_value = None
+    backend._resolve_hwnd.return_value = 12345
+    backend._resolve_hwnds.return_value = [12345]
+    backend._is_afh_window.return_value = False
+    backend._is_winui_window.return_value = False
+    backend.click_element_uia.return_value = True
+    return backend
+
+
+def _patch_backend(mock_backend):
+    return patch("naturo.cli.interaction._common._get_backend", return_value=mock_backend)
+
+
+def _patch_resolve_app_id(app=None, hwnd=None, pid=None):
+    return patch(
+        "naturo.cli.interaction._common._resolve_app_id",
+        return_value=(app, hwnd, pid),
+    )
+
+
+def _patch_auto_route(route=None):
+    return patch(
+        "naturo.cli.interaction._common._auto_route",
+        return_value=route or {},
+    )
+
+
+class TestWinuiClickDetection:
+    """click must detect WinUI 3 windows and use UIA click path."""
+
+    def test_winui_window_triggers_uia_click(self, runner, mock_backend):
+        """When _is_winui_window returns True, click should try UIA path."""
+        mock_backend._is_afh_window.return_value = False
+        mock_backend._is_winui_window.return_value = True
+        mock_backend.click_element_uia.return_value = True
+
+        with _patch_resolve_app_id(app="notepad", hwnd=12345), \
+             _patch_backend(mock_backend), _patch_auto_route():
+            result = runner.invoke(
+                click_cmd,
+                ["--coords", "100", "200", "--app", "notepad"],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0
+        # UIA click path should have been used
+        mock_backend.click_element_uia.assert_called_once()
+
+    def test_non_winui_window_skips_uia(self, runner, mock_backend):
+        """When neither AFH nor WinUI, normal click path is used."""
+        mock_backend._is_afh_window.return_value = False
+        mock_backend._is_winui_window.return_value = False
+
+        with _patch_resolve_app_id(app="notepad", hwnd=12345), \
+             _patch_backend(mock_backend), _patch_auto_route():
+            result = runner.invoke(
+                click_cmd,
+                ["--coords", "100", "200", "--app", "notepad"],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0
+        # Normal click path — no UIA
+        mock_backend.click.assert_called_once()
+        mock_backend.click_element_uia.assert_not_called()
+
+    def test_afh_window_still_works(self, runner, mock_backend):
+        """AFH detection (original path) should still trigger UIA click."""
+        mock_backend._is_afh_window.return_value = True
+        mock_backend._is_winui_window.return_value = False
+        mock_backend.click_element_uia.return_value = True
+
+        with _patch_resolve_app_id(app="calculator", hwnd=12345), \
+             _patch_backend(mock_backend), _patch_auto_route():
+            result = runner.invoke(
+                click_cmd,
+                ["--coords", "100", "200", "--app", "calculator"],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0
+        mock_backend.click_element_uia.assert_called_once()
+
+
+class TestIsWinuiWindow:
+    """Tests for the _is_winui_window static method."""
+
+    def test_non_windows_returns_false(self):
+        from naturo.backends.windows._element import ElementMixin
+        with patch("sys.platform", "linux"):
+            assert ElementMixin._is_winui_window(12345) is False


### PR DESCRIPTION
WinUI 3 apps (Win11 Notepad, Paint) run as standalone processes, not under ApplicationFrameHost. Added `_is_winui_window()` that detects DesktopWindowXamlSource child windows. Click command now checks both `_is_afh_window` and `_is_winui_window` for UIA click path.

**Tests**: 4 new tests. Ruff clean.

**[Orc-Mycelium]** Created on behalf of Dev-Sirius from session 2026-04-04.