### PR TITLE
fix: NO_DESKTOP_SESSION exits 1, not Click's usage-error 2 (fixes #866)

### DIFF
--- a/naturo/cli/core/_common.py
+++ b/naturo/cli/core/_common.py
@@ -44,16 +44,17 @@ def require_desktop_session(json_output: bool = False) -> Callable[[_F], _F]:
 
     Args:
         json_output: When True, emit a JSON ``NO_DESKTOP_SESSION`` error
-            envelope and exit with status 1.  When False, raise
-            :class:`click.UsageError` so Click prints a human-readable
-            message and exits with status 1.
+            envelope and exit with status 1.  When False, emit a clean
+            ``Error: ...`` message and exit with status 1 (no Click
+            ``Usage:`` banner — a missing desktop is a runtime failure, not a
+            usage error; see #866).
 
     Returns:
         A decorator that wraps the target command function with the guard.
 
     Raises:
-        click.UsageError: If no interactive desktop session is available and
-            ``json_output`` is False.
+        SystemExit: With status 1 if no interactive desktop session is
+            available.
     """
     def decorator(func: _F) -> _F:
         @functools.wraps(func)
@@ -70,13 +71,13 @@ def _enforce_desktop_session(json_output: bool) -> None:
     """Run the desktop-session pre-flight check, failing loudly on miss.
 
     Args:
-        json_output: When True, emit a JSON ``NO_DESKTOP_SESSION`` error and
-            ``sys.exit(1)``.  When False, raise :class:`click.UsageError`.
+        json_output: When True, emit a JSON ``NO_DESKTOP_SESSION`` envelope;
+            when False, emit a clean ``Error: ...`` message.  Either way the
+            process exits with status 1 — never Click's exit-2 ``Usage:``
+            banner, which is reserved for genuine argument errors (#866).
 
     Raises:
-        SystemExit: When ``json_output`` is True and no desktop session exists.
-        click.UsageError: When ``json_output`` is False and no desktop session
-            exists.
+        SystemExit: With status 1 when no desktop session exists.
     """
     from naturo.cli.interaction import _check_desktop_session
     try:
@@ -84,8 +85,12 @@ def _enforce_desktop_session(json_output: bool) -> None:
     except Exception as exc:
         if json_output:
             click.echo(_json_error_str("NO_DESKTOP_SESSION", str(exc)))
-            raise SystemExit(1)
-        raise click.UsageError(str(exc))
+        else:
+            # A missing desktop is a runtime/environment failure, not a usage
+            # error: emit a clean message and exit 1, never Click's exit-2
+            # ``Usage:`` banner (#866).
+            click.echo(f"Error: {exc}", err=True)
+        raise SystemExit(1)
 
 
 def _get_backend(json_output: bool = False):
@@ -103,7 +108,7 @@ def _get_backend(json_output: bool = False):
         A Backend instance for the current platform.
 
     Raises:
-        click.UsageError: If no interactive desktop session or no backend.
+        SystemExit: With status 1 if no interactive desktop session exists.
     """
     _enforce_desktop_session(json_output)
     from naturo.backends.base import get_backend

--- a/naturo/cli/interaction/_common.py
+++ b/naturo/cli/interaction/_common.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import json
 import logging
 import sys
-from typing import Callable, Optional
+from typing import Callable, NoReturn, Optional
 
 import click
 
@@ -755,30 +755,34 @@ def _check_desktop_session() -> None:
 
 
 def _get_backend(json_output: bool = False):
-    """Return the platform backend, raising UsageError if unavailable.
+    """Return the platform backend, failing loudly if unavailable.
 
-    Also performs a pre-flight check for an interactive desktop session
-    on Windows to provide clear errors instead of cryptic COM exceptions.
+    Performs a pre-flight check for an interactive desktop session on Windows
+    to provide clear errors instead of cryptic COM exceptions.  A missing
+    desktop or unavailable backend is a runtime/environment failure, not a
+    CLI usage error: it exits with status 1 and a clean message (JSON envelope
+    under ``-j``), never Click's exit-2 ``Usage:`` banner (#866).
 
     Args:
-        json_output: When True, emit JSON-formatted error and sys.exit
-            instead of raising an exception for NoDesktopSessionError.
+        json_output: When True, emit a JSON error envelope; when False, emit a
+            clean ``Error: ...`` message.  Either way the process exits 1 on
+            failure.
+
+    Returns:
+        A Backend instance for the current platform.
+
+    Raises:
+        SystemExit: With status 1 if no desktop session or no backend.
     """
     try:
         _check_desktop_session()
     except Exception as exc:
-        if json_output:
-            from naturo.cli.error_helpers import json_error
-            click.echo(json_error("NO_DESKTOP_SESSION", str(exc)))
-            sys.exit(1)
-        raise click.UsageError(str(exc))
+        _json_err(str(exc), json_output, code="NO_DESKTOP_SESSION")
     from naturo.backends.base import get_backend
     try:
         return get_backend()
     except Exception as exc:
-        if json_output:
-            _json_err(str(exc), True, code="BACKEND_ERROR")
-        raise click.UsageError(str(exc))
+        _json_err(str(exc), json_output, code="BACKEND_ERROR")
 
 
 _VERIFICATION_KEYS = frozenset({
@@ -808,10 +812,13 @@ def _json_ok(data: dict, json_output: bool) -> None:
 
 
 def _json_err(msg: str, json_output: bool, exit_code: int = 1,
-              code: str = "ACTION_ERROR") -> None:
+              code: str = "ACTION_ERROR") -> NoReturn:
     """Emit error result as JSON or plain text, then exit.
 
     Includes agent-friendly recovery hints from the error_helpers registry.
+    The plain-text path prints ``Error: <msg>`` to stderr (no Click ``Usage:``
+    banner) so runtime failures keep exit code 1 instead of Click's usage-error
+    exit code 2 (#866).  Always terminates the process; never returns.
     """
     if json_output:
         from naturo.cli.error_helpers import json_error

--- a/tests/test_cli_core_common.py
+++ b/tests/test_cli_core_common.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import json
 from unittest.mock import MagicMock, patch
 
-import click
 import pytest
 
 from naturo.cli.core._common import (
@@ -22,12 +21,15 @@ class TestGetBackend:
 
     @patch("naturo.cli.core._common._json_error_str")
     @patch("naturo.cli.interaction._check_desktop_session")
-    def test_desktop_check_fails_plain_raises_usage_error(
+    def test_desktop_check_fails_plain_exits_1_not_usage_error(
         self, mock_check, mock_json_err
     ):
+        # A missing desktop is a runtime failure: exit 1, never Click's exit-2
+        # UsageError / 'Usage:' banner (#866).
         mock_check.side_effect = RuntimeError("no desktop")
-        with pytest.raises(click.UsageError, match="no desktop"):
+        with pytest.raises(SystemExit) as exc_info:
             _get_backend(json_output=False)
+        assert exc_info.value.code == 1
 
     @patch("naturo.cli.core._common._json_error_str", return_value='{"error": "x"}')
     @patch("naturo.cli.interaction._check_desktop_session")

--- a/tests/test_cli_interaction_common.py
+++ b/tests/test_cli_interaction_common.py
@@ -643,15 +643,18 @@ class TestGetBackend:
             result = _get_backend()
         assert result is mock_backend
 
-    def test_raises_usage_error_on_no_desktop(self):
+    def test_exits_1_on_no_desktop_plain(self):
+        # A missing desktop is a runtime failure: exit 1, never Click's exit-2
+        # UsageError / 'Usage:' banner (#866).
         from naturo.cli.interaction._common import _get_backend
         from naturo.errors import NoDesktopSessionError
         with patch(
             "naturo.cli.interaction._common._check_desktop_session",
             side_effect=NoDesktopSessionError("no desktop"),
         ):
-            with pytest.raises(Exception):  # click.UsageError
+            with pytest.raises(SystemExit) as exc_info:
                 _get_backend(json_output=False)
+        assert exc_info.value.code == 1
 
     def test_json_mode_exits_on_no_desktop(self):
         from naturo.cli.interaction._common import _get_backend

--- a/tests/test_desktop_session.py
+++ b/tests/test_desktop_session.py
@@ -159,15 +159,20 @@ class TestCoreGetBackendDesktopCheck:
     NoDesktopSessionError that click/type/press already show.
     """
 
-    def test_raises_usage_error_on_no_desktop(self):
-        """core._get_backend() should raise UsageError when no desktop session."""
-        import click
+    def test_exits_1_on_no_desktop_plain(self):
+        """core._get_backend() should exit 1 (not Click's exit-2 UsageError).
+
+        A missing interactive desktop is a runtime/environment failure, not a
+        CLI usage error, so it must exit 1 with a clean ``Error: ...`` message
+        and no ``Usage:`` banner (#866).
+        """
         from naturo.cli.core import _get_backend
 
         with patch("naturo.cli.interaction._check_desktop_session",
                    side_effect=NoDesktopSessionError()):
-            with pytest.raises(click.UsageError, match="interactive desktop"):
+            with pytest.raises(SystemExit) as exc_info:
                 _get_backend()
+        assert exc_info.value.code == 1
 
     def test_json_output_exits_on_no_desktop(self):
         """core._get_backend(json_output=True) should sys.exit with JSON error."""

--- a/tests/test_interaction_common.py
+++ b/tests/test_interaction_common.py
@@ -5,7 +5,6 @@ import json
 import os
 from unittest.mock import MagicMock, patch
 
-import click
 import pytest
 
 from naturo.cli.interaction._common import (
@@ -416,10 +415,13 @@ class TestGetBackend:
 
     @patch("naturo.cli.interaction._common._check_desktop_session",
            side_effect=Exception("no desktop"))
-    def test_no_desktop_text_raises_usage_error(self, _mock):
+    def test_no_desktop_text_exits_1(self, _mock):
+        # A missing desktop is a runtime failure: exit 1, never Click's exit-2
+        # UsageError / 'Usage:' banner (#866).
         from naturo.cli.interaction._common import _get_backend
-        with pytest.raises(click.UsageError, match="no desktop"):
+        with pytest.raises(SystemExit) as exc_info:
             _get_backend(json_output=False)
+        assert exc_info.value.code == 1
 
 
 # ── _validate_method ────────────────────────────

--- a/tests/test_no_desktop_exit_contract_866.py
+++ b/tests/test_no_desktop_exit_contract_866.py
@@ -1,0 +1,102 @@
+"""Exit-code contract for runtime NO_DESKTOP_SESSION failures (#866).
+
+A missing interactive desktop is a runtime/environment failure, not a CLI
+*usage* error.  It must therefore exit with code 1 and a clean ``Error: ...``
+message — never Click's exit-2 ``Usage:`` banner.  The banner is reserved for
+genuine argument errors; emitting it for an environment failure misleads the
+standard scripting branch ``case $? in 2) usage_error ;; 1) op_failed ;; esac``
+into classifying a no-desktop session as a CLI-argument bug.
+
+Before this fix the input/runtime commands ``type``/``press``/``click``/
+``drag``/``highlight`` raised :class:`click.UsageError` in their no-desktop
+path (``naturo.cli.interaction._common._get_backend`` and the sister
+``naturo.cli.core._common._enforce_desktop_session``), exiting 2 with a
+``Usage:`` banner, while the read commands ``see``/``list apps`` already
+exited 1 cleanly.  This module locks every command onto the same exit-1,
+no-banner contract in both plain and ``-j`` mode.
+
+Closes #866.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from naturo.errors import NoDesktopSessionError
+
+
+@pytest.fixture
+def no_desktop(monkeypatch):
+    """Force the desktop-session pre-flight to fail at both guard sites.
+
+    ``naturo.cli.interaction._common._get_backend`` (input commands) calls the
+    module-local ``_check_desktop_session``, while
+    ``naturo.cli.core._common._enforce_desktop_session`` imports it from the
+    ``naturo.cli.interaction`` package; both names are patched so every command
+    under test takes the no-desktop branch regardless of which guard it hits.
+    """
+    def _raise() -> None:
+        raise NoDesktopSessionError()
+
+    monkeypatch.setattr(
+        "naturo.cli.interaction._common._check_desktop_session", _raise
+    )
+    monkeypatch.setattr(
+        "naturo.cli.interaction._check_desktop_session", _raise
+    )
+
+
+def _run(argv):
+    """Invoke the naturo CLI with *argv* and return the Click result."""
+    from naturo.cli import main
+
+    return CliRunner().invoke(main, argv, catch_exceptions=False)
+
+
+# Input/runtime commands that previously raised UsageError (exit 2 + banner)
+# on NO_DESKTOP_SESSION.  Arguments are valid so parsing succeeds and the
+# desktop guard is what trips.
+_RUNTIME_COMMANDS = [
+    pytest.param(["type", "hello", "--app", "notepad"], id="type"),
+    pytest.param(["press", "enter", "--app", "notepad"], id="press"),
+    pytest.param(["click", "e1", "--app", "notepad"], id="click"),
+    pytest.param(["drag", "--from", "e1", "--to", "e2"], id="drag"),
+    pytest.param(["highlight"], id="highlight"),
+]
+
+
+@pytest.mark.parametrize("argv", _RUNTIME_COMMANDS)
+def test_plain_mode_exits_1_without_usage_banner(no_desktop, argv):
+    """Each runtime command exits 1 with a clean message and no Usage banner."""
+    result = _run(argv)
+    assert result.exit_code == 1, result.output
+    assert "Usage:" not in result.output, result.output
+    assert "desktop" in result.output.lower(), result.output
+
+
+@pytest.mark.parametrize("argv", _RUNTIME_COMMANDS)
+def test_json_mode_exits_1_with_no_desktop_envelope(no_desktop, argv):
+    """The -j path already exits 1; lock it down so the contract stays symmetric."""
+    result = _run([*argv, "-j"])
+    assert result.exit_code == 1, result.output
+    payload = json.loads(result.output)
+    assert payload.get("success") is False, payload
+    code = payload.get("code") or payload.get("error", {}).get("code")
+    assert code == "NO_DESKTOP_SESSION", payload
+
+
+# Read commands that already satisfied the contract — guard against regression.
+_REFERENCE_COMMANDS = [
+    pytest.param(["see", "--app", "notepad"], id="see"),
+    pytest.param(["list", "apps"], id="list-apps"),
+]
+
+
+@pytest.mark.parametrize("argv", _REFERENCE_COMMANDS)
+def test_reference_read_commands_still_exit_1(no_desktop, argv):
+    """see / list apps must keep exiting 1 with no Usage banner."""
+    result = _run(argv)
+    assert result.exit_code == 1, result.output
+    assert "Usage:" not in result.output, result.output


### PR DESCRIPTION
## What
A missing interactive desktop (`NO_DESKTOP_SESSION`) is a **runtime/environment failure, not a CLI usage error**, yet the input commands `type` / `press` / `click` / `drag` / `highlight` exited with code **2** and printed Click's `Usage:` banner. That misleads the standard scripting branch — `case $? in 2) usage_error ;; 1) op_failed ;; esac` — into classifying a missing desktop as an argument bug (and reinforces it with the banner).

The read commands `see` / `list apps` already exited 1 cleanly, but only by accident: they wrap `_get_backend()` in a broad `except Exception` that happened to swallow the `click.UsageError`.

## How
Fix the contract at the source so it no longer depends on whether the caller catches the error:
- `naturo/cli/interaction/_common.py:_get_backend` — both the `NO_DESKTOP_SESSION` and `BACKEND_ERROR` branches now route through `_json_err()`, which emits a clean `Error: ...` message (or JSON envelope under `-j`) and exits **1**.
- `naturo/cli/core/_common.py:_enforce_desktop_session` — emits a clean message and exits **1** instead of raising `click.UsageError` (covers `highlight` / `drag` and any command not wrapped in a catch-all).
- `_json_err` annotated `NoReturn` (it always exits) so the control flow is provably terminating.

The `-j` path already returned exit 1 with the `NO_DESKTOP_SESSION` envelope; this makes the plain path symmetric. No behavior change on the happy path (verified: `list apps` still exits 0 on a real desktop).

## How tested
- New `tests/test_no_desktop_exit_contract_866.py` (12 tests): every runtime command exits 1 with **no** `Usage:` banner in both plain and `-j` mode, plus reference read commands (`see`/`list apps`) guarded against regression. Fully mocked (`_check_desktop_session` forced to raise) — no real desktop/DLL needed, CI-safe.
- Updated 3 existing tests that asserted the old `UsageError` behavior to the corrected exit-1 contract.
- `ruff` clean; `mypy` clean on changed modules (only the pre-existing `visual.py` PIL `LANCZOS` baseline remains).
- Broad CLI/interaction regression suite: 502 passed (the one failure, `test_valid_app_id_returns_handle_and_pid`, is the pre-existing Windows-local #944, confirmed failing on clean `develop`).
- `pytest --collect-only`: 6141 tests collected, no import/collection break (#936 lesson).

Closes #866.
