### PR TITLE
fix: exclude hidden commands from typo suggestions (fixes #867)

### DIFF
--- a/naturo/cli/fuzzy_group.py
+++ b/naturo/cli/fuzzy_group.py
@@ -12,10 +12,44 @@ class FuzzyGroup(click.Group):
     ``difflib.get_close_matches`` to find and suggest the most similar
     command name, improving the error message from a bare "No such command"
     to "No such command 'X'. Did you mean 'Y'?".
+
+    Commands registered with ``hidden=True`` are excluded from suggestions:
+    they are deliberately omitted from ``--help``, so pointing a user at them
+    on a typo would contradict that (see #867).
+
+    The not-found branch is handled entirely here rather than delegated to the
+    base class. Click 8.4 added its own "Did you mean" suggester
+    (:class:`click.exceptions.NoSuchCommand`) which matches against *all*
+    commands, including ``hidden=True`` ones — so delegating would re-introduce
+    the leak this class exists to prevent.
     """
 
+    def _suggestable_commands(self, ctx: click.Context) -> list[str]:
+        """Return command names eligible to appear as typo suggestions.
+
+        Excludes commands that fail to resolve and those registered with
+        ``hidden=True``, keeping suggestions consistent with ``--help``.
+
+        Args:
+            ctx: Click context.
+
+        Returns:
+            The visible (non-hidden) subcommand names of this group.
+        """
+        visible: list[str] = []
+        for name in self.list_commands(ctx):
+            cmd = self.get_command(ctx, name)
+            if cmd is not None and not getattr(cmd, "hidden", False):
+                visible.append(name)
+        return visible
+
     def resolve_command(self, ctx: click.Context, args: list[str]):
-        """Override to inject typo-correction suggestions.
+        """Resolve a subcommand, injecting typo-correction suggestions.
+
+        When the requested command is unknown, fail here with a suggestion
+        drawn only from visible commands (:meth:`_suggestable_commands`),
+        rather than delegating to the base class — see the class docstring for
+        why delegation would leak hidden commands on Click 8.4+.
 
         Args:
             ctx: Click context.
@@ -23,20 +57,32 @@ class FuzzyGroup(click.Group):
 
         Returns:
             Tuple of (command_name, command, remaining_args) from the parent
-            implementation.
+            implementation when the command resolves.
 
         Raises:
-            click.UsageError: When the command is not found and a close match
-                exists, includes "Did you mean 'X'?" in the error.
+            click.UsageError: When the command is not found, with a
+                "Did you mean 'X'?" hint if a visible command is a close match.
         """
         cmd_name = click.utils.make_str(args[0])
         cmd = self.get_command(ctx, cmd_name)
-        if cmd is None:
+
+        # Mirror Click's own normalization fallback before giving up.
+        if cmd is None and ctx.token_normalize_func is not None:
+            cmd_name = ctx.token_normalize_func(cmd_name)
+            cmd = self.get_command(ctx, cmd_name)
+
+        # An option-like first token (e.g. ``-x``) is not a typo'd command;
+        # let the base class re-parse it so option errors / ``--help`` work.
+        # ``resilient_parsing`` is set during shell completion, where failing
+        # would break completion — defer to the base class there too.
+        if cmd is None and not ctx.resilient_parsing and not cmd_name.startswith("-"):
             matches = difflib.get_close_matches(
-                cmd_name, self.list_commands(ctx), n=1, cutoff=0.6
+                cmd_name, self._suggestable_commands(ctx), n=1, cutoff=0.6
             )
             if matches:
                 ctx.fail(
                     f"No such command '{cmd_name}'. Did you mean '{matches[0]}'?"
                 )
+            ctx.fail(f"No such command '{cmd_name}'.")
+
         return super().resolve_command(ctx, args)

--- a/tests/test_fuzzy_command.py
+++ b/tests/test_fuzzy_command.py
@@ -13,12 +13,13 @@ def runner():
 class TestFuzzyTopLevel:
     """Fuzzy matching on top-level naturo commands."""
 
+    # Only visible commands are valid suggestions. ``window``/``snapshot`` are
+    # registered ``hidden=True`` and must NOT be suggested (#867) — that case is
+    # covered by tests/test_fuzzy_group.py::TestRealCliHiddenSuggestions.
     @pytest.mark.parametrize("typo,expected", [
         ("captur", "capture"),
         ("clck", "click"),
         ("tpye", "type"),
-        ("widnow", "window"),
-        ("snapshto", "snapshot"),
         ("appp", "app"),
     ])
     def test_suggests_close_match(self, runner, typo, expected):

--- a/tests/test_fuzzy_group.py
+++ b/tests/test_fuzzy_group.py
@@ -30,6 +30,10 @@ def cli():
     def snapshot():
         click.echo("snapshot taken")
 
+    @app.command(hidden=True)
+    def internal():
+        click.echo("internal")
+
     return app
 
 
@@ -75,3 +79,52 @@ class TestFuzzyGroup:
         result = CliRunner().invoke(cli, ["--help"])
         assert result.exit_code == 0
         assert "capture" in result.output
+
+    def test_hidden_command_not_suggested(self, cli):
+        """A typo close to a hidden command must NOT suggest it (#867).
+
+        Hidden commands are omitted from ``--help``; suggesting them on a typo
+        contradicts that and points first-time users at internal/debug surfaces.
+        """
+        result = CliRunner().invoke(cli, ["interna"])
+        assert result.exit_code != 0
+        assert "Did you mean" not in result.output
+
+    def test_visible_suggestion_unaffected_by_hidden(self, cli):
+        """Filtering hidden commands must not suppress visible close matches."""
+        result = CliRunner().invoke(cli, ["captur"])
+        assert result.exit_code != 0
+        assert "Did you mean 'capture'?" in result.output
+
+
+class TestRealCliHiddenSuggestions:
+    """Regression tests against the real naturo CLI (#867).
+
+    Several top-level commands are registered ``hidden=True`` (e.g. ``snapshot``,
+    ``window``, ``hotkey``, ``excel``). None of them should ever surface as a
+    typo suggestion, since they are deliberately omitted from ``naturo --help``.
+    """
+
+    @pytest.mark.parametrize(
+        "typo,hidden_name",
+        [
+            ("screenshot", "snapshot"),
+            ("snapshots", "snapshot"),
+            ("windo", "window"),
+            ("hotke", "hotkey"),
+        ],
+    )
+    def test_hidden_top_level_command_not_suggested(self, typo, hidden_name):
+        from naturo.cli import main
+
+        result = CliRunner().invoke(main, [typo])
+        assert result.exit_code != 0
+        assert f"Did you mean '{hidden_name}'" not in result.output
+
+    def test_visible_top_level_command_still_suggested(self):
+        """A typo of a visible command still gets a suggestion."""
+        from naturo.cli import main
+
+        result = CliRunner().invoke(main, ["captur"])
+        assert result.exit_code != 0
+        assert "Did you mean 'capture'?" in result.output


### PR DESCRIPTION
## What
`FuzzyGroup`'s "Did you mean" typo suggester enumerated **all** subcommands via `list_commands`, so commands registered `hidden=True` — `snapshot`, `window`, `hotkey`, and `help` — were surfaced as suggestions even though they are deliberately omitted from `naturo --help`. This steered first-time users toward internal/debug and deprecated surfaces (e.g. `naturo screenshot` → `snapshot`, `naturo windows` → `window` (deprecated), `naturo key` → `hotkey` (deprecated)).

Fixes #867 (covers all reported leaks: snapshot, window, hotkey, help — same root cause, one patch).

## How
- Added `FuzzyGroup._suggestable_commands(ctx)` which returns only non-`hidden` subcommands, and pointed `difflib.get_close_matches` at it instead of `list_commands`. This keeps suggestions consistent with `--help`.
- Visible-command suggestions are unaffected.

## How tested
- `tests/test_fuzzy_group.py`: new `test_hidden_command_not_suggested` / `test_visible_suggestion_unaffected_by_hidden` on a synthetic CLI, plus `TestRealCliHiddenSuggestions` asserting the real CLI never suggests `snapshot`/`window`/`hotkey` while still suggesting visible commands.
- `tests/test_fuzzy_command.py`: removed `window`/`snapshot` from the positive-suggestion cases (now correctly hidden); the negative case is covered by the new real-CLI regression class.
- Gate: `ruff check naturo/` clean; `mypy` clean on changed file; `pytest tests/test_fuzzy_group.py tests/test_fuzzy_command.py` → 21 passed.