### PR TITLE
feat: env-gated input-content safety guard for naturo type (fixes #960)

### DIFF
--- a/agents/local/runner.ps1
+++ b/agents/local/runner.ps1
@@ -40,7 +40,7 @@ New-Item -ItemType Directory -Force -Path $WorkDir | Out-Null
 
 switch ($Role) {
   'dev'  { $Wt = 'C:\Users\Naturobot\naturo-dev'; $Cycle = 'agents/local/dev-cycle.md' }
-  'qa'   { $Wt = 'C:\Users\Naturobot\naturo-qa';  $Cycle = 'agents/local/qa-cycle.md' }
+  'qa'   { $Wt = 'C:\Users\Naturobot\naturo-qa';  $Cycle = 'agents/local/qa-cycle.md'; $env:NATURO_SAFE_INPUT = '1' }  # (#960) code-enforced input-content guard for the unattended QA loop
   'orch' { $Wt = $Main;                           $Cycle = 'agents/local/orch-review.md' }
 }
 

--- a/naturo/cli/interaction/_type.py
+++ b/naturo/cli/interaction/_type.py
@@ -132,6 +132,24 @@ def type_cmd(text, delay, profile, wpm, press_return, tab_count, escape,
         _common._json_err(f"--wpm must be >= 1, got {wpm}", json_output, code="INVALID_INPUT")
         return
 
+    # (#960) Opt-in input-content safety guard. When NATURO_SAFE_INPUT=1 is set
+    # (the unattended QA loop), refuse to inject text that looks like a shell
+    # command — a SendInput focus race could otherwise deliver a destructive
+    # fragment (e.g. "$(rm -rf /)") to a terminal. Validates the final resolved
+    # content, so it also covers --paste/--file. Normal users (env unset) are
+    # unaffected.
+    if text is not None:
+        from naturo.safety import unsafe_input_reason
+        _unsafe = unsafe_input_reason(text)
+        if _unsafe:
+            _common._json_err(
+                f"Refusing to inject unsafe content ({_unsafe}) because "
+                f"NATURO_SAFE_INPUT=1 is set. Nothing was typed.",
+                json_output,
+                code="UNSAFE_INPUT_BLOCKED",
+            )
+            return
+
     backend = _common._get_backend(json_output)
 
     # Auto-routing: detect best interaction method for target app

--- a/naturo/mcp/_input.py
+++ b/naturo/mcp/_input.py
@@ -88,6 +88,22 @@ def register_input_tools(server, _get_backend, _safe_tool):
         """
         if wpm < 1:
             return {"success": False, "error": {"code": "INVALID_INPUT", "message": f"wpm must be >= 1, got {wpm}"}}
+        # (#960) Opt-in input-content safety guard. When NATURO_SAFE_INPUT=1 is
+        # set (the unattended QA loop), refuse to inject shell-command-like
+        # text — a SendInput focus race could otherwise deliver a destructive
+        # fragment (e.g. "$(rm -rf /)") to a terminal. Normal users (env unset)
+        # are unaffected.
+        from naturo.safety import unsafe_input_reason
+        unsafe = unsafe_input_reason(text)
+        if unsafe:
+            return {
+                "success": False,
+                "error": {
+                    "code": "UNSAFE_INPUT_BLOCKED",
+                    "message": f"Refusing to inject unsafe content ({unsafe}) because "
+                    f"NATURO_SAFE_INPUT=1 is set. Nothing was typed.",
+                },
+            }
         backend = _get_backend()
         backend.type_text(text=text, wpm=wpm, input_mode=input_mode)
         return {"success": True}

--- a/naturo/safety.py
+++ b/naturo/safety.py
@@ -1,0 +1,91 @@
+"""Opt-in input-content safety guard for unattended/agent sessions (#960).
+
+``SendInput`` is global: it delivers keystrokes to whatever window owns the
+foreground at the moment of injection.  In an unattended automation loop a focus
+race can therefore route part of a keystroke stream to the *wrong* window —
+including a terminal.  An autonomous QA agent once improvised a
+``"test$(rm -rf /)"`` probe string and a truncated ``est$(rm -rf /)`` fragment
+was observed reaching a command line.  Had a runnable fragment landed followed
+by Enter, it could have wiped the machine.
+
+Instruction-level guardrails are necessary but not sufficient once an agent can
+improvise input, so this module adds *code* enforcement.  It is strictly
+opt-in: the guard activates only when ``NATURO_SAFE_INPUT=1`` is set in the
+environment (the unattended QA role sets it).  Normal users — for whom typing
+shell commands into an editor is a legitimate use of a general automation tool —
+are unaffected when the variable is unset.
+
+The matcher is deliberately conservative: for a destructive-command blocker a
+false positive (refusing a benign-but-suspicious string in a QA probe) is
+cheap, while a false negative is catastrophic.
+"""
+from __future__ import annotations
+
+import os
+import re
+from typing import Optional
+
+#: Environment variable that, when set to ``"1"``, enables the input guard.
+SAFE_INPUT_ENV = "NATURO_SAFE_INPUT"
+
+#: Error code returned when injection is refused because the content is unsafe.
+UNSAFE_INPUT_CODE = "UNSAFE_INPUT_BLOCKED"
+
+# Dangerous content patterns, paired with a human-readable reason for the error
+# message.  Order matters only for which reason is reported first; the more
+# specific shell operators precede the generic single-character ones so the
+# message is as descriptive as possible.  Command verbs use word boundaries so
+# benign substrings ("warm", "delete", "reformatted") do not trip the guard.
+_DANGEROUS_PATTERNS: tuple[tuple[str, "re.Pattern[str]"], ...] = (
+    ("command substitution '$(...)'", re.compile(r"\$\(")),
+    ("backtick command substitution", re.compile(r"`")),
+    ("logical AND '&&'", re.compile(r"&&")),
+    ("logical OR '||'", re.compile(r"\|\|")),
+    ("command separator ';'", re.compile(r";")),
+    ("pipe '|'", re.compile(r"\|")),
+    ("output redirect '>'", re.compile(r">")),
+    ("input redirect '<'", re.compile(r"<")),
+    ("destructive command 'rm'", re.compile(r"\brm\b", re.IGNORECASE)),
+    ("destructive command 'rmdir'", re.compile(r"\brmdir\b", re.IGNORECASE)),
+    ("destructive command 'del'", re.compile(r"\bdel\b", re.IGNORECASE)),
+    ("destructive command 'format'", re.compile(r"\bformat\b", re.IGNORECASE)),
+    ("destructive command 'shutdown'", re.compile(r"\bshutdown\b", re.IGNORECASE)),
+    ("privilege escalation 'sudo'", re.compile(r"\bsudo\b", re.IGNORECASE)),
+)
+
+
+def is_safe_input_enabled() -> bool:
+    """Return whether the opt-in input-content guard is active.
+
+    Returns:
+        ``True`` only when the ``NATURO_SAFE_INPUT`` environment variable is
+        exactly ``"1"``.  Any other value (including unset) leaves the guard
+        disabled so normal users are never affected.
+    """
+    return os.environ.get(SAFE_INPUT_ENV) == "1"
+
+
+def unsafe_input_reason(text: Optional[str]) -> Optional[str]:
+    """Return why ``text`` is unsafe to inject, or ``None`` if it may proceed.
+
+    The guard is a no-op (always returns ``None``) when
+    ``NATURO_SAFE_INPUT`` is not set to ``"1"``, so callers can invoke this
+    unconditionally before typing/pasting without affecting normal users.
+
+    Args:
+        text: The literal content that would be injected as keystrokes (or via
+            clipboard paste).  ``None`` or empty text is always safe.
+
+    Returns:
+        A short human-readable reason (e.g. ``"destructive command 'rm'"``)
+        when the guard is enabled and the content matches a dangerous pattern;
+        otherwise ``None``.
+    """
+    if not is_safe_input_enabled():
+        return None
+    if not text:
+        return None
+    for reason, pattern in _DANGEROUS_PATTERNS:
+        if pattern.search(text):
+            return reason
+    return None

--- a/tests/test_safe_input_guard.py
+++ b/tests/test_safe_input_guard.py
@@ -1,0 +1,207 @@
+"""Tests for the opt-in input-content safety guard (naturo.safety, #960).
+
+The guard refuses to inject shell-command-like keystrokes when
+``NATURO_SAFE_INPUT=1`` is set, so a focus race in an unattended QA loop cannot
+deliver a destructive fragment (e.g. ``$(rm -rf /)``) to a terminal.  Normal
+users (env unset) must be completely unaffected.
+
+All tests are pure-Python (no desktop, no DLL) and run on Linux CI.
+"""
+from __future__ import annotations
+
+import json
+from unittest import mock
+
+import pytest
+
+from naturo.safety import (
+    SAFE_INPUT_ENV,
+    UNSAFE_INPUT_CODE,
+    is_safe_input_enabled,
+    unsafe_input_reason,
+)
+
+
+def _enabled():
+    return mock.patch.dict("os.environ", {SAFE_INPUT_ENV: "1"})
+
+
+class TestEnvGating:
+
+    def test_disabled_when_unset(self):
+        with mock.patch.dict("os.environ", {}, clear=True):
+            assert is_safe_input_enabled() is False
+            # Even an obviously dangerous string passes when the guard is off.
+            assert unsafe_input_reason("test$(rm -rf /)") is None
+
+    def test_disabled_when_not_exactly_one(self):
+        for value in ("0", "true", "yes", "2", ""):
+            with mock.patch.dict("os.environ", {SAFE_INPUT_ENV: value}, clear=True):
+                assert is_safe_input_enabled() is False
+                assert unsafe_input_reason("rm -rf /") is None
+
+    def test_enabled_when_exactly_one(self):
+        with _enabled():
+            assert is_safe_input_enabled() is True
+
+
+class TestBlocksDangerousContent:
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "test$(rm -rf /)",          # the exact near-miss from the report
+            "echo `whoami`",            # backtick command substitution
+            "foo && rm bar",            # logical AND + rm
+            "a || b",                   # logical OR
+            "first; second",            # command separator
+            "cat x | grep y",           # pipe
+            "echo hi > file",           # output redirect
+            "cmd < input",              # input redirect
+            "rm important.txt",         # rm verb
+            "rmdir folder",             # rmdir verb
+            "del C:\\file",             # del verb
+            "format C:",                # format verb
+            "shutdown /s",              # shutdown verb
+            "sudo reboot",              # sudo verb
+            "RM -RF /",                 # case-insensitive
+        ],
+    )
+    def test_dangerous_blocked_when_enabled(self, text):
+        with _enabled():
+            reason = unsafe_input_reason(text)
+            assert reason is not None, f"expected {text!r} to be blocked"
+            assert isinstance(reason, str) and reason
+
+
+class TestAllowsBenignContent:
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "QA_PROBE",
+            "Hello World",
+            "The quick brown fox.",
+            "warm welcome and a delete-free paragraph",  # substrings, not commands
+            "reformatted the document",                  # 'format' as substring
+            "user@example.com",
+            "Price: 100 dollars",
+            "naturo automates Windows",
+            "",
+            "12345",
+        ],
+    )
+    def test_benign_allowed_when_enabled(self, text):
+        with _enabled():
+            assert unsafe_input_reason(text) is None
+
+    def test_none_is_safe(self):
+        with _enabled():
+            assert unsafe_input_reason(None) is None
+
+
+def test_code_constant_value():
+    """The error code is the stable contract QA/agents key off."""
+    assert UNSAFE_INPUT_CODE == "UNSAFE_INPUT_BLOCKED"
+
+
+# ── Integration: CLI `naturo type` ───────────────────────────────────
+
+
+class TestCliTypeGuard:
+
+    def _invoke(self, args, backend):
+        from click.testing import CliRunner
+
+        from naturo.cli.interaction._type import type_cmd
+
+        with mock.patch(
+            "naturo.cli.interaction._common._resolve_app_id",
+            return_value=(None, None, None),
+        ), mock.patch(
+            "naturo.cli.interaction._common._get_backend", return_value=backend
+        ), mock.patch(
+            "naturo.cli.interaction._common._auto_route", return_value={}
+        ):
+            return CliRunner().invoke(type_cmd, args, catch_exceptions=False)
+
+    def test_blocks_dangerous_when_enabled(self):
+        from unittest.mock import MagicMock
+
+        backend = MagicMock()
+        with _enabled():
+            result = self._invoke(["test$(rm -rf /)", "-j"], backend)
+        assert result.exit_code == 1
+        payload = json.loads(result.output)
+        assert payload["success"] is False
+        assert payload["error"]["code"] == "UNSAFE_INPUT_BLOCKED"
+        # Nothing was injected.
+        backend.type_text.assert_not_called()
+
+    def test_allows_dangerous_when_disabled(self):
+        from unittest.mock import MagicMock
+
+        backend = MagicMock()
+        with mock.patch.dict("os.environ", {}, clear=True):
+            result = self._invoke(["test$(rm -rf /)", "-j"], backend)
+        assert result.exit_code == 0
+        backend.type_text.assert_called_once()
+
+    def test_allows_benign_when_enabled(self):
+        from unittest.mock import MagicMock
+
+        backend = MagicMock()
+        with _enabled():
+            result = self._invoke(["QA_PROBE", "-j"], backend)
+        assert result.exit_code == 0
+        backend.type_text.assert_called_once()
+
+
+# ── Integration: MCP `type` tool ─────────────────────────────────────
+
+mcp_available = True
+try:
+    from naturo.mcp_server import create_server
+except ImportError:  # pragma: no cover - mcp optional on some lanes
+    mcp_available = False
+
+
+@pytest.mark.skipif(not mcp_available, reason="mcp package not installed")
+class TestMcpTypeGuard:
+
+    def _call(self, server, arguments):
+        import asyncio
+
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(server.call_tool("type_text", arguments))
+        finally:
+            loop.close()
+
+    def _server(self, backend):
+        return mock.patch("naturo.mcp_server.get_backend", return_value=backend)
+
+    def test_blocks_dangerous_when_enabled(self):
+        from unittest.mock import MagicMock
+
+        backend = MagicMock()
+        with self._server(backend):
+            server = create_server()
+            with _enabled():
+                result = self._call(server, {"text": "test$(rm -rf /)"})
+        data = json.loads(result[0].text)
+        assert data["success"] is False
+        assert data["error"]["code"] == "UNSAFE_INPUT_BLOCKED"
+        backend.type_text.assert_not_called()
+
+    def test_allows_dangerous_when_disabled(self):
+        from unittest.mock import MagicMock
+
+        backend = MagicMock()
+        with self._server(backend):
+            server = create_server()
+            with mock.patch.dict("os.environ", {}, clear=True):
+                result = self._call(server, {"text": "test$(rm -rf /)"})
+        data = json.loads(result[0].text)
+        assert data["success"] is True
+        backend.type_text.assert_called_once()


### PR DESCRIPTION
## What
Adds an **opt-in, code-enforced** input-content safety guard for `naturo type` (CLI **and** the MCP `type` tool), closing #960 (P0 SAFETY).

`SendInput` is global — a focus race in the unattended QA loop can deliver part of a keystroke stream to the **wrong** foreground window, including a terminal. An autonomous QA agent once improvised a `"test$(rm -rf /)"` probe and a truncated `est$(rm -rf /)` fragment was observed reaching a command line. Instruction-level guardrails are necessary but not sufficient once an agent can improvise input, so this adds **code** enforcement.

- New `naturo/safety.py`: `unsafe_input_reason(text)` returns a reason string only when `NATURO_SAFE_INPUT=1` **and** the content matches a dangerous pattern (shell metacharacters `$(` `` ` `` `;` `&&` `||` `|` `>` `<`, and destructive command verbs `rm`/`rmdir`/`del`/`format`/`shutdown`/`sudo`). Conservative by design — for a destructive-command blocker a false positive is cheap, a false negative catastrophic.
- CLI `type` and MCP `type` refuse to inject when the guard fires, returning `UNSAFE_INPUT_BLOCKED` (exit 1 / `isError`) and typing **nothing**.
- `agents/local/runner.ps1` exports `NATURO_SAFE_INPUT=1` for the **qa** role only.

**Normal users (env unset) are completely unaffected** — naturo still types arbitrary text, including code and commands into editors. The guard is QA-only.

## How tested
- `naturo/safety.py` is ruff-clean and passes `mypy --strict` (py3.9) in isolation.
- New `tests/test_safe_input_guard.py` (35 tests, all CI-safe, no desktop):
  - Env gating: disabled unless `NATURO_SAFE_INPUT=1` exactly; dangerous strings pass when off.
  - Pattern matcher: 15 dangerous strings blocked (incl. the exact `test$(rm -rf /)` near-miss, case-insensitive), 10 benign strings allowed (incl. substring traps like "warm", "reformatted").
  - CLI integration: blocked→exit 1 + `UNSAFE_INPUT_BLOCKED` + `type_text` not called; disabled→types; benign→types.
  - MCP integration: blocked→`success:false` + `UNSAFE_INPUT_BLOCKED` + `type_text` not called; disabled→types.
- Regression: `test_cli_type` + `test_mcp_input` + `test_type_paste_and_on` + `test_type_newline_840` — 130 passed.

## Acceptance (from #960)
- [x] `NATURO_SAFE_INPUT=1` → `naturo type "test$(rm -rf /)"` → `UNSAFE_INPUT_BLOCKED`, types nothing
- [x] benign `QA_PROBE` still types fine
- [x] env unset → behavior unchanged
- [x] unit tests for the pattern matcher (no desktop)
- [x] runner exports the env for the qa role

🤖 Generated with [Claude Code](https://claude.com/claude-code)