### PR TITLE
fix: CLI get/set --window <unmatched> must fail loudly, not foreground (fixes #964)

### DIFF
--- a/naturo/backends/windows/_element/_tree.py
+++ b/naturo/backends/windows/_element/_tree.py
@@ -400,20 +400,16 @@ class ElementTreeMixin:
                     f"Run 'naturo see' first to capture elements."
                 )
 
-        # Resolve app/window_title to HWND for targeted lookup
+        # Resolve app/window_title to HWND for targeted lookup. A selector that
+        # is supplied but matches nothing must fail loudly: ``_resolve_hwnd``
+        # raises WindowNotFoundError and we let it propagate, rather than
+        # swallowing it and degrading to the foreground window (HWND 0). The old
+        # ``except`` + manual title scan only ever reproduced ``_resolve_hwnd``'s
+        # own substring matching, so a raise meant no window matched anywhere —
+        # falling back to the focused window was the silent-failure bug #964
+        # (the CLI analog of the MCP #957 ``require_hwnd`` contract).
         if (app or window_title) and not target_hwnd:
-            try:
-                target_hwnd = self._resolve_hwnd(
-                    app=app, window_title=window_title
-                )
-            except Exception:
-                # Fall back to scanning windows manually
-                if window_title:
-                    wins = core.list_windows()
-                    for w in wins:
-                        if window_title.lower() in (w.title or "").lower():
-                            target_hwnd = w.hwnd
-                            break
+            target_hwnd = self._resolve_hwnd(app=app, window_title=window_title)
 
         if not resolved_aid and not resolved_role and not resolved_name:
             # (#242) Fallback: when no element identifiers are provided but

