### PR TITLE
fix(#810): add _StdoutGuard to block print()/direct writes on stdio transport

### DIFF
--- a/naturo/cli/ai.py
+++ b/naturo/cli/ai.py
@@ -41,11 +41,16 @@ def start(transport, host, port, json_output) -> None:
         sys.exit(1)
 
     try:
-        # Suppress uvicorn/server logs in JSON mode to keep stdout clean
-        if json_output:
+        # (#810) stdio transport uses stdout for JSON-RPC — any logging
+        # output to stdout/stderr corrupts the protocol.  Suppress ALL
+        # loggers (not just uvicorn) by attaching a NullHandler to the
+        # root logger and disabling the lastResort handler.
+        if transport == "stdio" or json_output:
             import logging as _logging
-            for _logger_name in ("uvicorn", "uvicorn.error", "uvicorn.access", "mcp"):
-                _logging.getLogger(_logger_name).setLevel(_logging.CRITICAL)
+            root = _logging.getLogger()
+            root.addHandler(_logging.NullHandler())
+            root.setLevel(_logging.CRITICAL)
+            _logging.lastResort = None  # type: ignore[assignment]
         run_server(transport=transport, host=host, port=port)
     except OSError as e:
         # Port already in use or bind failure

--- a/naturo/mcp_server.py
+++ b/naturo/mcp_server.py
@@ -87,6 +87,40 @@ def create_server(host: str = "localhost", port: int = 3100) -> FastMCP:
 
 
 def run_server(transport: str = "stdio", host: str = "localhost", port: int = 3100):
-    """Run the MCP server with the specified transport."""
+    """Run the MCP server with the specified transport.
+
+    When *transport* is ``"stdio"``, all Python logging handlers that
+    write to ``sys.stdout`` are removed (or redirected to ``sys.stderr``)
+    so that debug/info messages do not corrupt the JSON-RPC stream (#810).
+    """
+    if transport == "stdio":
+        _suppress_stdout_logging()
     server = create_server(host=host, port=port)
     server.run(transport=transport)
+
+
+def _suppress_stdout_logging() -> None:
+    """Redirect or remove any logging handler that writes to stdout.
+
+    JSON-RPC over stdio uses stdout as the transport channel.  Any log
+    message that lands on stdout breaks the protocol.  This function
+    walks every registered handler on the root logger (and known
+    library loggers) and either redirects ``StreamHandler(sys.stdout)``
+    to ``sys.stderr`` or removes it entirely.
+    """
+    import sys
+
+    root = logging.getLogger()
+
+    for handler in list(root.handlers):
+        if isinstance(handler, logging.StreamHandler) and handler.stream is sys.stdout:
+            handler.setStream(sys.stderr)
+
+    # Silence chatty library loggers that may add their own handlers.
+    for name in ("uvicorn", "uvicorn.error", "uvicorn.access", "mcp",
+                 "httpx", "httpcore"):
+        lib_logger = logging.getLogger(name)
+        lib_logger.setLevel(logging.WARNING)
+        for handler in list(lib_logger.handlers):
+            if isinstance(handler, logging.StreamHandler) and handler.stream is sys.stdout:
+                handler.setStream(sys.stderr)

--- a/naturo/mcp_server.py
+++ b/naturo/mcp_server.py
@@ -6,7 +6,9 @@ capture, inspect, click, type, find elements, manage windows/apps.
 from __future__ import annotations
 
 import functools
+import io
 import logging
+import sys
 from typing import Any, Callable
 
 from mcp.server.fastmcp import FastMCP
@@ -89,14 +91,82 @@ def create_server(host: str = "localhost", port: int = 3100) -> FastMCP:
 def run_server(transport: str = "stdio", host: str = "localhost", port: int = 3100):
     """Run the MCP server with the specified transport.
 
-    When *transport* is ``"stdio"``, all Python logging handlers that
-    write to ``sys.stdout`` are removed (or redirected to ``sys.stderr``)
-    so that debug/info messages do not corrupt the JSON-RPC stream (#810).
+    When *transport* is ``"stdio"``, two layers of stdout protection are
+    applied so that nothing except the JSON-RPC byte stream can reach the
+    client (#810):
+
+    1. **Logging layer** — every ``StreamHandler`` that targets
+       ``sys.stdout`` is redirected to ``sys.stderr``.
+    2. **Print / direct-write layer** — ``sys.stdout`` is replaced with a
+       :class:`_StdoutGuard` wrapper whose ``.write()`` method forwards
+       text to ``sys.stderr``, while its ``.buffer`` attribute still
+       exposes the *real* ``stdout`` binary buffer so that the MCP
+       ``stdio_server()`` context-manager can perform its JSON-RPC I/O
+       on the correct file descriptor.
     """
     if transport == "stdio":
         _suppress_stdout_logging()
-    server = create_server(host=host, port=port)
-    server.run(transport=transport)
+        guard = _StdoutGuard(sys.stdout)
+        sys.stdout = guard  # type: ignore[assignment]
+        try:
+            server = create_server(host=host, port=port)
+            server.run(transport=transport)
+        finally:
+            sys.stdout = guard._real_stdout
+    else:
+        server = create_server(host=host, port=port)
+        server.run(transport=transport)
+
+
+class _StdoutGuard(io.TextIOBase):
+    """Stdout proxy that redirects text writes to stderr (#810).
+
+    The MCP ``stdio_server()`` transport grabs ``sys.stdout.buffer`` to
+    perform raw binary JSON-RPC I/O.  By exposing the *real* stdout
+    buffer via ``.buffer`` while redirecting all text writes to stderr,
+    this guard ensures that:
+
+    * ``print()`` calls and any library code that writes to ``sys.stdout``
+      end up on stderr (invisible to the MCP client).
+    * The MCP transport still has access to the correct file descriptor
+      for its JSON-RPC output.
+    """
+
+    def __init__(self, real_stdout: io.TextIOWrapper) -> None:
+        super().__init__()
+        self._real_stdout = real_stdout
+        # Expose the real binary buffer so mcp.server.stdio can wrap it.
+        self.buffer: io.RawIOBase = real_stdout.buffer  # type: ignore[assignment]
+
+    # --- text-layer writes are silently diverted to stderr ---------------
+
+    def write(self, s: str) -> int:  # type: ignore[override]
+        return sys.stderr.write(s)
+
+    def writelines(self, lines):  # type: ignore[override]
+        sys.stderr.writelines(lines)
+
+    def flush(self) -> None:
+        sys.stderr.flush()
+
+    # --- delegate read-side and encoding properties ----------------------
+
+    @property
+    def encoding(self) -> str:
+        return self._real_stdout.encoding
+
+    @property
+    def errors(self):
+        return self._real_stdout.errors
+
+    def readable(self) -> bool:
+        return False
+
+    def writable(self) -> bool:
+        return True
+
+    def fileno(self) -> int:  # needed by some libraries
+        return self._real_stdout.fileno()
 
 
 def _suppress_stdout_logging() -> None:
@@ -108,8 +178,6 @@ def _suppress_stdout_logging() -> None:
     library loggers) and either redirects ``StreamHandler(sys.stdout)``
     to ``sys.stderr`` or removes it entirely.
     """
-    import sys
-
     root = logging.getLogger()
 
     for handler in list(root.handlers):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -654,3 +654,40 @@ class TestResponseFormat:
                 assert "error" in data, f"{tool_name}({args}) missing error object"
                 assert "code" in data["error"], f"{tool_name}({args}) missing error.code"
                 assert "message" in data["error"], f"{tool_name}({args}) missing error.message"
+
+
+# ── MCP start logging suppression (#810) ────────────────────────────────────
+
+
+class TestMcpStartLoggingSuppression:
+    """#810: MCP stdio transport must suppress all logging."""
+
+    def test_stdio_installs_null_handler(self):
+        """naturo mcp start --transport stdio installs NullHandler on root."""
+        import logging
+        import click.testing
+
+        runner = click.testing.CliRunner()
+        from naturo.cli.ai import mcp
+
+        with patch("naturo.mcp_server.run_server"):
+            runner.invoke(mcp, ["start", "--transport", "stdio"])
+
+        root = logging.getLogger()
+        has_null = any(isinstance(h, logging.NullHandler) for h in root.handlers)
+        assert has_null, "Root logger should have NullHandler for stdio transport"
+
+    def test_json_mode_installs_null_handler(self):
+        """naturo mcp start --json installs NullHandler on root."""
+        import logging
+        import click.testing
+
+        runner = click.testing.CliRunner()
+        from naturo.cli.ai import mcp
+
+        with patch("naturo.mcp_server.run_server"):
+            runner.invoke(mcp, ["start", "--json"])
+
+        root = logging.getLogger()
+        has_null = any(isinstance(h, logging.NullHandler) for h in root.handlers)
+        assert has_null, "Root logger should have NullHandler in JSON mode"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -592,6 +592,28 @@ class TestMCPCli:
             result = runner.invoke(main, ["mcp", "install"])
         assert "Installing MCP dependencies" in result.output
 
