### PR TITLE
fix: preserve NaturoError identity in interaction -j errors (fixes #1004)

### DIFF
--- a/naturo/cli/interaction/_click.py
+++ b/naturo/cli/interaction/_click.py
@@ -350,7 +350,7 @@ def click_cmd(query: str | None, on_text: str | None, ref_alias: str | None,
                 backend.click(x=x, y=y, button=button, double=double,
                               input_mode=input_mode)
     except Exception as exc:
-        _common._json_err(str(exc), json_output)
+        _common._json_err(str(exc), json_output, exc=exc)
         return
 
     # (#168) Clipboard modifiers: --paste, --copy, --cut (post-click actions)

--- a/naturo/cli/interaction/_common.py
+++ b/naturo/cli/interaction/_common.py
@@ -812,14 +812,38 @@ def _json_ok(data: dict, json_output: bool) -> None:
 
 
 def _json_err(msg: str, json_output: bool, exit_code: int = 1,
-              code: str = "ACTION_ERROR") -> NoReturn:
+              code: str = "ACTION_ERROR", *,
+              exc: Optional[BaseException] = None) -> NoReturn:
     """Emit error result as JSON or plain text, then exit.
 
     Includes agent-friendly recovery hints from the error_helpers registry.
     The plain-text path prints ``Error: <msg>`` to stderr (no Click ``Usage:``
     banner) so runtime failures keep exit code 1 instead of Click's usage-error
     exit code 2 (#866).  Always terminates the process; never returns.
+
+    When ``exc`` is a semantic :class:`~naturo.errors.NaturoError`, its full
+    envelope (``code``/``category``/``suggested_action``/``recoverable``) is
+    preserved instead of being flattened to the generic ``code`` — so an
+    action-phase ``ElementNotFoundError`` surfaces as ``ELEMENT_NOT_FOUND``/
+    ``automation`` with its recovery hint, identical to ``get``/``scroll``,
+    rather than ``ACTION_ERROR``/``unknown`` (#1004). ``code`` is still used as
+    the fallback for non-``NaturoError`` exceptions and the ``exc``-less callers,
+    and the plain-text ``Error: <message>`` line is unchanged in every case
+    (``str(NaturoError) == NaturoError.message``).
+
+    Args:
+        msg: Human-readable error message (used as-is when no semantic ``exc``).
+        json_output: Whether to emit the JSON envelope instead of plain text.
+        exit_code: Process exit code (default 1).
+        code: Error code for the JSON envelope and the non-semantic fallback.
+        exc: The original exception, when available, so a ``NaturoError``'s
+            structured identity can be preserved.
     """
+    from naturo.errors import NaturoError
+    if isinstance(exc, NaturoError):
+        from naturo.cli.error_helpers import emit_exception_error
+        emit_exception_error(exc, json_output, fallback_code=code,
+                             exit_code=exit_code)
     if json_output:
         from naturo.cli.error_helpers import json_error
         click.echo(json_error(code, msg))

--- a/naturo/cli/interaction/_mouse.py
+++ b/naturo/cli/interaction/_mouse.py
@@ -134,7 +134,7 @@ def scroll(direction_arg, direction_option, amount, on_text, ref_alias, element_
     try:
         backend.scroll(direction=direction, amount=amount, x=x, y=y, smooth=smooth)
     except Exception as exc:
-        _common._json_err(str(exc), json_output)
+        _common._json_err(str(exc), json_output, exc=exc)
         return
 
     # Record the action
@@ -375,7 +375,7 @@ def drag(from_text, from_coords, from_selector, from_element,
                      overshoot=overshoot,
                      release_delay_ms=int(release_delay * 1000))
     except Exception as exc:
-        _common._json_err(str(exc), json_output)
+        _common._json_err(str(exc), json_output, exc=exc)
         return
 
     # Record the action
@@ -465,7 +465,7 @@ def move(to_text, coords, element_id, trajectory, duration, steps, jitter, overs
             overshoot=overshoot,
         )
     except Exception as exc:
-        _common._json_err(str(exc), json_output)
+        _common._json_err(str(exc), json_output, exc=exc)
         return
 
     # Record the action

--- a/naturo/cli/interaction/_press.py
+++ b/naturo/cli/interaction/_press.py
@@ -162,7 +162,7 @@ def press(keys: tuple[str, ...], count: int, delay: float, hold_duration: float 
                     )
                     return
             except Exception as exc:
-                _common._json_err(str(exc), json_output)
+                _common._json_err(str(exc), json_output, exc=exc)
                 return
         try:
             backend.click(click_x, click_y, button="left", input_mode=input_mode)
@@ -288,7 +288,7 @@ def press(keys: tuple[str, ...], count: int, delay: float, hold_duration: float 
             if idx < len(keys) - 1 and delay > 0:
                 time.sleep(delay / 1000.0)
     except Exception as exc:
-        _common._json_err(str(exc), json_output)
+        _common._json_err(str(exc), json_output, exc=exc)
         return
     finally:
         if _orig_handler is not None:

--- a/naturo/cli/interaction/_type.py
+++ b/naturo/cli/interaction/_type.py
@@ -259,7 +259,7 @@ def type_cmd(text, delay, profile, wpm, press_return, tab_count, escape,
                     )
                     return
             except Exception as exc:
-                _common._json_err(str(exc), json_output)
+                _common._json_err(str(exc), json_output, exc=exc)
                 return
         try:
             backend.click(click_x, click_y, button="left", input_mode=input_mode)
@@ -387,7 +387,7 @@ def type_cmd(text, delay, profile, wpm, press_return, tab_count, escape,
             backend.press_key("escape")
 
     except Exception as exc:
-        _common._json_err(str(exc), json_output)
+        _common._json_err(str(exc), json_output, exc=exc)
         return
 
     action = "pasted" if paste_mode else "typed"

--- a/tests/test_error_envelope_contract_1001.py
+++ b/tests/test_error_envelope_contract_1001.py
@@ -34,7 +34,17 @@ Three layers, by where an error can be born:
    historically drifted (``app``/``see``/``find``/``get``/``set``/``click``/
    ``type``/``drag``/``record``/``selector``/``visual``). Proves the runtime path,
    not just the parse wrapper, stays canonical.
-3. **Source-of-truth completeness.** Every code in the recovery-hint registry,
+3. **Action-phase semantic identity (interaction commands).** #884 converged the
+   envelope *shape* and #877 fixed the *semantics* for ``get``/``set``, but the
+   interaction commands' action-phase catch-alls still flattened a real
+   :class:`~naturo.errors.NaturoError` to ``ACTION_ERROR``/``unknown``/
+   ``recoverable:false`` — defeating the agent self-correction contract on the
+   single most-used command, ``click`` (#1004). This layer drives every
+   interaction command (``click``/``type``/``press``/``scroll``/``drag``/``move``)
+   with a backend whose action raises an ``ElementNotFoundError`` and asserts the
+   envelope keeps the exception's *code* and *category* — not just its shape — so
+   a future catch-all that drops ``exc=`` re-flattens here on day one.
+4. **Source-of-truth completeness.** Every code in the recovery-hint registry,
    and the base :class:`NaturoError` serializer, must yield the canonical schema —
    so the per-command paths above cannot drift from the contract they target.
 
@@ -46,6 +56,7 @@ from __future__ import annotations
 
 import json
 from typing import Iterator
+from unittest.mock import MagicMock
 
 import click
 import pytest
@@ -53,7 +64,7 @@ from click.testing import CliRunner
 
 from naturo.cli import main, run
 from naturo.cli.error_helpers import _RECOVERY_HINTS, json_error
-from naturo.errors import NaturoError, category_for_code
+from naturo.errors import ElementNotFoundError, NaturoError, category_for_code
 
 # The six canonical keys, in canonical order — identical to NaturoError.to_dict()
 # and the object json_error builds. The single shape every -j error must carry.
@@ -212,7 +223,96 @@ def test_runtime_failure_is_canonical(argv, expected_code) -> None:
     )
 
 
-# ── 3. source-of-truth completeness ──────────────────────────────────────────
+# ── 3. action-phase semantic identity (interaction commands, #1004) ──────────
+
+# (argv, backend-action-method) for every interaction command, driven through a
+# backend whose action method raises a semantic NaturoError. Coordinate / no-target
+# invocations are used so the failure is born in the action call itself — not in
+# element resolution — and reaches the command's action-phase catch-all. The
+# method name is the single backend call each command makes inside that try block.
+_INTERACTION_ACTION_FAILURES = [
+    (["click", "--coords", "500", "300"], "click"),
+    (["type", "hello"], "type_text"),
+    (["press", "enter"], "press_key"),
+    (["scroll", "down"], "scroll"),
+    (["drag", "--from-coords", "100", "100", "--to-coords", "500", "300"], "drag"),
+    (["move", "--coords", "500", "300"], "move_mouse"),
+]
+
+
+@pytest.mark.parametrize(
+    "argv,action_method",
+    _INTERACTION_ACTION_FAILURES,
+    ids=[argv[0] for argv, _ in _INTERACTION_ACTION_FAILURES],
+)
+def test_interaction_action_error_keeps_semantic_identity(argv, action_method, monkeypatch) -> None:
+    """An action-phase ``NaturoError`` keeps its code/category, not just its shape.
+
+    The interaction catch-alls used to flatten a real ``ElementNotFoundError`` to
+    ``ACTION_ERROR``/``unknown``/``recoverable:false`` (#1004), so an agent that
+    dispatches on ``error.code == "ELEMENT_NOT_FOUND"`` (the #877 contract) got the
+    wrong code from the most-used command. With a backend whose action raises that
+    error, every interaction command must now surface its *semantic* envelope —
+    identical code/category to ``get``/``scroll`` — and stay canonical in shape.
+    """
+    backend = MagicMock()
+    getattr(backend, action_method).side_effect = ElementNotFoundError(_ABSENT_ENTITY)
+    # Every interaction command obtains its backend through this one seam, so the
+    # patch covers click/type/press/scroll/drag/move (and any future command) alike.
+    monkeypatch.setattr(
+        "naturo.cli.interaction._common._get_backend",
+        lambda *args, **kwargs: backend,
+    )
+
+    result = CliRunner().invoke(main, [*argv, "-j"], catch_exceptions=True)
+
+    error = _single_error_object(result.output)
+    assert list(error.keys())[:6] == _CANONICAL_KEYS, (
+        f"{' '.join(argv)} -j error drifted from the canonical schema: {list(error.keys())}"
+    )
+    assert error["code"] == "ELEMENT_NOT_FOUND", (
+        f"{' '.join(argv)} flattened the semantic error to {error['code']} (#1004 regression)"
+    )
+    assert error["category"] == "automation", (
+        f"{' '.join(argv)} lost the error category: {error['category']}"
+    )
+    assert error["recoverable"] is True, f"{' '.join(argv)} dropped recoverable=true"
+    assert error["suggested_action"], f"{' '.join(argv)} dropped the recovery hint"
+
+
+def test_json_err_preserves_naturoerror_but_falls_back_for_plain_exception(capsys) -> None:
+    """``_common._json_err`` is the funnel #1004 fixed — pin both of its branches.
+
+    A ``NaturoError`` passed via ``exc=`` must keep its structured identity even
+    when the caller supplies a generic ``code``; a plain exception must fall back
+    to that ``code``. Both stay canonical in shape. Pinning the funnel directly
+    guards the mechanism even for callsites the command-level parametrization
+    above does not enumerate.
+    """
+    from naturo.cli.interaction import _common
+
+    # NaturoError: identity preserved, generic fallback code ("ACTION_ERROR") ignored.
+    with pytest.raises(SystemExit) as semantic_exit:
+        _common._json_err("flat message", json_output=True, code="ACTION_ERROR",
+                          exc=ElementNotFoundError("x"))
+    assert semantic_exit.value.code == 1
+    semantic = _single_error_object(capsys.readouterr().out)
+    assert list(semantic.keys())[:6] == _CANONICAL_KEYS
+    assert semantic["code"] == "ELEMENT_NOT_FOUND"
+    assert semantic["category"] == "automation"
+    assert semantic["recoverable"] is True
+
+    # Plain exception: falls back to the supplied code, shape still canonical.
+    with pytest.raises(SystemExit) as plain_exit:
+        _common._json_err("boom", json_output=True, code="ACTION_ERROR",
+                          exc=ValueError("boom"))
+    assert plain_exit.value.code == 1
+    plain = _single_error_object(capsys.readouterr().out)
+    assert list(plain.keys()) == _CANONICAL_KEYS
+    assert plain["code"] == "ACTION_ERROR"
+
+
+# ── 4. source-of-truth completeness ──────────────────────────────────────────
 
 def test_naturo_error_serializer_is_canonical() -> None:
     """The base exception serializer pins the canonical schema in one place."""


### PR DESCRIPTION
## What
The action-phase catch-alls in `click`/`type`/`press`/`scroll`/`drag`/`move` flattened a real `NaturoError` to the generic `ACTION_ERROR`/`category:unknown`/`suggested_action:null`/`recoverable:false` envelope, discarding the exception's semantic identity. An `ElementNotFoundError` from the single most-used command `click` surfaced as `ACTION_ERROR` instead of `ELEMENT_NOT_FOUND` — defeating the agent self-correction contract #877 established and whose *shape* #884 converged.

```
# before
$ naturo -j click --id <bad>
{"error": {"code": "ACTION_ERROR", "category": "unknown", "suggested_action": null, "recoverable": false, ...}}
# after (now matches get/scroll)
{"error": {"code": "ELEMENT_NOT_FOUND", "category": "automation", "suggested_action": "...", "recoverable": true, ...}}
```

## How
- Teach `_common._json_err` to accept the originating exception (keyword-only `exc=`); when it is a `NaturoError`, route through the existing `error_helpers.emit_exception_error` so the full structured envelope is preserved. Non-`NaturoError` exceptions and `exc`-less callers keep the generic fallback `code`, and the plain-text `Error: <message>` line is byte-for-byte unchanged (`str(NaturoError) == NaturoError.message`).
- Pass `exc=` at the eight action-phase catch-alls listed in #1004 (`_click.py`, `_mouse.py` ×3, `_press.py` ×2, `_type.py` ×2). Keyword-only param ⇒ every other `_json_err` caller is unaffected.

## How tested
- New semantic-identity layer on the #1001 contract test: drives every interaction command with a backend whose action raises `ElementNotFoundError` and asserts the envelope keeps **code/category** (not just shape), plus a direct two-branch funnel test of `_json_err`. A future catch-all that drops `exc=` re-flattens here on day one.
- `tests/test_error_envelope_contract_1001.py`: 204 passed. Error-envelope neighborhood (877/884/json contract): 230 passed. Interaction suites (click/type/press/mouse/common): 296 passed. Live repro confirmed `click --id <bad>` now emits `ELEMENT_NOT_FOUND`/`automation`/`recoverable:true`; text mode unchanged (exit 1).
- ruff clean. No production logic change beyond error emission; no public-API/CLI change.

Fixes #1004.