### PR TITLE
fix: converge all -j error envelopes on the canonical six-field shape (fixes #884)

### DIFF
--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -8,11 +8,29 @@ All Naturo CLI commands return structured errors in `--json` mode with the forma
   "error": {
     "code": "ERROR_CODE",
     "message": "Human-readable description",
+    "category": "automation",
+    "context": {},
     "suggested_action": "What to do to recover (for AI agents)",
     "recoverable": true
   }
 }
 ```
+
+Every `error` object carries the **same six keys, in this order**, regardless of
+which command failed or whether the code is recognised — so a scripted consumer
+can rely on each field being present without defensive checks. Fields degrade
+gracefully rather than being omitted: an unrecognised code yields
+`category: "unknown"`, `context: {}`, `suggested_action: null` and
+`recoverable: false`.
+
+- `category` — the error class for branching without parsing the message:
+  one of `environment`, `automation`, `validation`, `permissions`, `io`,
+  `session`, `ai`, `configuration`, `network` or `unknown`.
+- `context` — structured detail about the failure (e.g. `{"ref": "e1"}`);
+  `{}` when there is none.
+- `suggested_action` — recovery hint for AI agents, or `null` when the code has
+  no registered hint.
+- `recoverable` — whether retrying after the suggested fix might succeed.
 
 ## Error Codes
 

--- a/naturo/cli/error_helpers.py
+++ b/naturo/cli/error_helpers.py
@@ -15,7 +15,7 @@ from typing import Any, Callable, Iterable, NoReturn, Optional, TypeVar
 
 import click
 
-from naturo.errors import NaturoError
+from naturo.errors import NaturoError, category_for_code
 
 _CommandT = TypeVar("_CommandT", bound=click.Command)
 
@@ -298,37 +298,57 @@ def json_error(
     code: str,
     message: str,
     *,
+    category: Optional[str] = None,
+    context: Optional[dict[str, Any]] = None,
     suggested_action: Optional[str] = None,
     recoverable: Optional[bool] = None,
     extra: Optional[dict[str, Any]] = None,
 ) -> str:
-    """Build a JSON error response string with agent-friendly recovery hints.
+    """Build a JSON error response string in the canonical envelope shape.
 
-    If suggested_action or recoverable are not provided, looks up defaults
-    from the recovery hint registry based on the error code.
+    Every command's ``-j`` error path funnels through here, so the emitted shape
+    is the single source of truth for the CLI error contract. The ``error`` object
+    always carries the same six keys, in the same order, as
+    :meth:`naturo.errors.NaturoError.to_json_response` — ``code``, ``message``,
+    ``category``, ``context``, ``suggested_action`` and ``recoverable`` — so a
+    scripted consumer can rely on every field being present regardless of which
+    command failed or whether the code is recognised (see issue #884). Unspecified
+    fields fall back to sensible defaults rather than being omitted.
+
+    If ``category``, ``suggested_action`` or ``recoverable`` are not provided, they
+    are resolved from the error code: the category from
+    :func:`naturo.errors.category_for_code`, and the recovery hint/recoverability
+    from the local registry.
 
     Args:
         code: Error code string (e.g., 'INVALID_INPUT', 'WINDOW_NOT_FOUND').
         message: Human-readable error message.
-        suggested_action: Recovery hint for AI agents (auto-populated if None).
+        category: Error class (environment/validation/automation/...). Resolved
+            from the code when None, defaulting to 'unknown'.
+        context: Structured detail for the error. Defaults to an empty dict.
+        suggested_action: Recovery hint for AI agents (auto-populated if None;
+            may remain ``null`` when the code has no registered hint).
         recoverable: Whether retrying might help (auto-populated if None).
-        extra: Additional key-value pairs to include in the error object.
+        extra: Additional key-value pairs to merge into the error object on top of
+            the canonical keys.
 
     Returns:
         JSON string ready for click.echo().
     """
-    error: dict[str, Any] = {"code": code, "message": message}
-
     # Look up defaults from registry
     hint_action, hint_recoverable = _RECOVERY_HINTS.get(code, (None, False))
 
     action = suggested_action if suggested_action is not None else hint_action
     is_recoverable = recoverable if recoverable is not None else hint_recoverable
 
-    if action:
-        error["suggested_action"] = action
-    if is_recoverable:
-        error["recoverable"] = True
+    error: dict[str, Any] = {
+        "code": code,
+        "message": message,
+        "category": category if category is not None else category_for_code(code),
+        "context": context if context is not None else {},
+        "suggested_action": action,
+        "recoverable": bool(is_recoverable),
+    }
 
     if extra:
         error.update(extra)
@@ -349,17 +369,9 @@ def json_error_from_exception(exc: Exception) -> str:
         JSON string ready for click.echo().
     """
     if isinstance(exc, NaturoError):
-        error: dict[str, Any] = {
-            "code": exc.code,
-            "message": exc.message,
-        }
-        if exc.suggested_action:
-            error["suggested_action"] = exc.suggested_action
-        if exc.is_recoverable:
-            error["recoverable"] = True
-        if exc.context:
-            error["context"] = exc.context
-        return json.dumps({"success": False, "error": error})
+        # to_json_response() already yields the canonical six-key envelope, so the
+        # exception path and the raw-code path emit an identical shape (#884).
+        return json.dumps(exc.to_json_response())
 
     return json_error("UNKNOWN_ERROR", str(exc))
 

--- a/naturo/errors.py
+++ b/naturo/errors.py
@@ -79,6 +79,56 @@ class ErrorCategory:
     UNKNOWN = "unknown"
 
 
+# Canonical ``code -> category`` map. Single source of truth for the *raw-code*
+# JSON error path (:func:`naturo.cli.error_helpers.json_error`), where only an
+# error-code string is available — no :class:`NaturoError` instance to read the
+# category from. Keeping it here, beside the codes and the subclasses that define
+# them, lets every error converge on one ``category`` regardless of whether it was
+# raised as an exception or emitted by code string. Codes absent here fall back to
+# :attr:`ErrorCategory.UNKNOWN`. ``tests/test_error_envelope_884.py`` asserts this
+# map agrees with every NaturoError subclass that fixes a category.
+_ERROR_CATEGORIES: dict[str, str] = {
+    ErrorCode.PERMISSION_DENIED: ErrorCategory.PERMISSIONS,
+    ErrorCode.APP_NOT_FOUND: ErrorCategory.AUTOMATION,
+    ErrorCode.WINDOW_NOT_FOUND: ErrorCategory.AUTOMATION,
+    ErrorCode.ELEMENT_NOT_FOUND: ErrorCategory.AUTOMATION,
+    ErrorCode.MENU_NOT_FOUND: ErrorCategory.AUTOMATION,
+    ErrorCode.SNAPSHOT_NOT_FOUND: ErrorCategory.SESSION,
+    ErrorCode.STALE_SNAPSHOT_CACHE: ErrorCategory.SESSION,
+    ErrorCode.FILE_NOT_FOUND: ErrorCategory.IO,
+    ErrorCode.CAPTURE_FAILED: ErrorCategory.AUTOMATION,
+    ErrorCode.INTERACTION_FAILED: ErrorCategory.AUTOMATION,
+    ErrorCode.TIMEOUT: ErrorCategory.AUTOMATION,
+    ErrorCode.INVALID_INPUT: ErrorCategory.VALIDATION,
+    ErrorCode.INVALID_COORDINATES: ErrorCategory.VALIDATION,
+    ErrorCode.DIALOG_NOT_FOUND: ErrorCategory.AUTOMATION,
+    ErrorCode.DEPENDENCY_MISSING: ErrorCategory.CONFIGURATION,
+    ErrorCode.NO_DESKTOP_SESSION: ErrorCategory.ENVIRONMENT,
+    ErrorCode.FILE_IO_ERROR: ErrorCategory.IO,
+    ErrorCode.WORKTREE_MISMATCH: ErrorCategory.ENVIRONMENT,
+    ErrorCode.UNKNOWN_ERROR: ErrorCategory.UNKNOWN,
+    ErrorCode.AI_PROVIDER_UNAVAILABLE: ErrorCategory.AI,
+    ErrorCode.AI_ANALYSIS_FAILED: ErrorCategory.AI,
+}
+
+
+def category_for_code(code: str) -> str:
+    """Return the canonical error category for a raw error code.
+
+    Used by the raw-code JSON error path (:func:`naturo.cli.error_helpers.json_error`)
+    so an error emitted by code string alone carries the same ``category`` as the
+    equivalent :class:`NaturoError` would. Unrecognised codes degrade gracefully to
+    :attr:`ErrorCategory.UNKNOWN` rather than raising.
+
+    Args:
+        code: A standardized error-code string (e.g. ``"WINDOW_NOT_FOUND"``).
+
+    Returns:
+        The matching :class:`ErrorCategory` string, or ``ErrorCategory.UNKNOWN``.
+    """
+    return _ERROR_CATEGORIES.get(code, ErrorCategory.UNKNOWN)
+
+
 class NaturoError(Exception):
     """Base error for all Naturo operations.
 

--- a/tests/test_error_envelope_884.py
+++ b/tests/test_error_envelope_884.py
@@ -1,0 +1,202 @@
+"""Canonical ``-j`` error-envelope contract for #884.
+
+Background (issue #884)
+-----------------------
+The CLI emitted **three different shapes** for the ``error`` object under ``-j``,
+all keyed under ``{success: false, error: {...}}`` but with different field sets
+for the very same error code:
+
+* **A (rich, 6)** ``code, message, category, context, suggested_action, recoverable``
+  — ``app launch``/``quit``/``focus``/``maximize`` (via :meth:`NaturoError.to_json_response`).
+* **B (flat, 3)** ``code, message, suggested_action`` — ``see``/``capture``/``list``/
+  ``type``/``press``/``click``/``find`` (via :func:`json_error`).
+* **C (minimal, 2)** ``code, message`` — ``get``/``set`` UNKNOWN_ERROR path.
+
+Scripted callers could not rely on ``error.category``, ``error.context`` or
+``error.recoverable`` being present and had to fall back to message-string
+matching. The fix routes every raw-code error through :func:`json_error`, which
+now emits the **full canonical schema unconditionally** — the same six keys, in
+the same order, as :meth:`NaturoError.to_json_response`. This module pins that
+single shape so a future command cannot silently re-introduce drift.
+
+The test is pure-Python (no DLL, no desktop), so it runs on every CI lane.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from naturo.cli import main
+from naturo.cli.error_helpers import json_error, json_error_from_exception
+from naturo.errors import (
+    AppNotFoundError,
+    DialogNotFoundError,
+    ElementNotFoundError,
+    ErrorCategory,
+    InvalidInputError,
+    NaturoError,
+    NoDesktopSessionError,
+    StaleSnapshotCacheError,
+    category_for_code,
+)
+
+# The canonical six keys, in canonical order, matching NaturoError.to_dict().
+_CANONICAL_KEYS = ["code", "message", "category", "context", "suggested_action", "recoverable"]
+
+
+def _error_of(raw: str) -> dict:
+    """Parse a ``json_error``-style string and return its ``error`` object."""
+    payload = json.loads(raw)
+    assert payload["success"] is False
+    return payload["error"]
+
+
+# ── 1. json_error always emits the full canonical schema ─────────────────────
+
+
+def test_json_error_emits_all_canonical_keys_in_order() -> None:
+    """A known code emits exactly the six canonical keys, in canonical order."""
+    error = _error_of(json_error("WINDOW_NOT_FOUND", "Window not found: Notepad"))
+
+    assert list(error.keys()) == _CANONICAL_KEYS
+    assert error["code"] == "WINDOW_NOT_FOUND"
+    assert error["category"] == ErrorCategory.AUTOMATION
+    assert error["context"] == {}
+    assert error["suggested_action"]  # registry hint present
+    assert error["recoverable"] is True
+
+
+def test_json_error_unknown_code_still_emits_all_keys() -> None:
+    """An unrecognised code keeps the full shape — no key is dropped.
+
+    This is the heart of #884: the field set must not depend on whether the code
+    is known. Unknown codes get ``category='unknown'``, ``context={}``,
+    ``suggested_action=None`` and ``recoverable=False`` — every key present.
+    """
+    error = _error_of(json_error("CUSTOM_ERROR", "Something went wrong"))
+
+    assert list(error.keys()) == _CANONICAL_KEYS
+    assert error["category"] == ErrorCategory.UNKNOWN
+    assert error["context"] == {}
+    assert error["suggested_action"] is None
+    assert error["recoverable"] is False
+
+
+def test_json_error_validation_code_carries_category() -> None:
+    """INVALID_INPUT — the most common raw-code error — is categorised."""
+    error = _error_of(json_error("INVALID_INPUT", "Bad value"))
+
+    assert error["category"] == ErrorCategory.VALIDATION
+    assert error["recoverable"] is False
+
+
+def test_json_error_explicit_category_and_context_override() -> None:
+    """Callers may supply ``category``/``context`` explicitly."""
+    error = _error_of(
+        json_error(
+            "INVALID_INPUT",
+            "Bad value",
+            category=ErrorCategory.CONFIGURATION,
+            context={"parameter": "--depth"},
+        )
+    )
+
+    assert error["category"] == ErrorCategory.CONFIGURATION
+    assert error["context"] == {"parameter": "--depth"}
+
+
+def test_json_error_extra_fields_supplement_canonical_keys() -> None:
+    """``extra`` adds fields on top of — never instead of — the canonical six."""
+    error = _error_of(
+        json_error("INVALID_INPUT", "Bad value", extra={"valid_range": "1-10"})
+    )
+
+    assert set(_CANONICAL_KEYS).issubset(error.keys())
+    assert error["valid_range"] == "1-10"
+
+
+def test_json_error_recoverable_false_is_still_present() -> None:
+    """``recoverable=False`` must serialise as a present ``false``, not be omitted."""
+    error = _error_of(json_error("WINDOW_NOT_FOUND", "x", recoverable=False))
+
+    assert error["recoverable"] is False
+    assert "recoverable" in error
+
+
+# ── 2. json_error == NaturoError shape (the convergence guarantee) ───────────
+
+
+def test_json_error_shape_matches_naturo_error_shape() -> None:
+    """The raw-code path emits the same key set as the NaturoError path."""
+    raw = _error_of(json_error("APP_NOT_FOUND", "Application not found: notepad"))
+    rich = AppNotFoundError("notepad").to_dict()
+
+    assert list(raw.keys()) == list(rich.keys()) == _CANONICAL_KEYS
+
+
+def test_json_error_from_exception_emits_full_canonical_schema() -> None:
+    """NaturoError exceptions serialise to the canonical six keys."""
+    error = _error_of(json_error_from_exception(StaleSnapshotCacheError("e1")))
+
+    assert list(error.keys()) == _CANONICAL_KEYS
+    assert error["code"] == "STALE_SNAPSHOT_CACHE"
+    assert error["category"] == ErrorCategory.SESSION
+    assert error["context"] == {"ref": "e1"}
+    assert error["recoverable"] is True
+
+
+def test_json_error_from_plain_exception_is_canonical_unknown() -> None:
+    """A non-NaturoError exception becomes a full-shape UNKNOWN_ERROR."""
+    error = _error_of(json_error_from_exception(ValueError("boom")))
+
+    assert list(error.keys()) == _CANONICAL_KEYS
+    assert error["code"] == "UNKNOWN_ERROR"
+    assert error["category"] == ErrorCategory.UNKNOWN
+    assert error["message"] == "boom"
+
+
+# ── 3. category_for_code agrees with every NaturoError subclass ──────────────
+
+# Representative instances of every NaturoError subclass that fixes a category.
+# Guards against the code→category map drifting away from the subclass that
+# defines the authoritative category.
+_SUBCLASS_INSTANCES: list[NaturoError] = [
+    AppNotFoundError("x"),
+    ElementNotFoundError("x"),
+    DialogNotFoundError(),
+    InvalidInputError(),
+    NoDesktopSessionError(),
+    StaleSnapshotCacheError("e1"),
+]
+
+
+@pytest.mark.parametrize("exc", _SUBCLASS_INSTANCES, ids=lambda e: type(e).__name__)
+def test_category_for_code_matches_subclass(exc: NaturoError) -> None:
+    """``category_for_code`` returns the same category the subclass assigns."""
+    assert category_for_code(exc.code) == exc.category
+
+
+def test_category_for_code_unknown_defaults_to_unknown() -> None:
+    """An unmapped code degrades gracefully to the 'unknown' category."""
+    assert category_for_code("TOTALLY_MADE_UP") == ErrorCategory.UNKNOWN
+
+
+# ── 4. End-to-end: a real CLI command emits the canonical shape ──────────────
+
+
+def test_see_invalid_depth_emits_canonical_envelope() -> None:
+    """``naturo see -j --depth -1`` fails validation with the canonical shape.
+
+    Pure validation error (``depth`` out of range) — no DLL or desktop needed,
+    so this proves the convergence holds through an actual CLI invocation on CI.
+    """
+    result = CliRunner().invoke(main, ["see", "-j", "--depth", "-1"])
+
+    assert result.exit_code != 0
+    error = _error_of(result.output)
+    assert list(error.keys()) == _CANONICAL_KEYS
+    assert error["code"] == "INVALID_INPUT"
+    assert error["category"] == ErrorCategory.VALIDATION

--- a/tests/test_error_helpers.py
+++ b/tests/test_error_helpers.py
@@ -36,13 +36,20 @@ class TestJsonError:
         assert result["error"]["recoverable"] is True
 
     def test_basic_error_with_unknown_code(self):
-        """Unknown error codes get no recovery hints by default."""
+        """Unknown error codes keep the canonical shape with empty/false defaults.
+
+        Post-#884 the envelope never drops keys: an unrecognised code yields a
+        present-but-empty ``suggested_action`` (null), ``recoverable=False``,
+        ``category='unknown'`` and ``context={}``.
+        """
         result = json.loads(json_error("CUSTOM_ERROR", "Something went wrong"))
         assert result["success"] is False
         assert result["error"]["code"] == "CUSTOM_ERROR"
         assert result["error"]["message"] == "Something went wrong"
-        assert "suggested_action" not in result["error"]
-        assert "recoverable" not in result["error"]
+        assert result["error"]["suggested_action"] is None
+        assert result["error"]["recoverable"] is False
+        assert result["error"]["category"] == "unknown"
+        assert result["error"]["context"] == {}
 
     def test_explicit_suggested_action_overrides_default(self):
         """Explicit suggested_action overrides the registry default."""
@@ -54,13 +61,13 @@ class TestJsonError:
         assert result["error"]["suggested_action"] == "Try 'naturo window focus --app Chrome'"
 
     def test_explicit_recoverable_overrides_default(self):
-        """Explicit recoverable overrides the registry default."""
+        """Explicit recoverable overrides the registry default (and is present)."""
         result = json.loads(json_error(
             "WINDOW_NOT_FOUND",
             "Window not found",
             recoverable=False,
         ))
-        assert "recoverable" not in result["error"]
+        assert result["error"]["recoverable"] is False
 
     def test_extra_fields_included(self):
         """Extra fields are included in the error object."""
@@ -80,9 +87,9 @@ class TestJsonError:
             assert result["error"]["suggested_action"] == action
 
     def test_invalid_input_not_recoverable(self):
-        """INVALID_INPUT errors are not marked as recoverable."""
+        """INVALID_INPUT errors are present but marked not recoverable."""
         result = json.loads(json_error("INVALID_INPUT", "Bad value"))
-        assert "recoverable" not in result["error"]
+        assert result["error"]["recoverable"] is False
 
 
 class TestJsonErrorFromException:


### PR DESCRIPTION
## What
Fixes #884. The CLI emitted **three different shapes** for the JSON `error` object in `-j` mode — even for the same error code:

| Shape | Keys | Used by |
|------|------|---------|
| A (rich, 6) | code, message, category, context, suggested_action, recoverable | `app launch/quit/focus/maximize` |
| B (flat, 3) | code, message, suggested_action | `see`, `capture`, `list`, `type`, `press`, `click`, `find` |
| C (minimal, 2) | code, message | `get`, `set` (UNKNOWN_ERROR path) |

Scripted callers could not rely on `category`, `context` or `recoverable` being present and had to fall back to message-string matching.

This routes every raw-code error through `json_error`, which now emits the **full canonical schema unconditionally** — the same six keys, in the same order, as `NaturoError.to_json_response()`. All three shapes converge on one.

## How
- `naturo/cli/error_helpers.py`: `json_error` always emits `code, message, category, context, suggested_action, recoverable`. Unspecified fields degrade gracefully (category resolved via the new `category_for_code`, defaulting to `unknown`; `context={}`; `suggested_action=null`; `recoverable=false`) rather than being dropped. `json_error_from_exception` now delegates to `to_json_response()` so the exception and raw-code paths emit an identical shape.
- `naturo/errors.py`: add `_ERROR_CATEGORIES` (canonical `code -> category` map mirroring every `NaturoError` subclass) and `category_for_code()`, used by the raw-code path where no exception instance is available.
- `docs/ERROR_CODES.md`: documents the six-field contract and graceful-degradation defaults.

Codes with no `NaturoError` subclass (e.g. `RECORDING_NOT_FOUND`) degrade to `category="unknown"` by design — matching the issue's accepted solution. The self-maintaining schema contract is tracked separately by #1001.

## How tested
- New `tests/test_error_envelope_884.py` (17 tests): pins the canonical key set + order, the convergence guarantee (raw-code path == `NaturoError` path), graceful defaults for unknown codes, `extra`-field supplementing, and that `category_for_code` agrees with every `NaturoError` subclass. Includes an end-to-end `naturo see -j --depth -1` validation that runs DLL-free on every CI lane.
- Updated `tests/test_error_helpers.py` for the always-present-keys contract.
- `ruff check naturo/` clean; mypy clean on changed modules; the 39 envelope tests pass; `--collect-only` clean (no cross-platform import break).

🤖 Generated with [Claude Code](https://claude.com/claude-code)