### PR TITLE
fix: prevent shell injection in recording bash/python export

### DIFF
--- a/naturo/cli/recording_cmd.py
+++ b/naturo/cli/recording_cmd.py
@@ -6,6 +6,7 @@ that wrap the recording engine in naturo/recording.py.
 from __future__ import annotations
 
 import json
+import shlex
 import sys
 from datetime import datetime
 
@@ -401,36 +402,40 @@ def _export_recording(rec: Recording, fmt: str) -> str:
 
 
 def _step_to_naturo_cmd(step) -> str:
-    """Convert an ActionStep to a naturo CLI command string."""
+    """Convert an ActionStep to a shell-safe naturo CLI command string.
+
+    All user-provided values are escaped with shlex.quote() to prevent
+    shell injection in exported bash scripts.
+    """
     cmd = step.command
     args = step.args
 
     if cmd == "click":
-        parts = ["naturo click"]
+        parts = ["naturo", "click"]
         if "x" in args and "y" in args:
-            parts.append(f"{args['x']} {args['y']}")
+            parts.extend([str(args["x"]), str(args["y"])])
         if args.get("button", "left") != "left":
-            parts.append(f"--button {args['button']}")
+            parts.extend(["--button", shlex.quote(str(args["button"]))])
         if args.get("double_click"):
             parts.append("--double")
         return " ".join(parts)
 
     if cmd == "type":
         text = args.get("text", "")
-        return f'naturo type "{text}"'
+        return f"naturo type {shlex.quote(text)}"
 
     if cmd == "press":
         key = args.get("key", "")
-        return f"naturo press {key}"
+        return f"naturo press {shlex.quote(key)}"
 
     if cmd == "hotkey":
         keys = args.get("keys", [])
-        return f"naturo hotkey {'+'.join(keys)}"
+        return f"naturo hotkey {shlex.quote('+'.join(str(k) for k in keys))}"
 
     if cmd == "scroll":
         direction = args.get("direction", "down")
         amount = args.get("amount", 3)