+    def test_mcp_start_stdio_suppresses_logging(self, runner):
+        """#810: stdio transport must suppress all logging to avoid corrupting JSON-RPC."""
+        import logging
+
+        with patch("naturo.mcp_server.run_server") as mock_run:
+            from naturo.cli import main
+            result = runner.invoke(main, ["mcp", "start", "--transport", "stdio"])
+
+        mock_run.assert_called_once_with(transport="stdio", host="localhost", port=3100)
+        # Root logger should have been configured to suppress output
+        root = logging.getLogger()
+        assert root.level >= logging.CRITICAL
+        assert any(isinstance(h, logging.NullHandler) for h in root.handlers)
+
+    def test_mcp_start_stdio_no_stdout_pollution(self, runner):
+        """#810: MCP start with stdio must produce no text output on stdout."""
+        with patch("naturo.mcp_server.run_server"):
+            from naturo.cli import main
+            result = runner.invoke(main, ["mcp", "start", "--transport", "stdio"])
+
+        assert result.output == "", f"Unexpected stdout output: {result.output!r}"
+
 
 # ── Response Format Consistency ──────────────────────────────────────────────
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -656,38 +656,21 @@ class TestResponseFormat:
                 assert "message" in data["error"], f"{tool_name}({args}) missing error.message"
 
 
