### PR TITLE
fix: validate direct PID in MCP app_inspect so bogus PIDs fail loudly (fixes #901)

### DIFF
--- a/naturo/mcp/_window.py
+++ b/naturo/mcp/_window.py
@@ -355,6 +355,32 @@ def register_window_tools(server, _get_backend, _safe_tool):
             target_exe = proc.path or proc.name or ""
             target_name = proc.name or name
 
+        elif pid is not None:
+            # (#901) Validate a directly-supplied PID exactly as the CLI does,
+            # so a bogus or exited PID fails loudly instead of returning
+            # success:true with an empty exe and a phantom vision method. An
+            # agent enumerating PIDs must be able to trust this contract.
+            if pid <= 0:
+                return {
+                    "success": False,
+                    "error": {
+                        "code": "INVALID_INPUT",
+                        "message": f"Invalid PID: {pid}. PID must be a positive integer.",
+                    },
+                }
+            from naturo.process import find_process
+            proc = find_process(pid=pid)
+            if proc is None:
+                return {
+                    "success": False,
+                    "error": {
+                        "code": "PROCESS_NOT_FOUND",
+                        "message": f"No process found with PID {pid}. The process may have exited.",
+                    },
+                }
+            target_exe = proc.path or proc.name or ""
+            target_name = proc.name or target_name
+
         if target_pid is None:
             return {
                 "success": False,

--- a/tests/test_app_inspect_pid_validation_901.py
+++ b/tests/test_app_inspect_pid_validation_901.py
@@ -1,0 +1,103 @@
+"""Regression tests for #901 — MCP ``app_inspect`` must validate a direct PID.
+
+Root cause: ``app_inspect({pid: <int>})`` went straight to ``detect()`` without
+checking that the PID is positive and belongs to a live process.  For any
+integer — including impossible values (0, -1, 999999, INT32_MAX) — it returned
+``success: true`` with an empty ``exe``/``app`` plus a fabricated
+``framework`` and a phantom ``interaction_methods=[{method: vision}]``.  An
+agent enumerating PIDs would trust that contract and drive interactions against
+a process that does not exist.
+
+The CLI counterpart (``naturo app inspect --pid``) already validates: ``pid<=0``
+→ ``INVALID_INPUT`` and a missing process → ``PROCESS_NOT_FOUND``.  These tests
+lock the MCP surface to the same loud-failure contract (naturo never lies).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+mcp_available = True
+try:
+    from naturo.mcp_server import create_server
+except ImportError:  # pragma: no cover - mcp optional
+    mcp_available = False
+
+pytestmark = pytest.mark.skipif(not mcp_available, reason="mcp package not installed")
+
+
+def _call_tool(server, tool_name: str, arguments: dict):
+    """Drive an MCP tool to completion and return its result list."""
+    async def _run():
+        return await server.call_tool(tool_name, arguments)
+
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(_run())
+    finally:
+        loop.close()
+
+
+@pytest.fixture
+def server():
+    """An MCP server whose backend is mocked away (app_inspect probes directly)."""
+    with patch("naturo.mcp_server.get_backend", return_value=MagicMock()):
+        yield create_server()
+
+
+@pytest.mark.parametrize("bogus_pid", [0, -1, -2147483648])
+def test_non_positive_pid_is_invalid_input(server, bogus_pid):
+    """A PID <= 0 cannot exist — reject it with INVALID_INPUT, never probe."""
+    with patch("naturo.detect.detect") as mock_detect:
+        result = _call_tool(server, "app_inspect", {"pid": bogus_pid})
+    data = json.loads(result[0].text)
+    assert data["success"] is False
+    assert data["error"]["code"] == "INVALID_INPUT"
+    mock_detect.assert_not_called()
+
+
+@pytest.mark.parametrize("missing_pid", [1, 999999, 2147483647])
+def test_unknown_pid_is_process_not_found(server, missing_pid):
+    """A positive but non-existent PID must surface PROCESS_NOT_FOUND, not success."""
+    with (
+        patch("naturo.process.find_process", return_value=None),
+        patch("naturo.detect.detect") as mock_detect,
+    ):
+        result = _call_tool(server, "app_inspect", {"pid": missing_pid})
+    data = json.loads(result[0].text)
+    assert data["success"] is False
+    assert data["error"]["code"] == "PROCESS_NOT_FOUND"
+    # The phantom contract from the bug must never appear.
+    assert "framework" not in data
+    assert "interaction_methods" not in data
+    mock_detect.assert_not_called()
+
+
+def test_live_pid_is_inspected_and_exe_populated(server):
+    """A real PID is detected normally, with exe/app resolved from the process."""
+    fake_proc = MagicMock()
+    fake_proc.pid = 4321
+    fake_proc.path = "C:\\Windows\\System32\\notepad.exe"
+    fake_proc.name = "notepad.exe"
+    fake_detect_result = MagicMock()
+    fake_detect_result.to_dict.return_value = {
+        "frameworks": ["win32"],
+        "methods": ["uia"],
+        "recommended": "uia",
+    }
+    with (
+        patch("naturo.process.find_process", return_value=fake_proc),
+        patch("naturo.detect.detect", return_value=fake_detect_result) as mock_detect,
+    ):
+        result = _call_tool(server, "app_inspect", {"pid": 4321})
+    data = json.loads(result[0].text)
+    assert data["success"] is True
+    assert data["recommended"] == "uia"
+    mock_detect.assert_called_once()
+    # The validated process feeds detect() so exe is no longer empty (#901).
+    call_kwargs = mock_detect.call_args[1]
+    assert call_kwargs["pid"] == 4321
+    assert call_kwargs["exe"] == "C:\\Windows\\System32\\notepad.exe"

--- a/tests/test_mcp_window.py
+++ b/tests/test_mcp_window.py
@@ -305,13 +305,22 @@ class TestAppInspect:
         assert data["error"]["code"] == "PROCESS_NOT_FOUND"
 
     def test_inspect_by_pid(self, server, mock_backend):
+        # A directly-supplied PID must belong to a live process (#901); mock it
+        # so the validation passes and detection proceeds.
+        fake_proc = MagicMock()
+        fake_proc.pid = 1234
+        fake_proc.path = "C:\\app.exe"
+        fake_proc.name = "app.exe"
         fake_detect_result = MagicMock()
         fake_detect_result.to_dict.return_value = {
             "frameworks": ["wpf"],
             "methods": ["uia"],
             "recommended": "uia",
         }
-        with patch("naturo.detect.detect", return_value=fake_detect_result):
+        with (
+            patch("naturo.process.find_process", return_value=fake_proc),
+            patch("naturo.detect.detect", return_value=fake_detect_result),
+        ):
             result = _call_tool(server, "app_inspect", {"pid": 1234})
         data = json.loads(result[0].text)
         assert data["success"] is True


### PR DESCRIPTION
## What
`app_inspect({pid: <int>})` over MCP went straight to `detect()` for a directly-supplied PID, returning `success: true` with an empty `exe`/`app` plus a fabricated `framework` and a phantom `interaction_methods=[{method: vision}]` for **any** integer — including impossible values (0, -1, 999999, INT32_MAX). An agent enumerating PIDs to find a target would get `success:true` for every probe and burn cycles driving `capture_screen`/`click` against a process that does not exist. The CLI (`naturo app inspect --pid`) already validated; the MCP surface did not.

This violates the 'naturo never lies' architecture rule (SOUL.md): reported success must be real success.

## How
Mirror the CLI's validation in the directly-supplied-PID path of `naturo/mcp/_window.py`:
- `pid <= 0` → `INVALID_INPUT` ("PID must be a positive integer")
- process absent (`find_process(pid=pid) is None`) → `PROCESS_NOT_FOUND` ("The process may have exited")
- a validated process now feeds `exe`/`app` into `detect()`, so a real PID is no longer reported with an empty `exe`.

`detect()` is never reached for an invalid/absent PID.

## How tested
- New `tests/test_app_inspect_pid_validation_901.py` (7 cases, fully mocked → runs on Linux CI): non-positive PIDs → INVALID_INPUT; non-existent PIDs (1/999999/INT32_MAX) → PROCESS_NOT_FOUND with no phantom `framework`/`interaction_methods` and `detect` not called; a live PID → success with exe populated.
- Updated `tests/test_mcp_window.py::test_inspect_by_pid` to reflect the corrected contract (a direct PID must resolve to a live process).
- `test_app_inspect_pid_validation_901` + `test_mcp_window` + `test_no_desktop_guard_885` → 57 passed. `ruff check` clean; naturo code mypy-clean; collection-only succeeds (no Windows/optional deps).