### PR TITLE
fix: Z-order-aware capture --app/--pid composite so popups survive overlapping siblings (#843)

### DIFF
--- a/naturo/backends/windows/_capture.py
+++ b/naturo/backends/windows/_capture.py
@@ -13,7 +13,110 @@ logger = logging.getLogger(__name__)
 class CaptureMixin:
     """Screen and window capture via GDI + Pillow conversion."""
 
+    # Window classes that are always transient popups/menus and must be
+    # composited on top of everything else (#843).  Matched case-insensitively.
+    # ``#32768`` is the standard Win32 menu class; ``tooltips_class32`` is the
+    # common tooltip class; the remainder are popup/dropdown classes used by
+    # the shell, list-view dropdowns, and autocomplete panels.
+    _POPUP_WINDOW_CLASSES = frozenset(
+        c.lower() for c in (
+            "#32768",              # standard menus (File menu, context menu)
+            "tooltips_class32",    # tooltips
+            "ComboLBox",           # combo-box dropdown list
+            "DropDown",            # generic dropdown
+            "Auto-Suggest Dropdown",  # edit-control autocomplete
+            "ListBox",             # transient list popups
+        )
+    )
+
     # === Capture (Phase 1) ===
+
+    @staticmethod
+    def _order_hwnds_for_composite(
+        hwnds: list[int],
+        class_of,
+        zorder_rank_of,
+    ) -> list[int]:
+        """Order *hwnds* bottom→top for compositing (#843).
+
+        The composite must paste windows from the bottom of the Z-order to the
+        top, so that the top-most windows — including popup menus and tooltips
+        that overlap full-size sibling windows — are painted last and survive
+        in the final image.
+
+        Ordering rules (stable):
+
+        1. Non-popup windows come before popup/menu windows, so popups always
+           land on top regardless of their reported Z-order (a freshly opened
+           menu is normally top-most, but this guards against stale/odd
+           Z-order reporting).
+        2. Within each group, windows are sorted by Z-order rank where a
+           *higher* rank means closer to the top of the Z-order, so the
+           bottom-most window is pasted first and the top-most window last.
+        3. Ties (equal rank) preserve the input order for determinism.
+
+        Args:
+            hwnds: Window handles to order.
+            class_of: Callable ``hwnd -> str`` returning the window class name.
+            zorder_rank_of: Callable ``hwnd -> int`` returning a Z-order rank
+                where a larger value is closer to the top of the Z-order.
+
+        Returns:
+            The handles ordered so the first element should be pasted first
+            (bottom) and the last element pasted last (top).
+        """
+        popup_classes = CaptureMixin._POPUP_WINDOW_CLASSES
+
+        def _is_popup(h: int) -> bool:
+            try:
+                name = (class_of(h) or "").strip().lower()
+            except Exception:
+                return False
+            return name in popup_classes
+
+        decorated = []
+        for idx, h in enumerate(hwnds):
+            try:
+                rank = zorder_rank_of(h)
+            except Exception:
+                rank = 0
+            decorated.append((1 if _is_popup(h) else 0, rank, idx, h))
+
+        # Sort by (popup-flag asc, z-order rank asc, original index asc) so the
+        # last element is the top-most popup (or top-most non-popup if none).
+        decorated.sort(key=lambda t: (t[0], t[1], t[2]))
+        return [h for _, _, _, h in decorated]
+
+    @staticmethod
+    def _window_class_name(hwnd: int) -> str:
+        """Return the Win32 window class name for *hwnd* (empty on failure)."""
+        import ctypes
+
+        buf = ctypes.create_unicode_buffer(256)
+        n = ctypes.windll.user32.GetClassNameW(hwnd, buf, 256)
+        return buf.value if n else ""
+
+    @staticmethod
+    def _window_zorder_rank(hwnd: int) -> int:
+        """Return a Z-order rank for *hwnd*; larger means closer to the top.
+
+        Walks the Z-order downward from *hwnd* via ``GetWindow(GW_HWNDNEXT)``
+        and counts the windows below it.  More windows below ⇒ closer to the
+        top, so the returned rank sorts bottom→top when used as a sort key.
+        """
+        import ctypes
+
+        GW_HWNDNEXT = 2  # next window toward the bottom of the Z-order
+        rank = 0
+        cur = hwnd
+        # Bound the walk to avoid pathological loops on a corrupt Z-order list.
+        for _ in range(10000):
+            nxt = ctypes.windll.user32.GetWindow(cur, GW_HWNDNEXT)
+            if not nxt:
+                break
+            rank += 1
+            cur = nxt
+        return rank
 
     @staticmethod
     def _convert_bmp(bmp_path: str, output_path: str) -> tuple[int, int, str]:
@@ -311,7 +414,17 @@ class CaptureMixin:
         from PIL import Image
 
         core = self._ensure_core()
-        all_hwnds = [main_hwnd] + sibling_hwnds
+
+        # (#843) Order windows bottom→top of the actual Z-order so the top-most
+        # windows — including popup menus that overlap full-size siblings — are
+        # pasted last and survive in the composite.  The bare ``list_windows()``
+        # order pasted the main window first then siblings, so a full-size
+        # sibling pasted after a small popup would overpaint it.
+        all_hwnds = self._order_hwnds_for_composite(
+            [main_hwnd] + sibling_hwnds,
+            class_of=self._window_class_name,
+            zorder_rank_of=self._window_zorder_rank,
+        )
 
         # Gather window rects and captures
         captures: list[tuple[int, int, Image.Image]] = []  # (screen_x, screen_y, img)
@@ -354,7 +467,9 @@ class CaptureMixin:
             canvas_w = max_x - min_x
             canvas_h = max_y - min_y
 
-            # Composite: paint main window first, then overlays (popups on top)
+            # Composite: ``captures`` is already ordered bottom→top of the
+            # Z-order (popups last), so pasting in sequence leaves popups/menus
+            # painted on top of any overlapping full-size sibling windows.
             canvas = Image.new("RGB", (canvas_w, canvas_h), (0, 0, 0))
             for screen_x, screen_y, img in captures:
                 canvas.paste(img, (screen_x - min_x, screen_y - min_y))

--- a/tests/test_capture_popup_843.py
+++ b/tests/test_capture_popup_843.py
@@ -312,6 +312,161 @@ class TestCaptureAppWindows:
         mock_cw.assert_called_once()
 
 
+class TestCompositePasteOrder:
+    """Unit tests for the Z-order-aware paste ordering (#843).
+
+    These exercise ``_order_hwnds_for_composite`` directly with injected
+    class/Z-order lookups, so they run on any platform without a desktop.
+    """
+
+    @staticmethod
+    def _mixin():
+        from naturo.backends.windows._capture import CaptureMixin
+        return CaptureMixin
+
+    def test_zorder_topmost_pasted_last(self):
+        """Bottom-of-Z-order window is pasted first; top-most last."""
+        mixin = self._mixin()
+        # rank: larger = closer to top.  hwnd 30 is top-most.
+        ranks = {10: 0, 20: 1, 30: 2}
+        ordered = mixin._order_hwnds_for_composite(
+            [20, 30, 10],
+            class_of=lambda h: "Notepad",
+            zorder_rank_of=lambda h: ranks[h],
+        )
+        assert ordered == [10, 20, 30]
+
+    def test_popup_class_forced_on_top(self):
+        """A popup-class window is pasted last even if its Z-order rank is low."""
+        mixin = self._mixin()
+        # The popup (hwnd 99) reports a LOWER z-order rank than the editor
+        # windows, but must still be composited last because of its class.
+        classes = {1: "Notepad", 2: "Notepad", 99: "#32768"}
+        ranks = {1: 5, 2: 6, 99: 0}
+        ordered = mixin._order_hwnds_for_composite(
+            [1, 2, 99],
+            class_of=lambda h: classes[h],
+            zorder_rank_of=lambda h: ranks[h],
+        )
+        assert ordered[-1] == 99, "popup menu must be pasted last (on top)"
+
+    def test_popup_overlapping_fullsize_sibling_survives(self):
+        """The exact #843 scenario: a small popup overlapped by a full-size sibling.
+
+        The bug was that ``[main] + siblings`` order pasted a full-size editor
+        sibling AFTER the popup, overpainting it.  With Z-order ordering, the
+        top-most popup is pasted last so it survives.
+        """
+        mixin = self._mixin()
+        main_hwnd = 1000          # full-size main editor (bottom)
+        sibling_hwnd = 1001       # full-size session-restore editor (overlaps popup)
+        popup_hwnd = 1002         # small File menu (#32768), top-most
+        classes = {
+            main_hwnd: "Notepad",
+            sibling_hwnd: "Notepad",
+            popup_hwnd: "#32768",
+        }
+        ranks = {main_hwnd: 0, sibling_hwnd: 1, popup_hwnd: 2}
+        ordered = mixin._order_hwnds_for_composite(
+            [main_hwnd, sibling_hwnd, popup_hwnd],
+            class_of=lambda h: classes[h],
+            zorder_rank_of=lambda h: ranks[h],
+        )
+        # Popup must be the very last paste so no later full-size window
+        # overpaints its region.
+        assert ordered[-1] == popup_hwnd
+        assert ordered.index(popup_hwnd) > ordered.index(sibling_hwnd)
+
+    def test_lookup_failures_are_tolerated(self):
+        """Class/rank lookups that raise should not break ordering."""
+        mixin = self._mixin()
+
+        def boom(_h):
+            raise OSError("invalid window handle")
+
+        ordered = mixin._order_hwnds_for_composite(
+            [7, 8, 9],
+            class_of=boom,
+            zorder_rank_of=boom,
+        )
+        # Falls back to input order (all ranks 0, not popups).
+        assert ordered == [7, 8, 9]
+
+
+@pytest.mark.skipif(not _HAS_PIL, reason="Pillow not installed")
+class TestCompositePopupPixelsSurvive:
+    """End-to-end composite test proving popup pixels survive overlap (#843)."""
+
+    def test_popup_not_overpainted_by_fullsize_sibling(self):
+        """A full-size sibling overlapping a small popup must NOT erase it.
+
+        Renders each window in a distinct solid color, then asserts the popup's
+        color is present in the composite at the popup's location — i.e. the
+        full-size sibling did not overpaint it.
+        """
+        from PIL import Image
+
+        main_hwnd = 6001
+        sibling_hwnd = 6002   # full-size, overlaps the popup region
+        popup_hwnd = 6003     # small menu, must paint on top
+        pid = 123
+
+        # Main + sibling are full-size and overlap the popup; popup is small.
+        rect_map = {
+            main_hwnd: (0, 0, 800, 600),       # full-size
+            sibling_hwnd: (0, 0, 800, 600),    # full-size, same region
+            popup_hwnd: (100, 100, 300, 360),  # 200x260 menu inside both
+        }
+        colors = {
+            main_hwnd: (10, 10, 10),
+            sibling_hwnd: (20, 20, 20),
+            popup_hwnd: (200, 50, 50),  # distinctive red-ish menu color
+        }
+
+        def fake_core_capture(hwnd, bmp_path):
+            r = rect_map[hwnd]
+            _make_bmp(bmp_path, r[2] - r[0], r[3] - r[1], colors[hwnd])
+
+        backend, mock_core, fake_windll = _make_backend(
+            windows=[
+                _make_window(main_hwnd, pid, "Notepad", 0, 0, 800, 600),
+                _make_window(sibling_hwnd, pid, "Notepad", 0, 0, 800, 600),
+                _make_window(popup_hwnd, pid, "", 100, 100, 200, 260),
+            ],
+            pid_map={main_hwnd: pid, sibling_hwnd: pid, popup_hwnd: pid},
+            rect_map=rect_map,
+            core_capture_fn=fake_core_capture,
+        )
+
+        # Z-order: popup top-most; class lookup marks the popup as #32768.
+        zorder = {main_hwnd: 0, sibling_hwnd: 1, popup_hwnd: 2}
+        classes = {main_hwnd: "Notepad", sibling_hwnd: "Notepad", popup_hwnd: "#32768"}
+
+        with patch("ctypes.windll", fake_windll), \
+             patch.object(backend, "_window_class_name",
+                          side_effect=lambda h: classes[h]), \
+             patch.object(backend, "_window_zorder_rank",
+                          side_effect=lambda h: zorder[h]), \
+             tempfile.TemporaryDirectory() as tmpdir:
+            out_path = os.path.join(tmpdir, "composite.png")
+            result = backend.capture_app_windows(main_hwnd, out_path)
+
+            assert result.width == 800
+            assert result.height == 600
+            img = Image.open(out_path).convert("RGB")
+            # Sample the center of the popup region (200,230) in canvas coords
+            # (min_x = min_y = 0, so screen == canvas coords here).
+            px = img.getpixel((200, 230))
+            assert px == colors[popup_hwnd], (
+                f"popup overpainted: expected {colors[popup_hwnd]}, got {px}"
+            )
+            # Outside the popup, the top-most full-size sibling should show.
+            edge = img.getpixel((700, 500))
+            assert edge == colors[sibling_hwnd], (
+                f"expected top sibling color outside popup, got {edge}"
+            )
+
+
 class TestCaptureCLIAppWindowsIntegration:
     """Verify the CLI calls capture_app_windows when --app is used."""
 


### PR DESCRIPTION
@-