### PR TITLE
feat: package naturo as a Claude Desktop Extension (.mcpb bundle) (fixes #926)

### DIFF
--- a/packaging/mcpb/README.md
+++ b/packaging/mcpb/README.md
@@ -1,0 +1,37 @@
+# naturo Claude Desktop Extension (`.mcpb`)
+
+This directory packages naturo as an **MCP Bundle** (`.mcpb`, formerly `.dxt`) —
+a single file that [Claude Desktop](https://claude.ai/download) and other
+MCPB-aware clients can install in one click to add naturo's desktop-automation
+tools.
+
+## Build
+
+```bash
+python scripts/build_mcpb.py            # -> dist/naturo.mcpb
+python scripts/build_mcpb.py --check    # validate the manifest, write nothing
+```
+
+The build is pure-stdlib (no extra dependencies). It stamps
+[`manifest.json`](manifest.json) with the current package version
+(`naturo/version.py`) and the live MCP tool list parsed from `naturo/mcp/`, then
+zips it into `dist/naturo.mcpb`.
+
+## Install
+
+1. `pip install naturo` (see the prerequisite below).
+2. Open Claude Desktop → **Settings → Extensions** → **Install Extension** and
+   choose `dist/naturo.mcpb`, or double-click the file.
+3. naturo's tools (`see_ui_tree`, `click`, `type_text`, …) appear in Claude.
+
+## Prerequisite: `pip install naturo`
+
+This bundle is a thin wrapper: its `manifest.json` launches the installed
+`naturo` console script via `naturo mcp start`. It does **not** vendor naturo
+itself, because the engine depends on a Windows-only native core
+(`naturo_core.dll`) that cannot be bundled cross-platform. The user must
+`pip install naturo` first, exactly as for the manual
+[README MCP install snippets](../../README.md).
+
+A future, fully self-contained bundle that vendors the native core and Python
+runtime (so no separate `pip install` is needed) is tracked as a follow-up.

--- a/packaging/mcpb/manifest.json
+++ b/packaging/mcpb/manifest.json
@@ -1,0 +1,310 @@
+{
+  "manifest_version": "0.3",
+  "name": "naturo",
+  "display_name": "Naturo Desktop Automation",
+  "version": "0.3.1",
+  "description": "Windows desktop automation engine — see, click, type, and automate any app through UIA, MSAA, IA2, Java Access Bridge, Electron/CDP, and AI vision.",
+  "long_description": "Naturo exposes Windows desktop automation as MCP tools so AI agents can inspect the accessibility tree, capture screenshots, click, type, manage windows and apps, and drive dialogs. This bundle launches the installed `naturo` CLI via `naturo mcp start`; run `pip install naturo` first.",
+  "author": {
+    "name": "Ace Li",
+    "email": "ace@scoutli.ai",
+    "url": "https://github.com/AcePeak/naturo"
+  },
+  "homepage": "https://github.com/AcePeak/naturo",
+  "documentation": "https://github.com/AcePeak/naturo#readme",
+  "support": "https://github.com/AcePeak/naturo/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/AcePeak/naturo"
+  },
+  "license": "MIT",
+  "keywords": [
+    "automation",
+    "windows",
+    "desktop",
+    "ui",
+    "rpa",
+    "accessibility",
+    "uia",
+    "mcp"
+  ],
+  "server": {
+    "type": "binary",
+    "entry_point": "naturo",
+    "mcp_config": {
+      "command": "naturo",
+      "args": [
+        "mcp",
+        "start"
+      ],
+      "env": {}
+    }
+  },
+  "compatibility": {
+    "platforms": [
+      "win32"
+    ],
+    "runtimes": {
+      "python": ">=3.9"
+    }
+  },
+  "tools_generated": false,
+  "tools": [
+    {
+      "name": "app_hide",
+      "description": "Hide (minimize) all windows of an application."
+    },
+    {
+      "name": "app_inspect",
+      "description": "Probe an application to detect its UI framework and available interaction methods."
+    },
+    {
+      "name": "app_switch",
+      "description": "Switch to (focus) the most recent window of an application."
+    },
+    {
+      "name": "app_unhide",
+      "description": "Unhide (restore) all windows of an application."
+    },
+    {
+      "name": "capture_screen",
+      "description": "Capture a screenshot of the entire screen."
+    },
+    {
+      "name": "capture_window",
+      "description": "Capture a screenshot of a specific window."
+    },
+    {
+      "name": "click",
+      "description": "Click at coordinates or on a UI element."
+    },
+    {
+      "name": "clipboard_clear",
+      "description": "Clear the system clipboard contents."
+    },
+    {
+      "name": "clipboard_get",
+      "description": "Read the current clipboard text content."
+    },
+    {
+      "name": "clipboard_info",
+      "description": "Get information about the current clipboard contents."
+    },
+    {
+      "name": "clipboard_set",
+      "description": "Write text to the system clipboard."
+    },
+    {
+      "name": "create_snapshot",
+      "description": "Create a snapshot of the current UI state (screenshot + element tree)."
+    },
+    {
+      "name": "dialog_accept",
+      "description": "Accept (confirm) the active dialog by clicking OK/Yes/Open/Save."
+    },
+    {
+      "name": "dialog_click_button",
+      "description": "Click a specific button in the active dialog by name."
+    },
+    {
+      "name": "dialog_detect",
+      "description": "Detect active dialog windows (message boxes, file pickers, etc.)."
+    },
+    {
+      "name": "dialog_dismiss",
+      "description": "Dismiss (cancel) the active dialog by clicking Cancel/No/Close."
+    },
+    {
+      "name": "dialog_type",
+      "description": "Type text into a dialog's input field."
+    },
+    {
+      "name": "drag",
+      "description": "Drag from one point to another."
+    },
+    {
+      "name": "excel_info",
+      "description": "Get used range info for an Excel worksheet."
+    },
+    {
+      "name": "excel_list_sheets",
+      "description": "List all sheets in an Excel workbook."
+    },
+    {
+      "name": "excel_open",
+      "description": "Open an Excel workbook and return its info."
+    },
+    {
+      "name": "excel_read",
+      "description": "Read a cell or range value from an Excel workbook."
+    },
+    {
+      "name": "excel_run_macro",
+      "description": "Run a VBA macro in an Excel workbook."
+    },
+    {
+      "name": "excel_write",
+      "description": "Write a value to a cell in an Excel workbook."
+    },
+    {
+      "name": "expand_collapse_element",
+      "description": "Expand or collapse a combo box or tree item via ExpandCollapsePattern."
+    },
+    {
+      "name": "find_element",
+      "description": "Find a UI element by selector."
+    },
+    {
+      "name": "focus_window",
+      "description": "Bring a window to the foreground and give it focus."
+    },
+    {
+      "name": "get_element_value",
+      "description": "Read the current value/text of a UI element."
+    },
+    {
+      "name": "get_snapshot",
+      "description": "Retrieve a previously created snapshot."
+    },
+    {
+      "name": "hotkey",
+      "description": "Press a keyboard shortcut (key combination)."
+    },
+    {
+      "name": "launch_app",
+      "description": "Launch an application by name."
+    },
+    {
+      "name": "list_apps",
+      "description": "List running applications."
+    },
+    {
+      "name": "list_monitors",
+      "description": "List all connected monitors/displays."
+    },
+    {
+      "name": "list_snapshots",
+      "description": "List recent snapshots."
+    },
+    {
+      "name": "list_windows",
+      "description": "List all visible windows on the desktop."
+    },
+    {
+      "name": "menu_inspect",
+      "description": "Inspect the menu bar of an application."
+    },
+    {
+      "name": "move_mouse",
+      "description": "Move the mouse cursor to a position."
+    },
+    {
+      "name": "press_key",
+      "description": "Press a key or key combination."
+    },
+    {
+      "name": "quit_app",
+      "description": "Quit an application."
+    },
+    {
+      "name": "scroll",
+      "description": "Scroll the mouse wheel."
+    },
+    {
+      "name": "see_ui_tree",
+      "description": "Inspect the UI accessibility tree of a window."
+    },
+    {
+      "name": "select_element",
+      "description": "Select a list item, radio button, or tab via SelectionItemPattern."
+    },
+    {
+      "name": "set_element_value",
+      "description": "Set the value/text of a UI element via UIA ValuePattern."
+    },
+    {
+      "name": "taskbar_click",
+      "description": "Click a taskbar item to activate its window."
+    },
+    {
+      "name": "taskbar_list",
+      "description": "List items on the Windows taskbar."
+    },
+    {
+      "name": "toggle_element",
+      "description": "Toggle a checkbox or toggle button via UIA TogglePattern."
+    },
+    {
+      "name": "tray_click",
+      "description": "Click a system tray icon."
+    },
+    {
+      "name": "tray_list",
+      "description": "List system tray (notification area) icons."
+    },
+    {
+      "name": "type_text",
+      "description": "Type text using keyboard input."
+    },
+    {
+      "name": "virtual_desktop_close",
+      "description": "Close a virtual desktop."
+    },
+    {
+      "name": "virtual_desktop_create",
+      "description": "Create a new virtual desktop."
+    },
+    {
+      "name": "virtual_desktop_list",
+      "description": "List all virtual desktops (Windows 10/11)."
+    },
+    {
+      "name": "virtual_desktop_move_window",
+      "description": "Move a window to a different virtual desktop."
+    },
+    {
+      "name": "virtual_desktop_switch",
+      "description": "Switch to a virtual desktop by index."
+    },
+    {
+      "name": "wait_for_element",
+      "description": "Wait for a UI element to appear."
+    },
+    {
+      "name": "wait_for_window",
+      "description": "Wait for a window to appear."
+    },
+    {
+      "name": "wait_until_gone",
+      "description": "Wait for a UI element to disappear."
+    },
+    {
+      "name": "window_close",
+      "description": "Close a window (graceful or forced)."
+    },
+    {
+      "name": "window_maximize",
+      "description": "Maximize a window."
+    },
+    {
+      "name": "window_minimize",
+      "description": "Minimize a window."
+    },
+    {
+      "name": "window_move",
+      "description": "Move a window to a position (keeps current size)."
+    },
+    {
+      "name": "window_resize",
+      "description": "Resize a window (keeps current position)."
+    },
+    {
+      "name": "window_restore",
+      "description": "Restore a minimized or maximized window to normal state."
+    },
+    {
+      "name": "window_set_bounds",
+      "description": "Set window position and size in one call."
+    }
+  ]
+}

--- a/scripts/build_mcpb.py
+++ b/scripts/build_mcpb.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Build the naturo Claude Desktop Extension bundle (``naturo.mcpb``).
+
+An MCP Bundle (``.mcpb``, formerly ``.dxt``) is a zip archive with a
+``manifest.json`` at its root. MCPB-aware clients such as Claude Desktop read
+that manifest to install an MCP server in a single click. This script stamps the
+canonical manifest (``packaging/mcpb/manifest.json``) with the current package
+version and the live MCP tool list, then writes the bundle to
+``dist/naturo.mcpb``.
+
+The bundle wraps the *installed* ``naturo`` console script (it launches
+``naturo mcp start``) rather than vendoring the Windows-only native core, so
+``pip install naturo`` is a prerequisite. See ``packaging/mcpb/README.md`` for
+the rationale and the full-vendoring follow-up.
+
+Usage::
+
+    python scripts/build_mcpb.py            # -> dist/naturo.mcpb
+    python scripts/build_mcpb.py --check    # assemble + validate, write nothing
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+import sys
+import zipfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MANIFEST_SOURCE = REPO_ROOT / "packaging" / "mcpb" / "manifest.json"
+BUNDLE_README = REPO_ROOT / "packaging" / "mcpb" / "README.md"
+VERSION_FILE = REPO_ROOT / "naturo" / "version.py"
+MCP_TOOLS_DIR = REPO_ROOT / "naturo" / "mcp"
+DEFAULT_OUTPUT = REPO_ROOT / "dist" / "naturo.mcpb"
+
+# The decorator that marks a nested function as a registered MCP tool. Every
+# tool in ``naturo/mcp/_*.py`` is wrapped with it, so it is a reliable, parse-only
+# (no import, no native DLL) signal we can also rely on from CI.
+_TOOL_DECORATOR = "_safe_tool"
+
+# Top-level manifest fields the MCPB spec requires; validated before packaging so
+# a malformed bundle never ships. See https://github.com/anthropics/mcpb.
+_REQUIRED_FIELDS = ("manifest_version", "name", "version", "description", "author", "server")
+
+
+def read_version() -> str:
+    """Return the package version from ``naturo/version.py``.
+
+    Reads the source with a regex instead of importing the package so the build
+    works on any platform without the native core present.
+
+    Returns:
+        The ``__version__`` string (e.g. ``"0.3.1"``).
+
+    Raises:
+        ValueError: If ``__version__`` cannot be found.
+    """
+    text = VERSION_FILE.read_text(encoding="utf-8")
+    match = re.search(r'__version__\s*=\s*"([^"]+)"', text)
+    if not match:
+        raise ValueError(f"Could not find __version__ in {VERSION_FILE}")
+    return match.group(1)
+
+
+def _docstring_summary(node: ast.FunctionDef) -> str:
+    """Return the first non-empty line of a function's docstring, or ``""``."""
+    doc = ast.get_docstring(node) or ""
+    for line in doc.splitlines():
+        stripped = line.strip()
+        if stripped:
+            return stripped
+    return ""
+
+
+def extract_tools() -> list[dict[str, str]]:
+    """Enumerate the MCP tools from source as ``{"name", "description"}`` dicts.
+
+    Parses every ``naturo/mcp/*.py`` module with :mod:`ast` and collects each
+    function decorated with ``@_safe_tool`` (the tool registration marker). This
+    is purely static — it never imports naturo — so the tool list stays accurate
+    in cross-platform CI where the Windows native core is absent.
+
+    Returns:
+        Tool descriptors sorted by name.
+    """
+    tools: list[dict[str, str]] = []
+    for path in sorted(MCP_TOOLS_DIR.glob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef):
+                continue
+            decorator_names = {
+                d.id for d in node.decorator_list if isinstance(d, ast.Name)
+            }
+            if _TOOL_DECORATOR in decorator_names:
+                tools.append({"name": node.name, "description": _docstring_summary(node)})
+    tools.sort(key=lambda tool: tool["name"])
+    return tools
+
+
+def assemble_manifest() -> dict:
+    """Load the canonical manifest and stamp it with the live version and tools.
+
+    The committed ``manifest.json`` is the single source for static metadata;
+    this stamps the authoritative ``version`` (from ``naturo/version.py``) and
+    refreshes the ``tools`` list so the bundle can never drift from the code.
+
+    Returns:
+        The fully assembled manifest dict.
+
+    Raises:
+        ValueError: If a required top-level field is missing.
+    """
+    manifest = json.loads(MANIFEST_SOURCE.read_text(encoding="utf-8"))
+    manifest["version"] = read_version()
+    manifest["tools"] = extract_tools()
+    manifest["tools_generated"] = False
+
+    missing = [field for field in _REQUIRED_FIELDS if field not in manifest]
+    if missing:
+        raise ValueError(f"manifest.json is missing required field(s): {', '.join(missing)}")
+    return manifest
+
+
+def build_bundle(output: Path) -> Path:
+    """Write the assembled ``.mcpb`` bundle to ``output``.
+
+    Args:
+        output: Destination path for the bundle (parent dirs are created).
+
+    Returns:
+        The path written.
+    """
+    manifest = assemble_manifest()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    manifest_bytes = json.dumps(manifest, indent=2, ensure_ascii=False).encode("utf-8")
+
+    with zipfile.ZipFile(output, "w", zipfile.ZIP_DEFLATED) as bundle:
+        # manifest.json MUST sit at the archive root for MCPB clients to find it.
+        bundle.writestr("manifest.json", manifest_bytes)
+        if BUNDLE_README.is_file():
+            bundle.writestr("README.md", BUNDLE_README.read_text(encoding="utf-8"))
+    return output
+
+
+def main() -> int:
+    """CLI entry point. Returns a process exit code."""
+    parser = argparse.ArgumentParser(description="Build the naturo .mcpb bundle.")
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Assemble and validate the manifest without writing the bundle.",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help=f"Output path (default: {DEFAULT_OUTPUT.relative_to(REPO_ROOT)}).",
+    )
+    args = parser.parse_args()
+
+    manifest = assemble_manifest()
+    summary = (
+        f"manifest_version={manifest['manifest_version']} "
+        f"name={manifest['name']} version={manifest['version']} "
+        f"tools={len(manifest['tools'])}"
+    )
+    if args.check:
+        print(f"OK  {summary}")
+        return 0
+
+    path = build_bundle(args.output)
+    print(f"Built {path.relative_to(REPO_ROOT)}  ({summary})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -32,6 +32,11 @@ FILES = {
         "pattern": r'^(version\s*=\s*")[^"]+(")',
         "replace": r"\g<1>{version}\2",
     },
