### PR TITLE
feat: add enterprise visual regression features — ignore regions, update, suite (fixes #91)

### DIFF
--- a/naturo/cli/visual_cmd.py
+++ b/naturo/cli/visual_cmd.py
@@ -16,11 +16,14 @@ import click
 from naturo.cli.fuzzy_group import FuzzyGroup
 from naturo.visual import (
     save_baseline,
+    update_baseline,
     list_baselines,
     delete_baseline,
     compare_with_baseline,
     compare_images,
     generate_html_report,
+    load_suite,
+    run_suite,
     VisualReport,
 )
 
@@ -67,23 +70,40 @@ def visual_baseline(name: str, from_path: str, json_output: bool):
         click.echo(f"Path: {path}")
 
 
+def _parse_region(value: str) -> tuple[int, int, int, int]:
+    """Parse 'x,y,w,h' into a tuple of ints."""
+    parts = value.split(",")
+    if len(parts) != 4:
+        raise click.BadParameter(f"Expected x,y,w,h but got: {value}")
+    try:
+        return tuple(int(p.strip()) for p in parts)  # type: ignore[return-value]
+    except ValueError:
+        raise click.BadParameter(f"Non-integer in region: {value}")
+
+
 @click.command("compare")
 @click.argument("name")
 @click.option("--current", required=True, type=click.Path(exists=True),
               help="Path to current screenshot to compare.")
 @click.option("--threshold", type=float, default=0.95,
               help="Similarity threshold (0.0-1.0, default 0.95).")
+@click.option("--ignore-region", multiple=True,
+              help="Region to mask (x,y,w,h). Repeatable.")
 @click.option("-j", "--json", "json_output", is_flag=True, help="Output JSON.")
-def visual_compare(name: str, current: str, threshold: float, json_output: bool):
+def visual_compare(name: str, current: str, threshold: float,
+                   ignore_region: tuple, json_output: bool):
     """Compare a screenshot against its saved baseline.
 
     \b
     Examples:
         naturo visual compare login_screen --current new_screenshot.png
         naturo visual compare login_screen --current new.png --threshold 0.90
+        naturo visual compare dashboard --current new.png --ignore-region 10,5,200,30
     """
+    regions = [_parse_region(r) for r in ignore_region] if ignore_region else None
     try:
-        result = compare_with_baseline(current, name, threshold=threshold)
+        result = compare_with_baseline(current, name, threshold=threshold,
+                                       ignore_regions=regions)
     except FileNotFoundError as e:
         if json_output:
             click.echo(json.dumps({"success": False, "error": str(e)}))
@@ -212,13 +232,15 @@ def visual_delete(name: str, force: bool, json_output: bool):
 @click.option("--current-dir", type=click.Path(exists=True),
               help="Directory containing current screenshots (name.png).")
 @click.option("--threshold", type=float, default=0.95, help="Similarity threshold.")
+@click.option("--ignore-region", multiple=True,
+              help="Region to mask globally (x,y,w,h). Repeatable.")
 @click.option("--output", "-o", type=click.Path(), default=None,
               help="Output HTML report path.")
 @click.option("--name", "report_name", default=None, help="Report name.")
 @click.option("-j", "--json", "json_output", is_flag=True, help="Output JSON.")
 def visual_report(names: tuple, current_dir: Optional[str], threshold: float,
-                  output: Optional[str], report_name: Optional[str],
-                  json_output: bool):
+                  ignore_region: tuple, output: Optional[str],
+                  report_name: Optional[str], json_output: bool):
     """Run visual regression tests and generate a report.
 
     Compare multiple baselines against current screenshots at once.
@@ -228,8 +250,10 @@ def visual_report(names: tuple, current_dir: Optional[str], threshold: float,
     Examples:
         naturo visual report login dashboard --current-dir ./screenshots/
         naturo visual report --current-dir ./screenshots/ -o report.html
-        naturo visual report login dashboard --current-dir ./current/ --threshold 0.90
+        naturo visual report --current-dir ./current/ --ignore-region 0,0,200,30
     """
+    regions = [_parse_region(r) for r in ignore_region] if ignore_region else None
+
     if not current_dir:
         click.echo("Error: --current-dir is required.", err=True)
         sys.exit(1)
