### PR TITLE
fix: wrap subcommand usage errors in JSON envelope under -j (fixes #872)

### DIFF
--- a/naturo/cli/__init__.py
+++ b/naturo/cli/__init__.py
@@ -256,6 +256,39 @@ def _wants_global_json(argv: list[str]) -> bool:
     return False
 
 
+def _wants_json(argv: list[str]) -> bool:
+    """Return True if ``-j``/``--json`` appears anywhere on the command line.
+
+    Unlike :func:`_wants_global_json` (which only inspects the leading global
+    options), this scans the full token list so a subcommand-level ``-j`` placed
+    *after* the command name — e.g. ``naturo see --hwnd abc -j`` — is detected
+    too. Used to decide whether a parse-time usage error should be rendered as a
+    JSON envelope (#872). Tokens after a literal ``--`` are positional and never
+    treated as flags.
+
+    Args:
+        argv: CLI arguments excluding the program name.
+
+    Returns:
+        True when JSON output was requested anywhere, otherwise False.
+    """
+    index = 0
+    while index < len(argv):
+        token = argv[index]
+        if token == "--":
+            break  # everything after -- is a positional argument
+        if token in ("-j", "--json"):
+            return True
+        # Combined short-flag cluster, e.g. "-vj".
+        if token.startswith("-") and not token.startswith("--") and "j" in token[1:]:
+            return True
+        if token in _GLOBAL_VALUE_OPTIONS:
+            index += 2  # skip the option and its value
+            continue
+        index += 1
+    return False
+
+
 def _first_command_token(argv: list[str]) -> str | None:
     """Return the first positional token (the subcommand), or None.
 
@@ -310,22 +343,33 @@ def _root_help_json() -> str:
     )
 
 
-def _emit_root_usage_error_json(exc: click.UsageError) -> None:
-    """Emit a JSON error envelope for a root-level usage error and exit 1.
+def _emit_usage_error_json(exc: click.UsageError) -> None:
+    """Emit a JSON error envelope for any parse-time usage error and exit 1.
+
+    Handles both root-group errors (#874) and subcommand errors (#872): every
+    Click parse failure class — unknown option, unknown command, missing
+    argument, and invalid option/argument values (bad int/float/choice) — is
+    mapped onto the standard ``{success: false, error: {...}}`` envelope. The
+    ``--help`` hint targets the failing command so the suggested action is
+    actionable for nested commands (e.g. ``naturo clipboard set``).
 
     Args:
-        exc: The Click usage error raised by the root group.
+        exc: The Click usage error raised during argument parsing.
     """
     message = exc.format_message()
+    # ``exc.ctx`` is the context of the command that failed to parse; its
+    # ``command_path`` is "naturo" for the root group or e.g. "naturo clipboard
+    # set" for a nested subcommand.
+    help_target = "naturo" if exc.ctx is None else exc.ctx.command_path
     if isinstance(exc, click.NoSuchOption):
         code = "UNKNOWN_OPTION"
-        action = "Run 'naturo --help' to see the available options."
+        action = f"Run '{help_target} --help' to see the available options."
     elif message.startswith("No such command"):
         code = "UNKNOWN_COMMAND"
-        action = "Run 'naturo --help' for the command list."
+        action = f"Run '{help_target} --help' for the command list."
     else:
         code = "INVALID_INPUT"
-        action = "Run 'naturo --help' for usage."
+        action = f"Run '{help_target} --help' for usage."
     click.echo(json_error(code, message, suggested_action=action))
     # Contract exit code is 1 (runtime error), not Click's UsageError 2 — same
     # axis as #866/#872.
@@ -342,6 +386,9 @@ def run() -> None:
     """
     argv = sys.argv[1:]
     json_mode = _wants_global_json(argv)
+    # Usage errors honour ``-j`` placed anywhere (global or subcommand-level),
+    # since a parse failure can occur before Click binds the flag (#872).
+    json_usage = _wants_json(argv)
 
     # --version/--help are eager: Click runs and prints them before command
     # dispatch, so intercept them here when global JSON is requested and no
@@ -362,11 +409,12 @@ def run() -> None:
         result = main.main(args=argv, prog_name="naturo", standalone_mode=False)
         sys.exit(result if isinstance(result, int) else 0)
     except click.UsageError as exc:
-        # Only root-group usage errors are in scope; subcommand usage errors
-        # keep Click's default rendering (subcommand JSON is #872/#897).
-        is_root = exc.ctx is None or exc.ctx.command is main
-        if json_mode and is_root:
-            _emit_root_usage_error_json(exc)
+        # Every parse-time usage error — root group (#874) or subcommand
+        # (#872) — is wrapped in the JSON envelope when JSON was requested.
+        # Runtime guards (e.g. NO_DESKTOP_SESSION) emit their own envelope and
+        # sys.exit before reaching here, so this only catches parse failures.
+        if json_usage:
+            _emit_usage_error_json(exc)
         exc.show()
         sys.exit(exc.exit_code)
     except click.Abort:

--- a/tests/test_subcommand_usage_error_json_872.py
+++ b/tests/test_subcommand_usage_error_json_872.py
@@ -1,0 +1,161 @@
+"""Tests for the global ``-j/--json`` contract on subcommand usage errors (#872).
+
+Click raises a ``UsageError`` for every parse-time failure — unknown option,
+missing required argument, too-many-arguments, and invalid option/argument
+values (bad int/float/choice). For *subcommands* these errors were printed as a
+plain Click banner on stderr with exit code 2, even when ``-j``/``--json`` was
+requested, so scripts piping ``naturo <cmd> ... -j`` into a JSON parser crashed.
+
+The top-level twin of this bug was fixed by #874; this closes the gap for every
+subcommand. The console-script wrapper ``naturo.cli.run`` now wraps *all*
+parse-time ``UsageError``\\s in the standard JSON envelope (exit 1) whenever a
+JSON flag appears anywhere on the command line.
+
+These tests exercise the wrapper directly because ``click.testing.CliRunner``
+invokes the group and bypasses the wrapper. They are pure CLI level — no DLL,
+no desktop session, no input injection (every case fails during argument
+parsing, before any command body runs).
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from naturo.cli import _wants_json, run
+
+
+def _run(monkeypatch, argv):
+    """Invoke the console-script wrapper with a synthetic argv.
+
+    Returns a ``(exit_code, stdout, stderr)`` tuple.
+    """
+    monkeypatch.setattr("sys.argv", ["naturo", *argv])
+    with pytest.raises(SystemExit) as excinfo:
+        run()
+    code = excinfo.value.code
+    return 0 if code is None else code
+
+
+# ── argv scanner ─────────────────────────────────────────────────────────────
+
+class TestWantsJson:
+    def test_detects_flag_anywhere(self):
+        assert _wants_json(["-j", "see"]) is True
+        assert _wants_json(["see", "--depth", "abc", "-j"]) is True
+        assert _wants_json(["--json", "list"]) is True
+
+    def test_detects_combined_short_cluster(self):
+        assert _wants_json(["-vj", "see"]) is True
+        assert _wants_json(["see", "-vj"]) is True
+
+    def test_skips_global_value_option_value(self):
+        # The value of --log-level must not be mistaken for a flag.
+        assert _wants_json(["--log-level", "debug", "see"]) is False
+
+    def test_stops_at_double_dash(self):
+        # Everything after ``--`` is positional, never a JSON flag.
+        assert _wants_json(["type", "--", "-j"]) is False
+
+    def test_absent(self):
+        assert _wants_json(["see", "apps"]) is False
+        assert _wants_json(["list"]) is False
+
+
+# ── JSON envelope on every parse-time error category (R135) ──────────────────
+
+class TestSubcommandUsageErrorJson:
+    def _assert_envelope(self, monkeypatch, capsys, argv, expected_code):
+        code = _run(monkeypatch, argv)
+        out = capsys.readouterr().out
+        data = json.loads(out)  # must be a single, parseable JSON document
+        assert code == 1, f"{argv!r} should exit 1, got {code}"
+        assert data["success"] is False
+        assert data["error"]["code"] == expected_code
+        assert data["error"]["message"]
+        assert data["error"]["suggested_action"]
+        return data
+
+    def test_missing_required_argument(self, monkeypatch, capsys):
+        data = self._assert_envelope(
+            monkeypatch, capsys, ["clipboard", "set", "-j"], "INVALID_INPUT"
+        )
+        assert "Missing argument" in data["error"]["message"]
+
+    def test_unknown_flag(self, monkeypatch, capsys):
+        data = self._assert_envelope(
+            monkeypatch, capsys, ["type", "--bogus-flag-xyz", "-j"], "UNKNOWN_OPTION"
+        )
+        assert "bogus-flag-xyz" in data["error"]["message"]
+
+    def test_too_many_positional_args(self, monkeypatch, capsys):
+        self._assert_envelope(
+            monkeypatch, capsys, ["wait", "1", "2", "-j"], "INVALID_INPUT"
+        )
+
+    def test_invalid_float_value(self, monkeypatch, capsys):
+        self._assert_envelope(
+            monkeypatch, capsys, ["wait", "abc", "-j"], "INVALID_INPUT"
+        )
+
+    def test_invalid_int_value(self, monkeypatch, capsys):
+        self._assert_envelope(
+            monkeypatch, capsys, ["see", "--hwnd", "abc", "-j"], "INVALID_INPUT"
+        )
+
+    def test_invalid_root_choice_value(self, monkeypatch, capsys):
+        # Root-level option error (bad --log-level choice) with -j after the
+        # subcommand still gets the envelope (category 6).
+        self._assert_envelope(
+            monkeypatch, capsys, ["--log-level", "bogus", "see", "-j"], "INVALID_INPUT"
+        )
+
+    def test_unknown_subgroup_command(self, monkeypatch, capsys):
+        data = self._assert_envelope(
+            monkeypatch, capsys, ["app", "bogus-subcmd", "-j"], "UNKNOWN_COMMAND"
+        )
+        assert "bogus-subcmd" in data["error"]["message"]
+
+
+class TestFlagPositionVariants:
+    """``-j`` works before or after the subcommand (issue body)."""
+
+    def _envelope_code(self, monkeypatch, capsys, argv):
+        code = _run(monkeypatch, argv)
+        data = json.loads(capsys.readouterr().out)
+        assert code == 1
+        assert data["success"] is False
+        return data["error"]["code"]
+
+    def test_global_flag_before_subcommand(self, monkeypatch, capsys):
+        assert self._envelope_code(
+            monkeypatch, capsys, ["-j", "see", "--hwnd", "abc"]
+        ) == "INVALID_INPUT"
+
+    def test_long_global_flag_before_subcommand(self, monkeypatch, capsys):
+        assert self._envelope_code(
+            monkeypatch, capsys, ["--json", "see", "--hwnd", "abc"]
+        ) == "INVALID_INPUT"
+
+    def test_flag_after_subcommand(self, monkeypatch, capsys):
+        assert self._envelope_code(
+            monkeypatch, capsys, ["see", "--hwnd", "abc", "-j"]
+        ) == "INVALID_INPUT"
+
+
+# ── regression: non-JSON behaviour is byte-for-byte Click ────────────────────
+
+class TestPlainTextUnchanged:
+    def test_missing_arg_plain_text_exit_2(self, monkeypatch, capsys):
+        code = _run(monkeypatch, ["clipboard", "set"])
+        captured = capsys.readouterr()
+        assert code == 2  # Click's UsageError exit code, unchanged
+        assert "Usage: naturo clipboard set" in captured.err
+        assert captured.out == ""  # nothing on stdout — no stray JSON
+
+    def test_invalid_value_plain_text_exit_2(self, monkeypatch, capsys):
+        code = _run(monkeypatch, ["see", "--hwnd", "abc"])
+        captured = capsys.readouterr()
+        assert code == 2
+        assert "Usage: naturo see" in captured.err
+        assert captured.out == ""


### PR DESCRIPTION
## What

Closes #872. When `-j`/`--json` is requested, **every** Click parse-time error on a **subcommand** — unknown option, unknown command, missing required argument, and invalid option/argument values (bad int/float/choice) — is now wrapped in the standard JSON error envelope and exits 1, instead of leaking a plain Click usage banner on stderr with exit 2.

This is the subcommand twin of #874 (which fixed the same gap for the root group). It covers all six categories QA enumerated in R135 and honours `-j` placed **anywhere** on the command line (global `naturo -j see …` or subcommand-level `naturo see … -j`).

```
$ naturo see --hwnd abc -j
{"success": false, "error": {"code": "INVALID_INPUT", "message": "Invalid value for '--hwnd': 'abc' is not a valid integer.", "suggested_action": "Run 'naturo see --help' for usage."}}
$ echo $?
1
```

### Code-to-envelope mapping
| Failure | code |
|---|---|
| Unknown option (`NoSuchOption`) | `UNKNOWN_OPTION` |
| Unknown (sub)command | `UNKNOWN_COMMAND` |
| Missing arg / extra args / bad int/float/choice | `INVALID_INPUT` |

The `--help` hint targets the **failing** command (e.g. `Run 'naturo clipboard set --help' for usage.`).

## How

- Generalised `_emit_root_usage_error_json` → `_emit_usage_error_json`: derives the help target from `exc.ctx.command_path`, so it works for nested commands while preserving the root codes/behaviour from #874.
- New `_wants_json(argv)` scanner detects `-j`/`--json` (and `-vj` clusters) anywhere on the line, stopping at `--`. Needed because a parse failure can occur before Click binds the flag.
- `run()` now wraps **all** parse-time `UsageError`s (root or subcommand) when JSON was requested. Runtime guards (e.g. `NO_DESKTOP_SESSION`) already emit their own envelope and `sys.exit` before reaching the handler, so non-JSON behaviour is byte-for-byte Click (plain banner, exit 2).

## How tested

- New `tests/test_subcommand_usage_error_json_872.py` (17 tests): all six R135 categories, flag-position variants, unknown-subgroup-command, the `_wants_json` scanner, and **non-JSON regression** (plain banner, exit 2, empty stdout).
- Live-verified all six categories on Windows 11 (single valid JSON doc, exit 1, empty stderr) and confirmed non-`-j` paths unchanged.
- `ruff check` clean; `mypy` clean on the changed file; #874/#869/#783 envelope regression suites all green (37/37). The local full-suite `test_visual.py` errors are a pre-existing environmental pytest tmp-dir `PermissionError` unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)