-# ── MCP start logging suppression (#810) ────────────────────────────────────
+class TestStdioLogging:
+    """#810: MCP stdio transport must not emit debug text to stdout."""
 
-
-class TestMcpStartLoggingSuppression:
-    """#810: MCP stdio transport must suppress all logging."""
-
-    def test_stdio_installs_null_handler(self):
-        """naturo mcp start --transport stdio installs NullHandler on root."""
+    def test_suppress_stdout_logging(self):
+        """_suppress_stdout_logging redirects stdout handlers to stderr."""
         import logging
-        import click.testing
+        import sys
 
-        runner = click.testing.CliRunner()
-        from naturo.cli.ai import mcp
-
-        with patch("naturo.mcp_server.run_server"):
-            runner.invoke(mcp, ["start", "--transport", "stdio"])
+        from naturo.mcp_server import _suppress_stdout_logging
 
         root = logging.getLogger()
-        has_null = any(isinstance(h, logging.NullHandler) for h in root.handlers)
-        assert has_null, "Root logger should have NullHandler for stdio transport"
-
-    def test_json_mode_installs_null_handler(self):
-        """naturo mcp start --json installs NullHandler on root."""
-        import logging
-        import click.testing
-
-        runner = click.testing.CliRunner()
-        from naturo.cli.ai import mcp
-
-        with patch("naturo.mcp_server.run_server"):
-            runner.invoke(mcp, ["start", "--json"])
-
-        root = logging.getLogger()
-        has_null = any(isinstance(h, logging.NullHandler) for h in root.handlers)
-        assert has_null, "Root logger should have NullHandler in JSON mode"
+        stdout_handler = logging.StreamHandler(sys.stdout)
+        root.addHandler(stdout_handler)
+        try:
+            _suppress_stdout_logging()
+            assert stdout_handler.stream is sys.stderr
+        finally:
+            root.removeHandler(stdout_handler)

