### PR TITLE
feat: add browser stealth-check verification command (fixes #760)

### DIFF
--- a/naturo/browser/_stealth.py
+++ b/naturo/browser/_stealth.py
@@ -21,12 +21,13 @@ Usage (CLI)::
 
     naturo browser stealth              # Apply to running browser
     naturo browser stealth-flags        # Print flags for manual launch
+    naturo browser stealth-check        # Verify patches are working
 """
 
 from __future__ import annotations
 
 import logging
-from typing import List
+from typing import Dict, List
 
 logger = logging.getLogger(__name__)
 
@@ -148,3 +149,74 @@ def apply_stealth_patches(page) -> int:
             logger.warning("Failed to apply stealth patch: %s", exc)
     logger.info("Applied %d/%d stealth patches", count, len(ALL_PATCHES))
     return count
+
+
+# ── Stealth verification ────────────────────────────────────────────────────
+
+_CHECK_JS = """
+(function() {
+    var results = {};
+
+    // 1. navigator.webdriver should be undefined (not true)
+    results.webdriver = (navigator.webdriver === undefined || navigator.webdriver === false);
+
+    // 2. navigator.plugins should have entries
+    results.plugins = (navigator.plugins && navigator.plugins.length > 0);
+
+    // 3. navigator.languages should be populated
+    results.languages = (navigator.languages && navigator.languages.length > 0);
+
+    // 4. chrome.runtime should exist
+    results.chrome_runtime = !!(window.chrome && window.chrome.runtime);
+
+    // 5. WebGL vendor should not be empty/default
+    try {
+        var canvas = document.createElement('canvas');
+        var gl = canvas.getContext('webgl');
+        if (gl) {
+            var debugInfo = gl.getExtension('WEBGL_debug_renderer_info');
+            if (debugInfo) {
+                var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);
+                results.webgl_vendor = (vendor && vendor.length > 0);
+            } else {
+                results.webgl_vendor = true;  // No debug info = not detectable
+            }
+        } else {
+            results.webgl_vendor = true;  // No WebGL = not detectable
+        }
+    } catch(e) {
+        results.webgl_vendor = true;  // Error = not detectable
+    }
+
+    // 6. Notification.permission should not expose automation
+    try {
+        results.permissions = (typeof Notification === 'undefined'
+                               || Notification.permission !== 'denied');
+    } catch(e) {
+        results.permissions = true;
+    }
+
+    return results;
+})()
+"""
+
+
+def check_stealth(page) -> Dict[str, bool]:
+    """Run stealth verification checks against a BrowserPage.
+
+    Evaluates JavaScript checks for the 6 detection vectors that
+    :func:`apply_stealth_patches` addresses. Each check returns True
+    if the browser appears non-automated for that vector.
+
+    Args:
+        page: A :class:`~naturo.browser.BrowserPage` instance.
+
+    Returns:
+        Dict mapping check name to pass/fail boolean.  Keys:
+        ``webdriver``, ``plugins``, ``languages``, ``chrome_runtime``,
+        ``webgl_vendor``, ``permissions``.
+    """
+    result = page._cdp.evaluate(_CHECK_JS)
+    if not isinstance(result, dict):
+        raise RuntimeError(f"Stealth check returned unexpected type: {type(result)}")
+    return result

--- a/naturo/cli/browser_cmd.py
+++ b/naturo/cli/browser_cmd.py
@@ -779,6 +779,59 @@ def stealth_flags_cmd(json_output: bool) -> None:
         click.echo(" ".join(STEALTH_FLAGS))
 
 
+@browser.command("stealth-check")
+@click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
+@click.pass_context
+def stealth_check_cmd(ctx: click.Context, json_output: bool) -> None:
+    """Verify stealth patches are working in the running browser.
+
+    Runs 6 JavaScript checks against common bot-detection vectors:
+    webdriver, plugins, languages, chrome.runtime, WebGL vendor,
+    and permissions. Exits non-zero if any check fails.
+
+    \\b
+    Examples:
+        naturo browser stealth-check
+        naturo browser stealth-check --json
+    """
+    from naturo.browser._stealth import check_stealth
+
+    page = None
+    try:
+        page = _get_page(ctx)
+        results = check_stealth(page)
+        all_passed = all(results.values())
+
+        if json_output:
+            click.echo(json_module.dumps({
+                "success": all_passed,
+                "checks": results,
+            }))
+        else:
+            for name, passed in results.items():
+                status = "PASS" if passed else "FAIL"
+                click.echo(f"  {name}: {status}")
+            if all_passed:
+                click.echo(f"\nAll {len(results)} checks passed.")
+            else:
+                failed = [k for k, v in results.items() if not v]
+                click.echo(f"\n{len(failed)} check(s) failed: {', '.join(failed)}")
+
+        if not all_passed:
+            raise SystemExit(1)
+    except SystemExit:
+        raise
+    except Exception as exc:
+        if json_output:
+            click.echo(json_module.dumps({"error": str(exc)}))
+        else:
+            click.echo(f"Error: {exc}", err=True)
+        raise SystemExit(1)
+    finally:
+        if page is not None:
+            page.close()
+
+
 # ── Captcha ───────────────────────────────────────────────────────────────────
 
 

--- a/tests/test_stealth_check.py
+++ b/tests/test_stealth_check.py
@@ -1,0 +1,190 @@
+"""Tests for #760: browser stealth-check verification command.
+
+Tests check_stealth() function and the CLI stealth-check command.
+All tests mock the CDP layer — no browser required.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from naturo.browser._stealth import check_stealth
+from naturo.cli.browser_cmd import browser
+
+
+@pytest.fixture
+def mock_page():
+    """Create a mock BrowserPage with a mock CDP connection."""
+    page = MagicMock()
+    page._cdp = MagicMock()
+    return page
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+# ── check_stealth() unit tests ──────────────────────────────────────────────
+
+
+class TestCheckStealth:
+    """Tests for the check_stealth() function."""
+
+    def test_all_checks_pass(self, mock_page):
+        """All checks return True when stealth patches are applied."""
+        mock_page._cdp.evaluate.return_value = {
+            "webdriver": True,
+            "plugins": True,
+            "languages": True,
+            "chrome_runtime": True,
+            "webgl_vendor": True,
+            "permissions": True,
+        }
+        result = check_stealth(mock_page)
+        assert all(result.values())
+        assert len(result) == 6
+
+    def test_some_checks_fail(self, mock_page):
+        """Failed checks return False for their keys."""
+        mock_page._cdp.evaluate.return_value = {
+            "webdriver": False,
+            "plugins": True,
+            "languages": True,
+            "chrome_runtime": False,
+            "webgl_vendor": True,
+            "permissions": True,
+        }
+        result = check_stealth(mock_page)
+        assert result["webdriver"] is False
+        assert result["chrome_runtime"] is False
+        assert result["plugins"] is True
+
+    def test_all_checks_fail(self, mock_page):
+        """All checks fail when no stealth patches are applied."""
+        mock_page._cdp.evaluate.return_value = {
+            "webdriver": False,
+            "plugins": False,
+            "languages": False,
+            "chrome_runtime": False,
+            "webgl_vendor": False,
+            "permissions": False,
+        }
+        result = check_stealth(mock_page)
+        assert not any(result.values())
+
+    def test_unexpected_return_type_raises(self, mock_page):
+        """Non-dict return from JS raises RuntimeError."""
+        mock_page._cdp.evaluate.return_value = "unexpected"
+        with pytest.raises(RuntimeError, match="unexpected type"):
+            check_stealth(mock_page)
+
+    def test_none_return_raises(self, mock_page):
+        """None return from JS raises RuntimeError."""
+        mock_page._cdp.evaluate.return_value = None
+        with pytest.raises(RuntimeError, match="unexpected type"):
+            check_stealth(mock_page)
+
+
+# ── CLI stealth-check command tests ──────────────────────────────────────────
+
+
+ALL_PASS = {
+    "webdriver": True,
+    "plugins": True,
+    "languages": True,
+    "chrome_runtime": True,
+    "webgl_vendor": True,
+    "permissions": True,
+}
+
+SOME_FAIL = {
+    "webdriver": False,
+    "plugins": True,
+    "languages": True,
+    "chrome_runtime": False,
+    "webgl_vendor": True,
+    "permissions": True,
+}
+
+
+class TestStealthCheckCLI:
+    """Tests for the stealth-check CLI command."""
+
+    @patch("naturo.cli.browser_cmd._get_page")
+    def test_all_pass_text(self, mock_get_page, runner):
+        """Text output when all checks pass."""
+        page = MagicMock()
+        page._cdp.evaluate.return_value = ALL_PASS.copy()
+        mock_get_page.return_value = page
+
+        result = runner.invoke(browser, ["stealth-check"])
+        assert result.exit_code == 0
+        assert "PASS" in result.output
+        assert "All 6 checks passed" in result.output
+
+    @patch("naturo.cli.browser_cmd._get_page")
+    def test_all_pass_json(self, mock_get_page, runner):
+        """JSON output when all checks pass."""
+        page = MagicMock()
+        page._cdp.evaluate.return_value = ALL_PASS.copy()
+        mock_get_page.return_value = page
+
+        result = runner.invoke(browser, ["stealth-check", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["success"] is True
+        assert all(data["checks"].values())
+
+    @patch("naturo.cli.browser_cmd._get_page")
+    def test_some_fail_text(self, mock_get_page, runner):
+        """Text output with failures — exit code 1."""
+        page = MagicMock()
+        page._cdp.evaluate.return_value = SOME_FAIL.copy()
+        mock_get_page.return_value = page
+
+        result = runner.invoke(browser, ["stealth-check"])
+        assert result.exit_code == 1
+        assert "FAIL" in result.output
+        assert "webdriver" in result.output
+
+    @patch("naturo.cli.browser_cmd._get_page")
+    def test_some_fail_json(self, mock_get_page, runner):
+        """JSON output with failures — exit code 1, success: false."""
+        page = MagicMock()
+        page._cdp.evaluate.return_value = SOME_FAIL.copy()
+        mock_get_page.return_value = page
+
+        result = runner.invoke(browser, ["stealth-check", "--json"])
+        assert result.exit_code == 1
+        data = json.loads(result.output)
+        assert data["success"] is False
+        assert data["checks"]["webdriver"] is False
+
+    @patch("naturo.cli.browser_cmd._get_page")
+    def test_connection_error_text(self, mock_get_page, runner):
+        """Connection error produces text error and exit code 1."""
+        mock_get_page.side_effect = ConnectionError("No browser")
+
+        result = runner.invoke(browser, ["stealth-check"])
+        assert result.exit_code == 1
+
+    @patch("naturo.cli.browser_cmd._get_page")
+    def test_connection_error_json(self, mock_get_page, runner):
+        """Connection error produces JSON error and exit code 1."""
+        mock_get_page.side_effect = ConnectionError("No browser")
+
+        result = runner.invoke(browser, ["stealth-check", "--json"])
+        assert result.exit_code == 1
+        data = json.loads(result.output)
+        assert "error" in data
+
+    def test_help_output(self, runner):
+        """stealth-check --help should mention detection vectors."""
+        result = runner.invoke(browser, ["stealth-check", "--help"])
+        assert result.exit_code == 0
+        assert "stealth" in result.output.lower()
+        assert "webdriver" in result.output.lower()


### PR DESCRIPTION
New check_stealth() function runs 6 JS checks (webdriver, plugins, languages, chrome.runtime, WebGL vendor, permissions) against the browser and reports pass/fail. CLI command \`naturo browser stealth-check\` supports text and JSON output, exits non-zero when any check fails.

**Tests**: 12 new tests. Ruff clean, mypy clean.

**[Orc-Mycelium]** Created on behalf of Dev-Sirius.