### PR TITLE
feat: owned Electron fixture + real-Electron CDP recognition proof (fixes #933)

### DIFF
--- a/benchmarks/recognition/fixtures/electron/.gitignore
+++ b/benchmarks/recognition/fixtures/electron/.gitignore
@@ -1,0 +1,5 @@
+# Electron and npm install artifacts are reproducible from package.json +
+# package-lock.json; never commit them.
+node_modules/
+npm-debug.log*
+.npm/

--- a/benchmarks/recognition/fixtures/electron/index.html
+++ b/benchmarks/recognition/fixtures/electron/index.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'unsafe-inline'">
+  <title>Naturo Electron Recognition Fixture</title>
+  <style>
+    body { font-family: system-ui, sans-serif; margin: 0; color: #1c1c1c; }
+    header { background: #2d2d6b; color: #fff; padding: 10px 16px; }
+    header h1 { font-size: 18px; margin: 0 0 6px; }
+    .toolbar button { margin-right: 6px; }
+    main { display: flex; gap: 0; }
+    .tree-pane { width: 260px; border-right: 1px solid #ddd; padding: 8px; }
+    .content-pane { flex: 1; padding: 16px; }
+    .tree-item, .tree-child { padding: 3px 6px; cursor: pointer; }
+    .tree-child { padding-left: 22px; }
+    .form-row { margin: 8px 0; }
+    label { display: inline-block; min-width: 90px; }
+    table { border-collapse: collapse; margin-top: 12px; width: 100%; }
+    th, td { border: 1px solid #ccc; padding: 6px 10px; text-align: left; }
+    th { background: #eef; }
+    ul.task-list { list-style: none; padding: 0; }
+    ul.task-list li { padding: 4px 6px; border-bottom: 1px solid #eee; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Project Console (Electron fixture)</h1>
+    <nav class="toolbar" aria-label="Primary toolbar">
+      <button id="btn-build">Build</button>
+      <button id="btn-deploy">Deploy</button>
+      <button id="btn-rollback">Rollback</button>
+      <button id="btn-refresh" role="button">Refresh</button>
+      <button id="btn-settings" role="button">Settings</button>
+    </nav>
+  </header>
+
+  <main>
+    <!-- A real tree control: expandable groups with child nodes. -->
+    <aside class="tree-pane" role="tree" aria-label="Environment tree">
+      <div class="tree-item" role="treeitem" aria-expanded="true" tabindex="0">Production</div>
+      <div class="tree-child" role="treeitem" tabindex="0">web-prod-01</div>
+      <div class="tree-child" role="treeitem" tabindex="0">web-prod-02</div>
+      <div class="tree-child" role="treeitem" tabindex="0">db-prod-primary</div>
+      <div class="tree-item" role="treeitem" aria-expanded="true" tabindex="0">Staging</div>
+      <div class="tree-child" role="treeitem" tabindex="0">web-stage-01</div>
+      <div class="tree-child" role="treeitem" tabindex="0">db-stage</div>
+      <div class="tree-item" role="treeitem" aria-expanded="false" tabindex="0">Development</div>
+      <div class="tree-child" role="treeitem" tabindex="0">localhost-sandbox</div>
+    </aside>
+
+    <section class="content-pane">
+      <!-- Varied text inputs and selects. -->
+      <div class="form-row">
+        <label for="release-name">Release name</label>
+        <input id="release-name" type="text" placeholder="e.g. 2026.06-hotfix">
+      </div>
+      <div class="form-row">
+        <label for="release-tag">Git tag</label>
+        <input id="release-tag" type="text" placeholder="v0.0.0">
+      </div>
+      <div class="form-row">
+        <label for="target-env">Target</label>
+        <select id="target-env">
+          <option>Production</option>
+          <option>Staging</option>
+          <option>Development</option>
+        </select>
+        <input id="chk-canary" type="checkbox"><label for="chk-canary" style="min-width:auto">Canary first</label>
+      </div>
+      <div class="form-row">
+        <label for="notes">Notes</label>
+        <textarea id="notes" rows="3" placeholder="Release notes..."></textarea>
+      </div>
+      <div class="form-row">
+        <button id="btn-validate">Validate</button>
+        <button id="btn-submit">Submit release</button>
+        <button id="btn-cancel">Cancel</button>
+      </div>
+
+      <!-- A task list. -->
+      <h3>Pending tasks</h3>
+      <ul class="task-list" aria-label="Pending tasks">
+        <li><input type="checkbox" id="t1"><label for="t1">Run migrations</label></li>
+        <li><input type="checkbox" id="t2"><label for="t2">Warm caches</label></li>
+        <li><input type="checkbox" id="t3"><label for="t3">Notify on-call</label></li>
+        <li><input type="checkbox" id="t4"><label for="t4">Update status page</label></li>
+      </ul>
+
+      <!-- A data table with interactive row actions. -->
+      <h3>Recent deployments</h3>
+      <table aria-label="Recent deployments">
+        <thead>
+          <tr><th>Build</th><th>Environment</th><th>Status</th><th>Action</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>#4821</td><td>Production</td><td>Succeeded</td><td><button>View log</button></td></tr>
+          <tr><td>#4820</td><td>Staging</td><td>Succeeded</td><td><button>View log</button></td></tr>
+          <tr><td>#4819</td><td>Production</td><td>Failed</td><td><button>Retry</button></td></tr>
+          <tr><td>#4818</td><td>Development</td><td>Succeeded</td><td><button>View log</button></td></tr>
+        </tbody>
+      </table>
+    </section>
+  </main>
+</body>
+</html>

--- a/benchmarks/recognition/fixtures/electron/main.js
+++ b/benchmarks/recognition/fixtures/electron/main.js
@@ -1,0 +1,91 @@
+// Naturo recognition benchmark — owned Electron fixture (issue #933).
+//
+// This is a REAL Electron main process. It opens a single BrowserWindow that
+// renders ``index.html`` (varied interactive controls). The window is launched
+// with a Chrome DevTools Protocol (CDP) remote-debugging endpoint so naturo's
+// CDP provider can enumerate the renderer DOM — content that the Windows UIA
+// accessibility tree collapses into a single opaque node.
+//
+// The debug port and the requirement to allow CDP WebSocket origins are set
+// via command-line switches BEFORE ``app`` is ready, which is the only point
+// at which Chromium reads them. The port defaults to 9333 (distinct from
+// Chrome's 9222 used by the sibling HTML fixture) and can be overridden with
+// ``--remote-debugging-port=<port>`` on the command line or the
+// ``NATURO_FIXTURE_CDP_PORT`` environment variable.
+
+'use strict';
+
+const { app, BrowserWindow } = require('electron');
+const path = require('path');
+
+/**
+ * Resolve the CDP remote-debugging port.
+ *
+ * Precedence: an explicit ``--remote-debugging-port=<n>`` switch already on the
+ * command line, then ``NATURO_FIXTURE_CDP_PORT``, then the default 9333.
+ *
+ * @returns {string} The port as a string.
+ */
+function resolveDebugPort() {
+  const cliSwitch = process.argv.find((arg) =>
+    arg.startsWith('--remote-debugging-port=')
+  );
+  if (cliSwitch) {
+    return cliSwitch.split('=')[1];
+  }
+  return process.env.NATURO_FIXTURE_CDP_PORT || '9333';
+}
+
+const debugPort = resolveDebugPort();
+
+// These switches must be appended before the app is ready. ``--remote-allow-
+// origins=*`` is mandatory on modern Chromium, otherwise the CDP WebSocket
+// handshake is rejected. Setting the port via appendSwitch is harmless if the
+// same switch is already present on the command line (Chromium de-dupes).
+app.commandLine.appendSwitch('remote-debugging-port', debugPort);
+app.commandLine.appendSwitch('remote-allow-origins', '*');
+
+// Keep the fixture deterministic and headless-friendly on CI/desktop:
+// disable GPU acceleration (avoids driver variance) and run in a throwaway
+// user-data dir so no profile state leaks between runs.
+app.commandLine.appendSwitch('disable-gpu');
+if (process.env.NATURO_FIXTURE_USER_DATA_DIR) {
+  app.setPath('userData', process.env.NATURO_FIXTURE_USER_DATA_DIR);
+}
+
+/**
+ * Create the single fixture window and load the renderer.
+ *
+ * @returns {void}
+ */
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 1100,
+    height: 800,
+    show: true,
+    title: 'Naturo Electron Recognition Fixture',
+    webPreferences: {
+      // The renderer is a static, trusted local file with no privileged needs.
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
+    },
+  });
+  win.setMenuBarVisibility(false);
+  win.loadFile(path.join(__dirname, 'index.html'));
+}
+
+app.whenReady().then(() => {
+  createWindow();
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) {
+      createWindow();
+    }
+  });
+});
+
+// On Windows/Linux, quitting when all windows close lets the harness control
+// the process lifetime cleanly (it terminates us when measurement is done).
+app.on('window-all-closed', () => {
+  app.quit();
+});

--- a/benchmarks/recognition/fixtures/electron/package-lock.json
+++ b/benchmarks/recognition/fixtures/electron/package-lock.json
@@ -1,0 +1,872 @@
+{
+  "name": "naturo-recognition-electron-fixture",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "naturo-recognition-electron-fixture",
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "electron": "31.7.7"
+      }
+    },
+    "node_modules/@electron/get": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmmirror.com/@electron/get/-/get-2.0.3.tgz",
+      "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "env-paths": "^2.2.0",
+        "fs-extra": "^8.1.0",
+        "got": "^11.8.5",
+        "progress": "^2.0.3",
+        "semver": "^6.2.0",
+        "sumchecker": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "global-agent": "^3.0.0"
+      }
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmmirror.com/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@szmarczak/http-timer": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmmirror.com/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defer-to-connect": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@types/cacheable-request": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmmirror.com/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "^3.1.4",
+        "@types/node": "*",
+        "@types/responselike": "^1.0.0"
+      }
+    },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmmirror.com/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/keyv": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmmirror.com/@types/keyv/-/keyv-3.1.4.tgz",
+      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmmirror.com/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/responselike": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmmirror.com/@types/responselike/-/responselike-1.0.3.tgz",
+      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmmirror.com/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmmirror.com/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmmirror.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/cacheable-lookup": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmmirror.com/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.6.0"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmmirror.com/cacheable-request/-/cacheable-request-7.0.4.tgz",
+      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^6.0.1",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/clone-response": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmmirror.com/clone-response/-/clone-response-1.0.3.tgz",
+      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmmirror.com/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmmirror.com/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decompress-response/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmmirror.com/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmmirror.com/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmmirror.com/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/electron": {
+      "version": "31.7.7",
+      "resolved": "https://registry.npmmirror.com/electron/-/electron-31.7.7.tgz",
+      "integrity": "sha512-HZtZg8EHsDGnswFt0QeV8If8B+et63uD6RJ7I4/xhcXqmTIbI08GoubX/wm+HdY0DwcuPe1/xsgqpmYvjdjRoA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron/get": "^2.0.0",
+        "@types/node": "^20.9.0",
+        "extract-zip": "^2.0.1"
+      },
+      "bin": {
+        "electron": "cli.js"
+      },
+      "engines": {
+        "node": ">= 12.20.55"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmmirror.com/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmmirror.com/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmmirror.com/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmmirror.com/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmmirror.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmmirror.com/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmmirror.com/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
+    "node_modules/global-agent/node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmmirror.com/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmmirror.com/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmmirror.com/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/got": {
+      "version": "11.8.6",
+      "resolved": "https://registry.npmmirror.com/got/-/got-11.8.6.tgz",
+      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.2",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmmirror.com/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmmirror.com/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmmirror.com/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmmirror.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmmirror.com/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmmirror.com/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmmirror.com/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-url": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmmirror.com/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmmirror.com/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmmirror.com/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmmirror.com/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmmirror.com/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmmirror.com/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmmirror.com/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmmirror.com/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/responselike": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/responselike/-/responselike-2.0.1.tgz",
+      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lowercase-keys": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/roarr": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmmirror.com/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmmirror.com/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmmirror.com/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "type-fest": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmmirror.com/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/sumchecker": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/sumchecker/-/sumchecker-3.0.1.tgz",
+      "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmmirror.com/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmmirror.com/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmmirror.com/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmmirror.com/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    }
+  }
+}