--- a/tests/test_mcp_stdout_debug_810.py
+++ b/tests/test_mcp_stdout_debug_810.py
@@ -1,0 +1,108 @@
+"""Tests for MCP stdio transport logging suppression (#810).
+
+Verifies that when MCP server runs in stdio mode, no debug/info/warning
+output is emitted to stdout or stderr, as that would corrupt the JSON-RPC
+protocol.
+"""
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+mcp_available = True
+try:
+    from naturo.mcp_server import run_server, create_server
+except ImportError:
+    mcp_available = False
+
+pytestmark = pytest.mark.skipif(not mcp_available, reason="mcp package not installed")
+
+
+class TestStdioLoggingSuppression:
+    """Logging must be fully suppressed during stdio transport."""
+
+    def test_run_server_stdio_suppresses_stdout_handlers(self):
+        """run_server(transport='stdio') should redirect/remove stdout handlers."""
+        import sys
+        original_handlers = logging.root.handlers.copy()
+        original_level = logging.root.level
+
+        # Add a stdout handler to verify it gets redirected
+        stdout_handler = logging.StreamHandler(sys.stdout)
+        logging.root.addHandler(stdout_handler)
+
+        with patch("naturo.mcp_server.create_server") as mock_cs:
+            mock_server = MagicMock()
+            mock_cs.return_value = mock_server
+            run_server(transport="stdio")
+
+        # Stdout handler should have been redirected to stderr
+        assert stdout_handler.stream is sys.stderr
+
+        # Restore
+        logging.root.handlers = original_handlers
+        logging.root.setLevel(original_level)
+
+    def test_run_server_sse_does_not_suppress_logging(self):
+        """run_server(transport='sse') should NOT suppress logging."""
+        original_level = logging.root.level
+        original_handlers = logging.root.handlers.copy()
+
+        with patch("naturo.mcp_server.create_server") as mock_cs:
+            mock_server = MagicMock()
+            mock_cs.return_value = mock_server
+            run_server(transport="sse")
+
+        # Root logger level should NOT have been changed
+        assert logging.root.level == original_level
+
+        # Restore
+        logging.root.handlers = original_handlers
+
+    def test_cli_stdio_sets_root_critical(self):
+        """naturo mcp start (stdio) should set root logger to CRITICAL."""
+        from click.testing import CliRunner
+        from naturo.cli.ai import start
+
+        original_level = logging.root.level
+
+        with patch("naturo.mcp_server.run_server") as mock_run:
+            runner = CliRunner()
+            result = runner.invoke(start, ["--transport", "stdio"])
+
+        # Root logger should be CRITICAL
+        assert logging.root.level >= logging.CRITICAL
+
+        # Restore
+        logging.root.setLevel(original_level)
+
+
+class TestLoggerOutputCapture:
+    """Verify no actual output leaks during stdio mode."""
+
+    def test_no_stdout_leak_from_logger(self, capsys):
+        """Logger.warning() should not appear on stdout after stdio suppression."""
+        import sys
+        original_level = logging.root.level
+        original_handlers = logging.root.handlers.copy()
+
+        # Add a stdout handler (simulates what a library might do)
+        stdout_handler = logging.StreamHandler(sys.stdout)
+        logging.root.addHandler(stdout_handler)
+
+        with patch("naturo.mcp_server.create_server") as mock_cs:
+            mock_server = MagicMock()
+            mock_cs.return_value = mock_server
+            run_server(transport="stdio")
+
+        # Now emit a warning — should NOT appear on stdout
+        logging.getLogger("naturo").warning("This should not appear on stdout")
+
+        captured = capsys.readouterr()
+        assert "should not appear on stdout" not in captured.out
+
+        # Restore
+        logging.root.handlers = original_handlers
+        logging.root.setLevel(original_level)

--- a/tests/test_mcp_stdout_debug_810.py
+++ b/tests/test_mcp_stdout_debug_810.py
@@ -3,17 +3,26 @@
 Verifies that when MCP server runs in stdio mode, no debug/info/warning
 output is emitted to stdout or stderr, as that would corrupt the JSON-RPC
 protocol.
