### PR TITLE
feat: add drag --from-element/--to-element for UI tree name search (fixes #761)

### DIFF
--- a/naturo/cli/interaction/_mouse.py
+++ b/naturo/cli/interaction/_mouse.py
@@ -174,6 +174,15 @@ def scroll(direction_arg, direction_option, amount, on_text, ref_alias, element_
         'XML format: <selector app="notepad.exe"><node role="Button" name="Save"/></selector>.'
     ),
 )
+@click.option(
+    "--from-element",
+    default=None,
+    help=(
+        "Find source element by name in the UI tree. "
+        "Matches by element name/text (e.g. slider handle label). "
+        "Simpler alternative to --from-selector for common cases."
+    ),
+)
 @click.option("--to", "to_text", help="Destination element text")
 @click.option("--to-coords", nargs=2, type=int, metavar="X Y", help="Destination X Y coordinates")
 @click.option(
@@ -183,6 +192,15 @@ def scroll(direction_arg, direction_option, amount, on_text, ref_alias, element_
         "Unified selector for destination element. "
         'URI format: app://notepad.exe/ListItem[@name="Folder"]. '
         'XML format: <selector app="notepad.exe"><node role="ListItem" name="Folder"/></selector>.'
+    ),
+)
+@click.option(
+    "--to-element",
+    default=None,
+    help=(
+        "Find destination element by name in the UI tree. "
+        "Matches by element name/text. "
+        "Simpler alternative to --to-selector for common cases."
     ),
 )
 @click.option("--duration", type=float, default=0.5, help="Drag duration (seconds)", show_default=True)
