### PR TITLE
fix: accept limit in SnapshotManager.list_snapshots and fix MCP wrapper (fixes #890)

### DIFF
--- a/naturo/mcp/_snapshot.py
+++ b/naturo/mcp/_snapshot.py
@@ -166,13 +166,15 @@ def register_snapshot_tools(server, _get_backend, _safe_tool):
 
         return {
             "success": True,
+            "session": manager.session,
             "snapshots": [
                 {
-                    "snapshot_id": s.snapshot_id,
-                    "created_at": s.created_at,
-                    "window_title": s.window_title,
+                    "id": s.id,
+                    "created_at": s.created_at.isoformat(),
+                    "last_accessed_at": s.last_accessed_at.isoformat(),
+                    "size_bytes": s.size_in_bytes,
+                    "screenshot_count": s.screenshot_count,
                     "application_name": s.application_name,
-                    "is_valid": s.is_valid,
                 }
                 for s in snapshots
             ],

--- a/naturo/snapshot.py
+++ b/naturo/snapshot.py
@@ -629,8 +629,30 @@ class SnapshotManager:
         logger.debug("Most recent valid snapshot: %s", best)
         return best
 
-    def list_snapshots(self) -> List[SnapshotInfo]:
-        """Return summary information for all stored snapshots, newest first."""
+    def list_snapshots(self, limit: Optional[int] = None) -> List[SnapshotInfo]:
+        """Return summary information for stored snapshots, newest first.
+
+        Parameters
+        ----------
+        limit:
+            Maximum number of snapshots to return. When ``None`` (the default)
+            every snapshot is returned. When set, only the newest ``limit``
+            snapshots are returned.
+
+        Returns
+        -------
+        List[SnapshotInfo]
+            Snapshot summaries sorted newest-first, sliced to ``limit`` when
+            provided.
+
+        Raises
+        ------
+        ValueError
+            If ``limit`` is provided and is less than 1.
+        """
+        if limit is not None and limit < 1:
+            raise ValueError(f"limit must be >= 1, got {limit}")
+
         infos: List[SnapshotInfo] = []
 
         with self._lock:
@@ -677,6 +699,8 @@ class SnapshotManager:
                 )
 
         infos.sort(key=lambda s: s.created_at, reverse=True)
+        if limit is not None:
+            return infos[:limit]
         return infos
 
     def clean_snapshot(self, snapshot_id: str) -> None:

--- a/tests/test_mcp_snapshot.py
+++ b/tests/test_mcp_snapshot.py
@@ -223,23 +223,32 @@ class TestGetSnapshot:
 class TestListSnapshots:
 
     def test_returns_snapshot_list(self, server):
-        snap = MagicMock()
-        snap.snapshot_id = "snap-001"
-        snap.created_at = "2026-03-31T00:00:00"
-        snap.window_title = "Notepad"
-        snap.application_name = "notepad.exe"
-        snap.is_valid = True
+        from datetime import datetime, timezone
+
+        from naturo.models.snapshot import SnapshotInfo
+
+        snap = SnapshotInfo(
+            id="snap-001",
+            created_at=datetime(2026, 3, 31, tzinfo=timezone.utc),
+            last_accessed_at=datetime(2026, 3, 31, tzinfo=timezone.utc),
+            size_in_bytes=2048,
+            screenshot_count=1,
+            application_name="notepad.exe",
+        )
 
         mock_manager = MagicMock()
+        mock_manager.session = "default"
         mock_manager.list_snapshots.return_value = [snap]
 
         with patch("naturo.snapshot.get_snapshot_manager", return_value=mock_manager):
             result = _call_tool(server, "list_snapshots", {})
         data = json.loads(result[0].text)
         assert data["success"] is True
+        assert data["session"] == "default"
         assert len(data["snapshots"]) == 1
-        assert data["snapshots"][0]["snapshot_id"] == "snap-001"
-        assert data["snapshots"][0]["is_valid"] is True
+        assert data["snapshots"][0]["id"] == "snap-001"
+        assert data["snapshots"][0]["application_name"] == "notepad.exe"
+        assert data["snapshots"][0]["created_at"] == "2026-03-31T00:00:00+00:00"
         mock_manager.list_snapshots.assert_called_once_with(limit=10)
 
     def test_custom_limit(self, server):

--- a/tests/test_snapshot_list_limit.py
+++ b/tests/test_snapshot_list_limit.py
@@ -1,0 +1,152 @@
+"""Regression tests for #890 — ``list_snapshots`` limit handling.
+
+The MCP ``list_snapshots`` wrapper calls
+``SnapshotManager.list_snapshots(limit=...)``, but the manager method did not
+accept a ``limit`` parameter, so every MCP call failed with
+``TypeError: ... got an unexpected keyword argument 'limit'``. These tests pin
+down the contract:
+
+* ``SnapshotManager.list_snapshots`` accepts an optional ``limit`` and slices the
+  result newest-first.
+* The MCP wrapper returns a CLI-shaped success payload using the real
+  ``SnapshotInfo`` fields.
+
+All tests use a temporary on-disk snapshot store and require no real desktop /
+UI Automation DLL, so they are intentionally NOT marked ``@pytest.mark.desktop``.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+
+import pytest
+
+from naturo.snapshot import SnapshotManager
+
+
+def _make_manager(tmp_path) -> SnapshotManager:
+    """Build a SnapshotManager backed by an isolated temporary store."""
+    return SnapshotManager(storage_root=tmp_path, session="test-890")
+
+
+def _populate(manager: SnapshotManager, count: int) -> list[str]:
+    """Create ``count`` snapshots with distinct creation times, oldest first."""
+    ids: list[str] = []
+    for _ in range(count):
+        ids.append(manager.create_snapshot())
+        # Ensure distinct directory timestamps so ordering is deterministic.
+        time.sleep(0.01)
+    return ids
+
+
+class TestSnapshotManagerLimit:
+    """Direct unit tests for SnapshotManager.list_snapshots(limit=...)."""
+
+    def test_accepts_limit_kwarg(self, tmp_path):
+        """Reproduces #890: passing ``limit=`` must not raise TypeError."""
+        manager = _make_manager(tmp_path)
+        _populate(manager, 3)
+
+        # Before the fix this raised:
+        #   TypeError: list_snapshots() got an unexpected keyword argument 'limit'
+        result = manager.list_snapshots(limit=2)
+
+        assert len(result) == 2
+
+    def test_limit_slices_newest_first(self, tmp_path):
+        """A limit returns exactly the newest N entries, consistent with the
+        unlimited (newest-first) ordering."""
+        manager = _make_manager(tmp_path)
+        _populate(manager, 4)
+
+        full = manager.list_snapshots()
+        limited = manager.list_snapshots(limit=2)
+
+        assert len(full) == 4
+        assert limited == full[:2]
+
+    def test_no_limit_returns_all(self, tmp_path):
+        """``limit=None`` keeps behaviour identical to the original API."""
+        manager = _make_manager(tmp_path)
+        _populate(manager, 3)
+
+        assert len(manager.list_snapshots()) == 3
+        assert len(manager.list_snapshots(limit=None)) == 3
+
+    def test_limit_larger_than_count_returns_all(self, tmp_path):
+        """A limit exceeding the store size returns every snapshot."""
+        manager = _make_manager(tmp_path)
+        _populate(manager, 2)
+
+        assert len(manager.list_snapshots(limit=10)) == 2
+
+    def test_empty_store(self, tmp_path):
+        """An empty store returns an empty list regardless of limit."""
+        manager = _make_manager(tmp_path)
+
+        assert manager.list_snapshots() == []
+        assert manager.list_snapshots(limit=5) == []
+
+
+def _call_tool(server, tool_name: str, arguments: dict):
+    """Invoke an MCP tool function by name and return its raw result list."""
+    async def _run():
+        return await server.call_tool(tool_name, arguments)
+
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(_run())
+    finally:
+        loop.close()
+
+
+mcp_available = True
+try:
+    from naturo.mcp_server import create_server
+except ImportError:
+    mcp_available = False
+
+
+@pytest.mark.skipif(not mcp_available, reason="mcp package not installed")
+class TestMcpListSnapshotsEndToEnd:
+    """End-to-end MCP wrapper tests against a real SnapshotManager.
+
+    These would have caught #890 (and the latent field-name mismatch) because
+    they exercise the real manager instead of a fully mocked one.
+    """
+
+    def test_list_snapshots_succeeds_with_real_manager(self, tmp_path):
+        from unittest.mock import patch
+
+        manager = _make_manager(tmp_path)
+        _populate(manager, 3)
+
+        with patch("naturo.mcp_server.get_backend"), \
+             patch("naturo.snapshot.get_snapshot_manager", return_value=manager):
+            server = create_server()
+            result = _call_tool(server, "list_snapshots", {"limit": 2})
+
+        data = json.loads(result[0].text)
+        assert data["success"] is True
+        assert data["session"] == "test-890"
+        assert len(data["snapshots"]) == 2
+        # Payload must use the real SnapshotInfo fields (CLI-shaped).
+        first = data["snapshots"][0]
+        assert "id" in first
+        assert "created_at" in first
+        assert "application_name" in first
+
+    def test_list_snapshots_empty_store(self, tmp_path):
+        from unittest.mock import patch
+
+        manager = _make_manager(tmp_path)
+
+        with patch("naturo.mcp_server.get_backend"), \
+             patch("naturo.snapshot.get_snapshot_manager", return_value=manager):
+            server = create_server()
+            result = _call_tool(server, "list_snapshots", {})
+
+        data = json.loads(result[0].text)
+        assert data["success"] is True
+        assert data["snapshots"] == []


### PR DESCRIPTION
## What

MCP `list_snapshots` failed on **every** call with `TypeError: SnapshotManager.list_snapshots() got an unexpected keyword argument 'limit'` (#890). The wrapper passed `limit=` to a manager method that accepts no such parameter. The (never-reached) result mapping also referenced attributes that do not exist on `SnapshotInfo` (`snapshot_id`, `window_title`, `is_valid`) and emitted a non-serialisable `datetime` — so fixing only the `limit` kwarg would have surfaced an `AttributeError` / JSON error next. This PR fixes the whole 100% failure path.

## How

- Add an optional `limit` parameter to `SnapshotManager.list_snapshots` that slices the newest-first result. Behaviour is identical when `limit is None`; `limit < 1` raises a clear `ValueError`.
- Fix the MCP wrapper to emit a CLI-shaped payload using the real `SnapshotInfo` fields (`id`, `created_at`, `last_accessed_at`, `size_bytes`, `screenshot_count`, `application_name`) plus `session`, matching `naturo snapshot list -j`.
- Add desktop-independent regression tests (`tests/test_snapshot_list_limit.py`) for the limit contract and the end-to-end MCP wrapper against a real temp-backed manager. Update the existing `list_snapshots` MCP tests, which asserted the broken (mocked) field names, to the correct shape.

## How tested

- TDD: new tests reproduce the `TypeError` before the fix and verify newest-first limit slicing after.
- `ruff check naturo/`: clean.
- `mypy naturo/`: no errors in changed files (4 pre-existing, unrelated errors remain in `naturo/visual.py` re: Pillow stubs, identical on `develop`).
- `python -m pytest` snapshot/MCP-snapshot suite: 90 passed, 22 skipped (MCP tests skip locally — `mcp` not installed; they run on CI).

Note: the snapshot store is environment-independent, so the new tests are intentionally **not** marked `@pytest.mark.desktop`.