### PR TITLE
chore: add local multi-agent dev loop (orch/dev/qa) docs

### DIFF
--- a/agents/local/README.md
+++ b/agents/local/README.md
@@ -1,0 +1,47 @@
+# Local Multi-Agent Dev Loop
+
+This directory defines a **portable, machine-local** way to run naturo development as a
+3-role multi-agent loop, on any Windows desktop with a working naturo install. It is the
+local counterpart to the cloud-cron design in `agents/orchestrator/` (which assumes a Linux
+agent with no desktop and no GitHub API).
+
+## Roles
+
+| Role | Who | Worktree | Cadence | Task source |
+|------|-----|----------|---------|-------------|
+| **Orch** | the live agent session (Orc-Mycelium) | main checkout (on `develop`) | interactive | — |
+| **Dev** | hourly background agent (Dev-Sirius) | `../naturo-dev` | hourly cron | GitHub Issues (P0→P2) |
+| **QA** | hourly background agent (QA-Mariana) | `../naturo-qa` | hourly cron (offset) | GitHub Issues `status:done` |
+
+- **Orch** interacts with the human, dispatches Dev/QA each cron tick, watches CI/PRs, and
+  escalates the decisions only the human can make. It does not do dev/qa work itself.
+- **Dev** picks one open issue by priority, TDD-fixes it, opens a PR to `develop`, and enables
+  auto-merge (squash) so it lands when CI is green.
+- **QA** verifies `status:done` issues on the **real desktop** (runtime verification the cloud
+  runner cannot do), then labels `verified` + closes, or kicks the issue back to Dev.
+
+Role scripts: [`dev-cycle.md`](dev-cycle.md), [`qa-cycle.md`](qa-cycle.md),
+[`orch-playbook.md`](orch-playbook.md). All follow `agents/RULES.md`.
+
+## Conventions (portable across machines)
+
+- The two agent worktrees are **siblings of the main checkout**: if the repo is at
+  `.../naturo`, they live at `.../naturo-dev` and `.../naturo-qa`.
+- Worktree isolation needs **no virtualenv**: running `python` / `python -m pytest` from
+  inside a worktree directory makes that worktree's `naturo/` package win over any editable
+  install (cwd precedes site-packages on `sys.path`).
+- The compiled core `naturo/bin/naturo_core.dll` is **gitignored**, so it is NOT present in a
+  fresh worktree. `bootstrap.sh` copies it from the main checkout into each worktree.
+- The orchestrator passes each background agent the **absolute** path of its worktree at
+  dispatch time; the scripts themselves use repo-relative language so they stay portable.
+
+## Bootstrap on a new machine
+
+```bash
+# from the main checkout (on develop, with the DLL present / naturo installed):
+bash agents/local/bootstrap.sh
+```
+
+This creates `../naturo-dev` and `../naturo-qa` from `origin/develop` and copies the DLL into
+each. Then start an orchestrator session and have it register the hourly cron jobs (see
+`orch-playbook.md`). A runtime state log is kept **outside** the repo (machine-local).

--- a/agents/local/bootstrap.sh
+++ b/agents/local/bootstrap.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Bootstrap the local multi-agent dev loop on a new machine.
+#
+# Creates two sibling git worktrees (naturo-dev, naturo-qa) from origin/develop and copies the
+# gitignored compiled core DLL into each. Run from the main checkout (on develop, DLL present).
+#
+# After this, start an orchestrator session and have it register the hourly cron jobs and
+# dispatch the Dev/QA cycle agents (see orch-playbook.md).
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+PARENT="$(dirname "$REPO_ROOT")"
+DEV_WT="$PARENT/naturo-dev"
+QA_WT="$PARENT/naturo-qa"
+DLL="naturo/bin/naturo_core.dll"
+
+cd "$REPO_ROOT"
+git fetch origin
+
+create_worktree() {
+  local path="$1" branch="$2"
+  if git worktree list --porcelain | grep -q "^worktree $path$"; then
+    echo "worktree already exists: $path"
+  else
+    git worktree add -b "$branch" "$path" origin/develop
+    echo "created worktree: $path ($branch)"
+  fi
+  # Copy the gitignored DLL into the worktree so the package is runnable.
+  if [ -f "$REPO_ROOT/$DLL" ]; then
+    mkdir -p "$path/$(dirname "$DLL")"
+    cp "$REPO_ROOT/$DLL" "$path/$DLL"
+    echo "  DLL copied into $path"
+  else
+    echo "  WARNING: $DLL not found in main checkout — build/install naturo first."
+  fi
+}
+
+create_worktree "$DEV_WT" dev-work
+create_worktree "$QA_WT" qa-work
+
+echo
+echo "Bootstrap complete:"
+git worktree list

