### PR TITLE
fix: resolve window_title to one hwnd for MCP create_snapshot screenshot+tree (fixes #956)

### DIFF
--- a/naturo/mcp/_snapshot.py
+++ b/naturo/mcp/_snapshot.py
@@ -44,6 +44,23 @@ def register_snapshot_tools(server, _get_backend, _safe_tool):
         backend = _get_backend()
         manager = get_snapshot_manager()
 
+        # (#956) Resolve window_title to a concrete hwnd ONCE, before any
+        # snapshot is created, then feed the same hwnd to BOTH the screenshot
+        # capture and the element-tree build so they can never describe two
+        # different windows.  The Windows backend's capture_window does not
+        # implement title matching (a missing hwnd means the foreground
+        # window), whereas get_element_tree does — so passing the raw title to
+        # each independently let a matched, non-foreground title pair a
+        # foreground screenshot with the named window's tree and still report
+        # success:true (a silent data-integrity failure), and let an unmatched
+        # title leave an orphan foreground screenshot before get_element_tree
+        # raised WINDOW_NOT_FOUND.  Resolving up front mirrors the #954/#955
+        # capture_window fix and the CLI contract: an unmatched title now fails
+        # loudly (WINDOW_NOT_FOUND) before any snapshot is stored.
+        hwnd: Optional[int] = None
+        if window_title and hasattr(backend, "_resolve_hwnd"):
+            hwnd = backend._resolve_hwnd(window_title=window_title)
+
         # Create snapshot and capture
         snapshot_id = manager.create_snapshot()
 
@@ -52,7 +69,10 @@ def register_snapshot_tools(server, _get_backend, _safe_tool):
         with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:
             temp_path = f.name
         try:
-            backend.capture_window(window_title=window_title, output_path=temp_path)
+            if hwnd is not None:
+                backend.capture_window(hwnd=hwnd, output_path=temp_path)
+            else:
+                backend.capture_window(window_title=window_title, output_path=temp_path)
             manager.store_screenshot(snapshot_id, temp_path, metadata={
                 "window_title": window_title or "foreground",
             })
@@ -60,8 +80,12 @@ def register_snapshot_tools(server, _get_backend, _safe_tool):
             if os.path.exists(temp_path):
                 os.unlink(temp_path)
 
-        # Capture UI tree and store as flat element map
-        tree = backend.get_element_tree(window_title=window_title, depth=depth)
+        # Capture UI tree and store as flat element map.  Reuse the same hwnd so
+        # the tree describes the exact window the screenshot was taken of (#956).
+        if hwnd is not None:
+            tree = backend.get_element_tree(hwnd=hwnd, depth=depth)
+        else:
+            tree = backend.get_element_tree(window_title=window_title, depth=depth)
         if tree:
             from naturo.models.snapshot import UIElement
 

--- a/tests/test_mcp_snapshot.py
+++ b/tests/test_mcp_snapshot.py
@@ -148,15 +148,80 @@ class TestCreateSnapshot:
         mock_snapshot.screenshot_path = "/nonexistent/x.png"
         mock_manager.get_snapshot.return_value = mock_snapshot
 
+        mock_backend._resolve_hwnd.return_value = 1234
         mock_backend.get_element_tree.return_value = None
 
         with patch("naturo.snapshot.get_snapshot_manager", return_value=mock_manager):
             result = _call_tool(server, "create_snapshot", {"window_title": "Notepad"})
         data = json.loads(result[0].text)
         assert data["success"] is True
+        # window_title is resolved to an hwnd before capture (#956), mirroring
+        # the #954/#955 capture_window fix.
         mock_backend.capture_window.assert_called_once()
-        call_kwargs = mock_backend.capture_window.call_args
-        assert call_kwargs[1]["window_title"] == "Notepad"
+        assert mock_backend.capture_window.call_args[1]["hwnd"] == 1234
+
+    def test_matched_window_title_uses_same_hwnd_for_screenshot_and_tree(self, server, mock_backend):
+        """The screenshot and the element tree must describe the SAME window
+        (#956 — silent data-integrity failure).  A matched, non-foreground
+        window_title must resolve to one hwnd that is passed to BOTH
+        capture_window and get_element_tree, so they cannot diverge into a
+        foreground screenshot paired with the named window's tree."""
+        mock_manager = MagicMock()
+        mock_manager.create_snapshot.return_value = "snap-006"
+
+        mock_snapshot = MagicMock()
+        mock_snapshot.screenshot_path = "/nonexistent/x.png"
+        mock_manager.get_snapshot.return_value = mock_snapshot
+
+        mock_backend._resolve_hwnd.return_value = 4242
+        mock_backend.get_element_tree.return_value = None
+
+        with patch("naturo.snapshot.get_snapshot_manager", return_value=mock_manager):
+            result = _call_tool(server, "create_snapshot", {"window_title": "Notepad"})
+        data = json.loads(result[0].text)
+        assert data["success"] is True
+        mock_backend._resolve_hwnd.assert_called_once_with(window_title="Notepad")
+        assert mock_backend.capture_window.call_args[1]["hwnd"] == 4242
+        assert mock_backend.get_element_tree.call_args[1]["hwnd"] == 4242
+
+    def test_unmatched_window_title_fails_loudly_and_stores_no_snapshot(self, server, mock_backend):
+        """An unmatched window_title must fail with WINDOW_NOT_FOUND BEFORE any
+        snapshot is created — no orphan snapshot with a wrong-window screenshot
+        left behind (#956)."""
+        from naturo.errors import WindowNotFoundError
+
+        mock_manager = MagicMock()
+        mock_backend._resolve_hwnd.side_effect = WindowNotFoundError("zzz_nonexistent_qa")
+
+        with patch("naturo.snapshot.get_snapshot_manager", return_value=mock_manager):
+            result = _call_tool(server, "create_snapshot", {"window_title": "zzz_nonexistent_qa"})
+        data = json.loads(result[0].text)
+        assert data["success"] is False
+        assert data["error"]["code"] == "WINDOW_NOT_FOUND"
+        assert "zzz_nonexistent_qa" in data["error"]["message"]
+        # No screenshot captured and no orphan snapshot stored when resolution fails.
+        mock_backend.capture_window.assert_not_called()
+        mock_manager.create_snapshot.assert_not_called()
+
+    def test_foreground_snapshot_does_not_resolve_hwnd(self, server, mock_backend):
+        """With no window_title the foreground window is used directly — no hwnd
+        resolution, preserving the existing foreground contract (#956)."""
+        mock_manager = MagicMock()
+        mock_manager.create_snapshot.return_value = "snap-007"
+
+        mock_snapshot = MagicMock()
+        mock_snapshot.screenshot_path = "/nonexistent/x.png"
+        mock_manager.get_snapshot.return_value = mock_snapshot
+
+        mock_backend.get_element_tree.return_value = None
+
+        with patch("naturo.snapshot.get_snapshot_manager", return_value=mock_manager):
+            result = _call_tool(server, "create_snapshot", {})
+        data = json.loads(result[0].text)
+        assert data["success"] is True
+        mock_backend._resolve_hwnd.assert_not_called()
+        assert mock_backend.capture_window.call_args[1]["window_title"] is None
+        assert mock_backend.get_element_tree.call_args[1]["window_title"] is None
 
 
 class TestGetSnapshot:


### PR DESCRIPTION
## What

`create_snapshot` (MCP) resolved `window_title` **twice**: once via `capture_window(window_title=...)` and once via `get_element_tree(window_title=...)`. On the Windows backend `capture_window` does not implement title matching (a missing hwnd silently means the *foreground* window) while `get_element_tree` does. So for a matched, non-foreground title the snapshot bundled a **foreground screenshot** with the **named window's element tree** and still reported `success:true` — a silent data-integrity failure (same class as #954/#955). An unmatched title also left an orphan foreground screenshot before `get_element_tree` raised `WINDOW_NOT_FOUND`.

Fix: resolve `window_title` to a concrete `hwnd` **once** up front via `backend._resolve_hwnd`, then pass that same handle to **both** `capture_window(hwnd=...)` and `get_element_tree(hwnd=...)`. They can no longer describe two different windows. An unmatched title now fails loudly with `WINDOW_NOT_FOUND` **before any snapshot is stored**. The foreground path (no `window_title`) is unchanged, and backends without `_resolve_hwnd` fall back to prior behavior.

## How tested

- New unit tests in `tests/test_mcp_snapshot.py`:
  - matched title resolves to one hwnd passed to *both* capture and tree;
  - unmatched title → `success:false`/`WINDOW_NOT_FOUND`, no snapshot created, `capture_window` not called;
  - foreground (no title) → no `_resolve_hwnd` call, both calls use `window_title=None`.
- `tests/test_mcp_snapshot.py`: 17 passed.
- `ruff check naturo/`: clean. mypy on changed file: clean (`--follow-imports=skip`; repo-wide mypy has a pre-existing local-env issue with the third-party `mcp` package under py3.9 target).

Closes the #954/#956 silent-fallback class for the snapshot surface.