@@ -212,7 +230,8 @@ def scroll(direction_arg, direction_option, amount, on_text, ref_alias, element_
 @_common._method_option
 @_common._app_id_option
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def drag(from_text, from_coords, from_selector, to_text, to_coords, to_selector,
+def drag(from_text, from_coords, from_selector, from_element,
+         to_text, to_coords, to_selector, to_element,
          duration, steps, modifiers, trajectory, jitter, overshoot, release_delay,
          profile, app, pid, window_title, hwnd, method,
          app_id, json_output) -> None:
@@ -223,6 +242,7 @@ def drag(from_text, from_coords, from_selector, to_text, to_coords, to_selector,
       naturo drag --from e5 --to e12
       naturo drag --from-coords 100 100 --to-coords 500 300
       naturo drag --from e5 --to-coords 500 300
+      naturo drag --from-element "Slider" --to-coords 500 300
       naturo drag --from-selector 'app://*/ListItem[@name="File1"]' --to-selector 'app://*/TreeItem[@name="Folder"]'
     """
     # (#593) Resolve --app-id to app/hwnd/pid before any other logic
@@ -241,7 +261,7 @@ def drag(from_text, from_coords, from_selector, to_text, to_coords, to_selector,
     from_label = None
     to_label = None
 
-    # Resolve source: --from-selector > --from-coords > --from (eN ref)
+    # Resolve source: --from-selector > --from-element > --from-coords > --from (eN ref)
     if from_selector:
         resolved = _common._resolve_selector_target(
             from_selector, backend, app, window_title, hwnd, pid, json_output,
@@ -250,6 +270,21 @@ def drag(from_text, from_coords, from_selector, to_text, to_coords, to_selector,
             return
         fx, fy = resolved
         from_label = from_selector
+    elif from_element:
+        resolved = _common._find_element_by_text_fallback(
+            backend, from_element, app=app, hwnd=hwnd,
+            window_title=window_title, pid=pid,
+        )
+        if resolved is None:
+            _common._json_err(
+                f"Source element '{from_element}' not found in UI tree. "
+                f"Run 'naturo see' to inspect available elements.",
+                json_output,
+                code="ELEMENT_NOT_FOUND",
+            )
+            return
+        fx, fy = resolved
+        from_label = from_element
     elif from_coords:
         fx, fy = from_coords
     elif from_text and _re.fullmatch(r"e\d+", from_text):
@@ -268,14 +303,14 @@ def drag(from_text, from_coords, from_selector, to_text, to_coords, to_selector,
             return
     else:
         _common._json_err(
-            "Specify source: --from-selector, --from-coords X Y, or --from eN "
-            "(element ref from 'naturo see')",
+            "Specify source: --from-element, --from-selector, --from-coords X Y, "
+            "or --from eN (element ref from 'naturo see')",
             json_output,
             code="INVALID_INPUT",
         )
         return
 
-    # Resolve destination: --to-selector > --to-coords > --to (eN ref)
+    # Resolve destination: --to-selector > --to-element > --to-coords > --to (eN ref)
     if to_selector:
         resolved = _common._resolve_selector_target(
             to_selector, backend, app, window_title, hwnd, pid, json_output,
@@ -284,6 +319,21 @@ def drag(from_text, from_coords, from_selector, to_text, to_coords, to_selector,
             return
         tx, ty = resolved
         to_label = to_selector
+    elif to_element:
+        resolved = _common._find_element_by_text_fallback(
+            backend, to_element, app=app, hwnd=hwnd,
+            window_title=window_title, pid=pid,
+        )
+        if resolved is None:
+            _common._json_err(
+                f"Destination element '{to_element}' not found in UI tree. "
+                f"Run 'naturo see' to inspect available elements.",
+                json_output,
+                code="ELEMENT_NOT_FOUND",
+            )
+            return
+        tx, ty = resolved
+        to_label = to_element
     elif to_coords:
         tx, ty = to_coords
     elif to_text and _re.fullmatch(r"e\d+", to_text):
@@ -302,8 +352,8 @@ def drag(from_text, from_coords, from_selector, to_text, to_coords, to_selector,
             return
     else:
         _common._json_err(
-            "Specify destination: --to-selector, --to-coords X Y, or --to eN "
-            "(element ref from 'naturo see')",
+            "Specify destination: --to-element, --to-selector, --to-coords X Y, "
+            "or --to eN (element ref from 'naturo see')",
             json_output,
             code="INVALID_INPUT",
         )

--- a/tests/test_input_mouse.py
+++ b/tests/test_input_mouse.py
@@ -267,6 +267,123 @@ class TestDragCLIValidation:
         result = runner.invoke(main, ["drag"])
         assert result.exit_code != 0
 
+    def test_drag_from_element_option(self, runner):
+        """--from-element is documented in drag help (#761)."""
+        result = runner.invoke(main, ["drag", "--help"])
+        assert "--from-element" in result.output
+
+    def test_drag_to_element_option(self, runner):
+        """--to-element is documented in drag help (#761)."""
+        result = runner.invoke(main, ["drag", "--help"])
+        assert "--to-element" in result.output
+
+
+class TestDragFromElement:
+    """Test --from-element and --to-element drag options (#761)."""
+
+    def test_from_element_resolves_to_coords(self, runner):
+        """--from-element finds element by name and uses its center."""
+        from unittest.mock import patch, MagicMock
+
+        mock_backend = MagicMock()
+        with patch("naturo.cli.interaction._common._get_backend", return_value=mock_backend), \
+             patch("naturo.cli.interaction._common._find_element_by_text_fallback",
+                   return_value=(150, 200)) as mock_find:
+            result = runner.invoke(main, [
+                "drag", "--from-element", "Slider", "--to-coords", "500", "300",
+            ])
+        assert result.exit_code == 0
+        mock_find.assert_called_once()
+        mock_backend.drag.assert_called_once()
+        call_kwargs = mock_backend.drag.call_args
+        assert call_kwargs[1]["from_x"] == 150
+        assert call_kwargs[1]["from_y"] == 200
+
+    def test_to_element_resolves_to_coords(self, runner):
+        """--to-element finds element by name and uses its center."""
+        from unittest.mock import patch, MagicMock
+
+        mock_backend = MagicMock()
+        with patch("naturo.cli.interaction._common._get_backend", return_value=mock_backend), \
+             patch("naturo.cli.interaction._common._find_element_by_text_fallback",
+                   return_value=(400, 350)) as mock_find:
+            result = runner.invoke(main, [
+                "drag", "--from-coords", "100", "100", "--to-element", "Target",
+            ])
+        assert result.exit_code == 0
+        mock_find.assert_called_once()
+        mock_backend.drag.assert_called_once()
+        call_kwargs = mock_backend.drag.call_args
+        assert call_kwargs[1]["to_x"] == 400
+        assert call_kwargs[1]["to_y"] == 350
+
+    def test_from_element_not_found(self, runner):
+        """--from-element shows error when element not found."""
+        from unittest.mock import patch, MagicMock
+
+        mock_backend = MagicMock()
+        with patch("naturo.cli.interaction._common._get_backend", return_value=mock_backend), \
+             patch("naturo.cli.interaction._common._find_element_by_text_fallback",
+                   return_value=None):
+            result = runner.invoke(main, [
+                "drag", "--from-element", "Missing", "--to-coords", "500", "300",
+            ])
+        assert result.exit_code != 0
+        assert "Missing" in result.output or "not found" in result.output
+
+    def test_to_element_not_found(self, runner):
+        """--to-element shows error when element not found."""
+        from unittest.mock import patch, MagicMock
+
+        mock_backend = MagicMock()
+        with patch("naturo.cli.interaction._common._get_backend", return_value=mock_backend), \
+             patch("naturo.cli.interaction._common._find_element_by_text_fallback",
+                   return_value=None):
+            result = runner.invoke(main, [
+                "drag", "--from-coords", "100", "100", "--to-element", "Missing",
+            ])
+        assert result.exit_code != 0
+        assert "Missing" in result.output or "not found" in result.output
+
+    def test_from_element_json_output(self, runner):
+        """--from-element with --json includes from_ref in output."""
+        from unittest.mock import patch, MagicMock
+
+        mock_backend = MagicMock()
+        with patch("naturo.cli.interaction._common._get_backend", return_value=mock_backend), \
+             patch("naturo.cli.interaction._common._find_element_by_text_fallback",
+                   return_value=(150, 200)):
+            result = runner.invoke(main, [
+                "drag", "--from-element", "Handle", "--to-coords", "500", "300",
+                "--json",
+            ])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["data"]["from_ref"] == "Handle"
+
+    def test_both_from_and_to_element(self, runner):
+        """--from-element and --to-element both resolve correctly."""
+        from unittest.mock import patch, MagicMock
+
+        mock_backend = MagicMock()
+        call_count = 0
+
+        def find_element(backend, text, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return (100, 100)
+            return (500, 300)
+
+        with patch("naturo.cli.interaction._common._get_backend", return_value=mock_backend), \
+             patch("naturo.cli.interaction._common._find_element_by_text_fallback",
+                   side_effect=find_element):
+            result = runner.invoke(main, [
+                "drag", "--from-element", "Source", "--to-element", "Dest",
+            ])
+        assert result.exit_code == 0
+        mock_backend.drag.assert_called_once()
+
 
 class TestMoveCLIValidation:
     """move CLI option validation (T106-T107)."""


### PR DESCRIPTION
New --from-element and --to-element options on the drag command that find elements by name/text in the UI tree using _find_element_by_text_fallback(). Returns center coordinates as drag source/destination. Simpler alternative to --from-selector for common cases like slider captcha handles.

**Tests**: 8 new tests. Ruff clean, mypy clean.

**[Orc-Mycelium]** Created on behalf of Dev-Sirius.