### PR TITLE
fix: harden CDP attach with bounded auto-reconnect (#933 step 5)

### DIFF
--- a/naturo/cascade/_providers.py
+++ b/naturo/cascade/_providers.py
@@ -2,14 +2,83 @@
 from __future__ import annotations
 
 import logging
+import time
 from typing import List, Optional
 
 from naturo.backends.base import ElementInfo
 
 logger = logging.getLogger(__name__)
 
+#: How many times to (re)connect to the CDP endpoint before giving up.
+#: Real Electron apps frequently expose the DevTools endpoint a beat before the
+#: renderer target is enumerable (or drop the first WebSocket while the agent
+#: settles), so a single attempt is racy; a few bounded retries make the attach
+#: reliable without hanging the cascade.
+_CDP_ATTACH_ATTEMPTS = 4
+#: Base back-off between CDP attach attempts (seconds); grows linearly.
+_CDP_ATTACH_BACKOFF_S = 0.4
 
-# ── CDP element helper ────────────────────────────────────────────────────────
+
+def _fetch_cdp_dom_elements(debug_port: int) -> List[dict]:
+    """Connect to the CDP endpoint and return raw interactive DOM elements.
+
+    Performs a bounded connect/enumerate/reconnect loop: a real Electron app may
+    briefly report no enumerable page target or drop the first WebSocket while
+    its DevTools agent settles, so a single attempt is unreliable.  Each attempt
+    opens a fresh :class:`~naturo.cdp.CDPClient`, fetches elements, and closes
+    it; the first attempt that returns a non-empty result wins.
+
+    Args:
+        debug_port: Chrome DevTools Protocol port to attach to.
+
+    Returns:
+        The raw DOM-element dicts from CDP, or an empty list if the optional
+        CDP module is unavailable, every attempt failed, or the page genuinely
+        has no interactive content.
+    """
+    try:
+        from naturo.cdp import CDPClient
+    except ImportError:
+        logger.debug("CDP module not available; skipping CDP provider")
+        return []
+
+    last_exc: Optional[Exception] = None
+    for attempt in range(1, _CDP_ATTACH_ATTEMPTS + 1):
+        client = CDPClient(port=debug_port)
+        try:
+            client.connect()
+            dom_elements = client.get_interactive_elements()
+            if dom_elements:
+                return dom_elements
+            # Connected but nothing yet — the renderer may still be painting.
+            logger.debug(
+                "CDP attach %d/%d: connected but no elements yet (port=%d)",
+                attempt, _CDP_ATTACH_ATTEMPTS, debug_port,
+            )
+        except Exception as exc:
+            # Broad by design: any attach/enumeration failure is transient from
+            # the cascade's view — record it and retry on the next attempt.
+            last_exc = exc
+            logger.debug(
+                "CDP attach %d/%d failed (port=%d): %s",
+                attempt, _CDP_ATTACH_ATTEMPTS, debug_port, exc,
+            )
+        finally:
+            try:
+                client.close()
+            except Exception:
+                # Best-effort cleanup; a failed close must not mask results.
+                pass
+
+        if attempt < _CDP_ATTACH_ATTEMPTS:
+            time.sleep(_CDP_ATTACH_BACKOFF_S * attempt)
+
+    if last_exc is not None:
+        logger.debug(
+            "CDP attach exhausted %d attempts (port=%d): %s",
+            _CDP_ATTACH_ATTEMPTS, debug_port, last_exc,
+        )
+    return []
 
 
 def _fetch_cdp_elements(
@@ -35,18 +104,7 @@ def _fetch_cdp_elements(
         Returns empty list on any error.
     """
     try:
-        from naturo.cdp import CDPClient
-    except ImportError:
-        logger.debug("CDP module not available; skipping CDP provider")
-        return []
-
-    try:
-        client = CDPClient(port=debug_port)
-        client.connect()
-        try:
-            dom_elements = client.get_interactive_elements()
-        finally:
-            client.close()
+        dom_elements = _fetch_cdp_dom_elements(debug_port)
 
         elements: List[ElementInfo] = []
         px, py = parent_bounds[0], parent_bounds[1]

--- a/tests/test_cdp_cascade.py
+++ b/tests/test_cdp_cascade.py
@@ -205,6 +205,91 @@ class TestFetchCdpElements:
 
         assert results == []
 
+    def test_reconnects_after_transient_connect_failure(self):
+        """A transient connect failure is retried; a later attempt succeeds.
+
+        Real Electron apps occasionally drop the first CDP WebSocket while the
+        DevTools agent settles. The provider must reconnect rather than abandon
+        the whole CDP contribution after one failure.
+        """
+        good_element = {
+            "tagName": "button",
+            "role": "button",
+            "name": "Deploy",
+            "value": None,
+            "bounds": {"x": 10, "y": 10, "width": 80, "height": 30},
+            "selector": "button#deploy",
+            "nodeIndex": 0,
+        }
+        mock_client = MagicMock()
+        # First attempt raises on connect, second attempt connects cleanly.
+        mock_client.connect.side_effect = [Exception("WebSocket reset"), None]
+        mock_client.get_interactive_elements.return_value = [good_element]
+
+        with (
+            patch("naturo.cdp.CDPClient", return_value=mock_client),
+            patch("naturo.cascade._providers.time.sleep"),
+        ):
+            from naturo.cascade import _fetch_cdp_elements
+
+            results = _fetch_cdp_elements(
+                pid=1234, debug_port=9333, parent_bounds=(0, 0, 800, 600),
+            )
+
+        assert len(results) == 1
+        assert results[0].name == "Deploy"
+        assert mock_client.connect.call_count == 2
+
+    def test_retries_while_renderer_reports_no_elements(self):
+        """An initial empty result (renderer still painting) is retried."""
+        good_element = {
+            "tagName": "a",
+            "role": "link",
+            "name": "View log",
+            "value": None,
+            "bounds": {"x": 10, "y": 50, "width": 60, "height": 20},
+            "selector": "a.viewlog",
+            "nodeIndex": 0,
+        }
+        mock_client = MagicMock()
+        mock_client.connect.return_value = None
+        # First two attempts: renderer not ready (empty); third: populated.
+        mock_client.get_interactive_elements.side_effect = [[], [], [good_element]]
+
+        with (
+            patch("naturo.cdp.CDPClient", return_value=mock_client),
+            patch("naturo.cascade._providers.time.sleep"),
+        ):
+            from naturo.cascade import _fetch_cdp_elements
+
+            results = _fetch_cdp_elements(
+                pid=1234, debug_port=9333, parent_bounds=(0, 0, 800, 600),
+            )
+
+        assert len(results) == 1
+        assert results[0].name == "View log"
+        assert mock_client.get_interactive_elements.call_count == 3
+
+    def test_gives_up_after_bounded_attempts(self):
+        """Persistent failure is bounded — it does not loop forever."""
+        from naturo.cascade._providers import _CDP_ATTACH_ATTEMPTS
+
+        mock_client = MagicMock()
+        mock_client.connect.side_effect = Exception("always refused")
+
+        with (
+            patch("naturo.cdp.CDPClient", return_value=mock_client),
+            patch("naturo.cascade._providers.time.sleep"),
+        ):
+            from naturo.cascade import _fetch_cdp_elements
+
+            results = _fetch_cdp_elements(
+                pid=1234, debug_port=9333, parent_bounds=(0, 0, 800, 600),
+            )
+
+        assert results == []
+        assert mock_client.connect.call_count == _CDP_ATTACH_ATTEMPTS
+
     def test_role_mapping_fallback(self):
         """When role is empty, falls back to tag-based role mapping."""
         mock_elements = [


### PR DESCRIPTION
## What

Completes the final outstanding step of #933 — **harden CDP attach + auto-reconnect** — against the owned, real Electron fixture that landed in #938.

The cascade attached to an Electron/CEF CDP endpoint in a single shot (one `CDPClient.connect()` + `get_interactive_elements()`). Against a *real* Electron process this is racy: the app intermittently drops the first DevTools WebSocket while its agent settles, or reports no enumerable page target for a beat after the endpoint opens. When that happened the provider returned nothing and the **entire CDP contribution was silently lost** — the renderer content UIA is structurally blind to. The measured delta on the owned Electron fixture flickered between **+30** and **0** across runs.

This extracts the attach into `_fetch_cdp_dom_elements`, a bounded connect/enumerate/reconnect loop (4 attempts, linear back-off): each attempt opens a fresh client; the first non-empty result wins. Persistent failure still returns `[]` — it never loops unbounded or hangs the cascade.

## Result

| App | Before (flaky) | After (stable) |
| --- | --- | --- |
| Owned Electron fixture (real Electron app) | UIA 83 → cascade 83–113, delta **0..+30** | UIA 83 → cascade **113**, delta **+30** (cdp) every run |

Verified live on a real Electron process across repeated runs.

## How tested

- New **mock-only** unit tests in `tests/test_cdp_cascade.py` (no desktop/Electron needed, CI-safe): reconnect after a transient connect failure, retry while the renderer reports no elements yet, and bounded give-up.
- `ruff check` / `mypy` clean on the changed files.
- `pytest -m "not desktop"`: 87 passed (cascade + cdp + recognition suites).
- Live desktop: `test_electron_fixture_shows_cdp_delta` and `test_chromium_fixture_shows_cdp_delta` pass; the real-Electron delta is a stable **+30 via CDP**.

Note: #933's fixture, harness wiring, benchmark and docs already merged in #938; this PR only adds the attach hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)