### PR TITLE
test: assert input-injection safety in-process + add live-input tripwire (fixes #976)

### DIFF
--- a/naturo/safety.py
+++ b/naturo/safety.py
@@ -119,13 +119,43 @@ def is_safe_input_enabled() -> bool:
     return _safe_input_active()
 
 
+def contains_dangerous_input(text: Optional[str]) -> Optional[str]:
+    """Return why ``text`` looks like shell-command content, or ``None``.
+
+    This is the *ungated* matcher: unlike :func:`unsafe_input_reason`, it does
+    **not** consult :func:`is_safe_input_enabled`, so it classifies content the
+    same way whether or not the opt-in runtime guard is armed.  It carries no
+    policy of its own — it never blocks anything — and so does not change
+    runtime behaviour.  It exists so a safety *backstop* (e.g. the test-suite
+    tripwire that refuses live keystrokes of shell metacharacters, #976) can
+    detect the unsafe shape unconditionally, since such a backstop must hold
+    regardless of whether a given run happened to arm the opt-in guard.
+
+    Args:
+        text: The literal content that would be injected as keystrokes (or via
+            clipboard paste).  ``None`` or empty text is always safe.
+
+    Returns:
+        A short human-readable reason (e.g. ``"destructive command 'rm'"``)
+        when the content matches a dangerous pattern; otherwise ``None``.
+    """
+    if not text:
+        return None
+    for reason, pattern in _DANGEROUS_PATTERNS:
+        if pattern.search(text):
+            return reason
+    return None
+
+
 def unsafe_input_reason(text: Optional[str]) -> Optional[str]:
     """Return why ``text`` is unsafe to inject, or ``None`` if it may proceed.
 
     The guard is a no-op (always returns ``None``) when it is inactive — that
     is, when neither ``NATURO_SAFE_INPUT=1`` nor the sentinel lock file
     ``~/.naturo/safe-input.lock`` is present — so callers can invoke this
-    unconditionally before typing/pasting without affecting normal users.
+    unconditionally before typing/pasting without affecting normal users.  When
+    the guard is active it delegates to :func:`contains_dangerous_input` for the
+    actual content classification.
 
     Args:
         text: The literal content that would be injected as keystrokes (or via
@@ -138,9 +168,4 @@ def unsafe_input_reason(text: Optional[str]) -> Optional[str]:
     """
     if not is_safe_input_enabled():
         return None
-    if not text:
-        return None
-    for reason, pattern in _DANGEROUS_PATTERNS:
-        if pattern.search(text):
-            return reason
-    return None
+    return contains_dangerous_input(text)

--- a/tests/QA_AGENT.md
+++ b/tests/QA_AGENT.md
@@ -96,6 +96,11 @@ naturo app list
 >
 > ⛔ **即便如此,payload 仍必须永远无害**(双保险):绝不用真实破坏性命令(`rm -rf`、`del`、`format`、
 > `shutdown` 等),只用无害哨兵 `; echo INJECTED`——被错误执行也只打印 `INJECTED`。路径穿越同理用无害探针。
+>
+> ✅ **注入安全这一条已是进程内断言,不是 live 动作(#976):** `tests/test_input_injection_safety_976.py`
+> 在进程内断言守卫拒绝 shell 元字符且**零击键**(对 mock 的 SendInput/Phys32 边界);`tests/conftest.py` 的
+> 会话级 tripwire 进一步保证**任何**测试都无法把 shell 元字符经真实键盘打出(命中即 `AssertionError`)。
+> 因此 QA 只需运行 `pytest`,**不要**自己经 live `naturo type` 复现注入。
 - 命令注入(**仅 argv,传给 `see --app`,绝不 `type`**)：`naturo see --app "; echo INJECTED"`
 - 路径穿越(**仅 argv**)：`naturo capture live --path "../../naturo-path-traversal-probe.txt"`(无害探针)
 - 超长输入缓冲区(**用无害字符如 `A`×N,经 pytest 或 argv,不经 live type**)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -149,6 +149,55 @@ def _skip_desktop_tests(request: pytest.FixtureRequest):
             pytest.skip("No interactive desktop session available")
 
 
+@pytest.fixture(autouse=True, scope="session")
+def _forbid_unsafe_live_input():
+    """Structural backstop: no test may live-type shell metacharacters (#976).
+
+    R-SEC-012: an unattended QA cycle once typed ``$(rm -rf /)`` into a live
+    window through a global-``SendInput`` focus race.  The lesson is that a
+    safety test must never be able to perform the unsafe act it guards against —
+    the injection-safety property must be asserted in-process, never by putting
+    shell metacharacters on a real keyboard.
+
+    This session-wide tripwire patches the real keystroke-delivery boundary (the
+    ``SendInput`` and Phys32 input strategies) so that any attempt — by any test,
+    intentional or accidental — to type a string containing shell-command
+    content raises loudly *before* a single keystroke is emitted.  Benign text
+    still reaches the original implementation, so legitimate desktop ``type``
+    tests are unaffected.  Detection is ungated (it does not depend on the opt-in
+    ``NATURO_SAFE_INPUT`` runtime guard) so the backstop holds in every run.
+    """
+    from naturo.backends.windows import _strategies
+    from naturo.safety import contains_dangerous_input
+
+    originals: dict[type, object] = {}
+
+    def _make_guarded(original):
+        def guarded(self, text, delay_ms=5):
+            reason = contains_dangerous_input(text)
+            if reason is not None:
+                raise AssertionError(
+                    "R-SEC-012 tripwire: refusing to live-type shell-unsafe "
+                    f"content ({reason}) via {type(self).__name__}.type_text. "
+                    "Injection-safety must be asserted in-process (see "
+                    "tests/test_input_injection_safety_976.py), never through "
+                    f"real keystrokes. Payload repr: {text!r}"
+                )
+            return original(self, text, delay_ms)
+
+        return guarded
+
+    for strategy_cls in (_strategies.SendInputStrategy, _strategies.Phys32Strategy):
+        originals[strategy_cls] = strategy_cls.type_text
+        strategy_cls.type_text = _make_guarded(strategy_cls.type_text)  # type: ignore[method-assign]
+
+    try:
+        yield
+    finally:
+        for strategy_cls, original in originals.items():
+            strategy_cls.type_text = original  # type: ignore[method-assign]
+
+
 def cli_stdout(result):
     """Extract stdout-only text from a Click CliRunner result.
 

--- a/tests/test_input_injection_safety_976.py
+++ b/tests/test_input_injection_safety_976.py
@@ -1,0 +1,124 @@
+"""In-process injection-safety assertions and the live-input tripwire (#976).
+
+R-SEC-012 lesson: an unattended QA cycle once typed ``$(rm -rf /)`` into a live
+window through a global-``SendInput`` focus race.  The remediation principle is
+that *a safety test must never be able to perform the unsafe act it guards
+against* — the injection-safety property has to be asserted **in-process**, at
+the keystroke-delivery boundary, never by typing shell metacharacters at a real
+window.
+
+This module proves two things, both purely in-process (no desktop, no DLL, no
+real keystrokes):
+
+1. :func:`naturo.safety.contains_dangerous_input` — the *ungated* matcher that
+   classifies content regardless of whether the opt-in runtime guard is enabled
+   (the runtime guard, :func:`unsafe_input_reason`, only fires when the QA loop
+   has armed it; the tripwire below must detect unconditionally).
+2. The session-wide **tripwire** installed by ``conftest`` patches the real
+   ``SendInput`` / Phys32 keystroke boundary so any attempt — by any test — to
+   live-type shell-metacharacter content raises loudly *before* a single
+   keystroke is emitted, while benign text still reaches the real boundary.
+
+The payloads here are deliberately harmless sentinels (``echo INJECTED``); they
+still trip every shell-metacharacter pattern but would do nothing if somehow
+executed, honouring QA_AGENT.md §7's double-safety rule.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from naturo.safety import contains_dangerous_input, unsafe_input_reason
+
+# Harmless sentinels that still match the shell-metacharacter patterns.
+DANGEROUS_SENTINELS = [
+    "$(echo INJECTED)",   # command substitution
+    "`echo INJECTED`",    # backtick command substitution
+    "a && echo INJECTED",  # logical AND
+    "a || echo INJECTED",  # logical OR
+    "x; echo INJECTED",    # command separator
+    "echo INJECTED | cat",  # pipe
+    "echo INJECTED > f",   # output redirect
+    "cat < f",             # input redirect
+]
+
+BENIGN_INPUTS = [
+    "QA_PROBE",
+    "Hello World",
+    "The quick brown fox.",
+    "reformatted the document",  # 'format' as a substring, not a command
+    "",
+]
+
+
+class TestContainsDangerousInputIsUngated:
+    """``contains_dangerous_input`` classifies content independent of the env.
+
+    This is what makes the tripwire reliable: the runtime guard is opt-in, but a
+    safety backstop must refuse the unsafe act whether or not the loop armed the
+    guard, so it cannot key off ``NATURO_SAFE_INPUT`` / the sentinel file.
+    """
+
+    @pytest.mark.parametrize("text", DANGEROUS_SENTINELS)
+    def test_detects_dangerous_even_when_guard_disabled(self, text, monkeypatch):
+        # Force the opt-in runtime guard OFF regardless of the host machine's
+        # state (the real QA machine running this suite may have armed either
+        # the env var or the sentinel lock file).
+        monkeypatch.setattr("naturo.safety.is_safe_input_enabled", lambda: False)
+        # The gated runtime guard is a no-op when disabled ...
+        assert unsafe_input_reason(text) is None
+        # ... but the ungated matcher still flags the content.
+        reason = contains_dangerous_input(text)
+        assert reason, f"expected {text!r} to be classified dangerous"
+        assert isinstance(reason, str)
+
+    @pytest.mark.parametrize("text", BENIGN_INPUTS)
+    def test_benign_passes_ungated(self, text):
+        assert contains_dangerous_input(text) is None
+
+    def test_none_is_safe(self):
+        assert contains_dangerous_input(None) is None
+
+
+class TestLiveInputTripwire:
+    """The session tripwire refuses unsafe live keystrokes at the SendInput edge.
+
+    A ``MagicMock`` stands in for the native core, so the underlying
+    ``key_type`` / ``phys_key_type`` calls are observable and never reach a real
+    DLL.  These tests run on every platform (Linux CI included) because no
+    desktop or DLL is required.
+    """
+
+    def _make_strategy(self, strategy_cls):
+        from naturo.backends.windows._strategies import (
+            Phys32Strategy,
+            SendInputStrategy,
+        )
+
+        cls = {"send": SendInputStrategy, "phys": Phys32Strategy}[strategy_cls]
+        core = MagicMock()
+        return cls(core), core
+
+    @pytest.mark.parametrize("strategy_cls", ["send", "phys"])
+    @pytest.mark.parametrize("payload", DANGEROUS_SENTINELS)
+    def test_dangerous_live_type_is_refused_with_zero_keystrokes(
+        self, strategy_cls, payload
+    ):
+        strategy, core = self._make_strategy(strategy_cls)
+        with pytest.raises(AssertionError, match="R-SEC-012"):
+            strategy.type_text(payload)
+        # The native keystroke boundary was never reached: zero keystrokes.
+        core.key_type.assert_not_called()
+        core.phys_key_type.assert_not_called()
+
+    @pytest.mark.parametrize("strategy_cls", ["send", "phys"])
+    def test_benign_live_type_passes_through_to_the_core(self, strategy_cls):
+        strategy, core = self._make_strategy(strategy_cls)
+        strategy.type_text("Hello World")
+        if strategy_cls == "send":
+            core.key_type.assert_called_once_with("Hello World", 5)
+            core.phys_key_type.assert_not_called()
+        else:
+            core.phys_key_type.assert_called_once_with("Hello World", 5)
+            core.key_type.assert_not_called()


### PR DESCRIPTION
## What
Makes the command-injection / input-sanitization safety property **pytest-only and in-process**, so a safety test can never perform the unsafe act it guards against (R-SEC-012: a QA cycle once typed `$(rm -rf /)` into a live window through a global-`SendInput` focus race). This is the **code-only half** of the incident; the human re-enable of the QA loop stays a `needs:ace` decision (#975) and is **not** touched here (`runner.ps1` unchanged).

- **`naturo/safety.py`** — extract `contains_dangerous_input(text)`, the *ungated* shell-content matcher. `unsafe_input_reason` now delegates to it when the opt-in guard is armed, so **runtime behaviour is unchanged** (verified by the existing `tests/test_safe_input_guard.py`). The helper lets a backstop classify unsafe content regardless of whether a given run armed `NATURO_SAFE_INPUT` / the sentinel lock.
- **`tests/conftest.py`** — session-wide **tripwire** that patches the real `SendInput`/Phys32 keystroke boundary (`SendInputStrategy.type_text`, `Phys32Strategy.type_text`) so any test attempting to live-type shell metacharacters raises loudly *before a single keystroke*. Benign text passes through to the original implementation, so legitimate desktop `type` tests are unaffected.
- **`tests/test_input_injection_safety_976.py`** — in-process assertions: the guard rejects shell metacharacters with **zero keystrokes** (mocked SendInput/Phys32 boundary), and the ungated matcher classifies content independent of the opt-in env/sentinel. Pure-Python — no desktop, no DLL — so it runs on Linux CI. Harmless `echo INJECTED` sentinels (never destructive commands), per QA_AGENT.md §7.
- **`tests/QA_AGENT.md`** — §7 now documents the injection-safety check as an in-process assertion, not a live-window action.

## How tested
- `python -m pytest tests/test_input_injection_safety_976.py` → 32 passed.
- `python -m pytest tests/test_safe_input_guard.py tests/test_input_injection_safety_976.py` → 72 passed (existing guard behaviour intact).
- `python -m ruff check naturo/ tests/test_input_injection_safety_976.py tests/conftest.py` → clean.
- `--collect-only` on the new module collects cleanly (cross-platform, no Windows/optional deps).
- Full non-desktop suite: 5893 passed; the 28 failures/errors are all pre-existing Windows-local/env issues (Linux-only tests on Windows, `tmp_path`/yaml sandbox, locale #999, DLL version, timing flakiness, #944/#946) — confirmed identical on baseline (changes stashed). **Zero input/type/strategy/safety regressions.**

Closes #976. Paired human-only re-enable: #975.