### PR TITLE
fix: robust input-safety guard via sentinel lock file (fixes #972)

### DIFF
--- a/agents/local/runner.ps1
+++ b/agents/local/runner.ps1
@@ -47,15 +47,26 @@ if ($Role -eq 'qa') {
   exit 0
 }
 
-switch ($Role) {
-  'dev'  { $Wt = 'C:\Users\Naturobot\naturo-dev'; $Cycle = 'agents/local/dev-cycle.md' }
-  'qa'   { $Wt = 'C:\Users\Naturobot\naturo-qa';  $Cycle = 'agents/local/qa-cycle.md'; $env:NATURO_SAFE_INPUT = '1' }  # (#960) code-enforced input-content guard for the unattended QA loop
-  'orch' { $Wt = $Main;                           $Cycle = 'agents/local/orch-review.md' }
-}
-
 function Write-State([string]$line) {
   $stamp = (Get-Date).ToString('o')
   Add-Content -Path $StateLog -Value "$stamp  [runner:$Role]  $line"
+}
+
+switch ($Role) {
+  'dev'  { $Wt = 'C:\Users\Naturobot\naturo-dev'; $Cycle = 'agents/local/dev-cycle.md' }
+  'qa'   {
+    $Wt = 'C:\Users\Naturobot\naturo-qa';  $Cycle = 'agents/local/qa-cycle.md'
+    # (#960) code-enforced input-content guard for the unattended QA loop. Two
+    # independent signals activate it so it survives env-inheritance gaps (#972):
+    #   1. the env var (inherited by direct children of this process), and
+    #   2. a sentinel lock file under ~/.naturo, which every `naturo` invocation
+    #      probes regardless of how it was spawned.
+    $env:NATURO_SAFE_INPUT = '1'
+    $SafeInputLock = Join-Path $env:USERPROFILE '.naturo\safe-input.lock'
+    New-Item -ItemType File -Force -Path $SafeInputLock | Out-Null
+    Write-State "input-safety guard armed (NATURO_SAFE_INPUT=1 + sentinel $SafeInputLock)"
+  }
+  'orch' { $Wt = $Main;                           $Cycle = 'agents/local/orch-review.md' }
 }
 
 # --- Proxy: the cycle needs the internet (Claude API + GitHub). The interactive `pon` is a cmd

--- a/naturo/safety.py
+++ b/naturo/safety.py
@@ -10,10 +10,22 @@ by Enter, it could have wiped the machine.
 
 Instruction-level guardrails are necessary but not sufficient once an agent can
 improvise input, so this module adds *code* enforcement.  It is strictly
-opt-in: the guard activates only when ``NATURO_SAFE_INPUT=1`` is set in the
-environment (the unattended QA role sets it).  Normal users — for whom typing
-shell commands into an editor is a legitimate use of a general automation tool —
-are unaffected when the variable is unset.
+opt-in.  The guard activates when **either** of two independent signals is
+present (#972):
+
+* the ``NATURO_SAFE_INPUT=1`` environment variable, or
+* a sentinel lock file at ``~/.naturo/safe-input.lock``.
+
+The sentinel file exists because the environment variable alone proved
+fragile: it has to be inherited by every process in the chain that ultimately
+injects keystrokes, and on 2026-06-17 a QA cycle still typed ``$(rm -rf /)``
+because the opt-in env var was not effective for that cycle.  A file-based
+signal survives across process boundaries with no env-inheritance dependency,
+so the loop drops the lock once and every later ``naturo`` invocation sees it.
+
+Normal users — for whom typing shell commands into an editor is a legitimate
+use of a general automation tool — are unaffected: neither signal is present
+for interactive/TTY use, so the guard stays off.
 
 The matcher is deliberately conservative: for a destructive-command blocker a
 false positive (refusing a benign-but-suspicious string in a QA probe) is
@@ -23,6 +35,7 @@ from __future__ import annotations
 
 import os
 import re
+from pathlib import Path
 from typing import Optional
 
 #: Environment variable that, when set to ``"1"``, enables the input guard.
@@ -54,22 +67,64 @@ _DANGEROUS_PATTERNS: tuple[tuple[str, "re.Pattern[str]"], ...] = (
 )
 
 
+def _safe_input_lock_path() -> Path:
+    """Return the path to the sentinel lock file that activates the guard.
+
+    Uses the same ``~/.naturo`` directory naturo already uses for snapshots,
+    app-id maps and other per-user state, so the signal lives alongside the
+    rest of naturo's runtime files.  Resolved on each call (not cached) so a
+    test that points ``HOME``/``USERPROFILE`` at a temporary directory, or a
+    user whose home moves, is honoured.
+    """
+    return Path.home() / ".naturo" / "safe-input.lock"
+
+
+def _safe_input_active() -> bool:
+    """Return whether the opt-in input-content guard is currently active.
+
+    The guard activates when **either** signal is present (#972):
+
+    * the ``NATURO_SAFE_INPUT`` environment variable is exactly ``"1"``, or
+    * the sentinel lock file ``~/.naturo/safe-input.lock`` exists.
+
+    Either signal alone is sufficient.  The env var is kept as a fallback for
+    callers that still set it, but the file-based signal is the robust primary
+    because it does not depend on environment inheritance across process
+    boundaries.  When neither is present the guard is a no-op, so interactive
+    and normal-user sessions are never affected.
+    """
+    if os.environ.get(SAFE_INPUT_ENV) == "1":
+        return True
+    try:
+        return _safe_input_lock_path().exists()
+    except (OSError, RuntimeError):
+        # Probing the sentinel must never crash input.  ``Path.home()`` raises
+        # ``RuntimeError`` when the home directory cannot be determined (e.g. no
+        # HOME/USERPROFILE), and ``exists()`` can raise ``OSError``; in either
+        # case fall back to "not active via the file" (env was already checked).
+        return False
+
+
 def is_safe_input_enabled() -> bool:
     """Return whether the opt-in input-content guard is active.
 
+    Retained as the stable public name; delegates to :func:`_safe_input_active`
+    so the env var **or** the sentinel lock file enables the guard.
+
     Returns:
-        ``True`` only when the ``NATURO_SAFE_INPUT`` environment variable is
-        exactly ``"1"``.  Any other value (including unset) leaves the guard
-        disabled so normal users are never affected.
+        ``True`` when ``NATURO_SAFE_INPUT`` is exactly ``"1"`` or the sentinel
+        file ``~/.naturo/safe-input.lock`` exists; otherwise ``False`` so
+        normal users are never affected.
     """
-    return os.environ.get(SAFE_INPUT_ENV) == "1"
+    return _safe_input_active()
 
 
 def unsafe_input_reason(text: Optional[str]) -> Optional[str]:
     """Return why ``text`` is unsafe to inject, or ``None`` if it may proceed.
 
-    The guard is a no-op (always returns ``None``) when
-    ``NATURO_SAFE_INPUT`` is not set to ``"1"``, so callers can invoke this
+    The guard is a no-op (always returns ``None``) when it is inactive — that
+    is, when neither ``NATURO_SAFE_INPUT=1`` nor the sentinel lock file
+    ``~/.naturo/safe-input.lock`` is present — so callers can invoke this
     unconditionally before typing/pasting without affecting normal users.
 
     Args:

--- a/tests/test_safe_input_guard.py
+++ b/tests/test_safe_input_guard.py
@@ -1,15 +1,21 @@
-"""Tests for the opt-in input-content safety guard (naturo.safety, #960).
+"""Tests for the opt-in input-content safety guard (naturo.safety, #960/#972).
 
-The guard refuses to inject shell-command-like keystrokes when
-``NATURO_SAFE_INPUT=1`` is set, so a focus race in an unattended QA loop cannot
-deliver a destructive fragment (e.g. ``$(rm -rf /)``) to a terminal.  Normal
-users (env unset) must be completely unaffected.
+The guard refuses to inject shell-command-like keystrokes when it is active, so
+a focus race in an unattended QA loop cannot deliver a destructive fragment
+(e.g. ``$(rm -rf /)``) to a terminal.  It activates on **either** of two
+independent signals (#972): the ``NATURO_SAFE_INPUT=1`` environment variable or
+a sentinel lock file at ``~/.naturo/safe-input.lock``.  The file-based signal is
+the robust primary because it survives across process boundaries with no
+env-inheritance dependency.  Normal users (neither signal present) must be
+completely unaffected.
 
-All tests are pure-Python (no desktop, no DLL) and run on Linux CI.
+All tests are pure-Python (no desktop, no DLL, no real keystrokes) and run on
+Linux CI; the sentinel filesystem is mocked via a tmp HOME.
 """
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -43,6 +49,64 @@ class TestEnvGating:
     def test_enabled_when_exactly_one(self):
         with _enabled():
             assert is_safe_input_enabled() is True
+
+
+class TestSentinelFileGating:
+    """The sentinel lock file activates the guard independently of the env var.
+
+    This is the #972 robustness fix: the env var alone proved fragile because it
+    must be inherited by every process in the injection chain.  The lock file is
+    probed from disk on each call, so it works regardless of how ``naturo`` was
+    spawned.  The filesystem is mocked via a tmp HOME so no real file under the
+    developer's ``~/.naturo`` is touched.
+    """
+
+    @staticmethod
+    def _home(monkeypatch, tmp_path):
+        """Point ``Path.home()`` at ``tmp_path`` and clear the guard env var."""
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+        monkeypatch.delenv(SAFE_INPUT_ENV, raising=False)
+        return tmp_path / ".naturo" / "safe-input.lock"
+
+    def test_lock_path_lives_under_dot_naturo(self, monkeypatch, tmp_path):
+        from naturo.safety import _safe_input_lock_path
+
+        self._home(monkeypatch, tmp_path)
+        assert _safe_input_lock_path() == tmp_path / ".naturo" / "safe-input.lock"
+
+    def test_active_when_sentinel_exists_and_env_unset(self, monkeypatch, tmp_path):
+        """The exact #972 scenario: env var UNSET but the sentinel file exists."""
+        lock = self._home(monkeypatch, tmp_path)
+        lock.parent.mkdir(parents=True, exist_ok=True)
+        lock.touch()
+
+        assert SAFE_INPUT_ENV not in __import__("os").environ
+        assert is_safe_input_enabled() is True
+        # And it actually blocks the near-miss payload from the incident.
+        assert unsafe_input_reason("$(rm -rf /)") is not None
+
+    def test_inactive_when_neither_env_nor_sentinel(self, monkeypatch, tmp_path):
+        self._home(monkeypatch, tmp_path)  # tmp HOME has no .naturo dir/lock
+
+        assert is_safe_input_enabled() is False
+        # Dangerous content passes untouched — normal users are unaffected.
+        assert unsafe_input_reason("$(rm -rf /)") is None
+
+    def test_benign_passes_even_when_sentinel_present(self, monkeypatch, tmp_path):
+        lock = self._home(monkeypatch, tmp_path)
+        lock.parent.mkdir(parents=True, exist_ok=True)
+        lock.touch()
+
+        assert is_safe_input_enabled() is True
+        assert unsafe_input_reason("QA_PROBE") is None
+
+    def test_env_alone_still_works_without_sentinel(self, monkeypatch, tmp_path):
+        """Env-var fallback is preserved even when no sentinel file exists."""
+        self._home(monkeypatch, tmp_path)
+        monkeypatch.setenv(SAFE_INPUT_ENV, "1")
+
+        assert is_safe_input_enabled() is True
+        assert unsafe_input_reason("$(rm -rf /)") is not None
 
 
 class TestBlocksDangerousContent:


### PR DESCRIPTION
## Summary

Makes the input-content safety guard (`naturo/safety.py`, #960) **robust** so it no longer depends solely on the `NATURO_SAFE_INPUT` env var propagating. On 2026-06-17 a QA cycle still typed `$(rm -rf /)` because the env-var opt-in was not effective for that cycle — the variable must be inherited by every process in the injection chain.

## Activation logic (the fix)

The guard is now **active when `NATURO_SAFE_INPUT=1` (env) OR a sentinel lock file exists at `~/.naturo/safe-input.lock`**. A file-based signal survives across process boundaries with no env-inheritance dependency. Either signal alone suffices; the env var is kept as a fallback.

- New `_safe_input_active()` checks env OR sentinel; `is_safe_input_enabled()` delegates to it (stable public name preserved).
- `_safe_input_lock_path()` resolves to `~/.naturo/safe-input.lock` (same dir naturo uses for snapshots/app-ids).
- `unsafe_input_reason()` contract unchanged: returns a reason when active AND text matches a dangerous pattern, `None` otherwise. The existing dangerous-pattern set is untouched.
- Probing the sentinel never crashes input: `Path.home()` `RuntimeError` (no HOME/USERPROFILE) and `exists()` `OSError` are swallowed, falling back to the env-only result.
- **Not** defaulted on for interactive/TTY use — only env OR sentinel activates it, so a human typing arbitrary text is unaffected.

## Sentinel creation

`agents/local/runner.ps1`: the **qa** role now drops `~/.naturo/safe-input.lock` (`New-Item -ItemType File -Force`) in addition to setting the env var, so it is ready when QA re-enables. The EMERGENCY exit-0 block at the top is **left in place** (Ace re-enables separately).

## Tests

New `TestSentinelFileGating` (pure unit, filesystem mocked via tmp HOME, **no real keystrokes**):
- BLOCKS `$(rm -rf /)` when the sentinel exists but the env var is UNSET (the exact #972 scenario)
- OFF when neither env nor sentinel is present (dangerous content passes — normal users unaffected)
- benign text (`QA_PROBE`) always passes
- env-only fallback still works without a sentinel

`pytest tests/test_safe_input_guard.py -q` → **40 passed**. `ruff check` clean, `mypy naturo/safety.py` clean, `--collect-only` clean across the full suite (5883 tests).

Fixes #972.

🤖 Generated with [Claude Code](https://claude.com/claude-code)