-        return f"naturo scroll {direction} --amount {amount}"
+        return f"naturo scroll {shlex.quote(str(direction))} --amount {amount}"
 
     if cmd == "drag":
         return (f"naturo drag --from {args.get('from_x', 0)} {args.get('from_y', 0)} "

--- a/tests/test_recording_cli.py
+++ b/tests/test_recording_cli.py
@@ -246,8 +246,8 @@ class TestRecordExport:
             result = runner.invoke(main, ["record", "export", "rec_test", "--format", "python"])
             assert result.exit_code == 0
             assert "#!/usr/bin/env python3" in result.output
-            assert 'naturo click 100 200' in result.output
-            assert 'naturo type "hello"' in result.output
+            assert "naturo click 100 200" in result.output
+            assert "naturo type hello" in result.output
             assert "time.sleep" in result.output
 
     def test_export_bash(self, runner):
@@ -271,6 +271,103 @@ class TestRecordExport:
             result = runner.invoke(main, ["record", "export", "rec_test", "-o", out])
             assert result.exit_code == 0
             assert Path(out).exists()
+
+
+# ── shell escaping in exports ────────────────────────────────────────────────
+
+
+class TestExportShellEscaping:
+    """Verify that exported scripts are safe from shell injection."""
+
+    def test_bash_export_escapes_quotes_in_text(self, runner):
+        rec = Recording(
+            name="Test", recording_id="rec_test", created_at="2026-04-01T12:00:00",
+            steps=[ActionStep("type", {"text": 'say "hello"'}, 1000.0)],
+        )
+        with patch("naturo.cli.recording_cmd.load_recording", return_value=rec):
+            result = runner.invoke(main, ["record", "export", "rec_test", "--format", "bash"])
+            assert result.exit_code == 0
+            # shlex.quote wraps in single quotes for safety
+            assert "naturo type 'say \"hello\"'" in result.output
+
+    def test_bash_export_escapes_backticks(self, runner):
+        rec = Recording(
+            name="Test", recording_id="rec_test", created_at="2026-04-01T12:00:00",
+            steps=[ActionStep("type", {"text": "`whoami`"}, 1000.0)],
+        )
+        with patch("naturo.cli.recording_cmd.load_recording", return_value=rec):
+            result = runner.invoke(main, ["record", "export", "rec_test", "--format", "bash"])
+            assert result.exit_code == 0
+            # Must NOT contain unquoted backticks
+            assert '"`whoami`"' not in result.output
+            # shlex.quote wraps safely
+            assert "naturo type '`whoami`'" in result.output
+
+    def test_bash_export_escapes_dollar_expansion(self, runner):
+        rec = Recording(
+            name="Test", recording_id="rec_test", created_at="2026-04-01T12:00:00",
+            steps=[ActionStep("type", {"text": "$(rm -rf /)"}, 1000.0)],
+        )
+        with patch("naturo.cli.recording_cmd.load_recording", return_value=rec):
+            result = runner.invoke(main, ["record", "export", "rec_test", "--format", "bash"])
+            assert result.exit_code == 0
+            # Must be safely quoted, not raw command substitution
+            assert '"$(rm -rf /)"' not in result.output
+            assert "naturo type '$(rm -rf /)'" in result.output
+
+    def test_bash_export_escapes_semicolons(self, runner):
+        rec = Recording(
+            name="Test", recording_id="rec_test", created_at="2026-04-01T12:00:00",
+            steps=[ActionStep("type", {"text": "hello; rm -rf /"}, 1000.0)],
+        )
+        with patch("naturo.cli.recording_cmd.load_recording", return_value=rec):
+            result = runner.invoke(main, ["record", "export", "rec_test", "--format", "bash"])
+            assert result.exit_code == 0
+            assert "naturo type 'hello; rm -rf /'" in result.output
+
+    def test_bash_export_escapes_single_quotes_in_text(self, runner):
+        rec = Recording(
+            name="Test", recording_id="rec_test", created_at="2026-04-01T12:00:00",
+            steps=[ActionStep("type", {"text": "it's done"}, 1000.0)],
+        )
+        with patch("naturo.cli.recording_cmd.load_recording", return_value=rec):
+            result = runner.invoke(main, ["record", "export", "rec_test", "--format", "bash"])
+            assert result.exit_code == 0
+            # shlex.quote handles single quotes by switching to double-quote style
+            assert "naturo type" in result.output
+            # The text must not break shell parsing
+            assert result.output.count("naturo type") == 1
+
+    def test_bash_export_escapes_key_names(self, runner):
+        rec = Recording(
+            name="Test", recording_id="rec_test", created_at="2026-04-01T12:00:00",
+            steps=[ActionStep("press", {"key": "enter; whoami"}, 1000.0)],
+        )
+        with patch("naturo.cli.recording_cmd.load_recording", return_value=rec):
+            result = runner.invoke(main, ["record", "export", "rec_test", "--format", "bash"])
+            assert result.exit_code == 0
+            assert "naturo press 'enter; whoami'" in result.output
+
+    def test_python_export_escapes_text(self, runner):
+        rec = Recording(
+            name="Test", recording_id="rec_test", created_at="2026-04-01T12:00:00",
+            steps=[ActionStep("type", {"text": 'say "hello"'}, 1000.0)],
+        )
+        with patch("naturo.cli.recording_cmd.load_recording", return_value=rec):
+            result = runner.invoke(main, ["record", "export", "rec_test", "--format", "python"])
+            assert result.exit_code == 0
+            # Python export uses !r which properly escapes
+            assert "run(" in result.output
+
+    def test_simple_text_not_quoted(self, runner):
+        rec = Recording(
+            name="Test", recording_id="rec_test", created_at="2026-04-01T12:00:00",
+            steps=[ActionStep("type", {"text": "hello"}, 1000.0)],
+        )
+        with patch("naturo.cli.recording_cmd.load_recording", return_value=rec):
+            result = runner.invoke(main, ["record", "export", "rec_test", "--format", "bash"])
+            assert result.exit_code == 0
+            assert "naturo type hello" in result.output
 
 
 # ── record_action hook ───────────────────────────────────────────────────────


### PR DESCRIPTION
_step_to_naturo_cmd() was building shell commands via string interpolation, allowing recorded text containing backticks, \$(), quotes, or semicolons to execute arbitrary commands when the exported bash script was run. Now uses shlex.quote() for all user-provided values.

**Tests**: 8 new tests covering injection vectors. Ruff clean, mypy clean.

**[Orc-Mycelium]** Created on behalf of Dev-Sirius. **Security fix — prioritize review.**