### PR TITLE
fix: scope find_element by window_title; unmatched fails loudly (fixes #963)

### DIFF
--- a/naturo/backends/windows/_element/_tree.py
+++ b/naturo/backends/windows/_element/_tree.py
@@ -32,12 +32,22 @@ class ElementTreeMixin:
 
         Args:
             selector: Element selector in "role:name" or "name" format.
-            window_title: Not yet used (reserved for future).
+            window_title: Window title pattern (partial match, case-insensitive).
+                When provided, the search is scoped to the matching window.
             hwnd: Target window handle.  When provided, searches within this
-                window instead of the foreground window (#525).
+                window instead of the foreground window (#525) and takes
+                priority over ``window_title``.
 
         Returns:
             ElementInfo if found, None otherwise.
+
+        Raises:
+            WindowNotFoundError: When ``window_title`` is supplied but matches no
+                window. The selector is resolved up front through
+                ``_resolve_hwnd`` and the error is allowed to propagate rather
+                than degrading to the foreground window — the silent-fallback
+                bug #963 (sibling of #957/#964 and the same path used by
+                ``get_element_value``).
         """
         core = self._ensure_core()
 
@@ -51,7 +61,16 @@ class ElementTreeMixin:
         else:
             name = selector if selector else None
 
-        result = core.find_element(hwnd=hwnd or 0, role=role, name=name)
+        # Resolve the window selector before searching. A window_title that is
+        # supplied but matches nothing must fail loudly: ``_resolve_hwnd`` raises
+        # WindowNotFoundError and we let it propagate instead of silently
+        # searching the foreground window (HWND 0). With no selector the
+        # documented foreground default is preserved.
+        target_hwnd = hwnd or 0
+        if window_title and not target_hwnd:
+            target_hwnd = self._resolve_hwnd(window_title=window_title)
+
+        result = core.find_element(hwnd=target_hwnd, role=role, name=name)
         if result is None:
             return None
 

--- a/tests/test_find_element_window_scoping_963.py
+++ b/tests/test_find_element_window_scoping_963.py
@@ -1,0 +1,129 @@
+"""Loud-failure + window-scoping contract for ``find_element`` (#963).
+
+Silent-failure class (same family as #957/#964): a surface accepts a window
+selector (``window_title``), fails to resolve it, and *silently* searches the
+foreground window — reporting a result (or ``ELEMENT_NOT_FOUND``) against the
+**wrong** window. ``WindowsElementBackend.find_element`` was the last instance:
+its ``window_title`` parameter was documented "Not yet used (reserved for
+future)" and the search always ran against ``hwnd or 0`` (the foreground).
+
+The fix resolves the selector up front through ``_resolve_hwnd`` (the same path
+the sibling ``get_element_value`` uses, #964), letting ``WindowNotFoundError``
+propagate so an unmatched ``window_title`` fails loudly with ``WINDOW_NOT_FOUND``
+instead of degrading to the focused window. A matched title scopes the search to
+that window's handle. With no selector the documented foreground default (HWND
+``0``) is preserved.
+
+These tests run cross-platform (no DLL/desktop): the backend core and resolver
+are mocked so resolution behaves exactly as the real Windows backend does.
+
+Closes #963.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from naturo.errors import WindowNotFoundError
+
+# A window title guaranteed not to match any real window.
+_BOGUS_TITLE = "__no_such_window_zzz_963__"
+
+
+def _make_harness(resolved_hwnd=None):
+    """Build a minimal ``ElementTreeMixin`` host with a stubbed core and resolver.
+
+    ``_resolve_hwnd`` mimics the real backend: a supplied ``window_title`` that
+    matches a configured window returns its handle, otherwise it raises
+    ``WindowNotFoundError`` (never falling back to the foreground window).
+    """
+    from naturo.backends.windows._element._tree import ElementTreeMixin
+
+    class _Harness(ElementTreeMixin):
+        def __init__(self):
+            self._core = MagicMock()
+            self._resolved_hwnd = resolved_hwnd
+
+        def _ensure_core(self):
+            return self._core
+
+        def _resolve_hwnd(self, app=None, window_title=None, hwnd=None, pid=None):
+            if self._resolved_hwnd is not None:
+                return self._resolved_hwnd
+            raise WindowNotFoundError(window_title or app or "")
+
+    return _Harness()
+
+
+def test_backend_unmatched_window_title_raises_not_foreground():
+    """An unmatched ``window_title`` must raise, never search the foreground."""
+    harness = _make_harness(resolved_hwnd=None)
+    with pytest.raises(WindowNotFoundError):
+        harness.find_element(selector="Button:OK", window_title=_BOGUS_TITLE)
+    # The foreground element search must never be reached on a bogus selector.
+    harness._core.find_element.assert_not_called()
+
+
+def test_backend_matched_window_title_scopes_search_to_hwnd():
+    """A resolved ``window_title`` must scope the search to that window's HWND."""
+    harness = _make_harness(resolved_hwnd=4242)
+    harness._core.find_element.return_value = None
+    harness.find_element(selector="Button:OK", window_title="Calculator")
+    harness._core.find_element.assert_called_once_with(
+        hwnd=4242, role="Button", name="OK"
+    )
+
+
+def test_backend_no_selector_keeps_foreground_default():
+    """With no window selector the foreground default (HWND 0) is preserved."""
+    harness = _make_harness(resolved_hwnd=None)
+    harness._core.find_element.return_value = None
+    harness.find_element(selector="Button:OK")
+    harness._core.find_element.assert_called_once_with(
+        hwnd=0, role="Button", name="OK"
+    )
+
+
+def test_backend_explicit_hwnd_takes_priority_over_title():
+    """An explicit ``hwnd`` is honoured without re-resolving the title."""
+    harness = _make_harness(resolved_hwnd=None)  # would raise if resolution ran
+    harness._core.find_element.return_value = None
+    harness.find_element(selector="Button:OK", window_title="ignored", hwnd=99)
+    harness._core.find_element.assert_called_once_with(
+        hwnd=99, role="Button", name="OK"
+    )
+
+
+def test_mcp_find_element_unmatched_window_title_fails_loudly():
+    """The MCP ``find_element`` tool must surface WINDOW_NOT_FOUND, not success."""
+    import asyncio
+
+    mcp = pytest.importorskip("naturo.mcp_server")
+
+    backend = MagicMock()
+    backend.find_element.side_effect = WindowNotFoundError(_BOGUS_TITLE)
+
+    from unittest.mock import patch
+
+    with patch("naturo.mcp_server.get_backend", return_value=backend), \
+         patch("naturo.cli.interaction._check_desktop_session"):
+        server = mcp.create_server()
+        loop = asyncio.new_event_loop()
+        try:
+            result = loop.run_until_complete(
+                server.call_tool(
+                    "find_element",
+                    {"selector": "Button:OK", "window_title": _BOGUS_TITLE},
+                )
+            )
+        finally:
+            loop.close()
+
+    content = result[0] if isinstance(result, tuple) else result
+    payload = json.loads(content[0].text)
+    assert payload.get("success") is False, (
+        f"find_element fell back to the foreground on a bogus window_title: {payload}"
+    )
+    assert payload.get("error", {}).get("code") == "WINDOW_NOT_FOUND", payload

--- a/tests/test_mcp_window_selector_contract_957.py
+++ b/tests/test_mcp_window_selector_contract_957.py
@@ -55,12 +55,6 @@ _SEMANTIC_EXCEPTIONS = {
     # the silent-foreground-fallback bug this contract guards against.
     "wait_for_element",
     "wait_until_gone",
-    # find_element forwards window_title to backend.find_element, which does
-    # not implement title scoping yet (the param is reserved) and searches the
-    # foreground window. That is a separate silent-fallback gap tracked on its
-    # own issue; it cannot return WINDOW_NOT_FOUND until the backend resolves
-    # the title. Listed here so this contract stays green while that lands.
-    "find_element",
 }
 
 
@@ -117,6 +111,9 @@ def _make_backend():
     backend._resolve_hwnds.side_effect = not_found
     backend.get_element_tree.side_effect = not_found
     backend.get_element_value.side_effect = not_found
+    # find_element resolves window_title internally via _resolve_hwnd (#963), so
+    # an unmatched title raises here exactly as the real backend does.
+    backend.find_element.side_effect = not_found
     return backend
 
 


### PR DESCRIPTION
## What
`WindowsElementBackend.find_element` exposed a `window_title` parameter but documented it *"Not yet used (reserved for future)"* and always searched `hwnd or 0` (the foreground window). So `find_element(selector, window_title="Some Window")` **silently searched the wrong window** and reported a result (or `ELEMENT_NOT_FOUND`) against it — the same silent-fallback class as #954/#956/#957/#964.

## How
Resolve the window selector up front through `_resolve_hwnd` — the exact path the sibling `get_element_value` already uses (#964):

- An unmatched `window_title` raises `WindowNotFoundError`, which propagates to a `success:false` / `WINDOW_NOT_FOUND` envelope instead of degrading to the foreground window.
- A matched `window_title` scopes the search to that window's handle.
- An explicit `hwnd` still takes priority; no selector preserves the documented foreground default (HWND `0`).

This fixes the MCP `find_element` tool and `naturo.agent` uniformly. The `wait_for_element` / `wait_until_gone` tools wrap `find_element` in `try/except`, so their "an absent window is a valid target" semantics are unchanged (they remain legitimate `_SEMANTIC_EXCEPTIONS`).

`find_element` now honours the loud-failure contract, so it is removed from `_SEMANTIC_EXCEPTIONS` in the self-maintaining MCP contract test (`test_mcp_window_selector_contract_957.py`) — which now guards it automatically — and wired into that test's backend fixture.

## How tested
- New cross-platform (no DLL/desktop) test `tests/test_find_element_window_scoping_963.py`: unmatched title raises and never searches the foreground; matched title scopes to the resolved HWND; explicit hwnd wins; no-selector keeps HWND 0; the MCP tool surfaces `WINDOW_NOT_FOUND`. Failed pre-fix, passes post-fix.
- `test_mcp_window_selector_contract_957.py` now exercises `find_element` automatically and stays green.
- ruff clean; mypy no new findings (only the pre-existing local `mcp` follow-import noise; CI Lint&Type is green).
- Full non-desktop suite: only pre-existing platform-local/timing failures (`test_win32_hybrid` Linux-expectation tests on a Windows host, `test_agent` total_time flake), confirmed identical on baseline — none in changed paths.

Acceptance (from #963): `find_element(selector="Button:OK", window_title="__no_such_window__")` → `success:false` / `error.code == "WINDOW_NOT_FOUND"`, never a foreground result. ✔