+
+Gap addressed in this revision: the logging-only fix did not protect against
+``print()`` calls or libraries that write directly to ``sys.stdout``.  The
+``_StdoutGuard`` class redirects all text-layer stdout writes to stderr while
+keeping ``sys.stdout.buffer`` pointing at the real stdout so that the MCP
+``stdio_server()`` transport can still perform its JSON-RPC binary I/O on the
+correct file descriptor.
 """
 from __future__ import annotations
 
+import io
 import logging
+import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 mcp_available = True
 try:
-    from naturo.mcp_server import run_server, create_server
+    from naturo.mcp_server import run_server, create_server, _StdoutGuard
 except ImportError:
     mcp_available = False
 
@@ -84,7 +93,6 @@ class TestLoggerOutputCapture:
 
     def test_no_stdout_leak_from_logger(self, capsys):
         """Logger.warning() should not appear on stdout after stdio suppression."""
-        import sys
         original_level = logging.root.level
         original_handlers = logging.root.handlers.copy()
 
@@ -106,3 +114,88 @@ class TestLoggerOutputCapture:
         # Restore
         logging.root.handlers = original_handlers
         logging.root.setLevel(original_level)
+
+
+class TestStdoutGuard:
+    """Unit tests for the _StdoutGuard stdout proxy."""
+
+    def test_guard_write_goes_to_stderr(self):
+        """Text written to _StdoutGuard should land on stderr, not stdout."""
+        real_stdout = sys.stdout
+        stderr_capture = io.StringIO()
+
+        guard = _StdoutGuard(real_stdout)
+        # Redirect stderr to a capture buffer so we can inspect it.
+        original_stderr = sys.stderr
+        sys.stderr = stderr_capture
+        try:
+            guard.write("hello from guard\n")
+        finally:
+            sys.stderr = original_stderr
+
+        assert "hello from guard" in stderr_capture.getvalue()
+
+    def test_guard_exposes_real_buffer(self):
+        """_StdoutGuard.buffer must be the original sys.stdout.buffer."""
+        guard = _StdoutGuard(sys.stdout)
+        assert guard.buffer is sys.stdout.buffer
+
+    def test_guard_restores_stdout_after_run_server(self):
+        """sys.stdout must be restored to the real object after run_server returns."""
+        original_stdout = sys.stdout
+
+        with patch("naturo.mcp_server.create_server") as mock_cs:
+            mock_server = MagicMock()
+            mock_cs.return_value = mock_server
+            run_server(transport="stdio")
+
+        assert sys.stdout is original_stdout
+
+    def test_guard_restores_stdout_on_exception(self):
+        """sys.stdout must be restored even if server.run() raises."""
+        original_stdout = sys.stdout
+
+        with patch("naturo.mcp_server.create_server") as mock_cs:
+            mock_server = MagicMock()
+            mock_server.run.side_effect = RuntimeError("boom")
+            mock_cs.return_value = mock_server
+            with pytest.raises(RuntimeError, match="boom"):
+                run_server(transport="stdio")
+
+        assert sys.stdout is original_stdout
+
+    def test_print_during_stdio_does_not_appear_on_real_stdout(self, capsys):
+        """print() inside run_server(stdio) must not corrupt the JSON-RPC channel.
+
+        This is the end-to-end regression test for the gap identified in #810:
+        the logging-only fix left direct print() calls unblocked.  With
+        _StdoutGuard in place, any print() that fires while the server is
+        running is silently diverted to stderr.
+        """
+        def _leaky_server_run(transport, **_kwargs):
+            # Simulate a library or user code that calls print() directly.
+            print("DEBUG: this would corrupt JSON-RPC without the guard")
+
+        with patch("naturo.mcp_server.create_server") as mock_cs:
+            mock_server = MagicMock()
+            mock_server.run.side_effect = _leaky_server_run
+            mock_cs.return_value = mock_server
+            run_server(transport="stdio")
+
+        captured = capsys.readouterr()
+        # The print() must NOT have reached real stdout.
+        assert "DEBUG: this would corrupt JSON-RPC" not in captured.out
+        # It should have been diverted to stderr instead.
+        assert "DEBUG: this would corrupt JSON-RPC" in captured.err
+
+    def test_non_stdio_transport_does_not_install_guard(self):
+        """_StdoutGuard must NOT be installed for non-stdio transports."""
+        original_stdout = sys.stdout
+
+        with patch("naturo.mcp_server.create_server") as mock_cs:
+            mock_server = MagicMock()
+            mock_cs.return_value = mock_server
+            run_server(transport="sse")
+
+        # sys.stdout should never have been replaced.
+        assert sys.stdout is original_stdout


### PR DESCRIPTION
## Summary
Auto-created PR from branch `fix/issue-810-mcp-stdout-debug`. Code reviewed and fixed by Orc-Mycelium.

## Test plan
- CI must pass on all supported platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)