### PR TITLE
fix: make move --to/--id resolve element targets (fixes #1007)

### DIFF
--- a/naturo/cli/interaction/_common.py
+++ b/naturo/cli/interaction/_common.py
@@ -614,6 +614,70 @@ def _resolve_selector_target(
     return (x, y)
 
 
+def _resolve_text_or_ref_target(
+    target_id: str,
+    backend,
+    app: Optional[str],
+    json_output: bool,
+) -> Optional[tuple]:
+    """Resolve an element text / automation-id / ``eN`` ref to (x, y) coordinates.
+
+    Shared by ``scroll`` and ``move`` for their ``--on``/``--to`` (text) and
+    ``--id`` targeting. An ``eN`` token is resolved against the most recent
+    ``see`` snapshot; any other string is looked up by name/automation-id through
+    the backend's element search and reduced to the matched element's centre.
+
+    On failure this emits the canonical error envelope — ``REF_NOT_FOUND`` for a
+    stale ``eN`` ref, ``ELEMENT_NOT_FOUND`` for a missing text/id target — and
+    terminates the process (via :func:`_json_err`), so callers treat a ``None``
+    return as "stop".
+
+    Args:
+        target_id: The element token — an ``eN`` snapshot ref, visible text, or
+            automation ID.
+        backend: The platform backend instance.
+        app: Application name filter, used when resolving an ``eN`` ref.
+        json_output: Whether to emit a JSON error envelope on failure.
+
+    Returns:
+        ``(x, y)`` centre coordinates of the resolved element, or ``None`` on
+        failure (after an error has already been emitted).
+    """
+    import re as _re
+    if _re.fullmatch(r"e\d+", target_id):
+        from naturo.snapshot import get_snapshot_manager
+        mgr = get_snapshot_manager()
+        resolved = mgr.resolve_ref(target_id, app_name=app)
+        if resolved:
+            return resolved[0], resolved[1]
+        _json_err(
+            f"Element ref '{target_id}' not found. Run 'naturo see' first to "
+            f"capture a fresh snapshot, then use the eN ref within 10 minutes.",
+            json_output,
+            code="REF_NOT_FOUND",
+        )
+        return None
+
+    # Text / automation-id lookup — find element center via backend.
+    try:
+        elem = backend.find_element(target_id)
+    except Exception as exc:
+        _json_err(
+            f"Failed to find element '{target_id}': {exc}",
+            json_output,
+            code="ELEMENT_NOT_FOUND",
+        )
+        return None
+    if elem:
+        return elem.x + elem.width // 2, elem.y + elem.height // 2
+    _json_err(
+        f"Element '{target_id}' not found.",
+        json_output,
+        code="ELEMENT_NOT_FOUND",
+    )
+    return None
+
+
 # ── Shared helper ────────────────────────────────────────────────────────────
 
 

--- a/naturo/cli/interaction/_mouse.py
+++ b/naturo/cli/interaction/_mouse.py
@@ -91,45 +91,13 @@ def scroll(direction_arg, direction_option, amount, on_text, ref_alias, element_
         target_label = f"({x}, {y})"
     elif on_text or element_id:
         target_id = on_text or element_id
-        import re as _re
-        if _re.fullmatch(r"e\d+", target_id):
-            # Resolve eN ref from most recent `see` snapshot
-            from naturo.snapshot import get_snapshot_manager
-            mgr = get_snapshot_manager()
-            resolved = mgr.resolve_ref(target_id, app_name=app)
-            if resolved:
-                x, y = resolved[0], resolved[1]
-                target_label = target_id
-            else:
-                _common._json_err(
-                    f"Element ref '{target_id}' not found. Run 'naturo see' first to "
-                    f"capture a fresh snapshot, then use the eN ref within 10 minutes.",
-                    json_output,
-                    code="REF_NOT_FOUND",
-                )
-                return
-        else:
-            # Text-based element lookup — find element center via backend
-            try:
-                elem = backend.find_element(target_id)
-                if elem:
-                    x = elem.x + elem.width // 2
-                    y = elem.y + elem.height // 2
-                    target_label = target_id
-                else:
-                    _common._json_err(
-                        f"Element '{target_id}' not found.",
-                        json_output,
-                        code="ELEMENT_NOT_FOUND",
-                    )
-                    return
-            except Exception as exc:
-                _common._json_err(
-                    f"Failed to find element '{target_id}': {exc}",
-                    json_output,
-                    code="ELEMENT_NOT_FOUND",
-                )
-                return
+        resolved = _common._resolve_text_or_ref_target(
+            target_id, backend, app, json_output,
+        )
+        if resolved is None:
+            return
+        x, y = resolved
+        target_label = target_id
 
     try:
         backend.scroll(direction=direction, amount=amount, x=x, y=y, smooth=smooth)
@@ -430,6 +398,9 @@ def move(to_text, coords, element_id, trajectory, duration, steps, jitter, overs
     \b
     Examples:
       naturo move --coords 500 300
+      naturo move --to "Save"
+      naturo move --to e42
+      naturo move --id "button_ok"
       naturo move --selector 'app://*/Button[@name="Save"]'
     """
     # (#593) Resolve --app-id to app/hwnd/pid before any other logic
@@ -439,7 +410,7 @@ def move(to_text, coords, element_id, trajectory, duration, steps, jitter, overs
 
     backend = _common._get_backend(json_output)
 
-    # Resolve target: --selector > --coords
+    # Resolve target: --selector > --coords > --to/--id (text or eN ref)
     x, y = None, None
 
     if selector:
@@ -451,8 +422,20 @@ def move(to_text, coords, element_id, trajectory, duration, steps, jitter, overs
         x, y = resolved
     elif coords:
         x, y = coords
+    elif to_text or element_id:
+        target_id = to_text or element_id
+        resolved = _common._resolve_text_or_ref_target(
+            target_id, backend, app, json_output,
+        )
+        if resolved is None:
+            return
+        x, y = resolved
     else:
-        _common._json_err("Specify --selector, --coords X Y, or --to", json_output, code="INVALID_INPUT")
+        _common._json_err(
+            "Specify --selector, --coords X Y, --to TEXT, or --id",
+            json_output,
+            code="INVALID_INPUT",
+        )
         return
 
     try:

--- a/tests/test_input_mouse.py
+++ b/tests/test_input_mouse.py
@@ -409,6 +409,126 @@ class TestMoveCLIValidation:
         assert result.exit_code != 0
 
 
+class TestMoveTargetResolution:
+    """move resolves --to/--id element targets, not just --coords/--selector (#1007).
+
+    ``move`` advertises and accepts ``--to <text>`` and ``--id <automation-id>``,
+    but its resolver used to branch only on ``--selector``/``--coords`` and fall
+    through to ``INVALID_INPUT: "Specify ... --to"`` — telling the user to pass
+    ``--to`` when they just did. These tests pin that both options now drive the
+    same element-ref → centre-point resolution the sibling ``scroll`` command uses.
+    """
+
+    def test_move_to_text_resolves_to_element_center(self, runner):
+        """``move --to <text>`` finds the element and moves to its centre."""
+        from unittest.mock import patch, MagicMock
+
+        element = MagicMock(x=100, y=200, width=40, height=20)
+        mock_backend = MagicMock()
+        mock_backend.find_element.return_value = element
+        with patch("naturo.cli.interaction._common._get_backend", return_value=mock_backend):
+            result = runner.invoke(main, ["move", "--to", "Save"])
+        assert result.exit_code == 0, result.output
+        mock_backend.find_element.assert_called_once_with("Save")
+        mock_backend.move_mouse.assert_called_once()
+        args, kwargs = mock_backend.move_mouse.call_args
+        # Centre of (100,200) 40x20 → (120, 210)
+        assert args[0] == 120
+        assert args[1] == 210
+
+    def test_move_id_resolves_to_element_center(self, runner):
+        """``move --id <automation-id>`` resolves the same way as ``--to``."""
+        from unittest.mock import patch, MagicMock
+
+        element = MagicMock(x=10, y=10, width=20, height=20)
+        mock_backend = MagicMock()
+        mock_backend.find_element.return_value = element
+        with patch("naturo.cli.interaction._common._get_backend", return_value=mock_backend):
+            result = runner.invoke(main, ["move", "--id", "btn_ok"])
+        assert result.exit_code == 0, result.output
+        mock_backend.find_element.assert_called_once_with("btn_ok")
+        mock_backend.move_mouse.assert_called_once()
+        args, _ = mock_backend.move_mouse.call_args
+        assert args[0] == 20
+        assert args[1] == 20
+
+    def test_move_to_missing_element_yields_element_not_found(self, runner):
+        """A missing ``--to`` target yields ELEMENT_NOT_FOUND, never INVALID_INPUT.
+
+        The old bug returned ``INVALID_INPUT: "Specify --selector, --coords X Y,
+        or --to"`` for every ``--to`` value because the option was never read.
+        """
+        from unittest.mock import patch, MagicMock
+
+        mock_backend = MagicMock()
+        mock_backend.find_element.return_value = None
+        with patch("naturo.cli.interaction._common._get_backend", return_value=mock_backend):
+            result = runner.invoke(main, ["move", "--to", "does_not_exist", "-j"])
+        assert result.exit_code != 0
+        payload = json.loads(result.output)
+        assert payload["success"] is False
+        error = payload["error"]
+        assert error["code"] == "ELEMENT_NOT_FOUND"
+        assert error["category"] == "automation"
+        assert error["recoverable"] is True
+        mock_backend.move_mouse.assert_not_called()
+
+    def test_move_id_missing_element_yields_element_not_found(self, runner):
+        """A missing ``--id`` target yields ELEMENT_NOT_FOUND, never INVALID_INPUT."""
+        from unittest.mock import patch, MagicMock
+
+        mock_backend = MagicMock()
+        mock_backend.find_element.return_value = None
+        with patch("naturo.cli.interaction._common._get_backend", return_value=mock_backend):
+            result = runner.invoke(main, ["move", "--id", "ghost", "-j"])
+        assert result.exit_code != 0
+        error = json.loads(result.output)["error"]
+        assert error["code"] == "ELEMENT_NOT_FOUND"
+        mock_backend.move_mouse.assert_not_called()
+
+    def test_move_to_eN_ref_resolves_via_snapshot(self, runner):
+        """``move --to eN`` resolves an element ref from the latest snapshot."""
+        from unittest.mock import patch, MagicMock
+
+        mock_backend = MagicMock()
+        mock_mgr = MagicMock()
+        mock_mgr.resolve_ref.return_value = (333, 444, "snap1")
+        with patch("naturo.cli.interaction._common._get_backend", return_value=mock_backend), \
+             patch("naturo.snapshot.get_snapshot_manager", return_value=mock_mgr):
+            result = runner.invoke(main, ["move", "--to", "e7"])
+        assert result.exit_code == 0, result.output
+        mock_mgr.resolve_ref.assert_called_once()
+        mock_backend.find_element.assert_not_called()
+        args, _ = mock_backend.move_mouse.call_args
+        assert args[0] == 333
+        assert args[1] == 444
+
+    def test_move_stale_eN_ref_yields_ref_not_found(self, runner):
+        """A stale ``move --to eN`` ref yields REF_NOT_FOUND, not a move."""
+        from unittest.mock import patch, MagicMock
+
+        mock_backend = MagicMock()
+        mock_mgr = MagicMock()
+        mock_mgr.resolve_ref.return_value = None
+        with patch("naturo.cli.interaction._common._get_backend", return_value=mock_backend), \
+             patch("naturo.snapshot.get_snapshot_manager", return_value=mock_mgr):
+            result = runner.invoke(main, ["move", "--to", "e99", "-j"])
+        assert result.exit_code != 0
+        assert json.loads(result.output)["error"]["code"] == "REF_NOT_FOUND"
+        mock_backend.move_mouse.assert_not_called()
+
+    def test_move_no_target_still_reports_invalid_input(self, runner):
+        """With no target flag at all, move still reports INVALID_INPUT."""
+        from unittest.mock import patch, MagicMock
+
+        mock_backend = MagicMock()
+        with patch("naturo.cli.interaction._common._get_backend", return_value=mock_backend):
+            result = runner.invoke(main, ["move", "-j"])
+        assert result.exit_code != 0
+        assert json.loads(result.output)["error"]["code"] == "INVALID_INPUT"
+        mock_backend.move_mouse.assert_not_called()
+
+
 # ── Scroll delta computation logic ────────────────────────────────────────────
 
 


### PR DESCRIPTION
## What
`naturo move` declared and documented two element-targeting options — `--to <text>` and `--id <automation-id>` — but its resolver only branched on `--selector`/`--coords`. Every `--to`/`--id` invocation fell through to `INVALID_INPUT: "Specify --selector, --coords X Y, or --to"`, i.e. it told the user to pass `--to` **when they just did**. Both options were inert dead code (fixes #1007).

## How
- Extracted the `eN`-ref / text / automation-id → centre-point resolution that `scroll` already performed into a shared helper `_common._resolve_text_or_ref_target`.
- Wired `move`'s `--to`/`--id` through it (priority `--selector > --coords > --to/--id`).
- A missing target now yields the canonical `ELEMENT_NOT_FOUND` / `automation` / `recoverable:true` envelope (`REF_NOT_FOUND` for a stale `eN` ref), consistent with the #1004 / #877 contract; a bare `move` still reports `INVALID_INPUT` (message updated to list `--to TEXT` and `--id`).
- `scroll` is refactored onto the same helper with identical behaviour (no copy-paste).
- Documented the now-working `--to`/`--id` in `move --help` examples.

## How tested
- New `TestMoveTargetResolution` (7 tests): `--to`/`--id` resolve to the element centre and call `move_mouse`; missing target → `ELEMENT_NOT_FOUND`; stale `eN` ref → `REF_NOT_FOUND`; bare `move` → `INVALID_INPUT`; `move_mouse` not called on any failure.
- `ruff check naturo/` clean; `mypy` clean on changed files (`--follow-imports=silent`; the only error is pre-existing local `mcp` 3.10-syntax noise unrelated to this change).
- `pytest tests/test_input_mouse.py tests/test_error_envelope_contract_1001.py tests/test_cli_consistency.py tests/test_cli.py tests/test_cli_phase2.py` → 371 passed, 19 skipped (no regressions).
- Live repro on a real desktop: `move --to <missing>` / `move --id <missing>` now emit `ELEMENT_NOT_FOUND`/`automation`/`recoverable:true` (previously `INVALID_INPUT`); no cursor movement occurs when the element does not resolve.