@@ -259,7 +283,8 @@ def visual_report(names: tuple, current_dir: Optional[str], threshold: float,
             continue
 
         try:
-            result = compare_with_baseline(str(current_img), name, threshold=threshold)
+            result = compare_with_baseline(str(current_img), name, threshold=threshold,
+                                           ignore_regions=regions)
             report.add_result(result)
             if not json_output:
                 status = "PASS" if result.match else "FAIL"
@@ -287,6 +312,157 @@ def visual_report(names: tuple, current_dir: Optional[str], threshold: float,
         sys.exit(1)
 
 
+@click.command("update")
+@click.argument("name")
+@click.option("--from", "from_path", required=True, type=click.Path(exists=True),
+              help="Path to new screenshot to replace the baseline.")
+@click.option("-j", "--json", "json_output", is_flag=True, help="Output JSON.")
+def visual_update(name: str, from_path: str, json_output: bool):
+    """Update an existing baseline with a new screenshot.
+
+    \b
+    Examples:
+        naturo visual update login_screen --from new_screenshot.png
+        naturo visual update dashboard --from ~/captures/dash_v2.png
+    """
+    try:
+        path = update_baseline(from_path, name)
+    except FileNotFoundError as e:
+        if json_output:
+            click.echo(json.dumps({"success": False, "error": str(e)}))
+        else:
+            click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
+    except ImportError as e:
+        if json_output:
+            click.echo(json.dumps({"success": False, "error": str(e)}))
+        else:
+            click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
+
+    if json_output:
+        click.echo(json.dumps({"success": True, "name": name, "path": str(path)}))
+    else:
+        click.echo(f"Baseline updated: {name}")
+        click.echo(f"Path: {path}")
+
+
+@click.command("update-all")
+@click.option("--from-dir", required=True, type=click.Path(exists=True),
+              help="Directory containing new screenshots (name.png).")
+@click.option("-j", "--json", "json_output", is_flag=True, help="Output JSON.")
+def visual_update_all(from_dir: str, json_output: bool):
+    """Update all baselines from a directory of screenshots.
+
+    Each file in the directory is matched by name to an existing baseline.
+    Only existing baselines are updated; new files are skipped.
+
+    \b
+    Examples:
+        naturo visual update-all --from-dir ./new_screenshots/
+    """
+    from_path = Path(from_dir)
+    baselines = list_baselines()
+    baseline_names = {b["name"] for b in baselines}
+
+    updated = []
+    skipped = []
+    for img_file in sorted(from_path.glob("*.png")):
+        name = img_file.stem
+        if name in baseline_names:
+            try:
+                update_baseline(str(img_file), name)
+                updated.append(name)
+            except (FileNotFoundError, ImportError):
+                skipped.append(name)
+        else:
+            skipped.append(name)
+
+    if json_output:
+        click.echo(json.dumps({
+            "success": True,
+            "updated": updated,
+            "skipped": skipped,
+            "updated_count": len(updated),
+            "skipped_count": len(skipped),
+        }))
+    else:
+        for name in updated:
+            click.echo(f"  Updated: {name}")
+        for name in skipped:
+            click.echo(f"  Skipped: {name}")
+        click.echo(f"\n{len(updated)} updated, {len(skipped)} skipped")
+
+
+@click.command("suite")
+@click.argument("suite_path", type=click.Path(exists=True))
+@click.option("--output", "-o", type=click.Path(), default=None,
+              help="Output HTML report path.")
+@click.option("-j", "--json", "json_output", is_flag=True, help="Output JSON.")
+def visual_suite(suite_path: str, output: Optional[str], json_output: bool):
+    """Run a visual regression test suite from a JSON definition.
+
+    The suite JSON format:
+
+    \b
+        {
+          "name": "Login Flow",
+          "threshold": 0.95,
+          "tests": [
+            {"name": "login_screen", "current": "screenshots/login.png"},
+            {"name": "dashboard", "current": "screenshots/dash.png",
+             "threshold": 0.98, "ignore_regions": [[10, 5, 200, 30]]}
+          ]
+        }
+
+    \b
+    Examples:
+        naturo visual suite regression.json
+        naturo visual suite regression.json -o report.html
+        naturo visual suite regression.json --json
+    """
+    try:
+        suite = load_suite(suite_path)
+    except (FileNotFoundError, ValueError, json.JSONDecodeError) as e:
+        if json_output:
+            click.echo(json.dumps({"success": False, "error": str(e)}))
+        else:
+            click.echo(f"Error loading suite: {e}", err=True)
+        sys.exit(1)
+
+    try:
+        report = run_suite(suite)
+    except ImportError as e:
+        if json_output:
+            click.echo(json.dumps({"success": False, "error": str(e)}))
+        else:
+            click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
+
+    if not json_output:
+        click.echo(f"Suite: {suite.name}")
+        for r in report.results:
+            status = "PASS" if r.match else "FAIL"
+            click.echo(f"  [{status}] {r.name} — {r.similarity:.1%}")
+
+    if output:
+        try:
+            html_path = generate_html_report(report, output)
+            if not json_output:
+                click.echo(f"\nReport saved: {html_path}")
+        except Exception as e:
+            if not json_output:
+                click.echo(f"Error generating report: {e}", err=True)
+
+    if json_output:
+        click.echo(json.dumps(report.to_dict()))
+    else:
+        click.echo(f"\nResults: {report.passed} passed, {report.failed} failed")
+
+    if not report.all_passed:
+        sys.exit(1)
+
+
 # Register subcommands
 visual.add_command(visual_baseline, "baseline")
 visual.add_command(visual_compare, "compare")
@@ -294,3 +470,6 @@ visual.add_command(visual_diff, "diff")
 visual.add_command(visual_list, "list")
 visual.add_command(visual_delete, "delete")
 visual.add_command(visual_report, "report")
+visual.add_command(visual_update, "update")
+visual.add_command(visual_update_all, "update-all")
+visual.add_command(visual_suite, "suite")

--- a/naturo/visual.py
+++ b/naturo/visual.py
@@ -180,6 +180,55 @@ def delete_baseline(name: str, directory: Optional[Path] = None) -> bool:
     return deleted
 
 
+def update_baseline(
+    image_path: str | Path,
+    name: str,
+    directory: Optional[Path] = None,
+) -> Path:
+    """Update an existing baseline with a new screenshot.
+
+    Args:
+        image_path: Path to the new screenshot.
+        name: Baseline name to update.
+        directory: Custom baselines directory. Uses default if None.
+
+    Returns:
+        Path to the updated baseline image.
+
+    Raises:
+        FileNotFoundError: If the baseline does not exist.
+    """
+    _require_pil()
+    d = directory or BASELINES_DIR
+    existing = d / f"{name}.png"
+    if not existing.exists():
+        raise FileNotFoundError(f"Baseline not found: {name}")
+
+    return save_baseline(image_path, name, directory)
+
+
+def _apply_ignore_regions(
+    img: "Image.Image",
+    regions: list[tuple[int, int, int, int]],
+    fill: tuple[int, int, int] = (128, 128, 128),
+) -> "Image.Image":
+    """Mask regions of an image with a solid fill color.
+
+    Args:
+        img: PIL Image to mask.
+        regions: List of (x, y, width, height) tuples to mask.
+        fill: RGB fill color for masked regions.
+
+    Returns:
+        New image with masked regions.
+    """
+    masked = img.copy()
+    draw = ImageDraw.Draw(masked)
+    for x, y, w, h in regions:
+        draw.rectangle([x, y, x + w, y + h], fill=fill)
+    return masked
+
+
 def compare_images(
     baseline_path: str | Path,
     current_path: str | Path,
@@ -187,6 +236,7 @@ def compare_images(
     threshold: float = 0.95,
     diff_output: Optional[str | Path] = None,
     highlight_color: tuple = (255, 0, 0),
+    ignore_regions: Optional[list[tuple[int, int, int, int]]] = None,
 ) -> ComparisonResult:
     """Compare two images and generate a diff.
 
@@ -197,6 +247,7 @@ def compare_images(
         threshold: Similarity threshold (0.0-1.0). Above = pass, below = fail.
         diff_output: Path to save the diff image. None = don't save.
         highlight_color: RGB color for highlighting differences.
+        ignore_regions: List of (x, y, width, height) tuples to mask before comparison.
 
     Returns:
         ComparisonResult with similarity score and diff information.
@@ -205,6 +256,10 @@ def compare_images(
 
     baseline = Image.open(baseline_path).convert("RGB")
     current = Image.open(current_path).convert("RGB")
+
+    if ignore_regions:
+        baseline = _apply_ignore_regions(baseline, ignore_regions)
+        current = _apply_ignore_regions(current, ignore_regions)
 
     dimensions_match = baseline.size == current.size
 
@@ -259,6 +314,7 @@ def compare_with_baseline(
     threshold: float = 0.95,
     baselines_dir: Optional[Path] = None,
     reports_dir: Optional[Path] = None,
+    ignore_regions: Optional[list[tuple[int, int, int, int]]] = None,
 ) -> ComparisonResult:
     """Compare a screenshot against its saved baseline.
 
@@ -268,6 +324,7 @@ def compare_with_baseline(
         threshold: Similarity threshold (0.0-1.0).
         baselines_dir: Custom baselines directory.
         reports_dir: Custom reports directory for diff images.
+        ignore_regions: List of (x, y, width, height) tuples to mask before comparison.
 
     Returns:
         ComparisonResult with match/similarity data.
@@ -289,6 +346,7 @@ def compare_with_baseline(
         name=name,
         threshold=threshold,
         diff_output=diff_output,
+        ignore_regions=ignore_regions,
     )
 
 
@@ -456,3 +514,123 @@ def compute_ssim(
             count += 1
 
     return ssim_sum / count if count > 0 else 1.0
+
+
+@dataclass
+class SuiteTest:
+    """A single test case in a visual regression suite."""
+    name: str
+    current: str
+    threshold: Optional[float] = None
+    ignore_regions: Optional[list[tuple[int, int, int, int]]] = None
+
+
+@dataclass
+class Suite:
+    """A visual regression test suite loaded from JSON.
+
+    Suite JSON format::
+
+        {
+          "name": "Login Flow",
+          "threshold": 0.95,
+          "tests": [
+            {"name": "login_screen", "current": "screenshots/login.png"},
+            {"name": "dashboard", "current": "screenshots/dash.png",
+             "threshold": 0.98, "ignore_regions": [[10, 5, 200, 30]]}
+          ]
+        }
+    """
+    name: str
+    tests: list[SuiteTest]
+    threshold: float = 0.95
+
+
+def load_suite(path: str | Path) -> Suite:
+    """Load a visual regression suite from a JSON file.
+
+    Args:
+        path: Path to the suite JSON file.
+
+    Returns:
+        Parsed Suite object.
+
+    Raises:
+        FileNotFoundError: If the suite file does not exist.
+        ValueError: If the suite JSON is invalid.
+    """
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(f"Suite file not found: {path}")
+
+    with open(p, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    if "tests" not in data or not isinstance(data["tests"], list):
+        raise ValueError("Suite JSON must contain a 'tests' array")
+
+    suite_threshold = data.get("threshold", 0.95)
+    tests = []
+    for t in data["tests"]:
+        if "name" not in t or "current" not in t:
+            raise ValueError("Each test must have 'name' and 'current' fields")
+        regions = None
+        if "ignore_regions" in t:
+            regions = [tuple(r) for r in t["ignore_regions"]]
+        tests.append(SuiteTest(
+            name=t["name"],
+            current=t["current"],
+            threshold=t.get("threshold"),
+            ignore_regions=regions,
+        ))
+
+    return Suite(
+        name=data.get("name", p.stem),
+        tests=tests,
+        threshold=suite_threshold,
+    )
+
+
+def run_suite(
+    suite: Suite,
+    baselines_dir: Optional[Path] = None,
+    reports_dir: Optional[Path] = None,
+) -> VisualReport:
+    """Run all tests in a visual regression suite.
+
+    Args:
+        suite: Parsed Suite object.
+        baselines_dir: Custom baselines directory.
+        reports_dir: Custom reports directory.
+
+    Returns:
+        VisualReport with all comparison results.
+    """
+    report = VisualReport(
+        name=suite.name,
+        created_at=datetime.now().isoformat(),
+    )
+
+    for test in suite.tests:
+        threshold = test.threshold if test.threshold is not None else suite.threshold
+        try:
+            result = compare_with_baseline(
+                current_path=test.current,
+                name=test.name,
+                threshold=threshold,
+                baselines_dir=baselines_dir,
+                reports_dir=reports_dir,
+                ignore_regions=test.ignore_regions,
+            )
+            report.add_result(result)
+        except FileNotFoundError:
+            report.add_result(ComparisonResult(
+                name=test.name,
+                match=False,
+                similarity=0.0,
+                threshold=threshold,
+                baseline_path="<not found>",
+                current_path=test.current,
+            ))
+
+    return report

--- a/tests/test_visual.py
+++ b/tests/test_visual.py
@@ -294,3 +294,280 @@ class TestVisualCLI:
         assert "compare" in result.output
         assert "diff" in result.output
         assert "report" in result.output
+
+
+# ── Enterprise feature tests ────────────────────────────────────────────────
+
+
+class TestIgnoreRegions:
+    def test_ignore_region_masks_difference(self, red_image, tmp_path):
+        """A blue patch in a masked region should not cause a diff."""
+        # Create image with blue patch at (0,0)-(10,10)
+        patched = tmp_path / "patched.png"
+        img = Image.new("RGB", (100, 100), (255, 0, 0))
+        for x in range(10):
+            for y in range(10):
+                img.putpixel((x, y), (0, 0, 255))
+        img.save(patched)
+
+        # Without masking: should detect difference (100/10000 = 1% diff)
+        result = visual_mod.compare_images(red_image, patched, threshold=0.999)
+        assert result.match is False
+
+        # With masking over the blue patch: should pass
+        result2 = visual_mod.compare_images(
+            red_image, patched, threshold=0.999,
+            ignore_regions=[(0, 0, 10, 10)],
+        )
+        assert result2.match is True
+        assert result2.similarity == 1.0
+
+    def test_ignore_multiple_regions(self, red_image, tmp_path):
+        """Multiple ignore regions mask independently."""
+        patched = tmp_path / "multi.png"
+        img = Image.new("RGB", (100, 100), (255, 0, 0))
+        # Two blue patches
+        for x in range(5):
+            for y in range(5):
+                img.putpixel((x, y), (0, 0, 255))
+                img.putpixel((90 + x, 90 + y), (0, 0, 255))
+        img.save(patched)
+
+        result = visual_mod.compare_images(
+            red_image, patched, threshold=0.99,
+            ignore_regions=[(0, 0, 5, 5), (90, 90, 10, 10)],
+        )
+        assert result.match is True
+
+
+class TestUpdateBaseline:
+    def test_update_existing(self, tmp_dirs, red_image, blue_image):
+        bd, _ = tmp_dirs
+        visual_mod.save_baseline(red_image, "test_screen", bd)
+        path = visual_mod.update_baseline(blue_image, "test_screen", bd)
+        assert path.exists()
+        # Verify it's now the blue image
+        img = Image.open(path)
+        assert img.getpixel((50, 50)) == (0, 0, 255)
+
+    def test_update_nonexistent_raises(self, tmp_dirs, red_image):
+        bd, _ = tmp_dirs
+        with pytest.raises(FileNotFoundError):
+            visual_mod.update_baseline(red_image, "nonexistent", bd)
+
+
+class TestSuiteLoading:
+    def test_load_valid_suite(self, tmp_path):
+        suite_file = tmp_path / "suite.json"
+        suite_file.write_text(json.dumps({
+            "name": "Test Suite",
+            "threshold": 0.98,
+            "tests": [
+                {"name": "screen1", "current": "shots/s1.png"},
+                {"name": "screen2", "current": "shots/s2.png",
+                 "threshold": 0.90, "ignore_regions": [[10, 5, 200, 30]]},
+            ],
+        }))
+        suite = visual_mod.load_suite(suite_file)
+        assert suite.name == "Test Suite"
+        assert suite.threshold == 0.98
+        assert len(suite.tests) == 2
+        assert suite.tests[1].threshold == 0.90
+        assert suite.tests[1].ignore_regions == [(10, 5, 200, 30)]
+
+    def test_load_missing_file(self):
+        with pytest.raises(FileNotFoundError):
+            visual_mod.load_suite("/nonexistent.json")
+
+    def test_load_missing_tests_key(self, tmp_path):
+        suite_file = tmp_path / "bad.json"
+        suite_file.write_text(json.dumps({"name": "Bad"}))
+        with pytest.raises(ValueError, match="tests"):
+            visual_mod.load_suite(suite_file)
+
+    def test_load_missing_required_fields(self, tmp_path):
+        suite_file = tmp_path / "bad2.json"
+        suite_file.write_text(json.dumps({
+            "tests": [{"name": "only_name"}],
+        }))
+        with pytest.raises(ValueError, match="current"):
+            visual_mod.load_suite(suite_file)
+
+
+class TestRunSuite:
+    def test_run_suite_all_pass(self, tmp_dirs, red_image, red_copy):
+        bd, rd = tmp_dirs
+        visual_mod.save_baseline(red_image, "screen1", bd)
+
+        suite = visual_mod.Suite(
+            name="Test", threshold=0.95,
+            tests=[visual_mod.SuiteTest(name="screen1", current=str(red_copy))],
+        )
+        report = visual_mod.run_suite(suite, baselines_dir=bd, reports_dir=rd)
+        assert report.all_passed
+        assert report.passed == 1
+
+    def test_run_suite_missing_baseline(self, tmp_dirs, red_image):
+        bd, rd = tmp_dirs
+        suite = visual_mod.Suite(
+            name="Test", threshold=0.95,
+            tests=[visual_mod.SuiteTest(name="missing", current=str(red_image))],
+        )
+        report = visual_mod.run_suite(suite, baselines_dir=bd, reports_dir=rd)
+        assert not report.all_passed
+        assert report.failed == 1
+
+    def test_suite_per_test_threshold(self, tmp_dirs, red_image, slightly_different):
+        bd, rd = tmp_dirs
+        visual_mod.save_baseline(red_image, "screen1", bd)
+
+        suite = visual_mod.Suite(
+            name="Test", threshold=1.0,  # strict global
+            tests=[
+                visual_mod.SuiteTest(
+                    name="screen1",
+                    current=str(slightly_different),
+                    threshold=0.95,  # relaxed per-test
+                ),
+            ],
+        )
+        report = visual_mod.run_suite(suite, baselines_dir=bd, reports_dir=rd)
+        assert report.all_passed  # per-test threshold wins
+
+    def test_suite_with_ignore_regions(self, tmp_dirs, red_image, tmp_path):
+        bd, rd = tmp_dirs
+        visual_mod.save_baseline(red_image, "screen1", bd)
+
+        # Create image with blue corner
+        patched = tmp_path / "patched.png"
+        img = Image.new("RGB", (100, 100), (255, 0, 0))
+        for x in range(10):
+            for y in range(10):
+                img.putpixel((x, y), (0, 0, 255))
+        img.save(patched)
+
+        suite = visual_mod.Suite(
+            name="Test", threshold=0.99,
+            tests=[
+                visual_mod.SuiteTest(
+                    name="screen1",
+                    current=str(patched),
+                    ignore_regions=[(0, 0, 10, 10)],
+                ),
+            ],
+        )
+        report = visual_mod.run_suite(suite, baselines_dir=bd, reports_dir=rd)
+        assert report.all_passed
+
+
+class TestEnterpriseCLI:
+    def test_update_command(self, runner, tmp_dirs, red_image, blue_image):
+        runner.invoke(main, ["visual", "baseline", "s1", "--from", str(red_image)])
+        result = runner.invoke(main, [
+            "visual", "update", "s1", "--from", str(blue_image),
+        ])
+        assert result.exit_code == 0
+        assert "updated" in result.output.lower()
+
+    def test_update_nonexistent(self, runner, tmp_dirs, red_image):
+        result = runner.invoke(main, [
+            "visual", "update", "nope", "--from", str(red_image),
+        ])
+        assert result.exit_code != 0
+
+    def test_update_json(self, runner, tmp_dirs, red_image, blue_image):
+        runner.invoke(main, ["visual", "baseline", "s1", "--from", str(red_image)])
+        result = runner.invoke(main, [
+            "visual", "update", "s1", "--from", str(blue_image), "--json",
+        ])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["success"] is True
+
+    def test_update_all_command(self, runner, tmp_dirs, red_image, blue_image):
+        bd, _ = tmp_dirs
+        runner.invoke(main, ["visual", "baseline", "red", "--from", str(red_image)])
+        # Create dir with updated screenshot
+        update_dir = bd.parent / "updates"
+        update_dir.mkdir()
+        Image.new("RGB", (100, 100), (0, 255, 0)).save(update_dir / "red.png")
+        Image.new("RGB", (100, 100), (0, 255, 0)).save(update_dir / "unknown.png")
+
+        result = runner.invoke(main, [
+            "visual", "update-all", "--from-dir", str(update_dir),
+        ])
+        assert result.exit_code == 0
+        assert "Updated: red" in result.output
+        assert "Skipped: unknown" in result.output
+
+    def test_compare_with_ignore_region(self, runner, tmp_dirs, red_image, tmp_path):
+        runner.invoke(main, ["visual", "baseline", "s1", "--from", str(red_image)])
+        # Create image with blue corner
+        patched = tmp_path / "patched.png"
+        img = Image.new("RGB", (100, 100), (255, 0, 0))
+        for x in range(10):
+            for y in range(10):
+                img.putpixel((x, y), (0, 0, 255))
+        img.save(patched)
+
+        # Fails without masking (100/10000 = 1% diff, similarity=0.99)
+        result = runner.invoke(main, [
+            "visual", "compare", "s1", "--current", str(patched),
+            "--threshold", "0.999",
+        ])
+        assert result.exit_code != 0
+
+        # Passes with masking
+        result2 = runner.invoke(main, [
+            "visual", "compare", "s1", "--current", str(patched),
+            "--threshold", "0.999", "--ignore-region", "0,0,10,10",
+        ])
+        assert result2.exit_code == 0
+
+    def test_suite_command(self, runner, tmp_dirs, red_image, red_copy, tmp_path):
+        runner.invoke(main, ["visual", "baseline", "s1", "--from", str(red_image)])
+        suite_file = tmp_path / "suite.json"
+        suite_file.write_text(json.dumps({
+            "name": "CI Suite",
+            "tests": [
+                {"name": "s1", "current": str(red_copy)},
+            ],
+        }))
+        result = runner.invoke(main, ["visual", "suite", str(suite_file)])
+        assert result.exit_code == 0
+        assert "PASS" in result.output
+        assert "1 passed" in result.output
+
+    def test_suite_json_output(self, runner, tmp_dirs, red_image, red_copy, tmp_path):
+        runner.invoke(main, ["visual", "baseline", "s1", "--from", str(red_image)])
+        suite_file = tmp_path / "suite.json"
+        suite_file.write_text(json.dumps({
+            "name": "CI Suite",
+            "tests": [
+                {"name": "s1", "current": str(red_copy)},
+            ],
+        }))
+        result = runner.invoke(main, ["visual", "suite", str(suite_file), "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["all_passed"] is True
+
+    def test_suite_with_html_report(self, runner, tmp_dirs, red_image, red_copy, tmp_path):
+        runner.invoke(main, ["visual", "baseline", "s1", "--from", str(red_image)])
+        suite_file = tmp_path / "suite.json"
+        suite_file.write_text(json.dumps({
+            "name": "CI Suite",
+            "tests": [{"name": "s1", "current": str(red_copy)}],
+        }))
+        report_path = tmp_path / "report.html"
+        result = runner.invoke(main, [
+            "visual", "suite", str(suite_file), "-o", str(report_path),
+        ])
+        assert result.exit_code == 0
+        assert report_path.exists()
+
+    def test_help_includes_new_commands(self, runner):
+        result = runner.invoke(main, ["visual", "--help"])
+        assert result.exit_code == 0
+        assert "update" in result.output
+        assert "suite" in result.output


### PR DESCRIPTION
Three enterprise features for CI/CD visual regression workflows:
1. **Ignore regions** — mask dynamic UI areas before pixel comparison via --ignore-region
2. **Baseline update** — `naturo visual update` and `naturo visual update-all --from-dir` 
3. **Suite runner** — `naturo visual suite regression.json` with per-test thresholds and HTML report

**Tests**: 21 new tests. Ruff clean, mypy clean.

**[Orc-Mycelium]** Created on behalf of Dev-Sirius.