+    "packaging/mcpb/manifest.json": {
+        # Matches the "version" line only, never "manifest_version".
+        "pattern": r'^(\s*"version"\s*:\s*")[^"]+(")',
+        "replace": r"\g<1>{version}\2",
+    },
 }
 
 VERSION_RE = re.compile(r"^\d+\.\d+\.\d+$")
@@ -99,7 +104,7 @@ def bump(new_version: str) -> int:
         full_path.write_text(new_text, encoding="utf-8")
         print(f"  ✅ {rel_path}: updated to {new_version}")
 
-    print(f"\nDone. Run 'git diff' to verify, then commit.")
+    print("\nDone. Run 'git diff' to verify, then commit.")
     return 0
 
 

--- a/tests/test_mcpb_bundle.py
+++ b/tests/test_mcpb_bundle.py
@@ -1,0 +1,89 @@
+"""Guards for the Claude Desktop Extension bundle (`naturo.mcpb`, issue #926).
+
+A first-time user should be able to install naturo into Claude Desktop in one
+click. These tests assert that the committed ``manifest.json`` stays valid
+against the MCPB spec, never drifts from the real package version or MCP tool
+set, and that ``scripts/build_mcpb.py`` produces a well-formed bundle. They are
+deliberately import- and platform-light (no native core required) so they run in
+cross-platform CI exactly as on a Windows desktop.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import zipfile
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPTS = _REPO_ROOT / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+import build_mcpb  # noqa: E402  (path injected above)
+from naturo.version import __version__  # noqa: E402
+
+_MANIFEST_PATH = _REPO_ROOT / "packaging" / "mcpb" / "manifest.json"
+
+
+def _committed_manifest() -> dict:
+    return json.loads(_MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def test_manifest_exists() -> None:
+    assert _MANIFEST_PATH.is_file(), "packaging/mcpb/manifest.json must exist"
+
+
+def test_manifest_has_required_fields() -> None:
+    """Every field the MCPB spec marks required must be present."""
+    manifest = _committed_manifest()
+    for field in build_mcpb._REQUIRED_FIELDS:
+        assert field in manifest, f"manifest.json is missing required field '{field}'"
+    assert manifest["manifest_version"], "manifest_version must be non-empty"
+    assert manifest["author"].get("name"), "author.name is required by the spec"
+
+
+def test_manifest_launches_canonical_entry_point() -> None:
+    """The bundle must launch the documented `naturo mcp start` server."""
+    server = _committed_manifest()["server"]
+    config = server["mcp_config"]
+    assert config["command"] == "naturo"
+    assert config["args"] == ["mcp", "start"]
+
+
+def test_manifest_version_matches_package() -> None:
+    """manifest.json version must track naturo/version.py (bump_version.py guard)."""
+    assert _committed_manifest()["version"] == __version__
+
+
+def test_manifest_tools_match_source() -> None:
+    """The committed tool list must match the tools registered in naturo/mcp/."""
+    committed = {tool["name"] for tool in _committed_manifest()["tools"]}
+    source = {tool["name"] for tool in build_mcpb.extract_tools()}
+    assert committed == source, (
+        "manifest.json tools drifted from naturo/mcp/; "
+        f"missing={source - committed} stale={committed - source}"
+    )
+    assert len(committed) >= 50, "expected the full MCP tool surface to be listed"
+
+
+def test_every_tool_has_a_description() -> None:
+    for tool in _committed_manifest()["tools"]:
+        assert tool.get("description"), f"tool '{tool['name']}' has no description"
+
+
+def test_build_produces_valid_bundle(tmp_path: Path) -> None:
+    """build_bundle writes a zip with manifest.json at its root."""
+    output = tmp_path / "naturo.mcpb"
+    build_mcpb.build_bundle(output)
+
+    assert output.is_file()
+    assert zipfile.is_zipfile(output)
+    with zipfile.ZipFile(output) as bundle:
+        assert bundle.testzip() is None, "bundle archive is corrupt"
+        names = bundle.namelist()
+        assert "manifest.json" in names, "manifest.json must be at the bundle root"
+        built = json.loads(bundle.read("manifest.json"))
+
+    assert built["manifest_version"]
+    assert built["version"] == __version__
+    assert built["server"]["mcp_config"]["command"] == "naturo"


### PR DESCRIPTION
## What
Packages naturo as an installable **MCP Bundle** (`.mcpb`, formerly `.dxt`) so users can add naturo's desktop-automation tools to Claude Desktop in one click (closes #926, part of distribution epic #922/#919).

- **`packaging/mcpb/manifest.json`** — MCPB-spec manifest (`manifest_version` 0.3) describing the server (`naturo mcp start`), author, license, compatibility (win32, Python ≥3.9), and the full MCP tool surface (64 tools).
- **`scripts/build_mcpb.py`** — pure-stdlib builder. Stamps the manifest with the authoritative version (`naturo/version.py`) and re-derives the tool list from `naturo/mcp/` via `ast` (no native core / DLL import needed → cross-platform CI-safe), then zips it to `dist/naturo.mcpb` (`--check` validates without writing).
- **`packaging/mcpb/README.md`** — build/install steps and an honest note that the bundle wraps the *installed* `naturo` CLI (`pip install naturo` prerequisite), since the Windows-only native core can't be vendored cross-platform; a fully self-contained bundle is a tracked follow-up.
- **`scripts/bump_version.py`** — manifest version now bumped alongside the other version sources (+ fixed a pre-existing F541 in the file).

## How tested
- `python scripts/build_mcpb.py` → builds `dist/naturo.mcpb` (manifest.json at root + README); `--check` OK.
- `python scripts/bump_version.py --check` → all 4 version sources consistent (0.3.1), now including the manifest.
- **`tests/test_mcpb_bundle.py`** (7 tests, CI-safe, no DLL): required spec fields, canonical `naturo mcp start` entry point, version↔package sync, tool-list drift guard vs `naturo/mcp/`, every tool has a description, and the bundle builds into a valid zip with `manifest.json` at its root. `--collect-only` clean.
- ruff + mypy clean on changed files; full non-desktop suite: 5825 passed (only pre-existing env/platform-divergence failures, none in changed files).

## Notes / out of scope
- The 'install into Claude Desktop in one click' smoke-test requires a desktop GUI session and is a **manual** verification step (cannot run headless); the buildable artifact and its schema are fully covered by CI.
- Does **not** publish to any registry (that's #922/#928) — this only produces the local artifact.