### PR TITLE
fix: route MCP Pydantic validation sanitizer through real dispatch path (fixes #844)

### DIFF
--- a/naturo/mcp_server.py
+++ b/naturo/mcp_server.py
@@ -14,6 +14,7 @@ from typing import Any, Callable
 
 from mcp.server.fastmcp import FastMCP
 from mcp.server.fastmcp.exceptions import ToolError
+from mcp.types import ContentBlock
 
 from naturo.backends.base import get_backend, Backend
 from naturo.errors import ErrorCode, NaturoError
@@ -34,9 +35,58 @@ from naturo.mcp._excel import register_excel_tools
 logger = logging.getLogger(__name__)
 
 
+class _SanitizingFastMCP(FastMCP):
+    """FastMCP subclass that sanitizes Pydantic parameter-validation errors (#844).
+
+    FastMCP validates each tool's arguments with Pydantic *before* the tool
+    function runs, so the ``_safe_tool`` decorator — which wraps the function
+    body — never sees these failures.  When validation fails, ``Tool.run``
+    wraps the Pydantic ``ValidationError`` in a :class:`ToolError` whose
+    ``__cause__`` exposes an ``.errors()`` method, and the low-level MCP server
+    renders that error's ``str()`` straight into the client-facing text —
+    leaking the internal Pydantic model name (``launch_appArguments``), the raw
+    error format, and the ``errors.pydantic.dev`` URL.
+
+    Overriding :meth:`call_tool` is the only interception point that survives
+    real JSON-RPC dispatch.  ``FastMCP.__init__`` registers ``self.call_tool``
+    as the ``CallToolRequest`` handler while constructing the instance, so the
+    bound method captured there must *already* be the sanitizing one — which a
+    subclass override guarantees.  The previous approach (#853) reassigned
+    ``server.call_tool`` after construction; that only rebound a Python
+    attribute and never reached the handler the server actually invokes, so the
+    leak persisted in production while a direct-call unit test passed.
+    """
+
+    async def call_tool(  # type: ignore[override]
+        self, name: str, arguments: dict[str, Any],
+    ) -> Sequence[ContentBlock] | dict[str, Any]:
+        """Dispatch a tool call, replacing Pydantic validation leaks with clean text.
+
+        Args:
+            name: Name of the MCP tool being invoked.
+            arguments: Raw arguments supplied by the client.
+
+        Returns:
+            The tool's content, exactly as :meth:`FastMCP.call_tool` returns it.
+
+        Raises:
+            ToolError: On failure.  When the failure is a Pydantic
+                parameter-validation error, the message is sanitized via
+                :func:`_format_tool_validation_error`; all other errors
+                propagate unchanged so genuine failures stay diagnosable.
+        """
+        try:
+            return await super().call_tool(name, arguments)
+        except ToolError as exc:
+            cause = exc.__cause__
+            if cause is not None and hasattr(cause, "errors"):
+                raise ToolError(_format_tool_validation_error(name, cause)) from None
+            raise
+
+
 def create_server(host: str = "localhost", port: int = 3100) -> FastMCP:
     """Create and configure the Naturo MCP server."""
-    server = FastMCP(
+    server = _SanitizingFastMCP(
         name="naturo",
         host=host,
         port=port,
@@ -135,29 +185,9 @@ def create_server(host: str = "localhost", port: int = 3100) -> FastMCP:
     register_system_tools(server, _get_backend, _safe_tool)
     register_excel_tools(server, _get_backend, _safe_tool)
 
-    # (#844) Intercept ToolError from Pydantic validation and sanitize the
-    # error message.  FastMCP validates tool parameters via Pydantic BEFORE
-    # calling the wrapped function, so _safe_tool cannot catch these.  When
-    # validation fails, Tool.run() wraps the Pydantic ValidationError in a
-    # ToolError whose __cause__ has an .errors() method.  We override
-    # call_tool to detect this and return a clean, user-facing message.
-    _original_call_tool = server.call_tool
-
-    async def _sanitized_call_tool(
-        name: str, arguments: dict[str, Any],
-    ) -> Sequence[Any] | dict[str, Any]:
-        try:
-            return await _original_call_tool(name, arguments)
-        except ToolError as exc:
-            cause = exc.__cause__
-            if cause is not None and hasattr(cause, "errors"):
-                raise ToolError(
-                    _format_tool_validation_error(name, cause),
-                ) from None
-            raise
-
-    server.call_tool = _sanitized_call_tool  # type: ignore[assignment]
-
+    # Pydantic parameter-validation errors are sanitized by the
+    # _SanitizingFastMCP.call_tool override, which is wired into the low-level
+    # JSON-RPC handler at construction time (see the class docstring, #844).
     return server
 
 

--- a/tests/test_mcp_pydantic_leak.py
+++ b/tests/test_mcp_pydantic_leak.py
@@ -6,8 +6,11 @@ leaking Pydantic internals (model names, type annotations, validation URLs).
 
 Covers two layers:
   - _format_tool_validation_error: pure string-formatting helper
-  - _sanitized_call_tool: async wrapper that intercepts ToolError with a
-    Pydantic ValidationError __cause__ before it reaches the MCP client
+  - The sanitizing FastMCP subclass, exercised through the *real* low-level
+    JSON-RPC dispatch path (``request_handlers[CallToolRequest]``) — the same
+    path a live MCP client hits.  An earlier fix (#853) only reassigned
+    ``server.call_tool`` after construction, which never reached this handler,
+    so the leak persisted in production while a direct-call unit test passed.
 """
 from __future__ import annotations
 
@@ -96,111 +99,77 @@ class TestFormatValidationError:
         assert "value_error.number.not_gt" not in result
 
 
-class TestSanitizedCallTool:
-    """Integration tests for the _sanitized_call_tool async wrapper (#844).
+class TestRealDispatchSanitization:
+    """End-to-end tests through the real low-level JSON-RPC dispatch path (#844).
 
-    FastMCP validates tool parameters via Pydantic BEFORE calling the wrapped
-    function, so _safe_tool cannot catch those errors.  _sanitized_call_tool
-    is installed as server.call_tool and intercepts ToolError whose __cause__
-    has an .errors() method, re-raising a sanitized ToolError instead.
+    FastMCP registers ``self.call_tool`` as the ``CallToolRequest`` handler
+    during ``__init__``; the low-level server renders ``str(exc)`` of whatever
+    that handler raises into the client-facing error text.  These tests invoke
+    that registered handler directly — exactly what a live MCP client triggers —
+    so they catch wiring regressions (e.g. #853, where the sanitizer was only
+    bound to the unused ``server.call_tool`` attribute and never to the handler).
 
-    Tests run the async code via asyncio.run() to avoid a pytest-asyncio
+    Tests run the async code via ``asyncio.run()`` to avoid a pytest-asyncio
     dependency that is not present in this project's test environment.
     """
 
-    def test_validation_error_sanitized(self):
-        """_sanitized_call_tool re-raises ToolError with a clean message.
+    @staticmethod
+    def _dispatch(tool_name: str, arguments: dict):
+        """Drive a tools/call request through the registered handler.
 
-        Exercises the async path: a mock _original_call_tool raises ToolError
-        wrapping a Pydantic-like ValidationError; _sanitized_call_tool must
-        catch it and raise a new ToolError whose message contains the
-        human-readable field name but omits Pydantic internals (type codes,
-        raw Pydantic repr).
+        Returns the resulting ``CallToolResult`` (``ServerResult.root``).
         """
         import asyncio
-        from unittest.mock import AsyncMock, patch
+        from unittest.mock import patch
 
-        from mcp.server.fastmcp.exceptions import ToolError
+        from mcp.types import CallToolRequest, CallToolRequestParams
         from naturo.mcp_server import create_server
-
-        cause = _FakeValidationError([
-            {"loc": ("wpm",), "msg": "Input should be a valid integer", "type": "int_parsing"},
-        ])
-        tool_error = ToolError(f"Error executing tool type_text: {cause}")
-        tool_error.__cause__ = cause
 
         with patch("naturo.mcp_server.get_backend"):
             server = create_server()
 
-        # Inject a controlled _original_call_tool into the sanitized wrapper
-        # by rebuilding the wrapper inline — identical logic to production code.
-        original_mock = AsyncMock(side_effect=tool_error)
+        handler = server._mcp_server.request_handlers[CallToolRequest]
+        request = CallToolRequest(
+            method="tools/call",
+            params=CallToolRequestParams(name=tool_name, arguments=arguments),
+        )
+        result = asyncio.run(handler(request))
+        return result.root
 
-        async def _sanitized_call_tool(name, arguments):
-            try:
-                return await original_mock(name, arguments)
-            except ToolError as exc:
-                c = exc.__cause__
-                if c is not None and hasattr(c, "errors"):
-                    raise ToolError(
-                        _format_tool_validation_error(name, c),
-                    ) from None
-                raise
+    def test_wrong_param_name_sanitized(self):
+        """The exact scenario from #844: wrong param name → clean error text.
 
-        server.call_tool = _sanitized_call_tool  # type: ignore[assignment]
-
-        async def _run():
-            return await server.call_tool("type_text", {"wpm": "fast"})
-
-        with pytest.raises(ToolError) as exc_info:
-            asyncio.run(_run())
-
-        sanitized_msg = str(exc_info.value)
-        assert "wpm: Input should be a valid integer" in sanitized_msg
-        assert "int_parsing" not in sanitized_msg
-        assert "pydantic" not in sanitized_msg.lower()
-
-    def test_non_pydantic_error_passes_through(self):
-        """ToolError without a Pydantic __cause__ is re-raised unchanged.
-
-        When _original_call_tool raises a ToolError that is NOT wrapping a
-        Pydantic ValidationError (no .errors() on __cause__), the sanitizer
-        must propagate the original error object without any modification.
+        Sending ``launch_app`` with ``app_name`` (instead of the required
+        ``name``) must yield a user-facing message that names the missing
+        field but leaks none of Pydantic's internals.
         """
-        import asyncio
-        from unittest.mock import AsyncMock, patch
+        result = self._dispatch("launch_app", {"app_name": "notepad"})
 
-        from mcp.server.fastmcp.exceptions import ToolError
-        from naturo.mcp_server import create_server
+        assert result.isError is True
+        text = result.content[0].text
 
-        original_message = "Unknown tool: fake_tool"
-        plain_tool_error = ToolError(original_message)
-        # No __cause__ — plain_tool_error.__cause__ is None
+        # Clean, actionable message naming the offending tool and field.
+        assert "Invalid parameters for launch_app" in text
+        assert "name" in text
 
-        with patch("naturo.mcp_server.get_backend"):
-            server = create_server()
+        # None of the Pydantic leakage from the original bug report.
+        assert "validation error for" not in text
+        assert "launch_appArguments" not in text
+        assert "pydantic" not in text.lower()
+        assert "input_value" not in text
+        assert "[type=missing" not in text
 
-        original_mock = AsyncMock(side_effect=plain_tool_error)
+    def test_genuine_tool_error_passes_through(self):
+        """A non-Pydantic tool failure keeps its original message.
 
-        async def _sanitized_call_tool(name, arguments):
-            try:
-                return await original_mock(name, arguments)
-            except ToolError as exc:
-                c = exc.__cause__
-                if c is not None and hasattr(c, "errors"):
-                    raise ToolError(
-                        _format_tool_validation_error(name, c),
-                    ) from None
-                raise
+        Calling an unknown tool produces a ``ToolError`` with no Pydantic
+        ``__cause__``; the sanitizer must leave it untouched so real failures
+        stay diagnosable.
+        """
+        result = self._dispatch("definitely_not_a_real_tool", {})
 
-        server.call_tool = _sanitized_call_tool  # type: ignore[assignment]
-
-        async def _run():
-            return await server.call_tool("fake_tool", {})
-
-        with pytest.raises(ToolError) as exc_info:
-            asyncio.run(_run())
-
-        # The error must be the original, unmodified ToolError object
-        assert exc_info.value is plain_tool_error
-        assert original_message in str(exc_info.value)
+        assert result.isError is True
+        text = result.content[0].text
+        assert "definitely_not_a_real_tool" in text
+        # Not rewritten into the validation-error template.
+        assert "Invalid parameters for" not in text


### PR DESCRIPTION
## What
MCP tool calls with a wrong/missing parameter name leaked Pydantic internals to AI agents — the internal model name (`launch_appArguments`), the raw `[type=missing, input_value=…]` format, and the `errors.pydantic.dev` URL — instead of a clean, actionable message.

The earlier fix (#853) was **dead code in production**: it reassigned `server.call_tool` *after* `FastMCP.__init__` had already registered the original bound method as the low-level `CallToolRequest` handler. Live JSON-RPC dispatch never went through the reassigned attribute, so the leak persisted (verified by QA on the desktop runner).

## Root cause
`FastMCP` validates each tool's arguments with Pydantic **before** the tool function runs, so the existing `_safe_tool` body wrapper cannot catch these. On failure, `Tool.run` wraps the `ValidationError` in a `ToolError`, and the low-level server renders `str(exc)` straight into the client-facing text. The interception must live on the bound method captured at `_setup_handlers` time — reassigning the attribute afterwards has no effect.

## How
- Introduce `_SanitizingFastMCP(FastMCP)` and override `call_tool`. Because `_setup_handlers` (run inside `__init__`) registers `self.call_tool`, the subclass override **is** the method the low-level handler invokes — the only interception point that survives real dispatch.
- When the caught `ToolError`'s `__cause__` exposes `.errors()` (a Pydantic `ValidationError`), re-raise a clean `ToolError` via the existing `_format_tool_validation_error` helper. All other `ToolError`s propagate unchanged so genuine failures stay diagnosable.
- Remove the dead post-construction reassignment block.

## How tested
- **New `TestRealDispatchSanitization`** drives `request_handlers[CallToolRequest]` directly — the same path a live MCP client hits — reproducing the exact issue scenario (`launch_app` with `app_name`). It asserts the response text is `Invalid parameters for launch_app: name: Field required` and contains none of `validation error for` / `launch_appArguments` / `pydantic` / `input_value` / `[type=missing`. This test **fails on the old code and passes on the fix** (the previous unit test passed against the dead path because it called `server.call_tool` directly — it has been replaced).
- A second test confirms a non-Pydantic `ToolError` (unknown tool) passes through unmodified.
- `tests/test_mcp_pydantic_leak.py`: 9 passed. ruff clean; mypy clean on changed file (`--python-version 3.12`); the repo's py3.9 mypy run is blocked only by the pre-existing third-party `mcp` match-statement parse error, unrelated to this change. `--collect-only` clean (no Windows/optional deps).

Fixes #844.