### PR TITLE
fix: resolve window_title to hwnd in MCP capture_window (fixes #954)

### DIFF
--- a/naturo/mcp/_capture.py
+++ b/naturo/mcp/_capture.py
@@ -57,7 +57,18 @@ def register_capture_tools(server, _get_backend, _safe_tool):
             Dict with path, width, height, format, scale_factor, dpi.
         """
         backend = _get_backend()
-        result = backend.capture_window(window_title=window_title, output_path=output_path)
+        # (#954) Resolve window_title to a concrete hwnd via the same path the
+        # CLI uses, so an unmatched title raises WindowNotFoundError (surfaced
+        # as success:false / WINDOW_NOT_FOUND) instead of silently capturing the
+        # foreground window and reporting success:true.  The Windows backend's
+        # capture_window does not implement title matching (a missing hwnd means
+        # the foreground window), so resolution must happen here — mirroring
+        # naturo/cli/core/_capture.py — to keep the CLI and MCP contracts aligned.
+        if window_title and hasattr(backend, "_resolve_hwnd"):
+            hwnd = backend._resolve_hwnd(window_title=window_title)
+            result = backend.capture_window(hwnd=hwnd, output_path=output_path)
+        else:
+            result = backend.capture_window(window_title=window_title, output_path=output_path)
         response = {
             "success": True,
             "path": result.path,

--- a/tests/test_mcp_capture.py
+++ b/tests/test_mcp_capture.py
@@ -136,6 +136,7 @@ class TestCaptureWindow:
         capture_result.format = "png"
         capture_result.scale_factor = 1.0
         capture_result.dpi = 96
+        mock_backend._resolve_hwnd.return_value = 999
         mock_backend.capture_window.return_value = capture_result
 
         result = _call_tool(server, "capture_window", {"window_title": "Notepad"})
@@ -144,8 +145,48 @@ class TestCaptureWindow:
         assert data["width"] == 800
         assert data["height"] == 600
         assert "data_base64" in data
+        # window_title is resolved to an hwnd before capture (#954).
         mock_backend.capture_window.assert_called_once_with(
-            window_title="Notepad", output_path="capture.png"
+            hwnd=999, output_path="capture.png"
+        )
+
+    def test_unmatched_window_title_returns_window_not_found(self, server, mock_backend):
+        """An unmatched window_title must fail loudly, not silently capture the
+        foreground window (#954 — silent failure / CLI↔MCP contract drift)."""
+        from naturo.errors import WindowNotFoundError
+
+        mock_backend._resolve_hwnd.side_effect = WindowNotFoundError("zzz_nonexistent_qa")
+
+        result = _call_tool(server, "capture_window", {"window_title": "zzz_nonexistent_qa"})
+        data = json.loads(result[0].text)
+        assert data["success"] is False
+        assert data["error"]["code"] == "WINDOW_NOT_FOUND"
+        assert "zzz_nonexistent_qa" in data["error"]["message"]
+        # The backend must never be asked to capture when resolution fails.
+        mock_backend.capture_window.assert_not_called()
+
+    def test_matched_window_title_captures_resolved_hwnd(self, server, mock_backend, tmp_path):
+        """A matched window_title must capture the resolved window by hwnd, not
+        pass the raw title (which the Windows backend ignores -> foreground)."""
+        png_file = tmp_path / "win.png"
+        png_file.write_bytes(b"\x89PNGdata")
+
+        capture_result = MagicMock()
+        capture_result.path = str(png_file)
+        capture_result.width = 800
+        capture_result.height = 600
+        capture_result.format = "png"
+        capture_result.scale_factor = 1.0
+        capture_result.dpi = 96
+        mock_backend._resolve_hwnd.return_value = 4242
+        mock_backend.capture_window.return_value = capture_result
+
+        result = _call_tool(server, "capture_window", {"window_title": "Notepad"})
+        data = json.loads(result[0].text)
+        assert data["success"] is True
+        mock_backend._resolve_hwnd.assert_called_once_with(window_title="Notepad")
+        mock_backend.capture_window.assert_called_once_with(
+            hwnd=4242, output_path="capture.png"
         )
 
     def test_captures_foreground_window(self, server, mock_backend):


### PR DESCRIPTION
## What
`MCP capture_window(window_title=...)` silently ignored its `window_title` argument and captured the **foreground window**, returning `success:true`. An AI agent calling `capture_window(window_title="Notepad")` received whatever window happened to be in front, with no way to detect the mismatch — a **silent failure** (violates the "Never Lie" iron rule) and a **CLI↔MCP contract drift**: the CLI correctly returns `WINDOW_NOT_FOUND`.

Root cause: the MCP tool passed `window_title` straight to the Windows backend's `capture_window`, which does not implement title matching (a missing hwnd ⇒ foreground window). The CLI avoids this by resolving the title to an hwnd via `backend._resolve_hwnd(...)` first.

## How
Mirror the CLI in `naturo/mcp/_capture.py`: when `window_title` is given, resolve it via `backend._resolve_hwnd(window_title=...)` before calling `capture_window(hwnd=...)`. An unmatched title raises `WindowNotFoundError`, which `_safe_tool` already surfaces as the same typed envelope the CLI emits:

```json
{"success": false, "error": {"code": "WINDOW_NOT_FOUND", "message": "Window not found: <title>", "recoverable": true}}
```

The no-title (foreground) path is unchanged. No public-API/tool-signature change.

## How tested
- New TDD regression tests in `tests/test_mcp_capture.py` (confirmed RED before the fix):
  - `test_unmatched_window_title_returns_window_not_found` — unmatched title ⇒ `success:false` / `WINDOW_NOT_FOUND`, backend never asked to capture.
  - `test_matched_window_title_captures_resolved_hwnd` — matched title ⇒ captures the resolved hwnd, not the raw title.
- Updated `test_captures_specific_window` for the resolve-then-capture contract.
- `ruff check naturo/` clean; changed file is mypy-clean.
- Full capture-adjacent suite (`test_mcp_capture`, `test_mcp_error_mapping`, `test_cli_capture`, `test_capture`): 53 passed.

Closes the unmet half of the "Expected" block in #881 (the `WINDOW_NOT_FOUND` case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)