### PR TITLE
fix: support Unicode capture output paths via bridge-level staging (fixes #777)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Unicode capture paths regardless of native build** — `capture_screen` / `capture_window` again write to output paths containing non-ASCII characters (e.g. a Chinese/Japanese Windows username or folder in `%TEMP%`). The native core's Unicode fix ([#693](https://github.com/AcePeak/naturo/pull/693)) lives in source but the shipped DLL can lag a rebuild; the Python bridge now stages such captures through an ASCII-only temp file and moves the result to the requested path, so Unicode paths work independent of the native build ([#777](https://github.com/AcePeak/naturo/issues/777))
 - **NO_DESKTOP_SESSION silent-failure cluster** — `app windows`, `dialog detect`, `taskbar list`, `tray list`, `wait --gone` (CLI) and `capture_screen`, `list_windows`, `list_apps`, `app_inspect`, `capture_window`, `list_monitors` (MCP) no longer return fabricated success (empty arrays, all-black PNGs, stale window lists) without a desktop session. The session guard is now enforced structurally at the shared entrypoint and these surfaces fail loudly with `NO_DESKTOP_SESSION` (exit 1 / `isError:true`) ([#885](https://github.com/AcePeak/naturo/issues/885), [#868](https://github.com/AcePeak/naturo/issues/868), [#875](https://github.com/AcePeak/naturo/issues/875), [#878](https://github.com/AcePeak/naturo/issues/878), [#883](https://github.com/AcePeak/naturo/issues/883), [#893](https://github.com/AcePeak/naturo/issues/893))
 
 ## [0.3.1] — 2026-03-31

--- a/naturo/bridge/_core.py
+++ b/naturo/bridge/_core.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 import ctypes
 import os
 import platform
+import shutil
+import tempfile
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Optional
 
 from naturo.bridge._models import (
     ElementInfo,
@@ -15,6 +17,57 @@ from naturo.bridge._models import (
     _safe_json_loads,
 )
 from naturo.bridge._errors import NaturoCoreError
+
+
+def _windows_short_path(path: str) -> Optional[str]:
+    """Return the Windows 8.3 short path for an existing path, or None.
+
+    Short (8.3) paths contain only ASCII characters, which lets the native
+    capture core open a staging file even when ``%TEMP%`` lives under a
+    non-ASCII user profile (e.g. a Chinese Windows username).
+
+    Args:
+        path: An existing directory or file path.
+
+    Returns:
+        The 8.3 short path, or None if it could not be resolved.
+    """
+    get_short_path = ctypes.windll.kernel32.GetShortPathNameW  # type: ignore[attr-defined]
+    get_short_path.argtypes = [ctypes.c_wchar_p, ctypes.c_wchar_p, ctypes.c_uint32]
+    get_short_path.restype = ctypes.c_uint32
+    buffer = ctypes.create_unicode_buffer(260)
+    length = get_short_path(path, buffer, len(buffer))
+    if length == 0:
+        return None
+    if length >= len(buffer):
+        buffer = ctypes.create_unicode_buffer(length + 1)
+        length = get_short_path(path, buffer, len(buffer))
+        if length == 0:
+            return None
+    return buffer.value
+
+
+def _ascii_temp_dir() -> str:
+    """Return a temporary directory whose path contains only ASCII characters.
+
+    The native capture core writes files with narrow-string I/O that cannot
+    open non-ASCII paths, so any staging file must live in an ASCII-only
+    directory. The system temp directory is used directly when it is already
+    ASCII; otherwise its 8.3 short path is used on Windows.
+
+    Returns:
+        A temporary directory path, ASCII-only when one can be resolved
+        (best effort otherwise).
+    """
+    base = tempfile.gettempdir()
+    if base.isascii():
+        return base
+    if platform.system() == "Windows":
+        short = _windows_short_path(base)
+        if short and short.isascii():
+            return short
+    return base
+
 
 class NaturoCore:
     """Wrapper around naturo_core.dll/.so native library.
@@ -263,12 +316,72 @@ class NaturoCore:
         """
         return self._lib.naturo_shutdown()
 
+    def _capture_to_path(
+        self,
+        native_call: Callable[[bytes], int],
+        output_path: str,
+        op_name: str,
+    ) -> str:
+        """Invoke a native capture function, tolerating Unicode output paths.
+
+        The bundled native core writes BMP files with narrow-string file I/O,
+        which fails with a ``File I/O error`` when the output path contains
+        non-ASCII characters (a common case on Chinese/Japanese Windows, where
+        usernames and folders are non-ASCII — see #777). For such paths the
+        capture is written to an ASCII-only temporary file and then moved to
+        the requested destination, which Python handles natively. ASCII paths
+        are passed straight through, so behaviour is unchanged for them.
+
+        Args:
+            native_call: Callable that takes the UTF-8-encoded path bytes and
+                returns the native status code (0 on success).
+            output_path: Requested output file path.
+            op_name: Operation name used in error reporting.
+
+        Returns:
+            The requested output path.
+
+        Raises:
+            NaturoCoreError: If the output path is None or the native capture
+                fails.
+        """
+        if output_path is None:
+            raise NaturoCoreError(-1, op_name)
+
+        if output_path.isascii():
+            rc = native_call(output_path.encode("utf-8"))
+            if rc != 0:
+                raise NaturoCoreError(rc, op_name)
+            return output_path
+
+        # Non-ASCII destination: stage the capture in an ASCII-only temp file,
+        # then move it to the requested path.
+        fd, staging_path = tempfile.mkstemp(
+            suffix=".bmp", prefix="naturo_capture_", dir=_ascii_temp_dir()
+        )
+        os.close(fd)
+        try:
+            rc = native_call(staging_path.encode("utf-8"))
+            if rc != 0:
+                raise NaturoCoreError(rc, op_name)
+            parent = os.path.dirname(output_path)
+            if parent:
+                os.makedirs(parent, exist_ok=True)
+            # copyfile (not move) so an existing destination is overwritten and
+            # cross-volume staging works; the staging file is removed below.
+            shutil.copyfile(staging_path, output_path)
+        finally:
+            if os.path.exists(staging_path):
+                os.unlink(staging_path)
+        return output_path
+
     def capture_screen(self, screen_index: int = 0, output_path: str = "capture.bmp") -> str:
         """Capture a screenshot of the entire screen or a specific monitor.
 
         Args:
             screen_index: Zero-based monitor index. 0 for primary screen.
             output_path: File path to save the screenshot (BMP format).
+                Unicode (non-ASCII) paths are supported.
 
         Returns:
             The output file path.
@@ -276,14 +389,11 @@ class NaturoCore:
         Raises:
             NaturoCoreError: On capture failure or invalid arguments.
         """
-        if output_path is None:
-            raise NaturoCoreError(-1, "capture_screen")
-        rc = self._lib.naturo_capture_screen(
-            screen_index, output_path.encode("utf-8")
+        return self._capture_to_path(
+            lambda path_bytes: self._lib.naturo_capture_screen(screen_index, path_bytes),
+            output_path,
+            "capture_screen",
         )
-        if rc != 0:
-            raise NaturoCoreError(rc, "capture_screen")
-        return output_path
 
     def capture_window(self, hwnd: int = 0, output_path: str = "capture.bmp") -> str:
         """Capture a screenshot of a specific window.
@@ -291,6 +401,7 @@ class NaturoCore:
         Args:
             hwnd: Window handle. Pass 0 to capture the foreground window.
             output_path: File path to save the screenshot (BMP format).
+                Unicode (non-ASCII) paths are supported.
 
         Returns:
             The output file path.
@@ -298,14 +409,11 @@ class NaturoCore:
         Raises:
             NaturoCoreError: On capture failure or invalid arguments.
         """
-        if output_path is None:
-            raise NaturoCoreError(-1, "capture_window")
-        rc = self._lib.naturo_capture_window(
-            hwnd, output_path.encode("utf-8")
+        return self._capture_to_path(
+            lambda path_bytes: self._lib.naturo_capture_window(hwnd, path_bytes),
+            output_path,
+            "capture_window",
         )
-        if rc != 0:
-            raise NaturoCoreError(rc, "capture_window")
-        return output_path
 
     def list_windows(self) -> list[WindowInfo]:
         """List all visible top-level windows.

--- a/tests/test_capture_unicode_path.py
+++ b/tests/test_capture_unicode_path.py
@@ -1,0 +1,134 @@
+"""Unit tests for the bridge-level Unicode output-path guard (#777).
+
+The bundled ``naturo_core`` native library writes BMP files. Older builds use
+narrow-string file I/O that cannot open paths containing non-ASCII characters
+(for example a Chinese Windows username in ``%TEMP%``), returning a
+``File I/O error``. ``NaturoCore`` guards against this by routing non-ASCII
+output paths through an ASCII-only temporary file and then moving the result to
+the requested destination.
+
+These tests exercise that routing logic directly with a fake native call, so
+they require neither the native library nor a real display and run on every
+platform.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from naturo.bridge._core import NaturoCore
+from naturo.bridge._errors import NaturoCoreError
+
+
+def _make_core() -> NaturoCore:
+    """Build a NaturoCore without loading the native library.
+
+    ``_capture_to_path`` does not touch ``self._lib``, so bypassing
+    ``__init__`` lets the routing logic be tested without the DLL present.
+    """
+    return object.__new__(NaturoCore)
+
+
+def test_ascii_path_passes_straight_to_native(tmp_path):
+    """An ASCII path is handed to the native call unchanged (no staging)."""
+    core = _make_core()
+    dest = str(tmp_path / "shot.bmp")
+    calls = []
+
+    def fake_native(path_bytes: bytes) -> int:
+        calls.append(path_bytes)
+        with open(path_bytes.decode("utf-8"), "wb") as handle:
+            handle.write(b"BMP")
+        return 0
+
+    result = core._capture_to_path(fake_native, dest, "capture_screen")
+
+    assert result == dest
+    assert calls == [dest.encode("utf-8")]
+    assert os.path.exists(dest)
+
+
+def test_unicode_path_routes_through_ascii_temp(tmp_path):
+    """A non-ASCII path is captured to an ASCII temp file, then moved."""
+    core = _make_core()
+    unicode_dir = tmp_path / "naturo_测试_中文"
+    unicode_dir.mkdir()
+    dest = str(unicode_dir / "截图.bmp")
+    seen = []
+
+    def fake_native(path_bytes: bytes) -> int:
+        path = path_bytes.decode("utf-8")
+        seen.append(path)
+        with open(path, "wb") as handle:
+            handle.write(b"PIXELDATA")
+        return 0
+
+    result = core._capture_to_path(fake_native, dest, "capture_screen")
+
+    assert result == dest
+    # The native layer only ever saw an ASCII-only staging path.
+    assert len(seen) == 1
+    assert seen[0].isascii()
+    assert seen[0] != dest
+    # The captured bytes ended up at the requested Unicode destination.
+    assert os.path.exists(dest)
+    with open(dest, "rb") as handle:
+        assert handle.read() == b"PIXELDATA"
+    # The staging file was cleaned up.
+    assert not os.path.exists(seen[0])
+
+
+def test_unicode_path_overwrites_existing_destination(tmp_path):
+    """Re-capturing to an existing Unicode path overwrites it (no error)."""
+    core = _make_core()
+    unicode_dir = tmp_path / "中文_目录"
+    unicode_dir.mkdir()
+    dest = str(unicode_dir / "截图.bmp")
+    with open(dest, "wb") as handle:
+        handle.write(b"OLD")
+
+    def fake_native(path_bytes: bytes) -> int:
+        with open(path_bytes.decode("utf-8"), "wb") as handle:
+            handle.write(b"NEW")
+        return 0
+
+    core._capture_to_path(fake_native, dest, "capture_screen")
+
+    with open(dest, "rb") as handle:
+        assert handle.read() == b"NEW"
+
+
+def test_native_error_on_ascii_path_raises(tmp_path):
+    """A non-zero native status on an ASCII path raises NaturoCoreError."""
+    core = _make_core()
+    dest = str(tmp_path / "shot.bmp")
+
+    with pytest.raises(NaturoCoreError):
+        core._capture_to_path(lambda _: -3, dest, "capture_screen")
+
+
+def test_native_error_on_unicode_path_raises_and_cleans_up(tmp_path):
+    """A native failure on a Unicode path raises and leaves no staging file."""
+    core = _make_core()
+    dest = str(tmp_path / "中文.bmp")
+    seen = []
+
+    def fake_native(path_bytes: bytes) -> int:
+        seen.append(path_bytes.decode("utf-8"))
+        return -3
+
+    with pytest.raises(NaturoCoreError):
+        core._capture_to_path(fake_native, dest, "capture_screen")
+
+    assert not os.path.exists(dest)
+    assert seen and not os.path.exists(seen[0])
+
+
+def test_none_path_raises():
+    """A None output path raises NaturoCoreError without invoking native."""
+    core = _make_core()
+
+    with pytest.raises(NaturoCoreError):
+        core._capture_to_path(lambda _: 0, None, "capture_screen")


### PR DESCRIPTION
## What
`capture_screen` / `capture_window` failed with `NaturoCoreError: File I/O error` when the output path contained non-ASCII characters (e.g. a Chinese/Japanese Windows username or folder in `%TEMP%`). This blocks a core demographic — many CJK users have non-ASCII home directories.

## Root cause
The native core's Unicode-path fix (`_wfopen`, #693) exists in `core/src/capture.cpp`, but the **shipped prebuilt DLL is stale** — the compile runner (ROBOT-COMPILE) is offline (#842), so the binary still uses narrow-string file I/O that cannot open non-ASCII paths. Verified live on a real Windows desktop: ASCII paths capture fine, the Unicode path returns rc=-3 (File I/O error).

## Fix
A bridge-level Unicode-path guard in `NaturoCore` (`_capture_to_path`):
- ASCII paths pass straight to the native call — **no behaviour change**.
- Non-ASCII paths are staged to an ASCII-only temp file, then copied to the requested destination (Python handles Unicode natively). On a non-ASCII `%TEMP%` (Unicode username), the temp dir's 8.3 short path is used.

This makes capture Unicode-safe **independent of the native build**, and remains correct once the DLL is eventually rebuilt (the guard only engages for non-ASCII paths).

## How tested
- New unit tests `tests/test_capture_unicode_path.py` (6, all platforms, no DLL/display needed) — exercise the routing: ASCII passthrough, non-ASCII staging+move, overwrite, native-error propagation + temp cleanup, None handling.
- Live on Windows 11 desktop with the real DLL:
  - `capture_screen` to `…/naturo_测试_中文路径/截图.bmp` → **PASS** (was File I/O error before).
  - `capture_window` to a Unicode path with a real window handle → **PASS** (2.1 MB BMP).
- `ruff` clean; `mypy` clean on `_core.py`; full suite `--collect-only` clean (5780 tests, no import break).

Closes #777.