### PR TITLE
feat: add built-in selector templates for Top 20 Windows apps (fixes #104)

### DIFF
--- a/naturo/selectors_builtin/calc.json
+++ b/naturo/selectors_builtin/calc.json
@@ -1,0 +1,34 @@
+{
+  "display": {
+    "selector": "app://calculatorapp.exe/Window[@name=\"Calculator\"]/Text[@automationid=\"CalculatorResults\"]",
+    "description": "Calculator display showing current result"
+  },
+  "button-0": {
+    "selector": "app://calculatorapp.exe/Window[@name=\"Calculator\"]/Button[@automationid=\"num0Button\"]",
+    "description": "Number 0 button"
+  },
+  "button-1": {
+    "selector": "app://calculatorapp.exe/Window[@name=\"Calculator\"]/Button[@automationid=\"num1Button\"]",
+    "description": "Number 1 button"
+  },
+  "button-equals": {
+    "selector": "app://calculatorapp.exe/Window[@name=\"Calculator\"]/Button[@automationid=\"equalButton\"]",
+    "description": "Equals button"
+  },
+  "button-plus": {
+    "selector": "app://calculatorapp.exe/Window[@name=\"Calculator\"]/Button[@automationid=\"plusButton\"]",
+    "description": "Addition button"
+  },
+  "button-clear": {
+    "selector": "app://calculatorapp.exe/Window[@name=\"Calculator\"]/Button[@automationid=\"clearButton\"]",
+    "description": "Clear (C) button"
+  },
+  "mode-standard": {
+    "selector": "app://calculatorapp.exe/Window[@name=\"Calculator\"]/Button[@automationid=\"Standard\"]",
+    "description": "Switch to Standard mode"
+  },
+  "mode-scientific": {
+    "selector": "app://calculatorapp.exe/Window[@name=\"Calculator\"]/Button[@automationid=\"Scientific\"]",
+    "description": "Switch to Scientific mode"
+  }
+}

--- a/naturo/selectors_builtin/chrome.json
+++ b/naturo/selectors_builtin/chrome.json
@@ -1,0 +1,34 @@
+{
+  "address-bar": {
+    "selector": "app://chrome.exe/Window[@name=\"*Google Chrome\"]/Pane[@cls=\"Chrome_WidgetWin_1\"]/Edit[@name=\"Address and search bar\"]",
+    "description": "URL address bar and search input"
+  },
+  "tab-strip": {
+    "selector": "app://chrome.exe/Window[@name=\"*Google Chrome\"]/Pane[@cls=\"Chrome_WidgetWin_1\"]/Tab",
+    "description": "Tab strip containing all browser tabs"
+  },
+  "new-tab-button": {
+    "selector": "app://chrome.exe/Window[@name=\"*Google Chrome\"]/Pane[@cls=\"Chrome_WidgetWin_1\"]/Button[@name=\"New Tab\"]",
+    "description": "New tab button next to tab strip"
+  },
+  "back-button": {
+    "selector": "app://chrome.exe/Window[@name=\"*Google Chrome\"]/Pane[@cls=\"Chrome_WidgetWin_1\"]/Button[@name=\"Back\"]",
+    "description": "Navigation back button"
+  },
+  "forward-button": {
+    "selector": "app://chrome.exe/Window[@name=\"*Google Chrome\"]/Pane[@cls=\"Chrome_WidgetWin_1\"]/Button[@name=\"Forward\"]",
+    "description": "Navigation forward button"
+  },
+  "reload-button": {
+    "selector": "app://chrome.exe/Window[@name=\"*Google Chrome\"]/Pane[@cls=\"Chrome_WidgetWin_1\"]/Button[@name=\"Reload\"]",
+    "description": "Page reload button"
+  },
+  "menu-button": {
+    "selector": "app://chrome.exe/Window[@name=\"*Google Chrome\"]/Pane[@cls=\"Chrome_WidgetWin_1\"]/Button[@name=\"Chrome menu\"]",
+    "description": "Three-dot menu button"
+  },
+  "bookmark-bar": {
+    "selector": "app://chrome.exe/Window[@name=\"*Google Chrome\"]/Pane[@cls=\"Chrome_WidgetWin_1\"]/ToolBar[@name=\"Bookmarks\"]",
+    "description": "Bookmarks toolbar"
+  }
+}

--- a/naturo/selectors_builtin/cmd.json
+++ b/naturo/selectors_builtin/cmd.json
@@ -1,0 +1,10 @@
+{
+  "console-output": {
+    "selector": "app://cmd.exe/Window[@name=\"*cmd*\"]/Pane[@cls=\"ConsoleWindowClass\"]",
+    "description": "Console output and input area"
+  },
+  "title-bar": {
+    "selector": "app://cmd.exe/Window[@name=\"*cmd*\"]/TitleBar",
+    "description": "Window title bar"
+  }
+}

--- a/naturo/selectors_builtin/code.json
+++ b/naturo/selectors_builtin/code.json
@@ -1,0 +1,26 @@
+{
+  "explorer-view": {
+    "selector": "app://code.exe/Window[@name=\"*Visual Studio Code*\"]/Pane/Tree[@name=\"*Explorer*\"]",
+    "description": "File explorer side panel"
+  },
+  "editor-tabs": {
+    "selector": "app://code.exe/Window[@name=\"*Visual Studio Code*\"]/Pane/Tab[@name=\"*\"]",
+    "description": "Editor tab bar"
+  },
+  "terminal-panel": {
+    "selector": "app://code.exe/Window[@name=\"*Visual Studio Code*\"]/Pane[@name=\"*Terminal*\"]",
+    "description": "Integrated terminal panel"
+  },
+  "activity-bar": {
+    "selector": "app://code.exe/Window[@name=\"*Visual Studio Code*\"]/ToolBar[@name=\"Activity Bar\"]",
+    "description": "Left activity bar (Explorer, Search, Git, etc.)"
+  },
+  "status-bar": {
+    "selector": "app://code.exe/Window[@name=\"*Visual Studio Code*\"]/Pane[@name=\"Status Bar\"]",
+    "description": "Bottom status bar"
+  },
+  "search-input": {
+    "selector": "app://code.exe/Window[@name=\"*Visual Studio Code*\"]/Pane/Edit[@name=\"Search\"]",
+    "description": "Search input in search panel"
+  }
+}

--- a/naturo/selectors_builtin/control.json
+++ b/naturo/selectors_builtin/control.json
@@ -1,0 +1,18 @@
+{
+  "category-list": {
+    "selector": "app://explorer.exe/Window[@name=\"*Control Panel*\"]/Pane[@cls=\"ShellTabWindowClass\"]/List",
+    "description": "Category or item list in Control Panel"
+  },
+  "address-bar": {
+    "selector": "app://explorer.exe/Window[@name=\"*Control Panel*\"]/Pane[@cls=\"ShellTabWindowClass\"]/Edit[@name=\"Address*\"]",
+    "description": "Address bar showing Control Panel path"
+  },
+  "search-box": {
+    "selector": "app://explorer.exe/Window[@name=\"*Control Panel*\"]/Pane[@cls=\"ShellTabWindowClass\"]/Edit[@name=\"Search*\"]",
+    "description": "Search Control Panel box"
+  },
+  "back-button": {
+    "selector": "app://explorer.exe/Window[@name=\"*Control Panel*\"]/Pane[@cls=\"ShellTabWindowClass\"]/Button[@name=\"Back*\"]",
+    "description": "Navigation back button"
+  }
+}

--- a/naturo/selectors_builtin/excel.json
+++ b/naturo/selectors_builtin/excel.json
@@ -1,0 +1,30 @@
+{
+  "cell-grid": {
+    "selector": "app://excel.exe/Window[@name=\"*Excel*\"]/Pane[@cls=\"EXCEL7\"]/Table",
+    "description": "Main cell grid / spreadsheet area"
+  },
+  "formula-bar": {
+    "selector": "app://excel.exe/Window[@name=\"*Excel*\"]/Edit[@automationid=\"FormulaBar\"]",
+    "description": "Formula bar for cell editing"
+  },
+  "name-box": {
+    "selector": "app://excel.exe/Window[@name=\"*Excel*\"]/Edit[@automationid=\"NameBox\"]",
+    "description": "Cell reference name box (e.g. A1)"
+  },
+  "ribbon": {
+    "selector": "app://excel.exe/Window[@name=\"*Excel*\"]/Pane[@automationid=\"Ribbon\"]",
+    "description": "Ribbon toolbar"
+  },
+  "ribbon-home": {
+    "selector": "app://excel.exe/Window[@name=\"*Excel*\"]/Pane[@automationid=\"Ribbon\"]/Tab[@name=\"Home\"]",
+    "description": "Home ribbon tab"
+  },
+  "sheet-tabs": {
+    "selector": "app://excel.exe/Window[@name=\"*Excel*\"]/Tab[@automationid=\"SheetTab\"]",
+    "description": "Sheet tab bar at bottom"
+  },
+  "status-bar": {
+    "selector": "app://excel.exe/Window[@name=\"*Excel*\"]/StatusBar",
+    "description": "Status bar showing calculation results"
+  }
+}

--- a/naturo/selectors_builtin/explorer.json
+++ b/naturo/selectors_builtin/explorer.json
@@ -1,0 +1,26 @@
+{
+  "navigation-pane": {
+    "selector": "app://explorer.exe/Window[@name=\"*\"]/Pane[@cls=\"ShellTabWindowClass\"]/Tree[@name=\"Navigation pane\"]",
+    "description": "Left navigation tree (Quick access, This PC, etc.)"
+  },
+  "file-list": {
+    "selector": "app://explorer.exe/Window[@name=\"*\"]/Pane[@cls=\"ShellTabWindowClass\"]/List[@automationid=\"ItemsView\"]",
+    "description": "Main file/folder list view"
+  },
+  "address-bar": {
+    "selector": "app://explorer.exe/Window[@name=\"*\"]/Pane[@cls=\"ShellTabWindowClass\"]/Edit[@name=\"Address*\"]",
+    "description": "Address bar showing current path"
+  },
+  "search-box": {
+    "selector": "app://explorer.exe/Window[@name=\"*\"]/Pane[@cls=\"ShellTabWindowClass\"]/Edit[@name=\"Search*\"]",
+    "description": "Search box for finding files"
+  },
+  "back-button": {
+    "selector": "app://explorer.exe/Window[@name=\"*\"]/Pane[@cls=\"ShellTabWindowClass\"]/Button[@name=\"Back*\"]",
+    "description": "Navigation back button"
+  },
+  "up-button": {
+    "selector": "app://explorer.exe/Window[@name=\"*\"]/Pane[@cls=\"ShellTabWindowClass\"]/Button[@name=\"Up*\"]",
+    "description": "Navigate to parent folder"
+  }
+}

--- a/naturo/selectors_builtin/firefox.json
+++ b/naturo/selectors_builtin/firefox.json
@@ -1,0 +1,30 @@
+{
+  "address-bar": {
+    "selector": "app://firefox.exe/Window[@name=\"*Firefox*\"]/Pane[@cls=\"MozillaWindowClass\"]/Edit[@automationid=\"urlbar-input\"]",
+    "description": "URL address bar"
+  },
+  "tab-strip": {
+    "selector": "app://firefox.exe/Window[@name=\"*Firefox*\"]/Pane[@cls=\"MozillaWindowClass\"]/Tab[@automationid=\"tabbrowser-tabs\"]",
+    "description": "Tab strip containing all browser tabs"
+  },
+  "new-tab-button": {
+    "selector": "app://firefox.exe/Window[@name=\"*Firefox*\"]/Pane[@cls=\"MozillaWindowClass\"]/Button[@automationid=\"tabs-newtab-button\"]",
+    "description": "New tab button"
+  },
+  "back-button": {
+    "selector": "app://firefox.exe/Window[@name=\"*Firefox*\"]/Pane[@cls=\"MozillaWindowClass\"]/Button[@automationid=\"back-button\"]",
+    "description": "Navigation back button"
+  },
+  "forward-button": {
+    "selector": "app://firefox.exe/Window[@name=\"*Firefox*\"]/Pane[@cls=\"MozillaWindowClass\"]/Button[@automationid=\"forward-button\"]",
+    "description": "Navigation forward button"
+  },
+  "reload-button": {
+    "selector": "app://firefox.exe/Window[@name=\"*Firefox*\"]/Pane[@cls=\"MozillaWindowClass\"]/Button[@automationid=\"reload-button\"]",
+    "description": "Page reload button"
+  },
+  "hamburger-menu": {
+    "selector": "app://firefox.exe/Window[@name=\"*Firefox*\"]/Pane[@cls=\"MozillaWindowClass\"]/Button[@automationid=\"PanelUI-menu-button\"]",
+    "description": "Application menu (hamburger) button"
+  }
+}

--- a/naturo/selectors_builtin/msedge.json
+++ b/naturo/selectors_builtin/msedge.json
@@ -1,0 +1,34 @@
+{
+  "address-bar": {
+    "selector": "app://msedge.exe/Window[@name=\"*Edge*\"]/Pane[@cls=\"Chrome_WidgetWin_1\"]/Edit[@name=\"Address and search bar\"]",
+    "description": "URL address bar and search input"
+  },
+  "tab-strip": {
+    "selector": "app://msedge.exe/Window[@name=\"*Edge*\"]/Pane[@cls=\"Chrome_WidgetWin_1\"]/Tab",
+    "description": "Tab strip containing all browser tabs"
+  },
+  "new-tab-button": {
+    "selector": "app://msedge.exe/Window[@name=\"*Edge*\"]/Pane[@cls=\"Chrome_WidgetWin_1\"]/Button[@name=\"New tab\"]",
+    "description": "New tab button"
+  },
+  "back-button": {
+    "selector": "app://msedge.exe/Window[@name=\"*Edge*\"]/Pane[@cls=\"Chrome_WidgetWin_1\"]/Button[@name=\"Back\"]",
+    "description": "Navigation back button"
+  },
+  "forward-button": {
+    "selector": "app://msedge.exe/Window[@name=\"*Edge*\"]/Pane[@cls=\"Chrome_WidgetWin_1\"]/Button[@name=\"Forward\"]",
+    "description": "Navigation forward button"
+  },
+  "reload-button": {
+    "selector": "app://msedge.exe/Window[@name=\"*Edge*\"]/Pane[@cls=\"Chrome_WidgetWin_1\"]/Button[@name=\"Refresh\"]",
+    "description": "Page reload button"
+  },
+  "menu-button": {
+    "selector": "app://msedge.exe/Window[@name=\"*Edge*\"]/Pane[@cls=\"Chrome_WidgetWin_1\"]/Button[@name=\"Settings and more\"]",
+    "description": "Three-dot settings menu button"
+  },
+  "sidebar-button": {
+    "selector": "app://msedge.exe/Window[@name=\"*Edge*\"]/Pane[@cls=\"Chrome_WidgetWin_1\"]/Button[@name=\"Sidebar\"]",
+    "description": "Sidebar toggle button"
+  }
+}

--- a/naturo/selectors_builtin/mspaint.json
+++ b/naturo/selectors_builtin/mspaint.json
@@ -1,0 +1,26 @@
+{
+  "canvas": {
+    "selector": "app://mspaint.exe/Window[@name=\"*Paint*\"]/Pane[@cls=\"MSPaintView\"]/Pane[@name=\"Canvas*\"]",
+    "description": "Drawing canvas area"
+  },
+  "tool-palette": {
+    "selector": "app://mspaint.exe/Window[@name=\"*Paint*\"]/Pane[@automationid=\"Ribbon\"]/ToolBar[@name=\"Tools\"]",
+    "description": "Tool selection palette (pencil, brush, shapes, etc.)"
+  },
+  "color-picker": {
+    "selector": "app://mspaint.exe/Window[@name=\"*Paint*\"]/Pane[@automationid=\"Ribbon\"]/Pane[@name=\"Colors*\"]",
+    "description": "Color picker palette"
+  },
+  "ribbon": {
+    "selector": "app://mspaint.exe/Window[@name=\"*Paint*\"]/Pane[@automationid=\"Ribbon\"]",
+    "description": "Ribbon toolbar"
+  },
+  "file-tab": {
+    "selector": "app://mspaint.exe/Window[@name=\"*Paint*\"]/Pane[@automationid=\"Ribbon\"]/Button[@name=\"File*\"]",
+    "description": "File menu tab"
+  },
+  "size-slider": {
+    "selector": "app://mspaint.exe/Window[@name=\"*Paint*\"]/Pane[@automationid=\"Ribbon\"]/Slider[@name=\"Size*\"]",
+    "description": "Brush/tool size slider"
+  }
+}

--- a/naturo/selectors_builtin/notepad.json
+++ b/naturo/selectors_builtin/notepad.json
@@ -1,0 +1,30 @@
+{
+  "edit-area": {
+    "selector": "app://notepad.exe/Window[@name=\"*Notepad*\"]/Edit",
+    "description": "Main text editing area"
+  },
+  "menu-file": {
+    "selector": "app://notepad.exe/Window[@name=\"*Notepad*\"]/MenuBar/MenuItem[@name=\"File\"]",
+    "description": "File menu"
+  },
+  "menu-edit": {
+    "selector": "app://notepad.exe/Window[@name=\"*Notepad*\"]/MenuBar/MenuItem[@name=\"Edit\"]",
+    "description": "Edit menu"
+  },
+  "menu-format": {
+    "selector": "app://notepad.exe/Window[@name=\"*Notepad*\"]/MenuBar/MenuItem[@name=\"Format\"]",
+    "description": "Format menu"
+  },
+  "menu-view": {
+    "selector": "app://notepad.exe/Window[@name=\"*Notepad*\"]/MenuBar/MenuItem[@name=\"View\"]",
+    "description": "View menu"
+  },
+  "status-bar": {
+    "selector": "app://notepad.exe/Window[@name=\"*Notepad*\"]/StatusBar",
+    "description": "Status bar showing cursor position"
+  },
+  "tab-bar": {
+    "selector": "app://notepad.exe/Window[@name=\"*Notepad*\"]/Tab",
+    "description": "Tab bar for multi-tab Notepad (Windows 11)"
+  }
+}

--- a/naturo/selectors_builtin/outlook.json
+++ b/naturo/selectors_builtin/outlook.json
@@ -1,0 +1,26 @@
+{
+  "mail-list": {
+    "selector": "app://outlook.exe/Window[@name=\"*Outlook*\"]/Table[@name=\"*Message list*\"]",
+    "description": "Email message list"
+  },
+  "reading-pane": {
+    "selector": "app://outlook.exe/Window[@name=\"*Outlook*\"]/Pane[@name=\"Reading Pane*\"]",
+    "description": "Email reading/preview pane"
+  },
+  "folder-list": {
+    "selector": "app://outlook.exe/Window[@name=\"*Outlook*\"]/Tree[@name=\"*Folder*\"]",
+    "description": "Folder navigation tree (Inbox, Sent, etc.)"
+  },
+  "new-email-button": {
+    "selector": "app://outlook.exe/Window[@name=\"*Outlook*\"]/Button[@name=\"New Email*\"]",
+    "description": "New email compose button"
+  },
+  "search-box": {
+    "selector": "app://outlook.exe/Window[@name=\"*Outlook*\"]/Edit[@name=\"Search*\"]",
+    "description": "Mail search box"
+  },
+  "ribbon": {
+    "selector": "app://outlook.exe/Window[@name=\"*Outlook*\"]/Pane[@automationid=\"Ribbon\"]",
+    "description": "Ribbon toolbar"
+  }
+}

--- a/naturo/selectors_builtin/powerpnt.json
+++ b/naturo/selectors_builtin/powerpnt.json
@@ -1,0 +1,26 @@
+{
+  "slide-panel": {
+    "selector": "app://powerpnt.exe/Window[@name=\"*PowerPoint*\"]/Pane[@cls=\"mdiClass\"]/Pane[@name=\"Slide*\"]",
+    "description": "Main slide editing area"
+  },
+  "slide-thumbnails": {
+    "selector": "app://powerpnt.exe/Window[@name=\"*PowerPoint*\"]/Pane[@cls=\"mdiClass\"]/List[@name=\"Slides*\"]",
+    "description": "Slide thumbnail panel on the left"
+  },
+  "notes-area": {
+    "selector": "app://powerpnt.exe/Window[@name=\"*PowerPoint*\"]/Pane[@cls=\"mdiClass\"]/Edit[@name=\"Notes*\"]",
+    "description": "Speaker notes area below slide"
+  },
+  "ribbon": {
+    "selector": "app://powerpnt.exe/Window[@name=\"*PowerPoint*\"]/Pane[@automationid=\"Ribbon\"]",
+    "description": "Ribbon toolbar"
+  },
+  "ribbon-home": {
+    "selector": "app://powerpnt.exe/Window[@name=\"*PowerPoint*\"]/Pane[@automationid=\"Ribbon\"]/Tab[@name=\"Home\"]",
+    "description": "Home ribbon tab"
+  },
+  "status-bar": {
+    "selector": "app://powerpnt.exe/Window[@name=\"*PowerPoint*\"]/StatusBar",
+    "description": "Status bar with slide number and view controls"
+  }
+}

--- a/naturo/selectors_builtin/regedit.json
+++ b/naturo/selectors_builtin/regedit.json
@@ -1,0 +1,22 @@
+{
+  "tree-view": {
+    "selector": "app://regedit.exe/Window[@name=\"Registry Editor\"]/Tree[@cls=\"SysTreeView32\"]",
+    "description": "Registry key tree navigation"
+  },
+  "value-list": {
+    "selector": "app://regedit.exe/Window[@name=\"Registry Editor\"]/List[@cls=\"SysListView32\"]",
+    "description": "Registry value list for selected key"
+  },
+  "address-bar": {
+    "selector": "app://regedit.exe/Window[@name=\"Registry Editor\"]/Edit[@cls=\"Edit\"]",
+    "description": "Registry path address bar"
+  },
+  "status-bar": {
+    "selector": "app://regedit.exe/Window[@name=\"Registry Editor\"]/StatusBar",
+    "description": "Status bar showing selected key path"
+  },
+  "menu-edit": {
+    "selector": "app://regedit.exe/Window[@name=\"Registry Editor\"]/MenuBar/MenuItem[@name=\"Edit\"]",
+    "description": "Edit menu for find, modify, permissions"
+  }
+}

--- a/naturo/selectors_builtin/snippingtool.json
+++ b/naturo/selectors_builtin/snippingtool.json
@@ -1,0 +1,22 @@
+{
+  "new-button": {
+    "selector": "app://snippingtool.exe/Window[@name=\"Snipping Tool\"]/Button[@automationid=\"NewSnipButton\"]",
+    "description": "New snip capture button"
+  },
+  "mode-selector": {
+    "selector": "app://snippingtool.exe/Window[@name=\"Snipping Tool\"]/ComboBox[@automationid=\"SnipModeComboBox\"]",
+    "description": "Snip mode selector (Rectangle, Window, Full screen, Free-form)"
+  },
+  "delay-selector": {
+    "selector": "app://snippingtool.exe/Window[@name=\"Snipping Tool\"]/ComboBox[@automationid=\"DelayComboBox\"]",
+    "description": "Delay timer selector"
+  },
+  "screenshot-area": {
+    "selector": "app://snippingtool.exe/Window[@name=\"Snipping Tool\"]/Pane[@name=\"*screenshot*\"]",
+    "description": "Screenshot preview area"
+  },
+  "save-button": {
+    "selector": "app://snippingtool.exe/Window[@name=\"Snipping Tool\"]/Button[@name=\"Save*\"]",
+    "description": "Save snip button"
+  }
+}

--- a/naturo/selectors_builtin/systemsettings.json
+++ b/naturo/selectors_builtin/systemsettings.json
@@ -1,0 +1,26 @@
+{
+  "search-box": {
+    "selector": "app://systemsettings.exe/Window[@name=\"Settings\"]/Edit[@automationid=\"SearchTextBox\"]",
+    "description": "Settings search box"
+  },
+  "navigation-pane": {
+    "selector": "app://systemsettings.exe/Window[@name=\"Settings\"]/List[@automationid=\"NavigationMenuList\"]",
+    "description": "Left navigation menu (System, Bluetooth, Network, etc.)"
+  },
+  "system-category": {
+    "selector": "app://systemsettings.exe/Window[@name=\"Settings\"]/List[@automationid=\"NavigationMenuList\"]/ListItem[@name=\"System\"]",
+    "description": "System settings category"
+  },
+  "network-category": {
+    "selector": "app://systemsettings.exe/Window[@name=\"Settings\"]/List[@automationid=\"NavigationMenuList\"]/ListItem[@name=\"Network*\"]",
+    "description": "Network & internet settings category"
+  },
+  "back-button": {
+    "selector": "app://systemsettings.exe/Window[@name=\"Settings\"]/Button[@automationid=\"NavigationViewBackButton\"]",
+    "description": "Back navigation button"
+  },
+  "content-area": {
+    "selector": "app://systemsettings.exe/Window[@name=\"Settings\"]/Pane[@automationid=\"ContentFrame\"]",
+    "description": "Main content area for current setting page"
+  }
+}

--- a/naturo/selectors_builtin/taskmgr.json
+++ b/naturo/selectors_builtin/taskmgr.json
@@ -1,0 +1,26 @@
+{
+  "process-list": {
+    "selector": "app://taskmgr.exe/Window[@name=\"Task Manager\"]/Table[@automationid=\"ProcessList\"]",
+    "description": "Process list table in Processes tab"
+  },
+  "tab-processes": {
+    "selector": "app://taskmgr.exe/Window[@name=\"Task Manager\"]/List[@automationid=\"NavigationMenuList\"]/ListItem[@name=\"Processes\"]",
+    "description": "Processes tab"
+  },
+  "tab-performance": {
+    "selector": "app://taskmgr.exe/Window[@name=\"Task Manager\"]/List[@automationid=\"NavigationMenuList\"]/ListItem[@name=\"Performance\"]",
+    "description": "Performance tab"
+  },
+  "tab-details": {
+    "selector": "app://taskmgr.exe/Window[@name=\"Task Manager\"]/List[@automationid=\"NavigationMenuList\"]/ListItem[@name=\"Details\"]",
+    "description": "Details tab"
+  },
+  "search-box": {
+    "selector": "app://taskmgr.exe/Window[@name=\"Task Manager\"]/Edit[@automationid=\"SearchBox\"]",
+    "description": "Search/filter box"
+  },
+  "end-task-button": {
+    "selector": "app://taskmgr.exe/Window[@name=\"Task Manager\"]/Button[@name=\"End task\"]",
+    "description": "End task button for selected process"
+  }
+}

--- a/naturo/selectors_builtin/teams.json
+++ b/naturo/selectors_builtin/teams.json
@@ -1,0 +1,26 @@
+{
+  "chat-list": {
+    "selector": "app://ms-teams.exe/Window[@name=\"*Teams*\"]/List[@name=\"*Chat*\"]",
+    "description": "Chat conversation list"
+  },
+  "message-input": {
+    "selector": "app://ms-teams.exe/Window[@name=\"*Teams*\"]/Edit[@name=\"*message*\"]",
+    "description": "Message compose input field"
+  },
+  "send-button": {
+    "selector": "app://ms-teams.exe/Window[@name=\"*Teams*\"]/Button[@name=\"Send*\"]",
+    "description": "Send message button"
+  },
+  "call-button": {
+    "selector": "app://ms-teams.exe/Window[@name=\"*Teams*\"]/Button[@name=\"*call*\"]",
+    "description": "Start call button"
+  },
+  "search-box": {
+    "selector": "app://ms-teams.exe/Window[@name=\"*Teams*\"]/Edit[@name=\"Search*\"]",
+    "description": "Search bar for chats, people, and files"
+  },
+  "activity-nav": {
+    "selector": "app://ms-teams.exe/Window[@name=\"*Teams*\"]/Button[@name=\"Activity\"]",
+    "description": "Activity navigation button"
+  }
+}

--- a/naturo/selectors_builtin/windowsterminal.json
+++ b/naturo/selectors_builtin/windowsterminal.json
@@ -1,0 +1,18 @@
+{
+  "tab-bar": {
+    "selector": "app://windowsterminal.exe/Window[@name=\"*\"]/Tab[@automationid=\"TabView\"]",
+    "description": "Tab bar containing terminal tabs"
+  },
+  "new-tab-button": {
+    "selector": "app://windowsterminal.exe/Window[@name=\"*\"]/Button[@automationid=\"AddTabButton\"]",
+    "description": "New tab button"
+  },
+  "terminal-pane": {
+    "selector": "app://windowsterminal.exe/Window[@name=\"*\"]/Pane[@cls=\"TermControl\"]",
+    "description": "Active terminal input/output pane"
+  },
+  "settings-button": {
+    "selector": "app://windowsterminal.exe/Window[@name=\"*\"]/Button[@name=\"Settings*\"]",
+    "description": "Settings dropdown button"
+  }
+}

--- a/naturo/selectors_builtin/winword.json
+++ b/naturo/selectors_builtin/winword.json
@@ -1,0 +1,26 @@
+{
+  "document-area": {
+    "selector": "app://winword.exe/Window[@name=\"*Word*\"]/Pane[@cls=\"_WwG\"]/Document",
+    "description": "Main document editing area"
+  },
+  "ribbon": {
+    "selector": "app://winword.exe/Window[@name=\"*Word*\"]/Pane[@automationid=\"Ribbon\"]",
+    "description": "Ribbon toolbar"
+  },
+  "ribbon-home": {
+    "selector": "app://winword.exe/Window[@name=\"*Word*\"]/Pane[@automationid=\"Ribbon\"]/Tab[@name=\"Home\"]",
+    "description": "Home ribbon tab"
+  },
+  "ribbon-insert": {
+    "selector": "app://winword.exe/Window[@name=\"*Word*\"]/Pane[@automationid=\"Ribbon\"]/Tab[@name=\"Insert\"]",
+    "description": "Insert ribbon tab"
+  },
+  "status-bar": {
+    "selector": "app://winword.exe/Window[@name=\"*Word*\"]/StatusBar",
+    "description": "Status bar showing page/word count"
+  },
+  "file-tab": {
+    "selector": "app://winword.exe/Window[@name=\"*Word*\"]/Pane[@automationid=\"Ribbon\"]/Button[@name=\"File Tab\"]",
+    "description": "File tab (Backstage view)"
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ naturo = "naturo.cli:main"
 include = ["naturo*"]
 
 [tool.setuptools.package-data]
-naturo = ["bin/*.dll", "bin/*.so", "bin/*.dylib"]
+naturo = ["bin/*.dll", "bin/*.so", "bin/*.dylib", "selectors_builtin/*.json"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/test_builtin_selectors.py
+++ b/tests/test_builtin_selectors.py
@@ -132,6 +132,18 @@ class TestBuiltinCLIIntegration:
         assert "No built-in selectors" in result.output
 
 
+class TestPackageData:
+    """Ensure built-in templates are included in package distribution."""
+
+    def test_pyproject_includes_json_templates(self):
+        import tomllib
+        pyproject = Path(__file__).parent.parent / "pyproject.toml"
+        with open(pyproject, "rb") as f:
+            config = tomllib.load(f)
+        package_data = config["tool"]["setuptools"]["package-data"]["naturo"]
+        assert "selectors_builtin/*.json" in package_data
+
+
 class TestBuiltinLoaderFunction:
     """Test the _list_builtin_selectors function directly."""
 

--- a/tests/test_builtin_selectors.py
+++ b/tests/test_builtin_selectors.py
@@ -1,0 +1,150 @@
+"""Tests for built-in selector templates (issue #104).
+
+Validates that all 20 built-in app selector templates are correctly
+formatted, loadable, and integrate with the selector CLI commands.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from naturo.cli import main
+from naturo.cli import selector_cmd
+
+BUILTIN_DIR = Path(__file__).parent.parent / "naturo" / "selectors_builtin"
+
+EXPECTED_APPS = [
+    "calc",
+    "chrome",
+    "cmd",
+    "code",
+    "control",
+    "excel",
+    "explorer",
+    "firefox",
+    "msedge",
+    "mspaint",
+    "notepad",
+    "outlook",
+    "powerpnt",
+    "regedit",
+    "snippingtool",
+    "systemsettings",
+    "taskmgr",
+    "teams",
+    "windowsterminal",
+    "winword",
+]
+
+
+@pytest.fixture()
+def runner():
+    return CliRunner()
+
+
+class TestBuiltinTemplateFiles:
+    """Validate the template JSON files on disk."""
+
+    def test_builtin_directory_exists(self):
+        assert BUILTIN_DIR.is_dir(), f"Missing directory: {BUILTIN_DIR}"
+
+    def test_all_20_apps_present(self):
+        found = sorted(f.stem for f in BUILTIN_DIR.glob("*.json"))
+        assert found == EXPECTED_APPS
+
+    @pytest.mark.parametrize("app", EXPECTED_APPS)
+    def test_valid_json(self, app):
+        path = BUILTIN_DIR / f"{app}.json"
+        data = json.loads(path.read_text(encoding="utf-8"))
+        assert isinstance(data, dict)
+        assert len(data) >= 1, f"{app}.json must have at least 1 selector"
+
+    @pytest.mark.parametrize("app", EXPECTED_APPS)
+    def test_selector_format(self, app):
+        path = BUILTIN_DIR / f"{app}.json"
+        data = json.loads(path.read_text(encoding="utf-8"))
+        for name, info in data.items():
+            assert isinstance(info, dict), f"{app}/{name}: value must be dict"
+            assert "selector" in info, f"{app}/{name}: missing 'selector' key"
+            assert "description" in info, f"{app}/{name}: missing 'description' key"
+            assert info["selector"].startswith("app://"), (
+                f"{app}/{name}: selector must start with app://"
+            )
+            assert len(info["description"]) > 0, (
+                f"{app}/{name}: description must not be empty"
+            )
+
+    @pytest.mark.parametrize("app", EXPECTED_APPS)
+    def test_selector_names_are_kebab_case(self, app):
+        path = BUILTIN_DIR / f"{app}.json"
+        data = json.loads(path.read_text(encoding="utf-8"))
+        for name in data:
+            assert name == name.lower(), f"{app}/{name}: must be lowercase"
+            assert " " not in name, f"{app}/{name}: no spaces allowed"
+
+    def test_total_selector_count(self):
+        total = 0
+        for f in BUILTIN_DIR.glob("*.json"):
+            data = json.loads(f.read_text(encoding="utf-8"))
+            total += len(data)
+        assert total >= 100, f"Expected 100+ selectors, got {total}"
+
+
+class TestBuiltinCLIIntegration:
+    """Test that built-in selectors load through the CLI commands."""
+
+    def test_list_builtin_loads_all_apps(self, runner):
+        result = runner.invoke(main, ["selector", "list", "--builtin"])
+        assert result.exit_code == 0
+        for app in EXPECTED_APPS:
+            assert app in result.output, f"Missing app '{app}' in list output"
+
+    def test_list_builtin_json(self, runner):
+        result = runner.invoke(main, ["selector", "list", "--builtin", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert len(data) == 20
+        for app in EXPECTED_APPS:
+            assert app in data
+
+    def test_list_builtin_filter_by_app(self, runner):
+        result = runner.invoke(main, [
+            "selector", "list", "--builtin", "--app", "notepad",
+        ])
+        assert result.exit_code == 0
+        assert "notepad" in result.output
+        assert "edit-area" in result.output
+
+    def test_show_merges_builtin(self, runner):
+        result = runner.invoke(main, ["selector", "show", "calc"])
+        assert result.exit_code == 0
+        assert "display" in result.output
+        assert "CalculatorResults" in result.output
+
+    def test_list_builtin_nonexistent_app(self, runner):
+        result = runner.invoke(main, [
+            "selector", "list", "--builtin", "--app", "nonexistent",
+        ])
+        assert result.exit_code == 0
+        assert "No built-in selectors" in result.output
+
+
+class TestBuiltinLoaderFunction:
+    """Test the _list_builtin_selectors function directly."""
+
+    def test_loads_all_apps(self):
+        result = selector_cmd._list_builtin_selectors()
+        assert len(result) == 20
+        for app in EXPECTED_APPS:
+            assert app in result
+
+    def test_each_app_has_selectors(self):
+        result = selector_cmd._list_builtin_selectors()
+        for app, selectors in result.items():
+            assert len(selectors) >= 1, f"{app} must have at least 1 selector"
+            for name, info in selectors.items():
+                assert "selector" in info
+                assert "description" in info


### PR DESCRIPTION
20 JSON template files in naturo/selectors_builtin/ covering Notepad, Chrome, Firefox, Edge, Explorer, VS Code, Word, Excel, PowerPoint, Calculator, Settings, Task Manager, Windows Terminal, Outlook, Teams, CMD, Paint, Snipping Tool, Control Panel, and Registry Editor (119 selectors total). Templates use automationid where available for locale-independence.

**Tests**: 70 new tests. Ruff clean, mypy clean.

**[Orc-Mycelium]** Created on behalf of Dev-Sirius.