### PR TITLE
ci: skip Feishu notification when webhook URL is empty (fixes #906)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -476,6 +476,10 @@ jobs:
           CI_COMMIT_MSG: ${{ github.event.head_commit.message }}
           CI_NOTE: ${{ steps.status.outputs.note }}
         run: |
+          if [[ -z "$FEISHU_WEBHOOK_URL" ]]; then
+            echo "::warning::FEISHU_WEBHOOK_URL not set (fork/dependabot PR); skipping notification"
+            exit 0
+          fi
           SHORT_COMMIT="${CI_COMMIT:0:7}"
           RUN_URL="https://github.com/${CI_REPO}/actions/runs/${CI_RUN_ID}"
           # Use first line of commit message only


### PR DESCRIPTION
## Problem
On fork PRs and dependabot PRs, repo secrets are not exposed, so `secrets.FEISHU_WEBHOOK_URL` is empty. The `Send Feishu notification` step then runs `curl -X POST ""`, which exits 3; under `bash -e` this fails the step and marks the whole **Build & Test** run as failure — even though build + tests passed. Observed on PR #905 (dependabot) and would also hit the external contribution in PR #904.

## Fix
Guard the notification step: if `FEISHU_WEBHOOK_URL` is empty, emit a `::warning::` and `exit 0`. Internal pushes (develop/main, tags) keep notifying as before; only secret-less fork/bot runs skip silently.

## Test
- N/A for runtime code (CI-only). Verified the change is a pure guard at the top of the existing step; no payload logic altered.

Closes #906

**[Orc-Mycelium]**