### PR TITLE
fix: standardize browser launch -j to success envelope (fixes #879)

### DIFF
--- a/naturo/cli/_browser/lifecycle.py
+++ b/naturo/cli/_browser/lifecycle.py
@@ -67,7 +67,8 @@ def launch_cmd(ctx: click.Context, profile: Optional[str],
         )
         if json_output:
             click.echo(json_module.dumps({
-                "status": "ok",
+                "success": True,
+                "action": "browser_launch",
                 "pid": proc.pid,
                 "port": proc.port,
                 "profile": profile,

--- a/tests/test_browser_launcher.py
+++ b/tests/test_browser_launcher.py
@@ -461,9 +461,41 @@ class TestLaunchCli:
         result = runner.invoke(browser, ["launch", "--json"])
         assert result.exit_code == 0
         data = json.loads(result.output)
-        assert data["status"] == "ok"
+        # Standard success envelope (#879): success boolean, not status string.
+        assert data["success"] is True
+        assert "status" not in data
+        assert data["action"] == "browser_launch"
         assert data["pid"] == 999
         assert data["port"] == 9222
+        assert data["profile"] is None
+
+    @patch("naturo.browser._launcher.launch_chrome")
+    def test_launch_json_includes_profile(self, mock_launch, runner):
+        mock_proc = MagicMock()
+        mock_proc.pid = 999
+        mock_proc.port = 9222
+        mock_launch.return_value = mock_proc
+
+        result = runner.invoke(browser, ["launch", "--json", "--profile", "Work"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["success"] is True
+        assert data["profile"] == "Work"
+
+    @patch("naturo.browser._launcher.launch_chrome",
+           side_effect=RuntimeError("Chrome exited with code 0 before CDP became available"))
+    def test_launch_json_error_exits_nonzero(self, mock_launch, runner):
+        """A failed launch must emit the error envelope AND exit non-zero (#879).
+
+        Scripted callers rely on ``if naturo browser launch -j; then`` — a
+        zero exit code on failure makes the shell treat a broken launch as
+        success.
+        """
+        result = runner.invoke(browser, ["launch", "--json"])
+        assert result.exit_code != 0
+        data = json.loads(result.output)
+        assert data["success"] is False
+        assert "error" in data
 
     @patch("naturo.browser._launcher.launch_chrome", side_effect=FileNotFoundError("Chrome not found"))
     def test_launch_chrome_not_found_cli(self, mock_launch, runner):


### PR DESCRIPTION
## What

`naturo browser launch -j` emitted a non-standard `{"status": "ok", ...}` envelope on success, while every other `-j` command uses the standard `{"success": <bool>, ...}` contract. A scripter could not write one `jq '.success'` / error-check pattern across the CLI surface (same drift class as #876).

This changes the success output to:
```json
{"success": true, "action": "browser_launch", "pid": 74920, "port": 9222, "profile": null}
```

The **error path** was the P1 reliability concern (R134): it must emit `{"success": false, ...}` *and* exit non-zero so `if naturo browser launch -j; then` is safe. That already holds on current develop (`emit_exception_error` calls `sys.exit(1)`); this PR adds a regression test to lock it in.

> Note: this normalizes a CLI `-j` output shape. It is the exact change requested by QA (#879) toward the documented `success` envelope contract, not a new interface decision.

## How tested
- `tests/test_browser_launcher.py::TestLaunchCli` — 8 passed:
  - success `-j` now asserts `success: true`, `action`, `pid`, `port`, `profile`, and that `status` is gone
  - new `--profile` envelope test
  - new error-path test: `-j` failure exits non-zero with `success: false`
- `ruff check naturo/` clean; `mypy` clean on the changed file; `--collect-only` clean (no cross-platform collection break).
- Pre-existing Windows-local failures in `TestDefaultUserDataDir`/`TestListProfiles` are tracked separately (#946) and unrelated to this change.