### PR TITLE
refactor(type): move newline-splitting to backend layer only (#840)

### DIFF
--- a/naturo/backends/windows/_input.py
+++ b/naturo/backends/windows/_input.py
@@ -672,6 +672,8 @@ class InputMixin:
         Raises:
             NaturoCoreError: On system error.
         """
+        import re
+
         core = self._ensure_core()
         strategy = get_input_strategy(core, input_mode)
 
@@ -684,7 +686,6 @@ class InputMixin:
         # (#840) SendInput's UNICODE path silently drops \n and \r
         # control characters.  Split on line breaks and press Enter
         # between segments so multiline text is typed correctly.
-        import re
         segments = re.split(r"\r\n|\r|\n", text)
         for i, segment in enumerate(segments):
             if segment:

--- a/naturo/backends/windows/_input.py
+++ b/naturo/backends/windows/_input.py
@@ -681,7 +681,16 @@ class InputMixin:
             ms_per_char = int(60_000 / (wpm * 5))
             actual_delay = max(1, ms_per_char)
 
-        strategy.type_text(text, actual_delay)
+        # (#840) SendInput's UNICODE path silently drops \n and \r
+        # control characters.  Split on line breaks and press Enter
+        # between segments so multiline text is typed correctly.
+        import re
+        segments = re.split(r"\r\n|\r|\n", text)
+        for i, segment in enumerate(segments):
+            if segment:
+                strategy.type_text(segment, actual_delay)
+            if i < len(segments) - 1:
+                strategy.press_key("enter")
 
     def press_key(self, key: str = "", input_mode: str = "normal") -> None:
         """Press and release a named key.

--- a/naturo/cli/interaction/_type.py
+++ b/naturo/cli/interaction/_type.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import json
 import logging
-import re
 import sys
 
 import click
@@ -11,24 +10,6 @@ import click
 import naturo.cli.interaction._common as _common
 
 logger = logging.getLogger(__name__)
-
-
-def _type_with_newlines(backend, text: str, *, delay_ms: int, profile: str,
-                        wpm: int, input_mode: str) -> None:
-    """Type *text*, converting literal newlines to Enter keypresses.
-
-    SendInput cannot produce a newline character directly — the target
-    application expects VK_RETURN.  This helper splits *text* on
-    ``\\r\\n``, ``\\r``, or ``\\n`` boundaries, types each segment, and
-    presses Enter between them (#840).
-    """
-    segments = re.split(r"\r\n|\r|\n", text)
-    for i, segment in enumerate(segments):
-        if segment:
-            backend.type_text(segment, delay_ms=delay_ms, profile=profile,
-                              wpm=wpm, input_mode=input_mode)
-        if i < len(segments) - 1:
-            backend.press_key("enter")
 
 
 @click.command("type")
@@ -373,13 +354,11 @@ def type_cmd(text, delay, profile, wpm, press_return, tab_count, escape,
             if not _used_uia:
                 # UIA SetValue failed — fall back to SendInput
                 logger.debug("UIA SetValue failed, falling back to SendInput")
-                _type_with_newlines(backend, text, delay_ms=int(delay),
-                                    profile=profile, wpm=wpm,
-                                    input_mode=input_mode)
+                backend.type_text(text, delay_ms=int(delay), profile=profile,
+                                  wpm=wpm, input_mode=input_mode)
         else:
-            _type_with_newlines(backend, text, delay_ms=int(delay),
-                                profile=profile, wpm=wpm,
-                                input_mode=input_mode)
+            backend.type_text(text, delay_ms=int(delay), profile=profile,
+                              wpm=wpm, input_mode=input_mode)
 
         if press_return:
             backend.press_key("enter")

--- a/naturo/cli/interaction/_type.py
+++ b/naturo/cli/interaction/_type.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import sys
 
 import click
@@ -10,6 +11,24 @@ import click
 import naturo.cli.interaction._common as _common
 
 logger = logging.getLogger(__name__)
+
+
+def _type_with_newlines(backend, text: str, *, delay_ms: int, profile: str,
+                        wpm: int, input_mode: str) -> None:
+    """Type *text*, converting literal newlines to Enter keypresses.
+
+    SendInput cannot produce a newline character directly — the target
+    application expects VK_RETURN.  This helper splits *text* on
+    ``\\r\\n``, ``\\r``, or ``\\n`` boundaries, types each segment, and
+    presses Enter between them (#840).
+    """
+    segments = re.split(r"\r\n|\r|\n", text)
+    for i, segment in enumerate(segments):
+        if segment:
+            backend.type_text(segment, delay_ms=delay_ms, profile=profile,
+                              wpm=wpm, input_mode=input_mode)
+        if i < len(segments) - 1:
+            backend.press_key("enter")
 
 
 @click.command("type")
@@ -354,11 +373,13 @@ def type_cmd(text, delay, profile, wpm, press_return, tab_count, escape,
             if not _used_uia:
                 # UIA SetValue failed — fall back to SendInput
                 logger.debug("UIA SetValue failed, falling back to SendInput")
-                backend.type_text(text, delay_ms=int(delay), profile=profile,
-                                  wpm=wpm, input_mode=input_mode)
+                _type_with_newlines(backend, text, delay_ms=int(delay),
+                                    profile=profile, wpm=wpm,
+                                    input_mode=input_mode)
         else:
-            backend.type_text(text, delay_ms=int(delay), profile=profile, wpm=wpm,
-                              input_mode=input_mode)
+            _type_with_newlines(backend, text, delay_ms=int(delay),
+                                profile=profile, wpm=wpm,
+                                input_mode=input_mode)
 
         if press_return:
             backend.press_key("enter")

--- a/tests/test_cli_type.py
+++ b/tests/test_cli_type.py
@@ -14,7 +14,7 @@ from unittest.mock import MagicMock, patch, call
 import pytest
 from click.testing import CliRunner
 
-from naturo.cli.interaction._type import type_cmd
+from naturo.cli.interaction._type import type_cmd, _type_with_newlines
 
 
 @pytest.fixture
@@ -223,9 +223,11 @@ class TestInterpretEscapes:
         with _patch_resolve_app_id(), _patch_backend(mock_backend), _patch_auto_route():
             result = runner.invoke(type_cmd, ["hello\\tworld\\n", "-E"], catch_exceptions=False)
         assert result.exit_code == 0
+        # (#840) newlines are split: "hello\tworld" typed, then Enter pressed
         mock_backend.type_text.assert_called_once_with(
-            "hello\tworld\n", delay_ms=5, profile="linear", wpm=120, input_mode="normal",
+            "hello\tworld", delay_ms=5, profile="linear", wpm=120, input_mode="normal",
         )
+        mock_backend.press_key.assert_any_call("enter")
 
     def test_literal_backslash_preserved_without_flag(self, runner, mock_backend):
         with _patch_resolve_app_id(), _patch_backend(mock_backend), _patch_auto_route():
@@ -387,3 +389,60 @@ class TestRefAlias:
             result = runner.invoke(type_cmd, ["hello", "--ref", "Input"], catch_exceptions=False)
         assert result.exit_code == 0
         mock_backend.find_element.assert_called_once_with("Input")
+
+
+# ── Newline handling (#840) ─────────────────────────────────────────
+
+
+class TestTypeWithNewlines:
+    """#840: literal newlines must produce Enter keypresses, not be dropped."""
+
+    def test_no_newlines(self):
+        backend = MagicMock()
+        _type_with_newlines(backend, "hello", delay_ms=5, profile="linear",
+                            wpm=120, input_mode="normal")
+        backend.type_text.assert_called_once_with(
+            "hello", delay_ms=5, profile="linear", wpm=120, input_mode="normal",
+        )
+        backend.press_key.assert_not_called()
+
+    def test_single_newline(self):
+        backend = MagicMock()
+        _type_with_newlines(backend, "line1\nline2", delay_ms=5,
+                            profile="linear", wpm=120, input_mode="normal")
+        assert backend.type_text.call_count == 2
+        backend.type_text.assert_any_call(
+            "line1", delay_ms=5, profile="linear", wpm=120, input_mode="normal",
+        )
+        backend.type_text.assert_any_call(
+            "line2", delay_ms=5, profile="linear", wpm=120, input_mode="normal",
+        )
+        backend.press_key.assert_called_once_with("enter")
+
+    def test_crlf(self):
+        backend = MagicMock()
+        _type_with_newlines(backend, "a\r\nb", delay_ms=5, profile="linear",
+                            wpm=120, input_mode="normal")
+        assert backend.type_text.call_count == 2
+        backend.press_key.assert_called_once_with("enter")
+
+    def test_trailing_newline(self):
+        """Trailing newline produces Enter after last segment."""
+        backend = MagicMock()
+        _type_with_newlines(backend, "hello\n", delay_ms=5, profile="linear",
+                            wpm=120, input_mode="normal")
+        backend.type_text.assert_called_once_with(
+            "hello", delay_ms=5, profile="linear", wpm=120, input_mode="normal",
+        )
+        backend.press_key.assert_called_once_with("enter")
+
+    def test_cli_type_with_newline(self, runner, mock_backend):
+        """End-to-end: naturo type with -E flag and \\n in text."""
+        with _patch_resolve_app_id(), _patch_backend(mock_backend), _patch_auto_route():
+            result = runner.invoke(
+                type_cmd, ["line1\\nline2", "-E"],
+                catch_exceptions=False,
+            )
+        assert result.exit_code == 0
+        assert mock_backend.type_text.call_count == 2
+        mock_backend.press_key.assert_any_call("enter")

--- a/tests/test_cli_type.py
+++ b/tests/test_cli_type.py
@@ -14,7 +14,7 @@ from unittest.mock import MagicMock, patch, call
 import pytest
 from click.testing import CliRunner
 
-from naturo.cli.interaction._type import type_cmd, _type_with_newlines
+from naturo.cli.interaction._type import type_cmd
 
 
 @pytest.fixture
@@ -223,11 +223,11 @@ class TestInterpretEscapes:
         with _patch_resolve_app_id(), _patch_backend(mock_backend), _patch_auto_route():
             result = runner.invoke(type_cmd, ["hello\\tworld\\n", "-E"], catch_exceptions=False)
         assert result.exit_code == 0
-        # (#840) newlines are split: "hello\tworld" typed, then Enter pressed
+        # (#840) Newline handling lives in the backend, not the CLI layer.
+        # The CLI passes the full interpreted string (including \n) to backend.type_text.
         mock_backend.type_text.assert_called_once_with(
-            "hello\tworld", delay_ms=5, profile="linear", wpm=120, input_mode="normal",
+            "hello\tworld\n", delay_ms=5, profile="linear", wpm=120, input_mode="normal",
         )
-        mock_backend.press_key.assert_any_call("enter")
 
     def test_literal_backslash_preserved_without_flag(self, runner, mock_backend):
         with _patch_resolve_app_id(), _patch_backend(mock_backend), _patch_auto_route():
@@ -369,7 +369,28 @@ class TestUiaValueSet:
         with _patch_resolve_app_id(), _patch_backend(mock_backend), _patch_auto_route(route):
             result = runner.invoke(type_cmd, ["hello", "--json"], catch_exceptions=False)
         assert result.exit_code == 0
-        mock_backend.type_text.assert_called_once()
+        mock_backend.type_text.assert_called_once_with(
+            "hello", delay_ms=5, profile="linear", wpm=120, input_mode="normal",
+        )
+
+    def test_uia_fallback_passes_newlines_to_backend(self, runner, mock_backend):
+        """UIA fallback path must pass the full text (with newlines) to
+        backend.type_text — newline splitting happens inside the backend,
+        not the CLI layer (#840)."""
+        mock_backend.set_element_value.return_value = False
+        route = {"method": "uia"}
+
+        with _patch_resolve_app_id(), _patch_backend(mock_backend), _patch_auto_route(route):
+            result = runner.invoke(
+                type_cmd, ["line1\\nline2", "-E", "--json"],
+                catch_exceptions=False,
+            )
+        assert result.exit_code == 0
+        # The CLI must hand the full multiline string to the backend as-is.
+        # The backend is responsible for splitting on newlines (#840).
+        mock_backend.type_text.assert_called_once_with(
+            "line1\nline2", delay_ms=5, profile="linear", wpm=120, input_mode="normal",
+        )
 
 
 # ── --ref alias for --on ─────────────────────────────────────────────
@@ -395,54 +416,48 @@ class TestRefAlias:
 
 
 class TestTypeWithNewlines:
-    """#840: literal newlines must produce Enter keypresses, not be dropped."""
+    """#840: newline handling belongs in the backend, not the CLI layer.
 
-    def test_no_newlines(self):
-        backend = MagicMock()
-        _type_with_newlines(backend, "hello", delay_ms=5, profile="linear",
-                            wpm=120, input_mode="normal")
-        backend.type_text.assert_called_once_with(
+    The CLI must pass the full text (including newlines) directly to
+    backend.type_text().  The backend is responsible for converting
+    newlines to Enter keypresses.  These tests verify the CLI passes
+    the correct string; the backend-level splitting is tested in
+    test_type_newline_840.py.
+    """
+
+    def test_cli_passes_text_without_newline_to_backend(self, runner, mock_backend):
+        """Text without newlines is passed straight to backend.type_text."""
+        with _patch_resolve_app_id(), _patch_backend(mock_backend), _patch_auto_route():
+            result = runner.invoke(type_cmd, ["hello"], catch_exceptions=False)
+        assert result.exit_code == 0
+        mock_backend.type_text.assert_called_once_with(
             "hello", delay_ms=5, profile="linear", wpm=120, input_mode="normal",
         )
-        backend.press_key.assert_not_called()
 
-    def test_single_newline(self):
-        backend = MagicMock()
-        _type_with_newlines(backend, "line1\nline2", delay_ms=5,
-                            profile="linear", wpm=120, input_mode="normal")
-        assert backend.type_text.call_count == 2
-        backend.type_text.assert_any_call(
-            "line1", delay_ms=5, profile="linear", wpm=120, input_mode="normal",
-        )
-        backend.type_text.assert_any_call(
-            "line2", delay_ms=5, profile="linear", wpm=120, input_mode="normal",
-        )
-        backend.press_key.assert_called_once_with("enter")
+    def test_cli_passes_newline_text_to_backend(self, runner, mock_backend):
+        """CLI passes the full multiline string to backend.type_text as-is.
 
-    def test_crlf(self):
-        backend = MagicMock()
-        _type_with_newlines(backend, "a\r\nb", delay_ms=5, profile="linear",
-                            wpm=120, input_mode="normal")
-        assert backend.type_text.call_count == 2
-        backend.press_key.assert_called_once_with("enter")
-
-    def test_trailing_newline(self):
-        """Trailing newline produces Enter after last segment."""
-        backend = MagicMock()
-        _type_with_newlines(backend, "hello\n", delay_ms=5, profile="linear",
-                            wpm=120, input_mode="normal")
-        backend.type_text.assert_called_once_with(
-            "hello", delay_ms=5, profile="linear", wpm=120, input_mode="normal",
-        )
-        backend.press_key.assert_called_once_with("enter")
-
-    def test_cli_type_with_newline(self, runner, mock_backend):
-        """End-to-end: naturo type with -E flag and \\n in text."""
+        The backend owns the newline-splitting logic (#840); the CLI must
+        not split before calling type_text.
+        """
         with _patch_resolve_app_id(), _patch_backend(mock_backend), _patch_auto_route():
             result = runner.invoke(
                 type_cmd, ["line1\\nline2", "-E"],
                 catch_exceptions=False,
             )
         assert result.exit_code == 0
-        assert mock_backend.type_text.call_count == 2
-        mock_backend.press_key.assert_any_call("enter")
+        mock_backend.type_text.assert_called_once_with(
+            "line1\nline2", delay_ms=5, profile="linear", wpm=120, input_mode="normal",
+        )
+
+    def test_cli_passes_crlf_text_to_backend(self, runner, mock_backend):
+        """CRLF text is passed intact to backend.type_text."""
+        with _patch_resolve_app_id(), _patch_backend(mock_backend), _patch_auto_route():
+            result = runner.invoke(
+                type_cmd, ["a\r\nb"],
+                catch_exceptions=False,
+            )
+        assert result.exit_code == 0
+        mock_backend.type_text.assert_called_once_with(
+            "a\r\nb", delay_ms=5, profile="linear", wpm=120, input_mode="normal",
+        )

--- a/tests/test_input_keyboard.py
+++ b/tests/test_input_keyboard.py
@@ -468,3 +468,62 @@ class TestKeyboardFunctionalWindows:
         assert data.get("success") is True
         assert "text" in data.get("data", {})
         assert "length" in data.get("data", {})
+
+
+# ── #840: type_text newline splitting ────────────────────────────────────────
+
+
+class TestTypeTextNewlineSplitting:
+    """#840: type_text must split on newlines and press Enter between segments."""
+
+    def _make_mixin(self):
+        from unittest.mock import MagicMock
+        from naturo.backends.windows._input import InputMixin
+
+        obj = object.__new__(InputMixin)
+        obj._ensure_core = MagicMock()
+        return obj
+
+    def test_newline_splits_into_enter(self):
+        """Text with \\n is split into segments with Enter keypresses."""
+        from unittest.mock import MagicMock, patch
+
+        obj = self._make_mixin()
+        mock_strategy = MagicMock()
+
+        with patch("naturo.backends.windows._input.get_input_strategy",
+                   return_value=mock_strategy):
+            obj.type_text("hello\nworld")
+
+        assert mock_strategy.type_text.call_count == 2
+        mock_strategy.type_text.assert_any_call("hello", 5)
+        mock_strategy.type_text.assert_any_call("world", 5)
+        mock_strategy.press_key.assert_called_once_with("enter")
+
+    def test_crlf_splits_correctly(self):
+        """Text with \\r\\n produces one Enter, not two."""
+        from unittest.mock import MagicMock, patch
+
+        obj = self._make_mixin()
+        mock_strategy = MagicMock()
+
+        with patch("naturo.backends.windows._input.get_input_strategy",
+                   return_value=mock_strategy):
+            obj.type_text("line1\r\nline2\r\nline3")
+
+        assert mock_strategy.type_text.call_count == 3
+        assert mock_strategy.press_key.call_count == 2
+
+    def test_no_newline_no_split(self):
+        """Text without newlines is typed as a single call."""
+        from unittest.mock import MagicMock, patch
+
+        obj = self._make_mixin()
+        mock_strategy = MagicMock()
+
+        with patch("naturo.backends.windows._input.get_input_strategy",
+                   return_value=mock_strategy):
+            obj.type_text("no newlines here")
+
+        mock_strategy.type_text.assert_called_once_with("no newlines here", 5)
+        mock_strategy.press_key.assert_not_called()

--- a/tests/test_input_strategies.py
+++ b/tests/test_input_strategies.py
@@ -283,6 +283,97 @@ class TestInputMixinUsesStrategy:
             mock_strategy.type_text.assert_called_once_with("abc", 200)
 
 
+# ── Newline handling (#840) ──────────────────────────────────────────────────
+
+
+class TestTypeTextNewlines:
+    """#840: type_text splits on newlines and presses Enter between segments."""
+
+    @staticmethod
+    def _make_mixin(mock_strategy):
+        """Create an InputMixin wired to a mock strategy."""
+        from contextlib import contextmanager
+
+        @contextmanager
+        def _ctx():
+            core = _make_core()
+            with patch(
+                "naturo.backends.windows._input.get_input_strategy",
+                return_value=mock_strategy,
+            ):
+                from naturo.backends.windows._input import InputMixin
+                mixin = InputMixin.__new__(InputMixin)
+                mixin._ensure_core = MagicMock(return_value=core)
+                yield mixin
+        return _ctx()
+
+    def test_no_newlines_single_call(self):
+        """Text without newlines is typed in a single call."""
+        mock_strategy = MagicMock()
+        with self._make_mixin(mock_strategy) as mixin:
+            mixin.type_text("hello world")
+        mock_strategy.type_text.assert_called_once_with("hello world", 5)
+        mock_strategy.press_key.assert_not_called()
+
+    def test_lf_newline_splits_and_presses_enter(self):
+        """Unix \\n is split into two type_text calls with Enter between."""
+        mock_strategy = MagicMock()
+        with self._make_mixin(mock_strategy) as mixin:
+            mixin.type_text("line1\nline2")
+        assert mock_strategy.type_text.call_count == 2
+        mock_strategy.type_text.assert_any_call("line1", 5)
+        mock_strategy.type_text.assert_any_call("line2", 5)
+        mock_strategy.press_key.assert_called_once_with("enter")
+
+    def test_crlf_newline(self):
+        """Windows \\r\\n is treated as a single newline."""
+        mock_strategy = MagicMock()
+        with self._make_mixin(mock_strategy) as mixin:
+            mixin.type_text("a\r\nb")
+        assert mock_strategy.type_text.call_count == 2
+        mock_strategy.press_key.assert_called_once_with("enter")
+
+    def test_cr_newline(self):
+        """Old Mac \\r is treated as a newline."""
+        mock_strategy = MagicMock()
+        with self._make_mixin(mock_strategy) as mixin:
+            mixin.type_text("a\rb")
+        assert mock_strategy.type_text.call_count == 2
+        mock_strategy.press_key.assert_called_once_with("enter")
+
+    def test_multiple_newlines(self):
+        """Multiple newlines produce multiple Enter presses."""
+        mock_strategy = MagicMock()
+        with self._make_mixin(mock_strategy) as mixin:
+            mixin.type_text("a\nb\nc")
+        assert mock_strategy.type_text.call_count == 3
+        assert mock_strategy.press_key.call_count == 2
+
+    def test_trailing_newline(self):
+        """Trailing newline produces Enter after the text."""
+        mock_strategy = MagicMock()
+        with self._make_mixin(mock_strategy) as mixin:
+            mixin.type_text("hello\n")
+        mock_strategy.type_text.assert_called_once_with("hello", 5)
+        mock_strategy.press_key.assert_called_once_with("enter")
+
+    def test_leading_newline(self):
+        """Leading newline produces Enter before the text."""
+        mock_strategy = MagicMock()
+        with self._make_mixin(mock_strategy) as mixin:
+            mixin.type_text("\nhello")
+        mock_strategy.type_text.assert_called_once_with("hello", 5)
+        mock_strategy.press_key.assert_called_once_with("enter")
+
+    def test_only_newlines(self):
+        """Text of only newlines produces Enter presses with no type_text calls."""
+        mock_strategy = MagicMock()
+        with self._make_mixin(mock_strategy) as mixin:
+            mixin.type_text("\n\n")
+        mock_strategy.type_text.assert_not_called()
+        assert mock_strategy.press_key.call_count == 2
+
+
 # ── Extensibility Tests ──────────────────────────────────────────────────────
 
 

--- a/tests/test_type_newline_840.py
+++ b/tests/test_type_newline_840.py
@@ -1,0 +1,110 @@
+"""Tests for type_text handling of newline characters (#840).
+
+Verifies that newlines in text are converted to Enter keypresses instead
+of being silently dropped by the native DLL.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+
+@pytest.fixture
+def mock_strategy():
+    """Create a mock InputStrategy."""
+    s = MagicMock()
+    s.type_text = MagicMock()
+    s.press_key = MagicMock()
+    return s
+
+
+@pytest.fixture
+def backend(mock_strategy):
+    """Create an InputMixin with a mocked strategy."""
+    from naturo.backends.windows._input import InputMixin
+
+    class FakeBackend(InputMixin):
+        def _ensure_core(self):
+            return MagicMock()
+
+    b = FakeBackend()
+    return b
+
+
+class TestTypeTextNewlines:
+    """Newlines should be converted to Enter keypresses (#840)."""
+
+    def test_newline_splits_into_enter(self, backend, mock_strategy):
+        """'hello\\nworld' should type 'hello', press Enter, type 'world'."""
+        with patch("naturo.backends.windows._input.get_input_strategy",
+                    return_value=mock_strategy):
+            backend.type_text("hello\nworld")
+
+        assert mock_strategy.type_text.call_count == 2
+        mock_strategy.type_text.assert_any_call("hello", 5)
+        mock_strategy.type_text.assert_any_call("world", 5)
+        mock_strategy.press_key.assert_called_once_with("enter")
+
+    def test_multiple_newlines(self, backend, mock_strategy):
+        """'a\\nb\\nc' should produce 3 segments with 2 Enter presses."""
+        with patch("naturo.backends.windows._input.get_input_strategy",
+                    return_value=mock_strategy):
+            backend.type_text("a\nb\nc")
+
+        assert mock_strategy.type_text.call_count == 3
+        assert mock_strategy.press_key.call_count == 2
+
+    def test_trailing_newline(self, backend, mock_strategy):
+        """'hello\\n' should type 'hello' then press Enter."""
+        with patch("naturo.backends.windows._input.get_input_strategy",
+                    return_value=mock_strategy):
+            backend.type_text("hello\n")
+
+        mock_strategy.type_text.assert_called_once_with("hello", 5)
+        mock_strategy.press_key.assert_called_once_with("enter")
+
+    def test_leading_newline(self, backend, mock_strategy):
+        """'\\nhello' should press Enter then type 'hello'."""
+        with patch("naturo.backends.windows._input.get_input_strategy",
+                    return_value=mock_strategy):
+            backend.type_text("\nhello")
+
+        mock_strategy.type_text.assert_called_once_with("hello", 5)
+        mock_strategy.press_key.assert_called_once_with("enter")
+
+    def test_crlf_normalized(self, backend, mock_strategy):
+        """Windows-style \\r\\n should be treated as a single newline."""
+        with patch("naturo.backends.windows._input.get_input_strategy",
+                    return_value=mock_strategy):
+            backend.type_text("hello\r\nworld")
+
+        assert mock_strategy.type_text.call_count == 2
+        mock_strategy.press_key.assert_called_once_with("enter")
+
+    def test_bare_cr_normalized(self, backend, mock_strategy):
+        """Bare \\r should be treated as a newline."""
+        with patch("naturo.backends.windows._input.get_input_strategy",
+                    return_value=mock_strategy):
+            backend.type_text("hello\rworld")
+
+        assert mock_strategy.type_text.call_count == 2
+        mock_strategy.press_key.assert_called_once_with("enter")
+
+    def test_no_newline_passes_through(self, backend, mock_strategy):
+        """Text without newlines should be passed directly to strategy."""
+        with patch("naturo.backends.windows._input.get_input_strategy",
+                    return_value=mock_strategy):
+            backend.type_text("hello world")
+
+        mock_strategy.type_text.assert_called_once_with("hello world", 5)
+        mock_strategy.press_key.assert_not_called()
+
+    def test_only_newlines(self, backend, mock_strategy):
+        """'\\n\\n' should press Enter twice with no type_text calls."""
+        with patch("naturo.backends.windows._input.get_input_strategy",
+                    return_value=mock_strategy):
+            backend.type_text("\n\n")
+
+        mock_strategy.type_text.assert_not_called()
+        assert mock_strategy.press_key.call_count == 2


### PR DESCRIPTION
## Summary
Auto-created PR from branch `fix/issue-840-type-newline-drop`. Code reviewed and fixed by Orc-Mycelium.

## Test plan
- CI must pass on all supported platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)