### PR TITLE
ops: disable scheduled workflow crons on main (#857)

### DIFF
--- a/.github/workflows/desktop-tests.yml
+++ b/.github/workflows/desktop-tests.yml
@@ -3,8 +3,8 @@ name: Desktop Tests (Self-Hosted)
 on:
   # Desktop tests run on self-hosted runner (may be offline).
   # Triggered by QA agent or manually — NOT on push/PR to avoid blocking Dev workflow.
-  schedule:
-    - cron: '30 */2 * * *'   # Every 2 hours at :30 (runs only if runner is online)
+  # schedule:
+  #   - cron: '30 */2 * * *'   # Every 2 hours at :30 — DISABLED while runner offline (#857, #842)
   workflow_dispatch:
     inputs:
       test_filter:

--- a/.github/workflows/qa-agent.yml
+++ b/.github/workflows/qa-agent.yml
@@ -1,8 +1,8 @@
 name: QA Agent (Self-Hosted Desktop)
 
 on:
-  schedule:
-    - cron: '30 * * * *'   # Every hour at :30
+  # schedule:
+  #   - cron: '30 * * * *'   # Every hour at :30 — DISABLED while runner offline (#857, #842)
   workflow_dispatch:
     inputs:
       focus:


### PR DESCRIPTION
## Summary
- Disables cron triggers for `desktop-tests.yml` and `qa-agent.yml` on the `main` branch
- GitHub evaluates `schedule:` triggers from the **default branch** (main), not develop — the previous disable on develop (#857) had no effect
- Crons continued accumulating queued runs against the offline runner (15 cancelled today alone)

## Context
- Self-hosted runner ROBOT-COMPILE offline 12 days (#842)
- Re-enable crons when runner is restored

## Test plan
- [x] Verify no new queued runs appear after merge

**[Orc-Mycelium]**