### PR TITLE
docs: correct contributor workflow to develop-first (fixes #902)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,13 +42,15 @@ Request a fine-grained PAT from the maintainer with Issues read/write permission
 
 ### Bug Fix Workflow
 1. Pick an issue from GitHub Issues (P0 first)
-2. Create a branch: `fix/issue-<number>-short-description` (e.g. `fix/issue-12-dpi-awareness`)
+2. Create a branch off `develop`: `fix/issue-<number>-short-description` (e.g. `fix/issue-12-dpi-awareness`)
 3. One bug = one commit, reference the issue: `fix: [BUG-073] DPI awareness (fixes #12)`
-4. Push branch and open a PR — CI runs automatically
-5. CI green + review passed → squash merge to main
+4. Push branch and open a PR against `develop` — CI runs automatically
+5. CI green + review passed → squash merge to `develop`
 6. Comment on the issue with fix details: `**[Dev]** Fixed in PR #XX`
 
-> **Never push directly to main.** All changes go through PR + CI.
+> **All development happens on `develop`.** Feature branches → PR → `develop`.
+> Only release merges go `develop` → `main`, and only version tags land on `main`
+> (which is what publishes to PyPI). **Never push directly to `main`.**
 
 ### Code Standards
 - All tests must pass on Ubuntu + macOS + Windows


### PR DESCRIPTION
## Problem
`CONTRIBUTING.md` step 5 read "squash merge to **main**", directly contradicting the develop-first workflow (RULES.md §3: all development goes through `develop`; only release merges reach `main`).

This contradiction misled the project's first external contributor, who opened PR #892 against `main` instead of `develop`.

## Fix
- Step 2/4: branch off and open the PR against `develop` explicitly
- Step 5: squash merge to `develop` (not `main`)
- Expanded the warning note to explain that only release merges and version tags reach `main` (which publishes to PyPI)

Docs-only change. Closes #902.

**[Orc-Mycelium]**