### PR TITLE
docs: copy-paste see/find/click how-to against the owned Electron fixture (fixes #982)

### DIFF
--- a/docs/RECOGNITION.md
+++ b/docs/RECOGNITION.md
@@ -171,6 +171,31 @@ naturo see --app code --backend auto --stats
 
 Install the CDP dependency with `pip install naturo[cdp]`.
 
+**Try it against the owned fixture (no external app required).** The repo ships a
+real Electron app under `benchmarks/recognition/fixtures/electron/`, so you can
+reproduce the CDP recognition delta end-to-end without installing VS Code, Slack
+or any third-party Electron app:
+
+```bash
+# 1. Build the owned fixture once (Node.js required; electron is pinned by the lockfile):
+cd benchmarks/recognition/fixtures/electron && npm install
+
+# 2. Launch it with a CDP endpoint (main.js also reads NATURO_FIXTURE_CDP_PORT):
+npx electron . --remote-debugging-port=9222 --remote-allow-origins=*
+
+# 3. From another shell, let the cascade fuse UIA window chrome + CDP renderer
+#    content. `--stats` prints the per-provider breakdown; the `cdp` rows are the
+#    renderer controls (toolbar, release form, task list, deployments table) that
+#    a UIA-only tool collapses into one opaque node.
+naturo see --window "Naturo Electron Recognition Fixture" --cascade --stats
+
+# 4. Find a renderer control by its visible label — recognized via CDP, not UIA:
+naturo find "Submit release" --app electron
+
+# 5. Click one (e.g. the toolbar's Deploy button) by text within the window:
+naturo click "Deploy" --window "Naturo Electron Recognition Fixture"
+```
+
 ### Java Swing / SWT (Java Access Bridge)
 
 Enable the Java Access Bridge once per machine, then use the `jab` backend (the

--- a/tests/test_recognition_doc_982.py
+++ b/tests/test_recognition_doc_982.py
@@ -1,0 +1,84 @@
+"""Regression guard for the recognition headline doc (issue #982).
+
+``docs/RECOGNITION.md`` is the published proof of naturo's multi-framework
+recognition moat. A visitor must be able to read one document that (a) shows the
+coverage matrix versus UIA-only rivals, (b) carries the honest #931 benchmark
+numbers, and (c) gives a **copy-paste ``see`` / ``find`` / ``click`` example
+against the owned Electron fixture** — no external app required (issue #982
+acceptance). These tests pin those guarantees so the doc cannot silently drift
+away from the acceptance criteria or reference CLI commands that do not exist.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from naturo.cli import main
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_DOC = _REPO_ROOT / "docs" / "RECOGNITION.md"
+_README = _REPO_ROOT / "README.md"
+
+#: Window title set by ``benchmarks/recognition/fixtures/electron/main.js``.
+_FIXTURE_WINDOW_TITLE = "Naturo Electron Recognition Fixture"
+
+
+def _doc_text() -> str:
+    return _DOC.read_text(encoding="utf-8")
+
+
+def test_recognition_doc_exists() -> None:
+    """The headline recognition doc must exist (issue #982)."""
+    assert _DOC.is_file(), "docs/RECOGNITION.md must exist (issue #982)"
+
+
+def test_readme_links_recognition_doc_above_the_fold() -> None:
+    """README must link the doc above the fold as the differentiator headline."""
+    head = _README.read_text(encoding="utf-8").splitlines()[:40]
+    assert any("docs/RECOGNITION.md" in line for line in head), (
+        "README must link docs/RECOGNITION.md above the fold (issue #982)"
+    )
+
+
+def test_doc_has_capability_matrix_for_all_three_frameworks() -> None:
+    """The coverage matrix must name Electron, Java and SAP rows."""
+    text = _doc_text()
+    assert "Capability matrix" in text
+    for framework in ("Electron", "Java", "SAP"):
+        assert framework in text, f"matrix must cover the {framework} framework"
+
+
+def test_doc_carries_benchmark_numbers_without_fabrication() -> None:
+    """The measured #931 results table and an honest-gap note must be present."""
+    text = _doc_text()
+    assert "Measured benchmark" in text
+    # Honest about the frameworks that could not be measured live on the host.
+    assert "no Java app" in text or "could not be measured" in text
+
+
+def test_doc_has_owned_fixture_copy_paste_example() -> None:
+    """The Electron how-to must offer a runnable example on the OWNED fixture.
+
+    Acceptance bullet (#982): "a copy-paste ``naturo see/find/click`` example
+    against the owned fixture app." Earlier how-to text only targeted external
+    apps (VS Code / DBeaver), which a reader cannot reproduce without installing
+    them; the owned Electron fixture ships in-repo and needs no third-party app.
+    """
+    text = _doc_text()
+    assert _FIXTURE_WINDOW_TITLE in text, (
+        "the how-to must target the owned Electron fixture window so the "
+        "example is reproducible without any external app (issue #982)"
+    )
+    for command in ("naturo see", "naturo find", "naturo click"):
+        assert command in text, (
+            f"the owned-fixture how-to must show a `{command}` example (#982)"
+        )
+
+
+def test_documented_commands_are_real_cli_commands() -> None:
+    """The see/find/click commands the doc advertises must exist in the CLI."""
+    for command in ("see", "find", "click"):
+        assert command in main.commands, (
+            f"docs/RECOGNITION.md references `naturo {command}`, which the CLI "
+            f"must expose"
+        )


### PR DESCRIPTION
## What
`docs/RECOGNITION.md` already carried the coverage matrix, the honest #931 benchmark numbers and per-framework how-tos (landed via #931/#933). The one remaining #982 acceptance bullet was unmet: **a copy-paste `naturo see/find/click` example against the owned fixture app**. The existing Electron how-to only targeted external apps (VS Code / DBeaver), which a reader cannot reproduce without installing them.

This adds a runnable end-to-end example on the **in-repo owned Electron fixture** (`benchmarks/recognition/fixtures/electron/`): build it, launch it with a CDP endpoint, then `see` (with `--stats`), `find` and `click` its renderer controls — no external app required. Every command, flag and element label is verified against the CLI contract and the fixture's `main.js` / `index.html` (window title, `Submit release`, `Deploy`).

Also adds `tests/test_recognition_doc_982.py`, a self-maintaining doc-contract guard (modelled on `test_readme_mcp_install.py`) pinning the #982 acceptance so the doc cannot silently drift.

## How tested
- `python -m pytest tests/test_recognition_doc_982.py` → **6 passed** (the owned-fixture guard failed before the doc edit, passes after — TDD).
- Related suites: `test_recognition_benchmark.py`, `test_readme_mcp_install.py`, `test_cli_see.py` → green (non-desktop).
- `ruff check` clean; `--collect-only` clean (no Windows/optional-dep import at collection).
- All advertised flags confirmed against `naturo see/find/click --help` and the cascade engine (`--backend auto` / `--cascade` both route through CDP).

Docs-only change plus a guard test — no runtime/behaviour change.