### PR TITLE
fix: surface skips, errors, and HTML failures in visual report JSON mode

### DIFF
--- a/naturo/cli/visual_cmd.py
+++ b/naturo/cli/visual_cmd.py
@@ -276,9 +276,13 @@ def visual_report(names: tuple, current_dir: Optional[str], threshold: float,
             click.echo(msg)
         sys.exit(1)
 
+    skipped: list[str] = []
+    errors: list[str] = []
+
     for name in names:
         current_img = current_path / f"{name}.png"
         if not current_img.exists():
+            skipped.append(name)
             if not json_output:
                 click.echo(f"  [SKIP] {name} — no current screenshot at {current_img}")
             continue
@@ -291,25 +295,36 @@ def visual_report(names: tuple, current_dir: Optional[str], threshold: float,
                 status = "PASS" if result.match else "FAIL"
                 click.echo(f"  [{status}] {name} — {result.similarity:.1%}")
         except (FileNotFoundError, ImportError) as e:
+            errors.append(f"{name}: {e}")
             if not json_output:
                 click.echo(f"  [ERROR] {name} — {e}")
 
     # Generate HTML report
+    html_error: str | None = None
     if output:
         try:
             html_path = generate_html_report(report, output)
             if not json_output:
                 click.echo(f"\nReport saved: {html_path}")
-        except Exception as e:
+        except (OSError, ValueError) as e:
+            html_error = str(e)
             if not json_output:
                 click.echo(f"Error generating report: {e}", err=True)
 
     if json_output:
-        click.echo(json.dumps(report.to_dict()))
+        data = report.to_dict()
+        if skipped:
+            data["skipped"] = skipped
+        if errors:
+            data["errors"] = errors
+        if html_error:
+            data["html_error"] = html_error
+        click.echo(json.dumps(data))
     else:
-        click.echo(f"\nResults: {report.passed} passed, {report.failed} failed")
+        click.echo(f"\nResults: {report.passed} passed, {report.failed} failed"
+                    + (f", {len(skipped)} skipped" if skipped else ""))
 
-    if not report.all_passed:
+    if not report.all_passed or errors:
         sys.exit(1)
 
 

--- a/tests/test_visual.py
+++ b/tests/test_visual.py
@@ -593,3 +593,73 @@ class TestEnterpriseCLI:
         assert result.exit_code != 0
         data = json.loads(result.output)
         assert data["success"] is False
+
+    def test_report_skip_in_json(self, runner, tmp_dirs, red_image):
+        """Skipped items appear in JSON report output."""
+        runner.invoke(main, ["visual", "baseline", "s1", "--from", str(red_image)])
+        # current-dir has no s1.png → skip
+        result = runner.invoke(main, [
+            "visual", "report", "s1", "--current-dir", str(red_image.parent),
+            "--json",
+        ])
+        data = json.loads(result.output)
+        assert "skipped" in data
+        assert "s1" in data["skipped"]
+
+    def test_report_skip_in_text(self, runner, tmp_dirs, red_image, tmp_path):
+        """Text mode shows skip count in summary."""
+        runner.invoke(main, ["visual", "baseline", "s1", "--from", str(red_image)])
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+        result = runner.invoke(main, [
+            "visual", "report", "s1", "--current-dir", str(empty_dir),
+        ])
+        assert "SKIP" in result.output
+        assert "skipped" in result.output
+
+    def test_report_error_in_json(self, runner, tmp_dirs, red_image, tmp_path):
+        """Comparison errors appear in JSON report output."""
+        # Create a current image but no baseline for the name
+        current_dir = tmp_path / "current"
+        current_dir.mkdir()
+        (current_dir / "nobaseline.png").write_bytes(red_image.read_bytes())
+        result = runner.invoke(main, [
+            "visual", "report", "nobaseline", "--current-dir", str(current_dir),
+            "--json",
+        ])
+        data = json.loads(result.output)
+        assert "errors" in data
+        assert len(data["errors"]) > 0
+        assert result.exit_code != 0
+
+    def test_report_html_error_in_json(self, runner, tmp_dirs, red_image, red_copy):
+        """HTML generation errors surface in JSON output."""
+        bd, _ = tmp_dirs
+        runner.invoke(main, ["visual", "baseline", "s1", "--from", str(red_image)])
+        current_dir = red_copy.parent
+        # Rename red_copy to s1.png so report finds it
+        s1_current = current_dir / "s1.png"
+        red_copy.rename(s1_current)
+        # Use a path that will fail (directory as file)
+        bad_path = current_dir / "baddir"
+        bad_path.mkdir()
+        result = runner.invoke(main, [
+            "visual", "report", "s1", "--current-dir", str(current_dir),
+            "--output", str(bad_path),  # directory, not a file
+            "--json",
+        ])
+        data = json.loads(result.output)
+        # html_error may or may not be present depending on OS behavior,
+        # but the command should not crash
+        assert "results" in data or "html_error" in data
+
+    def test_report_errors_exit_nonzero(self, runner, tmp_dirs, red_image, tmp_path):
+        """Report exits non-zero when comparison errors occur."""
+        current_dir = tmp_path / "current"
+        current_dir.mkdir()
+        (current_dir / "missing_baseline.png").write_bytes(red_image.read_bytes())
+        result = runner.invoke(main, [
+            "visual", "report", "missing_baseline",
+            "--current-dir", str(current_dir),
+        ])
+        assert result.exit_code != 0


### PR DESCRIPTION
visual report silently swallowed three categories of information in JSON mode: skipped items, comparison errors, and HTML generation failures. Now tracks skipped/errored items and includes them in JSON output. Narrowed except Exception to except (OSError, ValueError). Exit non-zero when comparison errors occur.

**Tests**: 5 new tests. Ruff clean.

**[Orc-Mycelium]** Created on behalf of Dev-Sirius.