### PR TITLE
fix: R-SEC-012 input-sanitization test must not type a real destructive command (use harmless sentinel)

### DIFF
--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -475,7 +475,7 @@ These are not unit or integration tests — they are real-world scenario validat
 | R-SEC-009 | Hook safety: `--input-mode hardware` displays note about driver requirements | P2 | ✅ Pass | test_phase2_comprehensive.py |
 | R-SEC-010 | DLL load safety: library search order does not include CWD before package directory (prevents DLL hijacking) | P0 | ✅ Pass | test_security.py |
 | R-SEC-011 | DLL load safety: NATURO_CORE_PATH env var is validated (file exists, has expected exports) before loading | P3 | ❌ Missing | - |
-| R-SEC-012 | Input sanitization: `type` command does not execute shell commands — typing `$(rm -rf /)` literally types the string | P2 | ✅ Pass | test_phase2_comprehensive.py |
+| R-SEC-012 | Input sanitization: `type` command does not execute shell commands — typing the harmless sentinel `$(echo INJECTED)` literally types the string (it is not shell-evaluated). Payload is intentionally non-destructive: keystroke simulation can race a fragment into a real terminal, so test payloads must never be real commands like `rm -rf /`. | P2 | ✅ Pass | test_phase2_comprehensive.py |
 | R-SEC-013 | Resource exhaustion: very large element tree (depth=10 on complex app) does not OOM — buffer retry has upper bound | P3 | ❌ Missing | - |
 
 ### DevOps Role — Build & Deploy Testing

--- a/tests/test_phase2_comprehensive.py
+++ b/tests/test_phase2_comprehensive.py
@@ -546,16 +546,23 @@ class TestSecurityInputSanitization:
 
     def test_type_does_not_execute_shell(self, runner):
         """R-SEC-012: type command does not execute shell commands."""
-        # The type command should literally type the string, not execute it
-        # We can only verify the CLI doesn't crash and returns expected output
-        result = runner.invoke(main, ["type", "$(rm -rf /)", "--json"])
+        # The type command should literally type the string, not execute it.
+        #
+        # SAFETY: NEVER use real destructive commands (rm, del, format,
+        # shutdown, etc.) as an input-sanitization test payload. Keystroke
+        # simulation can race a fragment into a real terminal, where $()
+        # substitution + Enter would execute it. We use a harmless sentinel:
+        # if it were wrongly executed the output would contain "INJECTED";
+        # if it is typed literally the literal "$(echo INJECTED)" survives.
+        # `echo INJECTED` is harmless even if it ever reaches a real shell.
+        result = runner.invoke(main, ["type", "$(echo INJECTED)", "--json"])
         # Should fail on non-Windows but not crash
         if result.output.strip():
             try:
                 data = json.loads(result.output)
                 # If it ran, it should report typing the literal string
                 if data.get("success"):
-                    assert data.get("data", {}).get("text") == "$(rm -rf /)"
+                    assert data.get("data", {}).get("text") == "$(echo INJECTED)"
             except json.JSONDecodeError:
                 pass
 

--- a/tests/test_recording_cli.py
+++ b/tests/test_recording_cli.py
@@ -304,26 +304,33 @@ class TestExportShellEscaping:
             assert "naturo type '`whoami`'" in result.output
 
     def test_bash_export_escapes_dollar_expansion(self, runner):
+        # SAFETY: harmless sentinel — never a real destructive command (rm,
+        # del, format, ...) as a type/recording payload, since keystroke
+        # simulation can race a fragment into a terminal. `$(echo INJECTED)`
+        # still proves command substitution is safely quoted, and is harmless
+        # even if executed.
         rec = Recording(
             name="Test", recording_id="rec_test", created_at="2026-04-01T12:00:00",
-            steps=[ActionStep("type", {"text": "$(rm -rf /)"}, 1000.0)],
+            steps=[ActionStep("type", {"text": "$(echo INJECTED)"}, 1000.0)],
         )
         with patch("naturo.cli.recording_cmd.load_recording", return_value=rec):
             result = runner.invoke(main, ["record", "export", "rec_test", "--format", "bash"])
             assert result.exit_code == 0
             # Must be safely quoted, not raw command substitution
