### PR TITLE
fix: press --app exits with error when window focus fails (fixes #807)

### DIFF
--- a/naturo/cli/interaction/_press.py
+++ b/naturo/cli/interaction/_press.py
@@ -184,7 +184,16 @@ def press(keys: tuple[str, ...], count: int, delay: float, hold_duration: float 
                 _target_hwnd = backend._resolve_hwnd(
                     app=app, window_title=window_title, hwnd=hwnd, pid=pid,
                 )
-            if _target_hwnd:
+            if not _target_hwnd:
+                _target_desc = app or window_title or f"PID {pid}" or f"HWND {hwnd}"
+                _common._json_err(
+                    f"Could not find window for '{_target_desc}'. "
+                    "Is the application running and visible?",
+                    json_output,
+                    code="WINDOW_NOT_FOUND",
+                )
+                return
+            else:
                 backend.focus_window(hwnd=_target_hwnd)
                 # Record actual focused PID for routing accuracy
                 try:
@@ -208,9 +217,7 @@ def press(keys: tuple[str, ...], count: int, delay: float, hold_duration: float 
                 time.sleep(0.15)
         except Exception as exc:
             _common._json_err(
-                f"Failed to focus target window: {exc}. "
-                f"Cannot guarantee keystrokes reach "
-                f"'{app or window_title or hwnd}'.",
+                f"Cannot focus target window for press: {exc}",
                 json_output,
                 code="WINDOW_FOCUS_ERROR",
             )

--- a/naturo/cli/interaction/_press.py
+++ b/naturo/cli/interaction/_press.py
@@ -207,7 +207,14 @@ def press(keys: tuple[str, ...], count: int, delay: float, hold_duration: float 
                         logger.debug("UIA SetFocus failed (hwnd=%s): %s", _target_hwnd, exc)
                 time.sleep(0.15)
         except Exception as exc:
-            logger.debug("Failed to focus target window for press: %s", exc)
+            _common._json_err(
+                f"Failed to focus target window: {exc}. "
+                f"Cannot guarantee keystrokes reach "
+                f"'{app or window_title or hwnd}'.",
+                json_output,
+                code="WINDOW_FOCUS_ERROR",
+            )
+            return
 
     # (#231) Capture before-state for post-action verification
     _before_state = None

--- a/naturo/cli/interaction/_press.py
+++ b/naturo/cli/interaction/_press.py
@@ -171,7 +171,7 @@ def press(keys: tuple[str, ...], count: int, delay: float, hold_duration: float 
             _common._json_err(f"Failed to click target element: {exc}", json_output)
             return
 
-    # (#230/#612) Focus target window before sending key input.
+    # (#230/#612/#807) Focus target window before sending key input.
     # SendInput/key_press deliver to the foreground window, so we must
     # ensure the correct window has focus when --app/--hwnd is specified.
     # Uses backend.focus_window() which employs AttachThreadInput on
@@ -193,32 +193,31 @@ def press(keys: tuple[str, ...], count: int, delay: float, hold_duration: float 
                     code="WINDOW_NOT_FOUND",
                 )
                 return
-            else:
-                backend.focus_window(hwnd=_target_hwnd)
-                # Record actual focused PID for routing accuracy
+            backend.focus_window(hwnd=_target_hwnd)
+            # Record actual focused PID for routing accuracy
+            try:
+                import ctypes
+                import ctypes.wintypes
+                _focused_pid = ctypes.wintypes.DWORD()
+                ctypes.windll.user32.GetWindowThreadProcessId(  # type: ignore[attr-defined]
+                    _target_hwnd, ctypes.byref(_focused_pid)
+                )
+                if route_info and _focused_pid.value:
+                    route_info["focused_pid"] = _focused_pid.value
+                    route_info["focused_hwnd"] = _target_hwnd
+            except Exception as exc:
+                logger.debug("PID recording failed (Windows-only): %s", exc)
+            # Also try UIA SetFocus for schtasks/remote contexts (#226)
+            if hasattr(backend, "focus_element_uia"):
                 try:
-                    import ctypes
-                    import ctypes.wintypes
-                    _focused_pid = ctypes.wintypes.DWORD()
-                    ctypes.windll.user32.GetWindowThreadProcessId(  # type: ignore[attr-defined]
-                        _target_hwnd, ctypes.byref(_focused_pid)
-                    )
-                    if route_info and _focused_pid.value:
-                        route_info["focused_pid"] = _focused_pid.value
-                        route_info["focused_hwnd"] = _target_hwnd
+                    backend.focus_element_uia(hwnd=_target_hwnd)
                 except Exception as exc:
-                    logger.debug("PID recording failed (Windows-only): %s", exc)
-                # Also try UIA SetFocus for schtasks/remote contexts (#226)
-                if hasattr(backend, "focus_element_uia"):
-                    try:
-                        backend.focus_element_uia(hwnd=_target_hwnd)
-                    except Exception as exc:
-                        logger.debug("UIA SetFocus failed (hwnd=%s): %s", _target_hwnd, exc)
-                time.sleep(0.15)
+                    logger.debug("UIA SetFocus failed (hwnd=%s): %s", _target_hwnd, exc)
+            time.sleep(0.15)
         except Exception as exc:
             _common._json_err(
                 f"Failed to focus target window: {exc}. "
-                f"Cannot guarantee keystrokes reach '{app or window_title}'.",
+                f"Cannot guarantee keypresses reach '{app or window_title}'.",
                 json_output,
                 code="WINDOW_FOCUS_ERROR",
             )

--- a/naturo/cli/interaction/_press.py
+++ b/naturo/cli/interaction/_press.py
@@ -217,7 +217,8 @@ def press(keys: tuple[str, ...], count: int, delay: float, hold_duration: float 
                 time.sleep(0.15)
         except Exception as exc:
             _common._json_err(
-                f"Cannot focus target window for press: {exc}",
+                f"Failed to focus target window: {exc}. "
+                f"Cannot guarantee keystrokes reach '{app or window_title}'.",
                 json_output,
                 code="WINDOW_FOCUS_ERROR",
             )

--- a/tests/test_cli_press.py
+++ b/tests/test_cli_press.py
@@ -325,6 +325,64 @@ class TestPressErrors:
         assert result.exit_code != 0
         assert "key not recognized" in result.output
 
+    @patch("naturo.cli.interaction._common._auto_route", return_value=None)
+    @patch("naturo.cli.interaction._common._get_backend")
+    @patch("naturo.cli.interaction._common._resolve_app_id", return_value=("notepad.exe", None, None))
+    def test_focus_failure_exits_with_error(self, mock_resolve, mock_get_backend, mock_route, runner):
+        """press --app must exit with WINDOW_FOCUS_ERROR when focus_window fails (#807)."""
+        backend = MagicMock()
+        backend._resolve_hwnd.return_value = 12345
+        backend.focus_window.side_effect = RuntimeError("cannot attach to thread")
+        mock_get_backend.return_value = backend
+
+        result = runner.invoke(
+            press, ["enter", "--app", "notepad.exe", "--json", "--no-verify"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code != 0
+        data = json.loads(result.output)
+        assert data["success"] is False
+        assert data["error"]["code"] == "WINDOW_FOCUS_ERROR"
+        # Keys must NOT be sent when focus fails
+        backend.press_key.assert_not_called()
+        backend.hotkey.assert_not_called()
+
+    @patch("naturo.cli.interaction._common._auto_route", return_value=None)
+    @patch("naturo.cli.interaction._common._get_backend")
+    @patch("naturo.cli.interaction._common._resolve_app_id", return_value=("notepad.exe", None, None))
+    def test_window_not_found_exits_with_error(self, mock_resolve, mock_get_backend, mock_route, runner):
+        """press --app must exit with WINDOW_NOT_FOUND when target window cannot be resolved (#807)."""
+        backend = MagicMock()
+        backend._resolve_hwnd.return_value = None
+        mock_get_backend.return_value = backend
+
+        result = runner.invoke(
+            press, ["enter", "--app", "notepad.exe", "--json", "--no-verify"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code != 0
+        data = json.loads(result.output)
+        assert data["success"] is False
+        assert data["error"]["code"] == "WINDOW_NOT_FOUND"
+        backend.press_key.assert_not_called()
+
+    @patch("naturo.cli.interaction._common._auto_route", return_value=None)
+    @patch("naturo.cli.interaction._common._get_backend")
+    @patch("naturo.cli.interaction._common._resolve_app_id", return_value=("notepad.exe", None, None))
+    def test_focus_success_sends_keys(self, mock_resolve, mock_get_backend, mock_route, runner):
+        """press --app sends keys normally when focus_window succeeds (#807)."""
+        backend = MagicMock()
+        backend._resolve_hwnd.return_value = 12345
+        mock_get_backend.return_value = backend
+
+        result = runner.invoke(
+            press, ["enter", "--app", "notepad.exe", "--json", "--no-verify"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        backend.focus_window.assert_called_once_with(hwnd=12345)
+        backend.press_key.assert_called_once()
+
 
 # ── press command — --on element ────────────────
 

--- a/tests/test_cli_press.py
+++ b/tests/test_cli_press.py
@@ -519,3 +519,41 @@ class TestPressFocusFailure:
             data = json.loads(result.output)
             assert data["success"] is False
             assert data["error"]["code"] == "WINDOW_NOT_FOUND"
+
+    def test_press_app_focus_success_sends_keys(self, runner):
+        """When focus succeeds, press should send keys normally."""
+        mock_backend = MagicMock()
+        mock_backend._resolve_hwnd.return_value = 12345
+
+        with patch("naturo.cli.interaction._common._resolve_app_id",
+                   return_value=("notepad", None, None)), \
+             patch("naturo.cli.interaction._common._get_backend",
+                   return_value=mock_backend), \
+             patch("naturo.cli.interaction._common._auto_route",
+                   return_value=None):
+            result = runner.invoke(
+                press, ["enter", "--app", "notepad", "--json", "--no-verify"],
+                catch_exceptions=False,
+            )
+            assert result.exit_code == 0
+            mock_backend.focus_window.assert_called_once_with(hwnd=12345)
+            mock_backend.press_key.assert_called_once()
+
+    def test_press_app_no_keys_sent_on_failure(self, runner):
+        """When focus fails, no keys must be sent to avoid hitting wrong process."""
+        mock_backend = MagicMock()
+        mock_backend._resolve_hwnd.side_effect = Exception("Window not found")
+
+        with patch("naturo.cli.interaction._common._resolve_app_id",
+                   return_value=("notepad", None, None)), \
+             patch("naturo.cli.interaction._common._get_backend",
+                   return_value=mock_backend), \
+             patch("naturo.cli.interaction._common._auto_route",
+                   return_value=None):
+            result = runner.invoke(
+                press, ["ctrl+c", "--app", "notepad", "--json"],
+                catch_exceptions=False,
+            )
+            assert result.exit_code != 0
+            mock_backend.press_key.assert_not_called()
+            mock_backend.hotkey.assert_not_called()

--- a/tests/test_cli_press.py
+++ b/tests/test_cli_press.py
@@ -392,6 +392,61 @@ class TestPressOnElement:
         backend.press_key.assert_called_once()
 
 
+# ── --app window focus (#807) ───────────────────
+
+
+def _patch_backend(mock_backend):
+    return patch("naturo.cli.interaction._common._get_backend",
+                 return_value=mock_backend)
+
+
+def _patch_resolve_app_id(app=None, hwnd=None, pid=None):
+    return patch("naturo.cli.interaction._common._resolve_app_id",
+                 return_value=(app, hwnd, pid))
+
+
+def _patch_auto_route(route=None):
+    return patch("naturo.cli.interaction._common._auto_route",
+                 return_value=route or {})
+
+
+class TestAppFocus:
+    """#807: press --app must exit with error when window focus fails."""
+
+    @pytest.fixture
+    def mock_backend(self):
+        backend = MagicMock()
+        backend.press_key.return_value = None
+        backend.hotkey.return_value = None
+        backend.focus_window.return_value = None
+        backend._resolve_hwnd.return_value = 12345
+        return backend
+
+    def test_focus_failure_exits_with_error(self, runner, mock_backend):
+        mock_backend._resolve_hwnd.side_effect = Exception("window not found")
+
+        with _patch_resolve_app_id(app="gone"), \
+             _patch_backend(mock_backend), _patch_auto_route():
+            result = runner.invoke(
+                press, ["enter", "--app", "gone", "--json"],
+                catch_exceptions=False,
+            )
+        assert result.exit_code != 0
+        assert "WINDOW_FOCUS_ERROR" in result.output
+
+    def test_focus_failure_plain_text(self, runner, mock_backend):
+        mock_backend._resolve_hwnd.side_effect = Exception("window not found")
+
+        with _patch_resolve_app_id(app="gone"), \
+             _patch_backend(mock_backend), _patch_auto_route():
+            result = runner.invoke(
+                press, ["enter", "--app", "gone"],
+                catch_exceptions=False,
+            )
+        assert result.exit_code != 0
+        assert "focus" in result.output.lower() or "Error" in result.output
+
+
 # ── hotkey command (deprecated alias) ────────────
 
 

--- a/tests/test_cli_press.py
+++ b/tests/test_cli_press.py
@@ -476,3 +476,46 @@ class TestHotkeyAlias:
             result = runner.invoke(hotkey, ["--json"], catch_exceptions=False)
             assert result.exit_code != 0
             assert "INVALID_INPUT" in result.output or "keys" in result.output.lower()
+
+
+class TestPressFocusFailure:
+    """#807: press --app must error when the target window cannot be focused."""
+
+    def test_press_app_focus_error_json(self, runner):
+        """When focus_window raises, press should emit WINDOW_FOCUS_ERROR JSON."""
+        mock_backend = MagicMock()
+        mock_backend._resolve_hwnd.return_value = 12345
+        mock_backend.focus_window.side_effect = RuntimeError("cannot focus")
+
+        with patch("naturo.cli.interaction._common._resolve_app_id",
+                   return_value=("FakeApp", None, None)), \
+             patch("naturo.cli.interaction._common._get_backend",
+                   return_value=mock_backend), \
+             patch("naturo.cli.interaction._common._auto_route",
+                   return_value=None):
+            result = runner.invoke(
+                press, ["enter", "--app", "FakeApp", "--json"],
+                catch_exceptions=False,
+            )
+            data = json.loads(result.output)
+            assert data["success"] is False
+            assert data["error"]["code"] == "WINDOW_FOCUS_ERROR"
+
+    def test_press_app_window_not_found_json(self, runner):
+        """When _resolve_hwnd returns None, press should emit WINDOW_NOT_FOUND."""
+        mock_backend = MagicMock()
+        mock_backend._resolve_hwnd.return_value = None
+
+        with patch("naturo.cli.interaction._common._resolve_app_id",
+                   return_value=("FakeApp", None, None)), \
+             patch("naturo.cli.interaction._common._get_backend",
+                   return_value=mock_backend), \
+             patch("naturo.cli.interaction._common._auto_route",
+                   return_value=None):
+            result = runner.invoke(
+                press, ["enter", "--app", "FakeApp", "--json"],
+                catch_exceptions=False,
+            )
+            data = json.loads(result.output)
+            assert data["success"] is False
+            assert data["error"]["code"] == "WINDOW_NOT_FOUND"


### PR DESCRIPTION
## Summary
Auto-created PR from branch `fix/issue-807-press-wrong-process`. Code reviewed by Orc-Mycelium.

## Test plan
- CI must pass on all supported platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)