### PR TITLE
test: self-maintaining contract for the -j success envelope (fixes #979)

### DIFF
--- a/naturo/cli/error_helpers.py
+++ b/naturo/cli/error_helpers.py
@@ -11,11 +11,65 @@ from __future__ import annotations
 
 import json
 import sys
-from typing import Any, NoReturn, Optional
+from typing import Any, Callable, Iterable, NoReturn, Optional, TypeVar
 
 import click
 
 from naturo.errors import NaturoError
+
+_CommandT = TypeVar("_CommandT", bound=click.Command)
+
+
+def success_envelope(collection_key: str, items: Iterable[Any]) -> dict[str, Any]:
+    """Build the canonical ``-j`` success envelope for a collection read.
+
+    Every ``list``-style command that returns a collection under ``-j`` must emit
+    the same three-key shape so scripters and AI agents can rely on it. Routing
+    those callsites through this single helper keeps the shape from drifting (see
+    issue #979) — the matching contract test in ``tests/test_json_envelope_contract``
+    pins it.
+
+    Args:
+        collection_key: Top-level key under which the collection is published
+            (e.g. ``"selectors"``, ``"baselines"``, ``"recordings"``).
+        items: The collection to publish. Materialised into a fresh list so the
+            envelope never aliases (or is mutated by) the caller's sequence.
+
+    Returns:
+        A dict ``{"success": True, collection_key: [...], "count": len([...])}``,
+        with keys in that exact order, ready for ``json.dumps``.
+    """
+    materialised = list(items)
+    return {"success": True, collection_key: materialised, "count": len(materialised)}
+
+
+def collection_read(collection_key: str) -> Callable[[_CommandT], _CommandT]:
+    """Tag a Click command as a ``-j`` collection read for the contract test.
+
+    The decorator records ``collection_key`` on the command object so the
+    self-maintaining contract test can auto-enumerate the Click tree and assert
+    every tagged command emits :func:`success_envelope`'s canonical shape. It does
+    not alter the command's behaviour.
+
+    Apply it *above* ``@click.command`` so it receives the constructed command::
+
+        @collection_read("selectors")
+        @click.command("list")
+        def selector_list(...): ...
+
+    Args:
+        collection_key: The top-level collection key the command publishes; must
+            match the key it passes to :func:`success_envelope`.
+
+    Returns:
+        A decorator that annotates the command and returns it unchanged.
+    """
+
+    def decorator(command: _CommandT) -> _CommandT:
+        command._naturo_collection_key = collection_key  # type: ignore[attr-defined]
+        return command
+
+    return decorator
 
 # ── Recovery hint registry ───────────────────────────────────────────────────
 # Maps error codes to (suggested_action, recoverable) when we don't have a

--- a/naturo/cli/recording_cmd.py
+++ b/naturo/cli/recording_cmd.py
@@ -12,6 +12,7 @@ from datetime import datetime
 
 import click
 
+from naturo.cli.error_helpers import collection_read, success_envelope
 from naturo.cli.fuzzy_group import FuzzyGroup
 from naturo.recording import (
     Recording,
@@ -181,6 +182,7 @@ def record_play(recording_id: str, speed: float, dry_run: bool, json_output: boo
                     f"{error_count} failed, {skipped_count} skipped")
 
 
+@collection_read("recordings")
 @click.command("list")
 @click.option("-j", "--json", "json_output", is_flag=True, help="Output JSON.")
 def record_list(json_output: bool):
@@ -197,11 +199,7 @@ def record_list(json_output: bool):
     active = get_active_recording()
 
     if json_output:
-        output: dict = {
-            "success": True,
-            "recordings": recordings,
-            "count": len(recordings),
-        }
+        output: dict = success_envelope("recordings", recordings)
         if active:
             output["active"] = {
                 "recording_id": active.recording_id,

--- a/naturo/cli/selector_cmd.py
+++ b/naturo/cli/selector_cmd.py
@@ -12,6 +12,7 @@ from typing import Optional
 
 import click
 
+from naturo.cli.error_helpers import collection_read, success_envelope
 from naturo.cli.fuzzy_group import FuzzyGroup
 
 
@@ -222,6 +223,7 @@ def selector_load(app_name: str, name: str, json_output: bool):
         click.echo(sel_str)
 
 
+@collection_read("selectors")
 @click.command("list")
 @click.option("--app", "app_name", default=None, help="Filter by app name.")
 @click.option("--builtin", is_flag=True, help="Show built-in templates.")
@@ -262,11 +264,7 @@ def selector_list(app_name: Optional[str], builtin: bool, json_output: bool):
                     "selector": selector_value,
                     "description": description,
                 })
-        click.echo(json.dumps({
-            "success": True,
-            "selectors": selectors,
-            "count": len(selectors),
-        }))
+        click.echo(json.dumps(success_envelope("selectors", selectors)))
         return
 
     if not all_selectors:

--- a/naturo/cli/visual_cmd.py
+++ b/naturo/cli/visual_cmd.py
@@ -13,6 +13,7 @@ from typing import Optional
 
 import click
 
+from naturo.cli.error_helpers import collection_read, success_envelope
 from naturo.cli.fuzzy_group import FuzzyGroup
 from naturo.visual import (
     save_baseline,
@@ -173,6 +174,7 @@ def visual_diff(image1: str, image2: str, output: Optional[str],
             click.echo(f"  Diff image: {output}")
 
 
+@collection_read("baselines")
 @click.command("list")
 @click.option("-j", "--json", "json_output", is_flag=True, help="Output JSON.")
 def visual_list(json_output: bool):
@@ -185,11 +187,7 @@ def visual_list(json_output: bool):
     baselines = list_baselines()
 
     if json_output:
-        click.echo(json.dumps({
-            "success": True,
-            "baselines": baselines,
-            "count": len(baselines),
-        }))
+        click.echo(json.dumps(success_envelope("baselines", baselines)))
         return
 
     if not baselines:

--- a/tests/test_json_envelope_contract.py
+++ b/tests/test_json_envelope_contract.py
@@ -1,0 +1,195 @@
+"""Self-maintaining contract for the ``-j`` success envelope of collection reads.
+
+Background (issue #979)
+-----------------------
+Every ``list``-style command that emits a collection under ``-j`` hand-builds the
+same envelope at its callsite::
+
+    json.dumps({"success": True, "<collection>": items, "count": len(items)})
+
+Because each callsite wrote this literally, the envelope drifted silently every
+time a new read command was added — QA discovered the omissions one at a time
+(#876 ``selector list`` / ``record list``; #977 ``visual list`` / ``selector
+show``). Nothing structurally prevented the *next* read command from drifting.
+
+This module is that structural guard. It does two things:
+
+1. Unit-tests the single source of truth, :func:`success_envelope`, so the canonical
+   shape is pinned in one place.
+2. Walks the live Click command tree, finds every command tagged as a collection
+   read via :func:`collection_read`, runs it with ``-j`` against an **empty** store,
+   and asserts the emitted JSON is *exactly* ``{"success": bool, "<collection>":
+   list, "count": int}`` with ``count == len(collection)``. A new collection-read
+   command that forgets the envelope — or a marked command without an isolation
+   fixture — fails CI on day one instead of weeks later in QA.
+
+The test is pure-Python and touches only on-disk JSON stores (no DLL, no desktop),
+so it runs on every CI lane.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Iterator
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from naturo.cli import main
+from naturo.cli.error_helpers import success_envelope
+
+# ── Where each collection-read command keeps its on-disk store ────────────────
+# Maps a collection key to the ``(module, attribute)`` holding its storage root,
+# so the contract test can point it at an empty temp directory. Every command
+# discovered with that collection key MUST have an entry here — the walk below
+# asserts it, which is what forces a new collection read to wire in isolation
+# (and therefore prove its empty-store shape) before it can land.
+_STORE_ROOTS: dict[str, tuple[str, str]] = {
+    "selectors": ("naturo.cli.selector_cmd", "SELECTORS_DIR"),
+    "baselines": ("naturo.visual", "BASELINES_DIR"),
+    "recordings": ("naturo.recording", "RECORDINGS_DIR"),
+}
+
+# The collection reads we know exist today. The walk must rediscover at least
+# these; if one loses its marker (and so drops out of the contract), this set
+# makes the regression loud instead of silent.
+_KNOWN_COLLECTION_READS: dict[tuple[str, ...], str] = {
+    ("selector", "list"): "selectors",
+    ("visual", "list"): "baselines",
+    ("record", "list"): "recordings",
+}
+
+
+def _walk(group: click.Group, prefix: tuple[str, ...] = ()) -> Iterator[tuple[tuple[str, ...], click.Command]]:
+    """Yield ``(path, command)`` for every leaf command under ``group``."""
+    for name, command in group.commands.items():
+        path = prefix + (name,)
+        if isinstance(command, click.Group):
+            yield from _walk(command, path)
+        else:
+            yield path, command
+
+
+def _discover_collection_reads() -> dict[tuple[str, ...], str]:
+    """Find every command tagged via :func:`collection_read` in the live tree."""
+    found: dict[tuple[str, ...], str] = {}
+    for path, command in _walk(main):
+        key = getattr(command, "_naturo_collection_key", None)
+        if key is not None:
+            found[path] = key
+    return found
+
+
+# ── 1. Single source of truth ────────────────────────────────────────────────
+
+def test_success_envelope_canonical_shape() -> None:
+    """The helper emits exactly the three canonical keys, in order."""
+    items = [{"a": 1}, {"b": 2}]
+    envelope = success_envelope("widgets", items)
+
+    assert list(envelope.keys()) == ["success", "widgets", "count"]
+    assert envelope["success"] is True
+    assert envelope["widgets"] == items
+    assert envelope["count"] == 2
+
+
+def test_success_envelope_empty_collection() -> None:
+    """An empty collection yields ``count == 0`` and an empty list."""
+    envelope = success_envelope("widgets", [])
+
+    assert envelope == {"success": True, "widgets": [], "count": 0}
+
+
+def test_success_envelope_copies_items() -> None:
+    """The envelope must not alias the caller's list (mutation isolation)."""
+    items = [1, 2]
+    envelope = success_envelope("widgets", items)
+    items.append(3)
+
+    assert envelope["widgets"] == [1, 2]
+    assert envelope["count"] == 2
+
+
+def test_success_envelope_count_matches_any_iterable() -> None:
+    """``count`` reflects the materialised collection even for a generator."""
+    envelope = success_envelope("widgets", (n for n in range(3)))
+
+    assert envelope["widgets"] == [0, 1, 2]
+    assert envelope["count"] == 3
+
+
+# ── 2. Self-maintaining tree contract ────────────────────────────────────────
+
+def test_known_collection_reads_are_discovered() -> None:
+    """The marker survives on every collection read we ship today."""
+    discovered = _discover_collection_reads()
+    for path, key in _KNOWN_COLLECTION_READS.items():
+        assert discovered.get(path) == key, (
+            f"{' '.join(path)} lost its collection_read marker — its -j envelope "
+            f"is no longer guarded by the contract test."
+        )
+
+
+def test_every_collection_read_has_a_store_fixture() -> None:
+    """A marked command without an isolation fixture fails loudly here.
+
+    This is the self-maintaining hinge: adding a new ``collection_read`` command
+    forces the author to register its storage root, which in turn makes the
+    empty-store shape assertion below run against it.
+    """
+    for path, key in _discover_collection_reads().items():
+        assert key in _STORE_ROOTS, (
+            f"{' '.join(path)} is tagged collection_read('{key}') but '{key}' has "
+            f"no entry in _STORE_ROOTS — add one so the contract can isolate and "
+            f"verify its empty-store envelope."
+        )
+
+
+@pytest.fixture()
+def empty_store_dir() -> Iterator[Path]:
+    """Yield a fresh, empty, writable directory for a command's store.
+
+    Uses :func:`tempfile.mkdtemp` rather than the ``tmp_path`` fixture: the shared
+    pytest temp base on the agent host is contended by concurrent loop cycles and
+    its numbered-dir scan intermittently raises ``WinError 5``. ``mkdtemp`` creates
+    an isolated directory without scanning that base, so the contract stays
+    deterministic on both the agent host and CI.
+    """
+    path = Path(tempfile.mkdtemp(prefix="naturo-envelope-contract-"))
+    try:
+        yield path
+    finally:
+        shutil.rmtree(path, ignore_errors=True)
+
+
+@pytest.mark.parametrize(
+    "path,key",
+    sorted(_discover_collection_reads().items()),
+    ids=lambda value: " ".join(value) if isinstance(value, tuple) else str(value),
+)
+def test_collection_read_emits_canonical_envelope(
+    path: tuple[str, ...],
+    key: str,
+    empty_store_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every tagged read emits exactly the canonical envelope on an empty store."""
+    module_name, attribute = _STORE_ROOTS[key]
+    module = __import__(module_name, fromlist=[attribute])
+    monkeypatch.setattr(module, attribute, empty_store_dir / "store")
+
+    result = CliRunner().invoke(main, [*path, "-j"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+
+    assert set(payload) == {"success", key, "count"}, (
+        f"{' '.join(path)} -j drifted from the canonical envelope: {sorted(payload)}"
+    )
+    assert payload["success"] is True
+    assert isinstance(payload[key], list)
+    assert payload["count"] == len(payload[key]) == 0


### PR DESCRIPTION
## What

The `-j` success envelope for collection reads was hand-built at every callsite (`json.dumps({"success": True, <collection>: ..., "count": ...})`), with no shared helper and no contract test. It silently drifted each time a read command was added — QA caught the omissions one at a time (#876 `selector list`/`record list`; #977 `visual list`/`selector show`). This adds the structural guard that stops the next drift.

- **Single source of truth:** `error_helpers.success_envelope(collection_key, items)` returns the canonical `{success, <collection>, count}` shape. The collection-read list commands (`selector list`, `record list`, `visual list`) now route through it — **no behaviour change**, byte-identical JSON.
- **Self-maintaining contract:** a `collection_read(key)` marker tags those commands; `tests/test_json_envelope_contract.py` auto-enumerates the Click command tree, runs every tagged read with `-j` against an empty store, and asserts the output is *exactly* `{success: bool, <collection>: list, count: int}` with `count == len(collection)`. A new collection read that forgets the helper — or a marked command missing an isolation fixture — fails CI immediately instead of weeks later in QA.

Scope is the *success* envelope for collection reads (per the issue). Error-envelope/exit-code unification (#877/#866/#897/#884) and non-collection reads (`see` #865, `wait` #895) stay in their own issues.

## How tested

- `tests/test_json_envelope_contract.py` — 9 tests (helper unit shape/empty/copy/iterable + tree-walk discovery + per-command empty-store envelope), all green. Pure-Python, no DLL/desktop; `--collect-only` clean.
- Live smoke on Win11: `selector list` / `record list` / `visual list` with `-j` all emit the unchanged `[success, <collection>, count]` shape (record list with 49 real recordings still canonical).
- ruff clean; mypy clean on all four changed files.
- The contract fixture uses `tempfile.mkdtemp` rather than `tmp_path` to stay deterministic under the concurrent-loop temp-dir contention on the agent host (#935).

Fixes #979.