### PR TITLE
test: make PR #820 hwnd tests pass on Windows (fixes #870)

### DIFF
--- a/tests/test_cli_interaction_common.py
+++ b/tests/test_cli_interaction_common.py
@@ -257,10 +257,15 @@ class TestResolveAppId:
 class TestIsHwndAlive:
     """Tests for _is_hwnd_alive — HWND validity check."""
 
+    @patch("sys.platform", "linux")
     def test_returns_true_on_non_windows(self):
-        """On Linux/macOS (sys.platform != win32), always returns True."""
+        """On Linux/macOS (sys.platform != win32), always returns True.
+
+        ``sys.platform`` is forced to ``"linux"`` so the non-Windows branch is
+        exercised regardless of the host running the suite — on Windows the real
+        ``user32.IsWindow(0x1234)`` would return 0 for this fake handle (#870).
+        """
         from naturo.cli.interaction._common import _is_hwnd_alive
-        # On Linux this should return True since sys.platform != "win32"
         assert _is_hwnd_alive(0x1234) is True
 
     def test_returns_false_for_zero_handle(self):

--- a/tests/test_resolve_hwnd_session.py
+++ b/tests/test_resolve_hwnd_session.py
@@ -369,7 +369,11 @@ class TestResolveHwndPid:
     def test_pid_with_hwnd_prefers_hwnd(self):
         """Direct hwnd takes priority over pid."""
         backend = self._setup_backend(self._make_multi_app_windows())
-        with patch(f"{_SESSION_PATCH_BASE}._get_console_session_id", return_value=1), \
+        # _is_hwnd_alive is mocked True so the #788 liveness guard does not
+        # reject the synthetic handle on Windows, where IsWindow(9999) → 0
+        # (#870).  This test isolates hwnd-over-pid priority, not liveness.
+        with patch("naturo.cli.interaction._common._is_hwnd_alive", return_value=True), \
+             patch(f"{_SESSION_PATCH_BASE}._get_console_session_id", return_value=1), \
              patch(f"{_SESSION_PATCH_BASE}._get_process_session_id", return_value=1):
             result = backend._resolve_hwnd(hwnd=9999, pid=200)
         assert result == 9999
@@ -423,12 +427,17 @@ class TestResolveHwndStaleValidation:
             result = backend._resolve_hwnd(hwnd=0x1234)
         assert result == 0x1234
 
+    @patch("sys.platform", "linux")
     def test_non_windows_skips_validation(self):
-        """On non-Windows, _is_hwnd_alive returns True so HWND passes."""
+        """On non-Windows, _is_hwnd_alive returns True so HWND passes.
+
+        ``sys.platform`` is forced to ``"linux"`` so the real ``_is_hwnd_alive``
+        takes its non-Windows branch on any host — on Windows the genuine
+        ``IsWindow(0x5678)`` would return 0 and wrongly raise (#870).
+        """
         BackendClass = _make_backend()
         backend = MagicMock(spec=BackendClass)
         backend._resolve_hwnd = BackendClass._resolve_hwnd.__get__(backend)
 
-        # On Linux, _is_hwnd_alive returns True (non-Windows)
         result = backend._resolve_hwnd(hwnd=0x5678)
         assert result == 0x5678


### PR DESCRIPTION
## What
Fixes #870. Three unit tests added by PR #820 (the fix for #788) failed on Windows because they assumed the non-Windows branch of `_is_hwnd_alive`, which unconditionally returns `True`. On Windows the function correctly calls `user32.IsWindow()`, which returns 0 for the synthetic handles the tests use, so they raised `WindowNotFoundError` / returned `False` — failing on the very platform the feature targets. They went unnoticed while the self-hosted Windows runner (#842) has been offline.

Production code is **unchanged** — the defect was test-only.

## How
- `test_returns_true_on_non_windows` and `test_non_windows_skips_validation`: force `sys.platform` to `"linux"` so the real non-Windows branch is exercised on any host. Mirrors the existing sibling test `test_returns_true_when_window_valid` which uses `@patch("sys.platform", "win32")`. This keeps coverage on the Windows runner rather than skipping.
- `test_pid_with_hwnd_prefers_hwnd`: mock `_is_hwnd_alive` to `True` so the #788 liveness guard does not reject the synthetic handle (`IsWindow(9999) → 0` on Windows). The test isolates hwnd-over-pid priority, not handle liveness — matching the sibling `test_valid_hwnd_returned_directly`.

## How tested
- `python -m pytest tests/test_resolve_hwnd_session.py tests/test_cli_interaction_common.py -q` → **76 passed** (was 3 failed, 73 passed) on Windows 11 + DLL.
- `ruff check` clean on both files.
- No production code touched, so no behavior change.