--- a/naturo/cli/values/_set.py
+++ b/naturo/cli/values/_set.py
@@ -243,26 +243,29 @@ def set_cmd(ctx, target, value, ref, automation_id, role, name, toggle,
 
 
 def _resolve_hwnd(backend, app, window_title):
-    """Resolve app/window_title to a window handle.
+    """Resolve an explicitly-supplied app/window_title selector to a handle.
+
+    Called only when ``app`` or ``window_title`` was provided, so an unmatched
+    selector is an error, not a cue to fall back to the foreground window:
+    ``backend._resolve_hwnd`` raises :class:`~naturo.errors.WindowNotFoundError`
+    on no match and the exception propagates to the command's error handler,
+    which emits a ``WINDOW_NOT_FOUND`` envelope. Swallowing it and returning
+    ``0`` (foreground) was the silent-failure bug #964 — for ``set`` it wrote
+    the value to whatever window happened to be focused. Mirrors the MCP #957
+    ``require_hwnd`` loud-failure contract.
 
     Args:
         backend: Backend instance.
-        app: Application name.
-        window_title: Window title pattern.
+        app: Application name (partial match), or ``None``.
+        window_title: Window title pattern (partial match), or ``None``.
 
     Returns:
-        Window handle (int), or 0 if not resolved.
+        The resolved window handle (int).
+
+    Raises:
+        WindowNotFoundError: When the supplied selector matches no window.
     """
-    try:
-        return backend._resolve_hwnd(app=app, window_title=window_title)
-    except Exception:
-        if window_title:
-            core = backend._ensure_core()
-            wins = core.list_windows()
-            for w in wins:
-                if window_title.lower() in (w.title or "").lower():
-                    return w.hwnd
-    return 0
+    return backend._resolve_hwnd(app=app, window_title=window_title)
 
 
 def _do_set_value(backend, hwnd, automation_id, role, name, ref, value,

--- a/tests/test_window_selector_loud_failure_964.py
+++ b/tests/test_window_selector_loud_failure_964.py
@@ -1,0 +1,111 @@
+"""Loud-failure contract for CLI ``get`` / ``set`` window-selector resolution (#964).
+
+Silent-failure class (same family as #957, fixed for the MCP surface): a command
+accepts ``--window <title>``, fails to resolve it, and *silently* falls back to
+the foreground window — returning success against whatever happens to be focused.
+For ``set`` this writes to the wrong window (data-integrity hazard).
+
+Both surfaces shared the same defect: ``backend._resolve_hwnd`` raises
+:class:`~naturo.errors.WindowNotFoundError` on no match, but the call sites
+wrapped it in ``except Exception`` and degraded to ``target_hwnd = 0``
+(foreground). The fix routes both through the resolver without swallowing, so an
+explicitly-provided selector that matches nothing fails loudly with
+``WINDOW_NOT_FOUND`` — mirroring the sibling ``capture --window`` and the #957
+``require_hwnd`` contract. These tests run cross-platform (no DLL/desktop): the
+backend is mocked so its resolver raises exactly as the real one does.
+
+Closes #964.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from click.testing import CliRunner
+
+from naturo.errors import WindowNotFoundError
+
+# A window title guaranteed not to match any real window.
+_BOGUS_TITLE = "__no_such_window_zzz_964__"
+
+
+def test_get_backend_unmatched_window_title_raises_not_foreground():
+    """``get_element_value`` must re-raise WindowNotFoundError, never read the
+    foreground window when a window_title was given but resolves to nothing."""
+    from naturo.backends.windows._element._tree import ElementTreeMixin
+
+    class _Harness(ElementTreeMixin):
+        """Minimal ElementTreeMixin host with a resolver that mimics the real
+        backend: an unmatched window_title raises WindowNotFoundError."""
+
+        def __init__(self) -> None:
+            self._core = MagicMock()
+            self._core.list_windows.return_value = []
+
+        def _ensure_core(self):
+            return self._core
+
+        def _resolve_hwnd(self, app=None, window_title=None):
+            raise WindowNotFoundError(window_title or app or "")
+
+    harness = _Harness()
+    with pytest.raises(WindowNotFoundError):
+        harness.get_element_value(
+            automation_id="AddButton", window_title=_BOGUS_TITLE
+        )
+    # The foreground value lookup must never be reached on a bogus selector.
+    harness._core.get_element_value.assert_not_called()
+
+
+def _invoke(command, args, backend, monkeypatch, module):
+    """Run a CLI *command* with a mocked backend, on a simulated Windows host."""
+    monkeypatch.setattr(module, "_get_backend", lambda: backend)
+    monkeypatch.setattr(module.platform, "system", lambda: "Windows")
+    return CliRunner().invoke(command, args)
+
+
+def _make_backend():
+    backend = MagicMock()
+    backend._resolve_hwnd.side_effect = WindowNotFoundError(_BOGUS_TITLE)
+    backend._ensure_core.return_value.list_windows.return_value = []
+    return backend
+
+
+def test_cli_set_unmatched_window_fails_loud(monkeypatch):
+    """``set --window <unmatched>`` must emit WINDOW_NOT_FOUND, never write to
+    the foreground window."""
+    import naturo.cli.values._set as set_mod
+
+    backend = _make_backend()
+    result = _invoke(
+        set_mod.set_cmd,
+        ["AddButton", "hello", "--window", _BOGUS_TITLE, "-j"],
+        backend,
+        monkeypatch,
+        set_mod,
+    )
+    payload = json.loads(result.output)
+    assert payload.get("success") is False, (
+        f"set fell back to the foreground on a bogus --window: {payload}"
+    )
+    assert payload.get("error", {}).get("code") == "WINDOW_NOT_FOUND", payload
+    backend.set_element_value.assert_not_called()
+
+
+def test_cli_get_unmatched_window_fails_loud(monkeypatch):
+    """``get --window <unmatched>`` must emit WINDOW_NOT_FOUND end-to-end."""
+    import naturo.cli.values._get as get_mod
+
+    backend = _make_backend()
+    backend.get_element_value.side_effect = WindowNotFoundError(_BOGUS_TITLE)
+    result = _invoke(
+        get_mod.get_cmd,
+        ["AddButton", "--window", _BOGUS_TITLE, "-j"],
+        backend,
+        monkeypatch,
+        get_mod,
+    )
+    payload = json.loads(result.output)
+    assert payload.get("success") is False, payload
+    assert payload.get("error", {}).get("code") == "WINDOW_NOT_FOUND", payload


### PR DESCRIPTION
## What
`naturo get` / `set --window <title>` silently fell back to the **foreground window** when the title matched nothing, returning `success`. For `set` this **wrote the value to the wrong window** — a data-integrity hazard (silent-failure, the worst bug class). The sibling `capture --window` and the MCP #957 contract already fail loudly with `WINDOW_NOT_FOUND` for the same input.

Both surfaces shared one defect: `backend._resolve_hwnd` *does* raise `WindowNotFoundError` on no match, but the two call sites wrapped it in `except Exception` and degraded to `target_hwnd = 0` (foreground). The accompanying manual title scan only ever reproduced `_resolve_hwnd`'s own substring matching, so a raise already meant no window matched anywhere — the fallback could only ever hit the focused window.

- `naturo/backends/windows/_element/_tree.py` (`get_element_value`) — route straight through `_resolve_hwnd`; let `WindowNotFoundError` propagate. Removes the redundant manual scan.
- `naturo/cli/values/_set.py` (`_resolve_hwnd` helper) — same; the command's `except NaturoError` handler emits the `WINDOW_NOT_FOUND` envelope.

Mirrors the MCP #957 `require_hwnd` loud-failure contract: a selector that is *provided but unmatched* is an error; only **no** selector defaults to the foreground (HWND 0). Behavior for windows that *do* match is unchanged.

## How tested
- New `tests/test_window_selector_loud_failure_964.py` (cross-platform, mocked backend — no DLL/desktop): backend `get` resolution re-raises and never reads the foreground; CLI `get`/`set` emit `WINDOW_NOT_FOUND` and `set` never actuates. Added test fails on the pre-fix tree, passes after.
- `ruff check naturo/` clean; no new `mypy` findings.
- Related suites green: `test_get_cmd` + `test_set_cmd` (77), `test_mcp_window_selector_contract_957` + `test_mcp_inspect` (46), plus the new tests.
- Full non-desktop suite: only pre-existing platform-local failures (e.g. #946, #944), none in the changed paths.

Closes #964.

🤖 Generated with [Claude Code](https://claude.com/claude-code)