### PR TITLE
docs: one-line MCP install snippets for Claude Code / Cursor / VS Code / Windsurf (fixes #927)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,37 @@ pip install naturo
 
 Naturo includes a built-in [MCP](https://modelcontextprotocol.io/) server with 60+ tools for AI agent integration.
 
-### Claude Desktop / Claude Code
+### Quick install (one line)
+
+After `pip install naturo`, connect naturo to your agent with a single copy-paste command:
+
+**Claude Code**
+
+```bash
+claude mcp add naturo -- naturo mcp start
+```
+
+**VS Code** (GitHub Copilot / MCP)
+
+```bash
+code --add-mcp '{"name":"naturo","command":"naturo","args":["mcp","start"]}'
+```
+
+**Cursor** — add to `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` (per project):
+
+```json
+{ "mcpServers": { "naturo": { "command": "naturo", "args": ["mcp", "start"] } } }
+```
+
+**Windsurf** — add to `~/.codeium/windsurf/mcp_config.json`:
+
+```json
+{ "mcpServers": { "naturo": { "command": "naturo", "args": ["mcp", "start"] } } }
+```
+
+> `naturo` must be on your `PATH` — it is after `pip install naturo`. Restart the client after editing a JSON config so it picks up the new server.
+
+### Claude Desktop (manual config)
 
 Add to your Claude configuration file (`claude_desktop_config.json`):
 

--- a/tests/test_readme_mcp_install.py
+++ b/tests/test_readme_mcp_install.py
@@ -1,0 +1,54 @@
+"""Regression guard for the one-line MCP install snippets in the README.
+
+A first-time user must be able to connect naturo to their agent by copying a
+single command (issue #927). These tests assert that the README keeps a
+copy-paste install block for every supported client and that the commands the
+block advertises map to a real CLI invocation, so the snippets cannot silently
+drift away from the actual `naturo mcp start` entry point.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from naturo.cli import main
+
+_README = Path(__file__).resolve().parent.parent / "README.md"
+
+
+def _readme_text() -> str:
+    return _README.read_text(encoding="utf-8")
+
+
+def test_readme_exists() -> None:
+    assert _README.is_file(), "README.md must exist at the repository root"
+
+
+def test_advertised_command_is_real() -> None:
+    """The documented `naturo mcp start` command must exist in the CLI."""
+    assert "mcp" in main.commands, "CLI must expose an 'mcp' command group"
+    mcp_group = main.commands["mcp"]
+    assert "start" in getattr(mcp_group, "commands", {}), (
+        "CLI must expose 'mcp start'; the README install snippets reference it"
+    )
+
+
+def test_readme_has_one_line_claude_code_install() -> None:
+    """Claude Code gets a true one-liner via `claude mcp add`."""
+    text = _readme_text()
+    assert "claude mcp add naturo -- naturo mcp start" in text
+
+
+def test_readme_has_per_client_install_blocks() -> None:
+    """Every supported client must have a copy-paste install snippet."""
+    text = _readme_text()
+    for client in ("Claude Code", "Cursor", "VS Code", "Windsurf"):
+        assert client in text, f"README is missing an install snippet for {client}"
+
+
+def test_readme_install_snippets_use_canonical_command() -> None:
+    """All snippets must launch the server via the canonical entry point."""
+    text = _readme_text()
+    # stdio clients (Cursor / VS Code / Windsurf) configure command+args
+    assert '"command": "naturo"' in text
+    assert '"args": ["mcp", "start"]' in text


### PR DESCRIPTION
## What
Adds a **Quick install (one line)** block at the top of the MCP Server Setup section so a first-time user can connect naturo to their agent with a single copy-paste command, instead of hand-editing a JSON config (issue #927, P1, competitiveness).

- **Claude Code**: `claude mcp add naturo -- naturo mcp start`
- **VS Code**: `code --add-mcp '{...}'`
- **Cursor**: ready-to-paste `mcpServers` JSON + config-file path (`~/.cursor/mcp.json`)
- **Windsurf**: ready-to-paste `mcpServers` JSON + config-file path (`~/.codeium/windsurf/mcp_config.json`)

All snippets launch the server via the canonical `naturo mcp start` entry point (already used by the existing Claude Desktop config and registered in the CLI). The old heading is renamed to **Claude Desktop (manual config)**; no content removed.

## How tested
- New `tests/test_readme_mcp_install.py` (non-desktop) asserts: every supported client keeps a copy-paste snippet, the one-liner is present, snippets use the canonical command, and `naturo mcp start` maps to a real CLI invocation (`main.commands['mcp'].commands['start']`) — so docs cannot silently drift from the entry point.
- `python -m ruff check` clean; new test `5 passed`; collection clean.
- Docs-only change (README + one isolated test); no production code touched.