### PR TITLE
feat: add selector load command and @app/name resolution (fixes #105)

### DIFF
--- a/naturo/cli/interaction/_common.py
+++ b/naturo/cli/interaction/_common.py
@@ -486,6 +486,15 @@ def _resolve_selector_target(
         parse, SelectorParseError, SelectorResolver, normalize_app_name,
     )
 
+    # Resolve @app/name references to stored selector strings (#105)
+    if selector_str.startswith("@"):
+        from naturo.cli.selector_cmd import resolve_named_selector
+        try:
+            selector_str = resolve_named_selector(selector_str)
+        except (KeyError, ValueError) as exc:
+            _json_err(str(exc), json_output, code="SELECTOR_REF_ERROR")
+            return None
+
     # Parse the selector
     try:
         ast = parse(selector_str)

--- a/naturo/cli/selector_cmd.py
+++ b/naturo/cli/selector_cmd.py
@@ -80,6 +80,46 @@ def _list_builtin_selectors() -> dict[str, dict]:
     return result
 
 
+def resolve_named_selector(reference: str) -> str:
+    """Resolve an ``@app/name`` reference to its selector string.
+
+    Searches user selectors first, then built-in templates.
+
+    Args:
+        reference: An ``@app/name`` reference (the leading ``@`` is optional).
+
+    Returns:
+        The selector string stored under that name.
+
+    Raises:
+        KeyError: If the reference cannot be found in user or built-in selectors.
+        ValueError: If the reference format is invalid.
+    """
+    ref = reference.lstrip("@")
+    if "/" not in ref:
+        raise ValueError(
+            f"Invalid selector reference '{reference}': expected @app/name format"
+        )
+    app_name, name = ref.split("/", 1)
+    if not app_name or not name:
+        raise ValueError(
+            f"Invalid selector reference '{reference}': app and name must be non-empty"
+        )
+
+    # User selectors take priority over built-in templates
+    user_sels = _load_selectors(app_name)
+    if name in user_sels:
+        info = user_sels[name]
+        return info.get("selector", info) if isinstance(info, dict) else info
+
+    builtin_sels = _list_builtin_selectors().get(app_name, {})
+    if name in builtin_sels:
+        info = builtin_sels[name]
+        return info.get("selector", info) if isinstance(info, dict) else info
+
+    raise KeyError(f"Selector not found: @{app_name}/{name}")
+
+
 @click.group("selector", cls=FuzzyGroup)
 def selector():
     """Manage saved selectors for UI elements.
@@ -87,6 +127,7 @@ def selector():
     \b
     Examples:
         naturo selector save notepad save-btn 'app://notepad.exe/Button[@name="Save"]'
+        naturo selector load notepad save-btn
         naturo selector list
         naturo selector list --app notepad
         naturo selector show notepad
@@ -133,6 +174,52 @@ def selector_save(app_name: str, name: str, selector_value: str,
         action = "Updated" if is_update else "Saved"
         click.echo(f"{action}: @{app_name}/{name}")
         click.echo(f"Selector: {selector_value}")
+
+
+@click.command("load")
+@click.argument("app_name")
+@click.argument("name")
+@click.option("-j", "--json", "json_output", is_flag=True, help="Output JSON.")
+def selector_load(app_name: str, name: str, json_output: bool):
+    """Load a saved selector by name.
+
+    Searches user selectors first, then built-in templates.
+    Use with interaction commands: naturo click --selector @app/name
+
+    \b
+    Examples:
+        naturo selector load notepad save-btn
+        naturo selector load chrome address-bar --json
+    """
+    try:
+        sel_str = resolve_named_selector(f"{app_name}/{name}")
+    except KeyError:
+        msg = f"Selector not found: @{app_name}/{name}"
+        if json_output:
+            click.echo(json.dumps({"success": False, "error": msg}))
+        else:
+            click.echo(f"Error: {msg}", err=True)
+        sys.exit(1)
+
+    # Get full info for description
+    user_sels = _load_selectors(app_name)
+    builtin_sels = _list_builtin_selectors().get(app_name, {})
+    merged = {**builtin_sels, **user_sels}
+    info = merged.get(name, {})
+    desc = info.get("description", "") if isinstance(info, dict) else ""
+    source = "user" if name in user_sels else "builtin"
+
+    if json_output:
+        click.echo(json.dumps({
+            "success": True,
+            "app": app_name,
+            "name": name,
+            "selector": sel_str,
+            "description": desc,
+            "source": source,
+        }))
+    else:
+        click.echo(sel_str)
 
 
 @click.command("list")
@@ -431,6 +518,7 @@ def selector_test(app_name: str, name: str, json_output: bool):
 
 # Register subcommands
 selector.add_command(selector_save, "save")
+selector.add_command(selector_load, "load")
 selector.add_command(selector_list, "list")
 selector.add_command(selector_show, "show")
 selector.add_command(selector_delete, "delete")

--- a/tests/test_selector_cmd.py
+++ b/tests/test_selector_cmd.py
@@ -85,6 +85,113 @@ class TestSelectorSave:
         assert data["name"] == "btn"
 
 
+# ── selector load ────────────────────────────────────────────────────────────
+
+
+class TestSelectorLoad:
+    def test_load_user_selector(self, runner, tmp_selectors):
+        runner.invoke(main, [
+            "selector", "save", "notepad", "save-btn",
+            "app://notepad.exe/Button[@name='Save']",
+            "-d", "Save button",
+        ])
+        result = runner.invoke(main, ["selector", "load", "notepad", "save-btn"])
+        assert result.exit_code == 0
+        assert "app://notepad.exe/Button[@name='Save']" in result.output
+
+    def test_load_not_found(self, runner, tmp_selectors):
+        result = runner.invoke(main, ["selector", "load", "notepad", "nope"])
+        assert result.exit_code != 0
+
+    def test_load_json_output(self, runner, tmp_selectors):
+        runner.invoke(main, [
+            "selector", "save", "notepad", "save-btn",
+            "app://notepad.exe/Button[@name='Save']",
+            "-d", "Save button",
+        ])
+        result = runner.invoke(main, [
+            "selector", "load", "notepad", "save-btn", "--json",
+        ])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["success"] is True
+        assert data["selector"] == "app://notepad.exe/Button[@name='Save']"
+        assert data["source"] == "user"
+        assert data["description"] == "Save button"
+
+    def test_load_builtin_fallback(self, runner, tmp_selectors, tmp_builtin):
+        result = runner.invoke(main, [
+            "selector", "load", "notepad", "edit-area", "--json",
+        ])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["success"] is True
+        assert data["source"] == "builtin"
+
+    def test_load_user_takes_priority_over_builtin(self, runner, tmp_selectors, tmp_builtin):
+        # Save user selector with same name as builtin
+        runner.invoke(main, [
+            "selector", "save", "notepad", "edit-area",
+            "app://notepad.exe/Edit[@name='Custom']",
+        ])
+        result = runner.invoke(main, [
+            "selector", "load", "notepad", "edit-area", "--json",
+        ])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["source"] == "user"
+        assert "Custom" in data["selector"]
+
+
+# ── resolve_named_selector ──────────────────────────────────────────────────
+
+
+class TestResolveNamedSelector:
+    def test_resolve_user_selector(self, tmp_selectors):
+        # Write selector file directly
+        data = {"btn": {"selector": "app://test.exe/Button", "description": ""}}
+        (tmp_selectors / "testapp.json").write_text(json.dumps(data))
+        result = selector_cmd.resolve_named_selector("@testapp/btn")
+        assert result == "app://test.exe/Button"
+
+    def test_resolve_without_at_prefix(self, tmp_selectors):
+        data = {"btn": {"selector": "app://test.exe/Button", "description": ""}}
+        (tmp_selectors / "testapp.json").write_text(json.dumps(data))
+        result = selector_cmd.resolve_named_selector("testapp/btn")
+        assert result == "app://test.exe/Button"
+
+    def test_resolve_not_found_raises_key_error(self, tmp_selectors):
+        with pytest.raises(KeyError, match="Selector not found"):
+            selector_cmd.resolve_named_selector("@noapp/nosel")
+
+    def test_resolve_invalid_format_raises_value_error(self, tmp_selectors):
+        with pytest.raises(ValueError, match="expected @app/name"):
+            selector_cmd.resolve_named_selector("@invalid")
+
+    def test_resolve_empty_parts_raises_value_error(self, tmp_selectors):
+        with pytest.raises(ValueError, match="must be non-empty"):
+            selector_cmd.resolve_named_selector("@/name")
+
+
+# ── @app/name resolution in interaction commands ────────────────────────────
+
+
+class TestSelectorRefResolution:
+    """Test @app/name resolution in _resolve_selector_target."""
+
+    def test_at_ref_resolved_before_parse(self, tmp_selectors):
+        """Verify resolve_named_selector is called for @ references."""
+        data = {"btn": {"selector": "app://notepad.exe/Button[@name='OK']", "description": ""}}
+        (tmp_selectors / "notepad.json").write_text(json.dumps(data))
+        resolved = selector_cmd.resolve_named_selector("@notepad/btn")
+        assert resolved == "app://notepad.exe/Button[@name='OK']"
+
+    def test_at_ref_builtin_resolved(self, tmp_selectors, tmp_builtin):
+        """Verify builtin selectors are resolved via @ references."""
+        resolved = selector_cmd.resolve_named_selector("@notepad/edit-area")
+        assert "notepad.exe" in resolved
+
+
 # ── selector list ────────────────────────────────────────────────────────────
 
 
@@ -276,10 +383,15 @@ class TestSelectorHelp:
         result = runner.invoke(main, ["selector", "--help"])
         assert result.exit_code == 0
         assert "save" in result.output
+        assert "load" in result.output
         assert "list" in result.output
         assert "export" in result.output
         assert "import" in result.output
         assert "test" in result.output
+
+    def test_selector_load_help(self, runner):
+        result = runner.invoke(main, ["selector", "load", "--help"])
+        assert result.exit_code == 0
 
     def test_selector_save_help(self, runner):
         result = runner.invoke(main, ["selector", "save", "--help"])


### PR DESCRIPTION
Builds on PR #805 (basic selector management). Adds:
- `naturo selector load <app> <name>` to retrieve saved selectors by name
- @app/name reference resolution in all interaction commands (click, type, press, scroll, move, drag)
- Public `resolve_named_selector()` API (user selectors override built-in templates)

**Tests**: 13 new tests. Ruff clean, mypy clean.

**[Orc-Mycelium]** Created on behalf of Dev-Sirius.