-            assert '"$(rm -rf /)"' not in result.output
-            assert "naturo type '$(rm -rf /)'" in result.output
+            assert '"$(echo INJECTED)"' not in result.output
+            assert "naturo type '$(echo INJECTED)'" in result.output
 
     def test_bash_export_escapes_semicolons(self, runner):
+        # SAFETY: harmless sentinel — `echo INJECTED` instead of a destructive
+        # command, while still exercising semicolon command-chaining escaping.
         rec = Recording(
             name="Test", recording_id="rec_test", created_at="2026-04-01T12:00:00",
-            steps=[ActionStep("type", {"text": "hello; rm -rf /"}, 1000.0)],
+            steps=[ActionStep("type", {"text": "hello; echo INJECTED"}, 1000.0)],
         )
         with patch("naturo.cli.recording_cmd.load_recording", return_value=rec):
             result = runner.invoke(main, ["record", "export", "rec_test", "--format", "bash"])
             assert result.exit_code == 0
-            assert "naturo type 'hello; rm -rf /'" in result.output
+            assert "naturo type 'hello; echo INJECTED'" in result.output
 
     def test_bash_export_escapes_single_quotes_in_text(self, runner):
         rec = Recording(


### PR DESCRIPTION
## Problem

Security test **R-SEC-012** ("verify `type` does not execute shell commands") hardcoded the **real destructive command `$(rm -rf /)`** as its test payload, in both `docs/TEST_PLAN.md` (row R-SEC-012) and `tests/test_phase2_comprehensive.py`.

The pytest itself runs in-process and is safe. But a QA agent reproducing R-SEC-012 against the **live desktop** runs `naturo type "$(rm -rf /)"`, which global-keystroke-races a fragment into a terminal — catastrophic if it lands in a shell that performs `$()` substitution followed by an Enter. Because the payload was hardcoded, this risk recurred every test round.

## Fix

Keep the exact security coverage, remove the destructive payload. Replace it with a **harmless sentinel** `$(echo INJECTED)` that still proves the same property (typed literally, not shell-executed) and is 100% safe even if it races into a real shell:
- if wrongly executed -> output would contain `INJECTED`
- if typed literally -> the literal `$(echo INJECTED)` survives
- `echo INJECTED` is harmless even in a real shell

### Changes
- `tests/test_phase2_comprehensive.py` — `TestSecurityInputSanitization.test_type_does_not_execute_shell`: payload + assertion now use `$(echo INJECTED)`; added a SAFETY comment forbidding real destructive commands as input-sanitization payloads.
- `tests/test_recording_cli.py` — neutralized the same pattern in the bash-export escaping tests: `$(rm -rf /)` -> `$(echo INJECTED)` and `hello; rm -rf /` -> `hello; echo INJECTED`. Command-substitution and semicolon-chaining escaping coverage is preserved; SAFETY comments added.
- `docs/TEST_PLAN.md` — row R-SEC-012 rewritten to describe the harmless sentinel.

### Intentionally NOT changed
- `tests/test_safe_input_guard.py` (#960 safety-guard tests) deliberately checks that the guard **blocks** patterns like `$(rm -rf /)`. These tests never simulate real keystrokes, so they remain as-is.
- Legitimate bash cleanup (`rm -rf .tmp`) in scripts.

## Verification
- `ruff check naturo/` — all checks passed
- `pytest tests/test_phase2_comprehensive.py -k Sanitization -q` — 1 passed
- `pytest tests/test_recording_cli.py -k "dollar or semicolon" -q` — 2 passed
- `pytest --collect-only` — 120 tests collected, clean

Fixes R-SEC-012.

🤖 Generated with [Claude Code](https://claude.com/claude-code)