--- a/benchmarks/recognition/fixtures/electron/package.json
+++ b/benchmarks/recognition/fixtures/electron/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "naturo-recognition-electron-fixture",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Deterministic, owned Electron app used by naturo's recognition-coverage benchmark to prove the CDP cascade recovers renderer content that UIA is structurally blind to (issue #933).",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron ."
+  },
+  "license": "MIT",
+  "devDependencies": {
+    "electron": "31.7.7"
+  }
+}

--- a/benchmarks/recognition/harness.py
+++ b/benchmarks/recognition/harness.py
@@ -37,6 +37,10 @@ Public entry points
 * :func:`measure_window` — measure an *already-open* window by HWND/PID.
 * :func:`ChromiumFixtureApp` — launch/stop a controlled Chromium app on the
   bundled fixture (the reproducible Electron-class case).
+* :func:`ElectronFixtureApp` — launch/stop an *owned, real* Electron process
+  (``fixtures/electron/``) and measure it. This is a genuine Electron app, not
+  a browser standing in for one, so the CDP delta it shows is the literal
+  Electron case rather than a representative proxy.
 * :func:`measure_running_app` — find a running app by window-title substring
   and measure it (for ad-hoc Electron/Java apps available on the desktop).
 """
@@ -58,6 +62,9 @@ logger = logging.getLogger(__name__)
 
 FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
 DEFAULT_CDP_PORT = 9222
+#: CDP port for the owned Electron fixture — deliberately distinct from the
+#: Chromium fixture's 9222 so both can run back-to-back without colliding.
+DEFAULT_ELECTRON_CDP_PORT = 9333
 
 
 @dataclass
@@ -418,6 +425,238 @@ class ChromiumFixtureApp:
             self._user_data_dir = None
 
     def __enter__(self) -> "ChromiumFixtureApp":
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        self.stop()
+
+
+def _resolve_electron_binary(fixture_dir: Path) -> Optional[str]:
+    """Locate the installed Electron executable for the fixture.
+
+    Electron's npm package records the path to its bundled binary (relative to
+    the package root) in ``node_modules/electron/path.txt``.  We honour that
+    first and fall back to the conventional ``dist/electron.exe`` location.
+
+    Args:
+        fixture_dir: The ``fixtures/electron`` directory containing
+            ``node_modules`` after ``npm install``.
+
+    Returns:
+        Absolute path to ``electron.exe``, or ``None`` if Electron is not
+        installed (``npm install`` has not been run).
+    """
+    electron_pkg = fixture_dir / "node_modules" / "electron"
+    path_txt = electron_pkg / "path.txt"
+    if path_txt.is_file():
+        try:
+            relative = path_txt.read_text(encoding="utf-8").strip()
+        except OSError:
+            relative = ""
+        if relative:
+            candidate = electron_pkg / "dist" / relative
+            if candidate.is_file():
+                return str(candidate)
+    fallback = electron_pkg / "dist" / "electron.exe"
+    if fallback.is_file():
+        return str(fallback)
+    return None
+
+
+class ElectronFixtureApp:
+    """Launch and control naturo's *owned*, real Electron fixture app.
+
+    Unlike :class:`ChromiumFixtureApp` (a browser standing in for the Electron
+    content layer), this spins up an actual Electron main process from
+    ``fixtures/electron/`` whose single :class:`BrowserWindow` renders varied
+    interactive controls (toolbar buttons, text inputs, a tree, a task list, a
+    data table).  The window is launched with a CDP remote-debugging endpoint,
+    so the cascade's CDP provider enumerates the renderer DOM that the Windows
+    UIA tree collapses into one opaque node.
+
+    Because this is a genuine Electron process, the measured delta is the
+    literal Electron case — not a representative proxy.
+
+    Use as a context manager::
+
+        with ElectronFixtureApp() as app:
+            result = app.measure()
+    """
+
+    #: Window title set by ``fixtures/electron/main.js`` (used to find the HWND).
+    WINDOW_TITLE_SUBSTRING = "Naturo Electron Recognition Fixture"
+
+    def __init__(
+        self,
+        *,
+        port: int = DEFAULT_ELECTRON_CDP_PORT,
+        electron_path: Optional[str] = None,
+    ) -> None:
+        """Initialise the controller.
+
+        Args:
+            port: CDP remote-debugging port the Electron app should expose.
+            electron_path: Override the auto-detected Electron executable.
+        """
+        self.app_dir = FIXTURES_DIR / "electron"
+        self.port = port
+        self.electron_path = electron_path or _resolve_electron_binary(self.app_dir)
+        self._process: Optional[subprocess.Popen] = None
+        self._user_data_dir: Optional[str] = None
+
+    @property
+    def available(self) -> bool:
+        """Whether Electron is installed and the fixture sources are present."""
+        return (
+            self.electron_path is not None
+            and (self.app_dir / "main.js").is_file()
+            and (self.app_dir / "index.html").is_file()
+        )
+
+    def start(self, ready_timeout: float = 60.0) -> None:
+        """Launch the Electron app and wait for both CDP and page load.
+
+        Args:
+            ready_timeout: Maximum seconds to wait for the CDP endpoint and a
+                rendered renderer page.
+
+        Raises:
+            RuntimeError: If Electron is unavailable, or the CDP endpoint /
+                renderer does not become ready within ``ready_timeout``.
+        """
+        import os
+        import tempfile
+
+        if not self.available or self.electron_path is None:
+            raise RuntimeError(
+                "Electron fixture unavailable: "
+                f"electron={self.electron_path!r}, app_dir={self.app_dir!r}. "
+                "Run `npm install` in benchmarks/recognition/fixtures/electron/."
+            )
+
+        self._user_data_dir = tempfile.mkdtemp(prefix="naturo_bench_electron_")
+        env = dict(os.environ)
+        env["NATURO_FIXTURE_CDP_PORT"] = str(self.port)
+        env["NATURO_FIXTURE_USER_DATA_DIR"] = self._user_data_dir
+        args: List[str] = [
+            self.electron_path,
+            str(self.app_dir),
+            f"--remote-debugging-port={self.port}",
+            "--remote-allow-origins=*",
+        ]
+        logger.info("Launching Electron fixture: %s", self.app_dir)
+        self._process = subprocess.Popen(args, env=env)
+
+        deadline = time.monotonic() + ready_timeout
+        while time.monotonic() < deadline:
+            if _port_is_open("127.0.0.1", self.port):
+                break
+            time.sleep(0.5)
+        else:
+            self.stop()
+            raise RuntimeError(
+                f"Electron CDP endpoint did not open on port {self.port} "
+                f"within {ready_timeout:.0f}s."
+            )
+
+        if not self._wait_page_loaded(deadline):
+            self.stop()
+            raise RuntimeError("Electron renderer did not finish loading in time.")
+
+    def _wait_page_loaded(self, deadline: float) -> bool:
+        """Poll the CDP ``/json`` list until the renderer page is available.
+
+        Args:
+            deadline: ``time.monotonic()`` value after which to give up.
+
+        Returns:
+            ``True`` once the fixture's renderer is the active target, else
+            ``False`` on timeout.
+        """
+        url = f"http://127.0.0.1:{self.port}/json"
+        while time.monotonic() < deadline:
+            try:
+                with urllib.request.urlopen(url, timeout=2) as response:
+                    import json
+
+                    targets = json.loads(response.read().decode("utf-8"))
+                for target in targets:
+                    if target.get("type") == "page" and "index.html" in target.get(
+                        "url", ""
+                    ):
+                        time.sleep(1.0)  # settle the render
+                        return True
+            except (OSError, ValueError):
+                pass
+            time.sleep(0.5)
+        return False
+
+    def find_window(self):
+        """Find the Electron fixture window via the backend.
+
+        Returns:
+            A window-info object (with ``hwnd``/``pid``) for the fixture
+            window, or ``None`` if it cannot be located.
+        """
+        backend = get_backend()
+        for window in backend.list_windows():
+            if self.WINDOW_TITLE_SUBSTRING in (window.title or ""):
+                return window
+        return None
+
+    def measure(self, depth: int = 15) -> CoverageResult:
+        """Measure recognition coverage on the Electron fixture window.
+
+        Args:
+            depth: Maximum accessibility-tree depth to walk.
+
+        Returns:
+            A :class:`CoverageResult` for the owned Electron app.
+
+        Raises:
+            RuntimeError: If the fixture window cannot be found.
+        """
+        window = self.find_window()
+        if window is None:
+            raise RuntimeError(
+                "Could not locate the Electron fixture window. "
+                "Did the Electron app launch and render the fixture?"
+            )
+        return measure_window(
+            app="Owned Electron fixture (real Electron app)",
+            framework="Electron/CDP",
+            hwnd=window.hwnd,
+            pid=window.pid,
+            depth=depth,
+            notes=(
+                "A real Electron process: the renderer's interactive controls "
+                "(toolbar, inputs, tree, task list, table) live in the Chromium "
+                "content layer that UIA collapses to one opaque node. Only the "
+                "CDP provider recovers them — this is the literal Electron case, "
+                "not a browser proxy."
+            ),
+        )
+
+    def stop(self) -> None:
+        """Terminate the Electron app and remove its throwaway profile."""
+        if self._process is not None:
+            try:
+                self._process.terminate()
+                self._process.wait(timeout=10)
+            except (OSError, subprocess.TimeoutExpired):
+                try:
+                    self._process.kill()
+                except OSError:
+                    pass
+            self._process = None
+        if self._user_data_dir is not None:
+            import shutil
+
+            shutil.rmtree(self._user_data_dir, ignore_errors=True)
+            self._user_data_dir = None
+
+    def __enter__(self) -> "ElectronFixtureApp":
         self.start()
         return self
 

--- a/benchmarks/recognition/run_benchmark.py
+++ b/benchmarks/recognition/run_benchmark.py
@@ -6,10 +6,11 @@ Usage::
     python -m benchmarks.recognition.run_benchmark --json     # JSON output
     python -m benchmarks.recognition.run_benchmark --markdown # Markdown table
 
-The benchmark always runs the reproducible Chromium fixture (the
-Electron-class web-content case).  It additionally probes for a few common
-real apps (a JetBrains IDE, DBeaver, Feishu) that may be open on the current
-desktop, and includes them when present — documenting them as gaps when not.
+The benchmark runs two reproducible fixtures — the Chromium HTML fixture (the
+Electron-class web-content case) and an owned, real Electron app (the literal
+Electron case) — and additionally probes for a few common real apps (a
+JetBrains IDE, DBeaver, Feishu) that may be open on the current desktop,
+including them when present and documenting them as gaps when not.
 
 Each row reports, on the *same* app:
 
@@ -33,6 +34,7 @@ from typing import List
 from benchmarks.recognition.harness import (
     ChromiumFixtureApp,
     CoverageResult,
+    ElectronFixtureApp,
     measure_running_app,
 )
 
@@ -80,7 +82,18 @@ def collect_results() -> tuple[List[CoverageResult], List[str]]:
             "machine."
         )
 
-    # 2. Optional real desktop apps (included only when actually open).
+    # 2. Owned, real Electron fixture (the literal Electron case).
+    electron = ElectronFixtureApp()
+    if electron.available:
+        with electron:
+            results.append(electron.measure())
+    else:
+        gaps.append(
+            "Electron fixture skipped: Electron not installed. Run `npm "
+            "install` in benchmarks/recognition/fixtures/electron/."
+        )
+
+    # 3. Optional real desktop apps (included only when actually open).
     for spec in OPTIONAL_APPS:
         result = measure_running_app(
             app=spec["app"],
@@ -95,7 +108,7 @@ def collect_results() -> tuple[List[CoverageResult], List[str]]:
                 f"desktop — no window titled '*{spec['title_substring']}*'."
             )
 
-    # 3. SAP GUI is not available in this environment.
+    # 4. SAP GUI is not available in this environment.
     gaps.append(
         "SAP GUI (SAP scripting/COM): not installed in this environment — "
         "future work."

--- a/docs/RECOGNITION.md
+++ b/docs/RECOGNITION.md
@@ -67,6 +67,7 @@ found the elements UIA alone could not.
 | App | Framework | UIA-only | Cascade | Delta | Extra via |
 | --- | --- | ---: | ---: | ---: | --- |
 | Chrome (local web/Electron-class app) | Electron/CDP | 52 | 89 | **+37** | cdp (+34) |
+| Owned Electron fixture (real Electron app) | Electron/CDP | 83 | 113 | **+30** | cdp (+30) |
 
 **Documented gaps (measured honestly — no fabrication):**
 
@@ -86,10 +87,18 @@ In the Chrome run, the UIA-only baseline recognized **52** elements — and
 content elements that UIA is structurally blind to. That is precisely the class
 of element a UIA-only tool would fail to click.
 
-> **Why Chrome proves the Electron case.** Electron apps embed the identical
-> Chromium content layer and expose the same CDP endpoint. The web-content
-> recognition gap measured here is exactly the gap a UIA-only tool hits on VS
-> Code, Slack, or Feishu.
+The second row is the **literal Electron case**: naturo's own Electron fixture
+(`benchmarks/recognition/fixtures/electron/`) is a genuine Electron main process
+rendering a `BrowserWindow`, not a browser standing in for one. There, UIA-only
+recognized **83** elements (the native window frame) while the cascade reached
+**113** — the **CDP** provider recovered **30** renderer controls (toolbar
+buttons, the environment tree, release-form inputs, the task list, the
+deployments table) that the Windows UIA tree collapses into one opaque node.
+
+> **Why Chrome also proves the Electron case.** Electron apps embed the identical
+> Chromium content layer and expose the same CDP endpoint, so the Chrome row and
+> the owned-Electron row measure the same recognition gap two ways — the gap a
+> UIA-only tool hits on VS Code, Slack, or Feishu.
 
 ## Reproduce it
 
@@ -109,13 +118,30 @@ delta is deterministic and **offline** — no network, no live-site drift. It
 also probes for common Electron/Java apps that happen to be open and includes
 them when present.
 
+To include the **owned, real Electron** row, install the fixture's toolchain
+once (Node.js required); the runner adds the row automatically when present and
+documents it as a gap when not:
+
+```bash
+cd benchmarks/recognition/fixtures/electron && npm install   # pins electron via package-lock.json
+```
+
 The harness is reusable directly:
 
 ```python
-from benchmarks.recognition.harness import ChromiumFixtureApp, measure_running_app
+from benchmarks.recognition.harness import (
+    ChromiumFixtureApp,
+    ElectronFixtureApp,
+    measure_running_app,
+)
 
 # Reproducible Electron-class case (launches + cleans up its own browser):
 with ChromiumFixtureApp() as app:
+    result = app.measure()
+    print(result.uia_only_count, result.cascade_count, result.extra_sources)
+
+# Literal Electron case (launches + cleans up a real Electron process):
+with ElectronFixtureApp() as app:        # requires `npm install` in the fixture dir
     result = app.measure()
     print(result.uia_only_count, result.cascade_count, result.extra_sources)
 

--- a/tests/test_recognition_benchmark.py
+++ b/tests/test_recognition_benchmark.py
@@ -15,6 +15,7 @@ import pytest
 from benchmarks.recognition.harness import (
     ChromiumFixtureApp,
     CoverageResult,
+    ElectronFixtureApp,
     _provider_counts,
 )
 from benchmarks.recognition import run_benchmark
@@ -149,4 +150,34 @@ def test_chromium_fixture_shows_cdp_delta() -> None:
     assert result.extra_sources.get("cdp", 0) >= 20, (
         "Expected the CDP provider to recognize the fixture's web content "
         f"that UIA cannot see; got {result.extra_sources}."
+    )
+
+
+@pytest.mark.desktop
+def test_electron_fixture_shows_cdp_delta() -> None:
+    """Live proof on a real Electron app: cascade beats UIA via CDP.
+
+    Launches naturo's owned Electron fixture (a genuine Electron main process)
+    and asserts the full cascade recognizes meaningfully more elements than the
+    UIA-only baseline, with the extra elements coming from the CDP provider.
+    This is the literal Electron case, not a browser proxy.
+    """
+    fixture = ElectronFixtureApp()
+    if not fixture.available:
+        pytest.skip(
+            "Electron not installed (run `npm install` in "
+            "benchmarks/recognition/fixtures/electron/)."
+        )
+    try:
+        from naturo.cdp import CDPClient  # noqa: F401
+    except Exception:
+        pytest.skip("websocket-client (naturo[cdp]) not installed.")
+
+    with fixture:
+        result = fixture.measure()
+
+    assert result.cascade_count > result.uia_only_count
+    assert result.extra_sources.get("cdp", 0) >= 20, (
+        "Expected the CDP provider to recognize the Electron renderer's "
+        f"content that UIA cannot see; got {result.extra_sources}."
     )


### PR DESCRIPTION
## What

Part of the recognition-supremacy moat (#920). Closes the honest gap left by the recognition benchmark (#936): it previously proved the Electron-class CDP delta with **Chrome standing in** for Electron. This adds a **genuine Electron app** so the benchmark measures the **literal Electron case**.

- New owned fixture `benchmarks/recognition/fixtures/electron/` — a real Electron main process rendering a `BrowserWindow` with varied interactive controls (toolbar buttons, an environment tree, release-form inputs/select/checkboxes, a task list, a deployments table). Launched with a CDP endpoint (port 9333, distinct from the Chrome fixture's 9222), `contextIsolation`+`sandbox` on, deterministic flags, throwaway user-data dir.
- `ElectronFixtureApp` harness (launch → wait for CDP + render → find window → measure → clean stop), with a binary resolver honoring `node_modules/electron/path.txt`.
- `run_benchmark.py` now emits the owned-Electron row, and documents it as a gap when the toolchain isn't installed (no fabrication).
- `package-lock.json` pins electron `31.7.7` for a reproducible `npm install`; `node_modules` is gitignored.
- `docs/RECOGNITION.md` updated with the measured numbers and reproduce steps.

## Measured (Windows 11, 2026-06-16)

| App | UIA-only | Cascade | Delta | Extra via |
| --- | ---: | ---: | ---: | --- |
| Owned Electron fixture (real Electron app) | 83 | 113 | **+30** | cdp (+30) |

All 30 extra elements are renderer controls the Windows UIA tree collapses into one opaque node; only the CDP provider in the cascade recovers them. This is exactly the gap a UIA-only tool hits on VS Code / Slack / Feishu.

## How tested

- `ruff check` — clean; `mypy` (isolated) — clean on both modules.
- `pytest tests/test_recognition_benchmark.py` — **9 passed**, including a new `@pytest.mark.desktop` live test that launches the real Electron app and asserts cascade > UIA via CDP (≥20 CDP elements).
- `python -m benchmarks.recognition.run_benchmark --markdown` — produces the table above on this desktop.
- Full suite collects clean (5771 tests).

## Done-when (per #933)

✅ Owned, deterministic Electron app built · ✅ wired into the harness · ✅ benchmark shows a **real Electron** app where the cascade recovers content UIA is blind to, reproducibly, **with a test** · ✅ numbers in `docs/RECOGNITION.md`.