### PR TITLE
fix: selector list -j and record list -j emit standard success envelope (fixes #876)

### DIFF
--- a/naturo/cli/recording_cmd.py
+++ b/naturo/cli/recording_cmd.py
@@ -197,7 +197,11 @@ def record_list(json_output: bool):
     active = get_active_recording()
 
     if json_output:
-        output: dict = {"recordings": recordings}
+        output: dict = {
+            "success": True,
+            "recordings": recordings,
+            "count": len(recordings),
+        }
         if active:
             output["active"] = {
                 "recording_id": active.recording_id,

--- a/naturo/cli/selector_cmd.py
+++ b/naturo/cli/selector_cmd.py
@@ -247,7 +247,26 @@ def selector_list(app_name: Optional[str], builtin: bool, json_output: bool):
             all_selectors = {}
 
     if json_output:
-        click.echo(json.dumps(all_selectors))
+        selectors = []
+        for app, sels in all_selectors.items():
+            for name, info in sels.items():
+                if isinstance(info, dict):
+                    selector_value = info.get("selector", "")
+                    description = info.get("description", "")
+                else:
+                    selector_value = info
+                    description = ""
+                selectors.append({
+                    "app": app,
+                    "name": name,
+                    "selector": selector_value,
+                    "description": description,
+                })
+        click.echo(json.dumps({
+            "success": True,
+            "selectors": selectors,
+            "count": len(selectors),
+        }))
         return
 
     if not all_selectors:

--- a/tests/test_builtin_selectors.py
+++ b/tests/test_builtin_selectors.py
@@ -106,9 +106,14 @@ class TestBuiltinCLIIntegration:
         result = runner.invoke(main, ["selector", "list", "--builtin", "--json"])
         assert result.exit_code == 0
         data = json.loads(result.output)
-        assert len(data) == 20
+        # #876: standard envelope — success + count + a flat selector list,
+        # each record self-describing its owning app.
+        assert data["success"] is True
+        assert data["count"] == len(data["selectors"])
+        apps = {entry["app"] for entry in data["selectors"]}
+        assert len(apps) == 20
         for app in EXPECTED_APPS:
-            assert app in data
+            assert app in apps
 
     def test_list_builtin_filter_by_app(self, runner):
         result = runner.invoke(main, [

--- a/tests/test_list_envelope_876.py
+++ b/tests/test_list_envelope_876.py
@@ -1,0 +1,98 @@
+"""Regression tests for #876 — ``selector list -j`` and ``record list -j``
+must emit the standard top-level JSON envelope (``success`` + ``count``).
+
+Every other ``-j`` read command (``list apps``, ``app windows``,
+``clipboard get`` ...) returns ``{"success": true, "<collection>": ..., "count": N}``
+so a scripter can rely on a single ``jq '.success'`` error-check across the
+whole CLI surface.  Before this fix, ``selector list -j`` returned a bare
+app-keyed dict (``{}`` when empty) and ``record list -j`` returned
+``{"recordings": [...]}`` — neither carried ``success`` or ``count``.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from naturo.cli import main
+from naturo.cli import selector_cmd
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def tmp_selectors(tmp_path):
+    """Patch the user-selectors directory to a temp location."""
+    with patch.object(selector_cmd, "SELECTORS_DIR", tmp_path):
+        yield tmp_path
+
+
+class TestSelectorListEnvelope:
+    def test_empty_has_success_and_zero_count(self, runner, tmp_selectors):
+        result = runner.invoke(main, ["selector", "list", "-j"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["success"] is True
+        assert data["selectors"] == []
+        assert data["count"] == 0
+
+    def test_populated_lists_every_selector_with_count(self, runner, tmp_selectors):
+        runner.invoke(main, ["selector", "save", "notepad", "btn1", "sel1"])
+        runner.invoke(main, ["selector", "save", "chrome", "addr", "sel2"])
+        result = runner.invoke(main, ["selector", "list", "-j"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["success"] is True
+        assert data["count"] == 2
+        assert len(data["selectors"]) == 2
+        # Each record carries its owning app, name, and selector value.
+        apps = {entry["app"] for entry in data["selectors"]}
+        assert apps == {"notepad", "chrome"}
+        for entry in data["selectors"]:
+            assert set(entry) >= {"app", "name", "selector", "description"}
+        notepad = next(e for e in data["selectors"] if e["app"] == "notepad")
+        assert notepad["name"] == "btn1"
+        assert notepad["selector"] == "sel1"
+
+    def test_filter_by_app_keeps_envelope(self, runner, tmp_selectors):
+        runner.invoke(main, ["selector", "save", "notepad", "btn1", "sel1"])
+        runner.invoke(main, ["selector", "save", "chrome", "addr", "sel2"])
+        result = runner.invoke(main, ["selector", "list", "--app", "notepad", "-j"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["success"] is True
+        assert data["count"] == 1
+        assert [e["app"] for e in data["selectors"]] == ["notepad"]
+
+
+class TestRecordListEnvelope:
+    def test_empty_has_success_and_zero_count(self, runner):
+        with patch("naturo.cli.recording_cmd.list_recordings", return_value=[]), \
+             patch("naturo.cli.recording_cmd.get_active_recording", return_value=None):
+            result = runner.invoke(main, ["record", "list", "-j"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["success"] is True
+        assert data["recordings"] == []
+        assert data["count"] == 0
+
+    def test_populated_has_success_and_count(self, runner):
+        recs = [
+            {"recording_id": "rec_001", "name": "Flow A",
+             "created_at": "2026-04-01", "step_count": 5},
+            {"recording_id": "rec_002", "name": "Flow B",
+             "created_at": "2026-04-02", "step_count": 3},
+        ]
+        with patch("naturo.cli.recording_cmd.list_recordings", return_value=recs), \
+             patch("naturo.cli.recording_cmd.get_active_recording", return_value=None):
+            result = runner.invoke(main, ["record", "list", "-j"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["success"] is True
+        assert data["count"] == 2
+        assert len(data["recordings"]) == 2

--- a/tests/test_selector_cmd.py
+++ b/tests/test_selector_cmd.py
@@ -229,7 +229,11 @@ class TestSelectorList:
         result = runner.invoke(main, ["selector", "list", "--json"])
         assert result.exit_code == 0
         data = json.loads(result.output)
-        assert "notepad" in data
+        # #876: standard envelope — top-level success + count, selectors as a list.
+        assert data["success"] is True
+        assert data["count"] == 1
+        assert data["selectors"][0]["app"] == "notepad"
+        assert data["selectors"][0]["name"] == "btn1"
 
 
 # ── selector show ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

`selector list -j` returned a bare app-keyed dict (`{}` when empty) and `record list -j` returned `{"recordings": [...]}` — neither carried the top-level `success` / `count` fields that every other `-j` read command (`list apps`, `app windows`, `clipboard get`) emits. Scripters could not rely on a single `jq '.success'` error-check across the CLI surface (#876).

Both commands now emit the standard envelope:

- `selector list -j` → `{"success": true, "selectors": [{"app", "name", "selector", "description"}, ...], "count": N}` (app-keyed dict flattened to a list so every record self-describes its owning app).
- `record list -j` → `{"success": true, "recordings": [...], "count": N}` (`active` block preserved when present).

## How tested

- New `tests/test_list_envelope_876.py`: empty + populated + app-filter cases for both commands assert `success`/`count` and per-record shape.
- Updated the existing `test_selector_cmd.py::test_list_json` to the new envelope.
- Quality gate: `ruff` clean; full `test_selector_cmd.py` + `test_recording_cmd.py` + new tests = 125 passed (isolated basetemp; the shared-`%TEMP%` WinError-5 races seen otherwise are a multi-worktree env artifact, not code).

Closes #876.