### PR TITLE
fix: map MCP NaturoCoreError to typed codes without leaking class names (fixes #881)

### DIFF
--- a/naturo/mcp_server.py
+++ b/naturo/mcp_server.py
@@ -17,6 +17,7 @@ from mcp.server.fastmcp.exceptions import ToolError
 from mcp.types import ContentBlock
 
 from naturo.backends.base import get_backend, Backend
+from naturo.bridge import NaturoCoreError
 from naturo.errors import ErrorCode, NaturoError
 from naturo.process import launch_app as _launch_app
 
@@ -33,6 +34,44 @@ from naturo.mcp._system import register_system_tools
 from naturo.mcp._excel import register_excel_tools
 
 logger = logging.getLogger(__name__)
+
+# The MCP envelope's generic "something broke" code.  Mirrors the CLI's
+# catch-all; not part of the typed ErrorCode catalog because it carries no
+# actionable meaning beyond "unexpected internal failure".
+_INTERNAL_ERROR_CODE = "INTERNAL_ERROR"
+
+# (#881) ``NaturoCoreError`` carries only an integer native code; translate it
+# to the typed :class:`ErrorCode` catalog so MCP clients receive a documented
+# ``error.code`` instead of an opaque ``INTERNAL_ERROR``.  Native codes ``-2``
+# (System/COM error) and ``-4`` (buffer too small) have no more-specific typed
+# peer and honestly remain the generic internal-error code.
+_CORE_ERROR_CODE_MAP: dict[int, str] = {
+    -1: ErrorCode.INVALID_INPUT,   # Invalid argument
+    -3: ErrorCode.FILE_IO_ERROR,   # File I/O error
+}
+
+
+def _core_error_envelope(exc: NaturoCoreError) -> dict[str, Any]:
+    """Build a leak-free MCP error envelope for a bridge ``NaturoCoreError``.
+
+    The client-facing message uses the native error *description*
+    (:attr:`NaturoCoreError.ERROR_MESSAGES`) rather than ``str(exc)``.  The
+    latter embeds the failing call's context, which for keyboard/mouse
+    operations includes a ``repr()`` of the arguments (e.g. ``key_press('F1')``);
+    using only the description guarantees the message never exposes the
+    ``NaturoCoreError`` class name or argument values (#881).
+
+    Args:
+        exc: The bridge error raised by a native ``naturo_core`` call.
+
+    Returns:
+        A ``{"success": False, "error": {"code", "message"}}`` envelope whose
+        ``code`` is drawn from the typed :class:`ErrorCode` catalog when a
+        specific peer exists, and :data:`_INTERNAL_ERROR_CODE` otherwise.
+    """
+    code = _CORE_ERROR_CODE_MAP.get(exc.code, _INTERNAL_ERROR_CODE)
+    message = NaturoCoreError.ERROR_MESSAGES.get(exc.code, f"Unknown error ({exc.code})")
+    return {"success": False, "error": {"code": code, "message": message}}
 
 
 class _SanitizingFastMCP(FastMCP):
@@ -140,16 +179,24 @@ def create_server(host: str = "localhost", port: int = 3100) -> FastMCP:
                 if e.is_recoverable:
                     error_info["recoverable"] = True
                 return {"success": False, "error": error_info}
+            except NaturoCoreError as e:
+                # (#881) Map the native bridge error to a typed code and a
+                # message free of the C++/Python class name and argument repr,
+                # rather than leaking "NaturoCoreError: <op>(<args>): ...".
+                logger.exception("Core error in tool %s", fn.__name__)
+                return _core_error_envelope(e)
             except Exception as e:
                 # (#844) Catch Pydantic ValidationError separately to avoid
                 # leaking internal field paths, validator names, and raw repr.
-                msg = _format_validation_error(e) if _is_validation_error(e) else f"{type(e).__name__}: {e}"
-                code = "INVALID_INPUT" if _is_validation_error(e) else "INTERNAL_ERROR"
-                if code == "INTERNAL_ERROR":
-                    logger.exception("Unhandled error in tool %s", fn.__name__)
-                else:
+                if _is_validation_error(e):
+                    msg = _format_validation_error(e)
                     logger.warning("Validation error in tool %s: %s", fn.__name__, msg)
-                return {"success": False, "error": {"code": code, "message": msg}}
+                    return {"success": False, "error": {"code": ErrorCode.INVALID_INPUT, "message": msg}}
+                # (#881) Surface the message via str(e) — without the
+                # type(e).__name__ prefix that leaked exception class names
+                # (NaturoCoreError, TypeError, ValueError, …) to MCP clients.
+                logger.exception("Unhandled error in tool %s", fn.__name__)
+                return {"success": False, "error": {"code": _INTERNAL_ERROR_CODE, "message": str(e)}}
         return wrapper
 
     def _is_validation_error(exc: Exception) -> bool:

--- a/tests/test_mcp_error_mapping.py
+++ b/tests/test_mcp_error_mapping.py
@@ -1,0 +1,123 @@
+"""Tests for the MCP error-envelope mapping (#881).
+
+The MCP surface calls the same native ``naturo_core`` library as the CLI, but
+historically wrapped every non-``NaturoError`` failure into
+``{"code": "INTERNAL_ERROR", "message": "<ClassName>: <text>"}``.  That leaked
+the internal exception class name (``NaturoCoreError``, ``TypeError``, …) and,
+for keyboard/mouse failures, a ``repr()`` of the failing call's arguments
+(e.g. ``key_press('F1')``), and it collapsed every native error code into the
+single ``INTERNAL_ERROR`` bucket.
+
+These tests lock the contract:
+
+1. Bridge ``NaturoCoreError`` native codes map to the typed :class:`ErrorCode`
+   catalog where a specific peer exists.
+2. ``error.message`` never contains a Python/C++ exception class name.
+3. ``error.message`` never contains a ``repr()`` of the failing call's
+   arguments.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import MagicMock, patch
+
+from naturo.bridge import NaturoCoreError
+from naturo.errors import ErrorCode
+from naturo.mcp_server import _core_error_envelope, create_server
+
+
+def _call_tool(srv, name, args):
+    """Invoke an MCP tool through the server's async dispatch and return blocks."""
+    async def _run():
+        return await srv.call_tool(name, args)
+
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(_run())
+    finally:
+        loop.close()
+
+
+class TestCoreErrorEnvelope:
+    """Unit tests for the pure ``NaturoCoreError`` → envelope mapping."""
+
+    def test_invalid_argument_maps_to_invalid_input(self):
+        """Native code -1 (invalid argument) becomes the typed INVALID_INPUT."""
+        env = _core_error_envelope(NaturoCoreError(-1, "capture_window"))
+        assert env == {
+            "success": False,
+            "error": {"code": ErrorCode.INVALID_INPUT, "message": "Invalid argument"},
+        }
+
+    def test_system_com_error_maps_to_internal_error(self):
+        """Native code -2 has no specific typed peer; it stays INTERNAL_ERROR."""
+        env = _core_error_envelope(NaturoCoreError(-2, "capture_window"))
+        assert env["error"]["code"] == "INTERNAL_ERROR"
+        assert env["error"]["message"] == "System/COM error"
+
+    def test_file_io_error_maps_to_typed_code(self):
+        """Native code -3 (file I/O) becomes the typed FILE_IO_ERROR."""
+        env = _core_error_envelope(NaturoCoreError(-3, "save_capture"))
+        assert env["error"]["code"] == ErrorCode.FILE_IO_ERROR
+        assert env["error"]["message"] == "File I/O error"
+
+    def test_unknown_native_code_falls_back_cleanly(self):
+        """An unmapped native code degrades to INTERNAL_ERROR without leaking."""
+        env = _core_error_envelope(NaturoCoreError(-99, "weird_op"))
+        assert env["error"]["code"] == "INTERNAL_ERROR"
+        assert "NaturoCoreError" not in env["error"]["message"]
+        assert "weird_op" not in env["error"]["message"]
+
+    def test_message_never_leaks_class_name_or_arg_repr(self):
+        """The context may embed a repr of arguments; the message must not."""
+        env = _core_error_envelope(NaturoCoreError(-2, "key_press('F1')"))
+        message = env["error"]["message"]
+        assert "NaturoCoreError" not in message
+        assert "key_press" not in message
+        assert "F1" not in message
+
+
+class TestSafeToolMapping:
+    """End-to-end mapping through a real tool's ``_safe_tool`` wrapper."""
+
+    def test_core_error_through_tool_is_typed_and_clean(self):
+        """A NaturoCoreError raised inside a tool surfaces a typed, clean code."""
+        mock_backend = MagicMock()
+        mock_backend.capture_screen.side_effect = NaturoCoreError(-1, "capture_screen")
+        with patch("naturo.mcp_server.get_backend", return_value=mock_backend):
+            srv = create_server()
+            result = _call_tool(srv, "capture_screen", {})
+            data = json.loads(result[0].text)
+            assert data["success"] is False
+            assert data["error"]["code"] == ErrorCode.INVALID_INPUT
+            assert "NaturoCoreError" not in data["error"]["message"]
+
+    def test_press_key_core_error_hides_arg_repr(self):
+        """press_key failures must not echo the key argument or class name."""
+        mock_backend = MagicMock()
+        mock_backend.press_key.side_effect = NaturoCoreError(-2, "key_press('F1')")
+        with patch("naturo.mcp_server.get_backend", return_value=mock_backend):
+            srv = create_server()
+            result = _call_tool(srv, "press_key", {"key": "F1"})
+            data = json.loads(result[0].text)
+            assert data["success"] is False
+            assert data["error"]["code"] == "INTERNAL_ERROR"
+            message = data["error"]["message"]
+            assert "NaturoCoreError" not in message
+            assert "key_press" not in message
+            assert "F1" not in message
+
+    def test_generic_exception_drops_class_name_prefix(self):
+        """A non-validation exception keeps its text but loses the class prefix."""
+        mock_backend = MagicMock()
+        mock_backend.capture_screen.side_effect = TypeError(
+            "list_snapshots() got an unexpected keyword argument 'limit'"
+        )
+        with patch("naturo.mcp_server.get_backend", return_value=mock_backend):
+            srv = create_server()
+            result = _call_tool(srv, "capture_screen", {})
+            data = json.loads(result[0].text)
+            assert data["success"] is False
+            assert data["error"]["code"] == "INTERNAL_ERROR"
+            assert "TypeError" not in data["error"]["message"]

--- a/tests/test_mcp_error_mapping.py
+++ b/tests/test_mcp_error_mapping.py
@@ -22,9 +22,21 @@ import asyncio
 import json
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from naturo.bridge import NaturoCoreError
 from naturo.errors import ErrorCode
-from naturo.mcp_server import _core_error_envelope, create_server
+
+# Skip the whole module when the optional ``mcp`` dependency is absent: it is
+# not installed on the non-Windows CI runners, where importing ``mcp_server``
+# raises ImportError at collection time.  Mirrors the other MCP test modules.
+mcp_available = True
+try:
+    from naturo.mcp_server import _core_error_envelope, create_server
+except ImportError:
+    mcp_available = False
+
+pytestmark = pytest.mark.skipif(not mcp_available, reason="mcp package not installed")
 
 
 def _call_tool(srv, name, args):


### PR DESCRIPTION
## What

MCP tools wrapped every native `naturo_core` failure into `{\"code\": \"INTERNAL_ERROR\", \"message\": \"NaturoCoreError: <op>(<args>): <text>\"}`. That:

- leaked the internal `NaturoCoreError` C++/bridge class name to MCP clients,
- for keyboard/mouse ops, echoed a `repr()` of the failing call's arguments (e.g. `key_press('F1')`) into the message, and
- collapsed every native code into the single `INTERNAL_ERROR` bucket, so AI agents could not discriminate failure kinds programmatically.

This adds a mapping layer (`_core_error_envelope`) that translates `NaturoCoreError`'s native code to the typed `ErrorCode` catalog and builds a leak-free message from the native error *description* only.

| native code | meaning | mapped MCP `error.code` |
|---|---|---|
| -1 | Invalid argument | `INVALID_INPUT` |
| -3 | File I/O error | `FILE_IO_ERROR` |
| -2 | System/COM error | `INTERNAL_ERROR` (no typed peer — honest) |
| -4 | Buffer too small | `INTERNAL_ERROR` (no typed peer — honest) |

The generic `except Exception` branch also drops the `type(e).__name__` prefix, so `TypeError`/`ValueError`/etc. class names no longer leak either.

### Scope note

The `NO_DESKTOP_SESSION` headline case from the issue is already handled upstream: `_get_backend()` runs `_check_desktop_session()` as a pre-flight (#885), so no-desktop failures surface as `NO_DESKTOP_SESSION` before a native call ever runs. The native bridge only emits codes -1..-4 (no dedicated "no desktop" / "window not found" code), so those typed codes legitimately come from Python-side pre-flight checks, not from mapping `-2`. This PR closes the remaining gap: the class-name/arg-repr leak and the `-1`/`-3` bucketing.

## How tested

New `tests/test_mcp_error_mapping.py` (8 tests, all pass):
- pure `_core_error_envelope` mapping for -1/-2/-3 and an unknown code,
- message never contains `NaturoCoreError` or the arg `repr()`,
- end-to-end through a real tool's `_safe_tool` wrapper (typed code, clean message),
- generic non-validation exception drops the class-name prefix.

Local gate: `ruff check naturo/` clean; new tests + 276 MCP/related tests pass. (`mypy` and some snapshot/inspect tests fail locally due to pre-existing environment quirks — a `python_version=3.9` config vs the `mcp` dep's 3.10 syntax, and Windows `tmp_path` permission errors — both unrelated to this change and absent on CI's Linux runners.)