### PR TITLE
docs: soften README 'AI Agent Ready' claim while -j envelope is standardized (fixes #887)

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,7 +615,7 @@ See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for details.
 | Feature | naturo | PyAutoGUI | pywinauto | AutoIt | WinAppDriver |
 |---------|--------|-----------|-----------|--------|--------------|
 | **MCP Server** | ✅ Built-in | ❌ | ❌ | ❌ | ❌ |
-| **AI Agent Ready** | ✅ JSON output, agent CLI | ❌ | ❌ | ❌ | ❌ |
+| **AI Agent Ready** | ⚠️ JSON output, agent CLI (`-j` envelope being standardized) | ❌ | ❌ | ❌ | ❌ |
 | **Browser Automation** | ✅ CDP (Chrome/Edge) | ❌ | ❌ | ❌ | ❌ |
 | **UI Frameworks** | UIA + MSAA + IA2 + JAB + CDP + AI Vision | None (image only) | UIA, Win32 | Win32 messages | UIA only |
 | **Cascade Recognition** | ✅ Multi-source fusion with auto-dedup | ❌ | ❌ | ❌ | ❌ |


### PR DESCRIPTION
## What
The README 'Comparison' table marked **AI Agent Ready** with a bare `✅`, but the `-j` JSON envelope contract is still inconsistent across 10+ open bugs (#864, #865, #872, #874, #876, #877, #879, #881, #882, #884). A skeptical evaluator who installs and writes a `-j` script hits envelope drift on the first counter-example — the trust hazard #887 describes.

This softens the cell to `⚠️ JSON output, agent CLI (`-j` envelope being standardized)` — still a clear differentiator (every competitor is `❌`), but honest about the in-flight standardization. Aligns with the project's 'Never Lie' principle.

## Scope note
The companion claim in #887 — **Post-Action Verify** (L624) — is left as `✅`. Its entire cited contradicting cluster (#868, #875, #878, #883, #885) is now **CLOSED**, so that ✅ is accurate. Only the still-contradicted claim is softened.

## How tested
Docs-only one-line diff (no Python touched). `ruff check naturo/` passes; mypy/pytest unaffected by a README change. Markdown table renders correctly.