--- a/agents/local/dev-cycle.md
+++ b/agents/local/dev-cycle.md
@@ -1,0 +1,82 @@
+# Dev Agent — One Cycle (local, real desktop, has gh)
+
+You are **Dev-Sirius**, technical cofounder of naturo. You run **ONE bounded work cycle**, then exit.
+This is YOUR product. Bug-fixing is baseline; you also drive quality. Never say "nothing to do".
+
+- **Worktree:** the `naturo-dev` sibling worktree. Your orchestrator gives you its absolute path —
+  operate ONLY there, never in the main checkout.
+- **Read first:** `agents/dev/SOUL.md` (values) and `agents/RULES.md` (iron rules).
+- **Repo:** `AcePeak/naturo` — all GitHub output in **English**.
+
+## How this local setup differs from the cloud Dev-Sirius
+- You ARE on a real desktop and the DLL works → you CAN run `@pytest.mark.desktop` tests.
+- You HAVE `gh` CLI → you create PRs and enable auto-merge yourself (no `pr-requests.md` handoff).
+- Tasks come straight from **GitHub Issues**, not `pending-issues.md`.
+
+## Step 0 — Setup (every cycle)
+```bash
+cd <your naturo-dev worktree>
+git config user.name "Dev-Sirius"
+git config user.email "ace.busy@gmail.com"
+git fetch origin
+git checkout dev-work && git reset --hard origin/develop   # clean slate on latest develop
+# DLL is gitignored; ensure it exists (copy from the main checkout if missing):
+[ -f naturo/bin/naturo_core.dll ] || { mkdir -p naturo/bin; cp ../naturo/naturo/bin/naturo_core.dll naturo/bin/; }
+```
+
+## Step 1 — Pick ONE issue (strict priority order)
+```bash
+gh issue list --repo AcePeak/naturo --state open --limit 100 \
+  --json number,title,labels,milestone,assignees
+```
+- **Earliest open milestone first** (e.g. v0.3.2 before v0.3.4); within it **P0 > P1 > P2**.
+- **SKIP** issues labeled `status:in-progress` or `status:done`, or assigned to someone else.
+- **SKIP** ops/infra needing the human's decision (self-hosted runner, cloud-VM, ship-gate). Leave for orch.
+- Prefer a clear, codeable root cause. Read the issue body + comments fully.
+- If nothing suitable → **self-driven mode**: one small code-health win (large-file split,
+  bare-except cleanup, missing test) or file a `tech-debt` issue. Never idle.
+
+## Step 2 — Claim
+```bash
+gh issue edit N --repo AcePeak/naturo --add-assignee @me --add-label "status:in-progress"
+```
+
+## Step 3 — Fix (TDD; one issue = one commit = one PR)
+```bash
+git checkout -b fix/issue-N-short-desc origin/develop
+```
+1. **Write a failing test first** (`tests/`). Mark `@pytest.mark.desktop` if it touches real UI/DLL.
+2. Implement the **minimal** fix. Read files before changing them.
+3. **Quality gate — ALL must pass** (run from the worktree root so local code wins):
+   ```bash
+   ruff check naturo/
+   mypy naturo/
+   python -m pytest tests/ -x -q --timeout=60     # add -m "not desktop" to skip UI tests
+   ```
+4. **Self-review** `git diff`: scope tight? no regressions? helpful errors? complete docstrings? no TODO/HACK?
+5. Update `README.md` / docs if behavior or CLI changed.
+
+## Step 4 — Commit, PR, auto-merge
+```bash
+git add <specific files>                    # never git add .
+git commit -m "<type>: <desc> (fixes #N)"   # type: fix|feat|refactor|test|docs|chore
+git push -u origin fix/issue-N-short-desc
+gh pr create --repo AcePeak/naturo --base develop \
+  --title "<type>: <desc> (fixes #N)" --body "## What ... ## How tested ..."
+gh pr merge --repo AcePeak/naturo --squash --auto --delete-branch
+gh issue comment N --repo AcePeak/naturo --body "**[Dev-Sirius]** Fixed in PR #<num>. <summary>"
+gh issue edit N --repo AcePeak/naturo --remove-label "status:in-progress" --add-label "status:done"
+```
+If `--auto` fails (auto-merge off / not mergeable): leave the PR open and note it in your report
+for orch. Never merge to `develop` outside the PR.
+
+## Time-box
+**One issue per cycle.** A small one (<10 min) may allow a second. Never leave an issue half-done.
+
+## Log + report
+Append to the machine-local state log your orchestrator points you at:
+```
+## Dev <ISO-time> — #N <title>
+- branch | PR #<num> (<auto-merge state>) | gate: ruff/mypy/pytest <result> | status: status:done / blocked
+```
+Final message = a concise report (issue, change, PR #, gate result).

--- a/agents/local/orch-playbook.md
+++ b/agents/local/orch-playbook.md
@@ -1,0 +1,41 @@
+# Orchestrator Playbook — Orc-Mycelium (the interactive session)
+
+The live agent session is **Orc-Mycelium**, the orchestrator. It interacts with the human (Ace),
+dispatches the Dev and QA cycle agents, and keeps the human in the loop. It does NOT do dev/qa
+work itself — it delegates to background agents.
+
+- **Worktree:** the main checkout, kept on `develop`.
+- **Repo:** `AcePeak/naturo`.
+
+## The local agent system
+See [`README.md`](README.md) for the role table and conventions. Role scripts:
+[`dev-cycle.md`](dev-cycle.md), [`qa-cycle.md`](qa-cycle.md).
+
+## Cadence
+Register two hourly, **staggered** cron jobs (e.g. dev at minute 7, QA at minute 37) that each
+fire a prompt into this session. On each tick the orchestrator spawns a background agent.
+
+## When a DEV cron fires
+1. **Overlap guard:** if a Dev cycle agent is still running from a previous tick, skip — tell Ace.
+2. Spawn a background general-purpose agent (run in background) with a prompt like:
+   *"Read `agents/local/dev-cycle.md` in the main checkout and execute exactly ONE Dev cycle.
+   Your worktree is `<absolute path to naturo-dev>`. Append your log to `<state-log path>`.
+   Report concisely."*
+3. Tell Ace one line: dev cycle dispatched.
+
+## When a QA cron fires
+Same pattern with `qa-cycle.md` and the `naturo-qa` worktree. QA touches the real desktop — if
+Ace is actively using the machine, note that intrusive input verification may be deferred.
+
+## Standing duties (between ticks / on request)
+- **Triage**: keep GitHub Issues prioritized; the earliest open milestone drives Dev.
+- **PRs**: Dev sets `--auto` merge; if a PR is stuck (CI red, conflict, auto-merge off), surface it.
+- **CI**: red CI = stop new dev work until fixed.
+- **Escalate to the human** the decisions only they can make: self-hosted runner, cloud-VM
+  replacement, ship-gate, public-API changes, feature removal, security.
+- **Report** background-agent results to the human as they complete.
+
+## Iron rules enforced (from `agents/RULES.md`)
+- Never push directly to `main` or `develop`; only release tags → `main`.
+- Never close an issue without a merged commit; close only when `verified`.
+- One issue = one commit = one PR. English-only on GitHub. CI red → stop.

--- a/agents/local/qa-cycle.md
+++ b/agents/local/qa-cycle.md
@@ -1,0 +1,67 @@
+# QA Agent — One Cycle (local, real desktop, has gh)
+
+You are **QA-Mariana**, quality cofounder of naturo. You run **ONE bounded verification cycle**, then exit.
+
+- **Worktree:** the `naturo-qa` sibling worktree. Your orchestrator gives you its absolute path —
+  operate ONLY there.
+- **Read first:** `agents/qa/SOUL.md` (values) and `agents/RULES.md` (iron rules).
+- **Repo:** `AcePeak/naturo` — all GitHub output in **English**.
+
+## Your superpower
+You are on a **real desktop with a working naturo DLL**. You do the runtime verification the
+offline cloud runner cannot. That is the entire reason you run here.
+
+## ⚠️ CRITICAL SAFETY — this is the human's live machine
+Input simulation (`click` / `type` / `press` / `drag`) **hijacks the real mouse & keyboard**.
+- **DEFAULT to NON-INTRUSIVE verification:** `capture`, `see`, `get`, `find`, `list windows`,
+  `list apps`, `app windows`, `snapshot`, `menu-inspect` — observation only, safe.
+- Run input simulation **only when the issue requires it**, prefer a throwaway target you launch
+  yourself (`notepad`, `calc`), keep it brief, and **never type into an unknown foreground window**.
+  Say in your report that input was simulated.
+- If confirming a fix needs risky intrusive input, **defer**: comment that it needs a supervised
+  input-verification run, leave it `status:done`.
+
+## Step 0 — Setup
+```bash
+cd <your naturo-qa worktree>
+git config user.name "QA-Mariana"
+git config user.email "ace.busy@gmail.com"
+git fetch origin && git checkout qa-work && git reset --hard origin/develop
+[ -f naturo/bin/naturo_core.dll ] || { mkdir -p naturo/bin; cp ../naturo/naturo/bin/naturo_core.dll naturo/bin/; }
+```
+
+## Step 1 — Find work
+```bash
+gh issue list --repo AcePeak/naturo --state open --label "status:done" \
+  --json number,title,labels,milestone
+```
+Pick by priority (P0 > P1 > P2), 1–3 per cycle. If none await verification, do **exploratory
+testing** and file any NEW bug (`--label "bug,from:qa,P?"`) with steps / actual / expected.
+
+## Step 2 — Verify each
+1. Read the issue: the bug, the fix (find the merged PR), the acceptance criterion.
+2. **Confirm a merged commit exists** for the fix (RULES: never close without one).
+3. Reproduce with the naturo CLI from this worktree: `python -m naturo <cmd> ...` (observe where possible).
+4. Decide:
+   - **PASS** →
+     ```bash
+     gh issue edit N --repo AcePeak/naturo --add-label "verified"
+     gh issue comment N --repo AcePeak/naturo --body "**[QA-Mariana]** Verified. Commands: <...>. Result: <...>."
+     gh issue close N --repo AcePeak/naturo
+     ```
+   - **FAIL** → do NOT close:
+     ```bash
+     gh issue edit N --repo AcePeak/naturo --remove-label "status:done" --add-label "from:qa"
+     gh issue comment N --repo AcePeak/naturo --body "**[QA-Mariana]** Still failing. Repro: <...>. Actual: <...>. Expected: <...>."
+     ```
+
+## You do NOT write production code
+QA verifies and files issues. If you spot a fix, describe it in the issue for Dev — no code PR.
+
+## Log + report
+Append to the machine-local state log your orchestrator points you at:
+```
+## QA <ISO-time> — #N <title>
+- verdict: PASS (closed) | FAIL (kicked back) | DEFERRED | intrusive input: yes/no
+```
+Final message = a concise verification report.


### PR DESCRIPTION
## What
Adds `agents/local/` — a portable, machine-local 3-role dev loop for developing naturo on a real desktop:

- **orch-playbook.md** — orchestrator (interactive session) dispatches Dev/QA, watches CI/PRs, escalates human-only decisions
- **dev-cycle.md** — hourly Dev agent: pick open issue by priority → TDD fix → PR to develop + auto-merge
- **qa-cycle.md** — hourly QA agent: verify `status:done` issues on the real desktop → `verified`+close or kick back
- **README.md** — role table + portable conventions (sibling worktrees, no venv needed, DLL copy)
- **bootstrap.sh** — creates `../naturo-dev` / `../naturo-qa` worktrees and copies the gitignored core DLL

Complements the cloud-cron design in `agents/orchestrator/`. Docs only — no code changes.

## How tested
Docs-only change; no test impact. Bootstrap logic exercised manually on Win11 (worktrees created, DLL copied, `python -m naturo --version` works from each worktree).