### PR TITLE
fix: press unknown-key error returns INVALID_INPUT envelope (fixes #991)

### DIFF
--- a/naturo/cli/interaction/_press.py
+++ b/naturo/cli/interaction/_press.py
@@ -1,6 +1,7 @@
 """Press and hotkey commands — single keys, combos, or sequential sequences."""
 from __future__ import annotations
 
+import difflib
 import logging
 
 import click
@@ -8,6 +9,67 @@ import click
 import naturo.cli.interaction._common as _common
 
 logger = logging.getLogger(__name__)
+
+
+# Representative valid key names, used only to build recovery hints and the
+# fuzzy "did you mean" suggestion (#991).  This list is NEVER consulted to
+# decide whether a key is valid — the native core is the sole authority on
+# that — so an omission here can only cost a suggestion, never wrongly reject a
+# key the core would have accepted.
+_COMMON_KEY_NAMES: tuple[str, ...] = (
+    "enter", "tab", "escape", "esc", "space", "backspace", "delete",
+    "insert", "home", "end", "pageup", "pagedown",
+    "up", "down", "left", "right",
+    "f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "f10", "f11", "f12",
+    "ctrl", "alt", "shift", "win",
+)
+
+_VALID_KEY_HINT = (
+    "Valid keys include enter, tab, esc, space, up/down/left/right, f1-f12, "
+    "and combos like 'ctrl+c'. Run 'naturo press --help' for examples."
+)
+
+
+def _emit_unknown_key_error(key_spec: str, json_output: bool) -> None:
+    """Emit an ``INVALID_INPUT`` envelope for a key the native core rejected.
+
+    The core rejects an unrecognized key name with a generic ``Invalid
+    argument`` whose message leaks the internal function name (e.g.
+    ``key_press('entr')``) and carries no recovery guidance (#991).  Translate
+    that into the same agent-friendly envelope every other command emits: an
+    ``INVALID_INPUT`` code, a clean user-facing message, and a
+    ``suggested_action`` listing valid keys plus a fuzzy "did you mean" hint
+    for near-misses.  Validity itself is never decided here — this runs only
+    after the core has already rejected the key.
+
+    Args:
+        key_spec: The key spec the user supplied (e.g. ``"entr"`` or
+            ``"ctrl+notakey"``), reported back verbatim so the caller can see
+            exactly what was rejected.
+        json_output: Whether to emit the JSON envelope instead of plain text.
+
+    Returns:
+        Never returns — always exits the process with status 1.
+    """
+    from naturo.cli.error_helpers import emit_error
+
+    stripped = key_spec.strip()
+    if not stripped:
+        message = "Empty key name."
+        suggested_action = _VALID_KEY_HINT
+    else:
+        message = f"Unknown key: {key_spec!r}"
+        suggested_action = _VALID_KEY_HINT
+        # Bonus: fuzzy "did you mean" for a single near-miss key name (#149).
+        if "+" not in stripped:
+            close = difflib.get_close_matches(
+                stripped.lower(), _COMMON_KEY_NAMES, n=1, cutoff=0.6,
+            )
+            if close:
+                suggested_action = f"Did you mean '{close[0]}'? {suggested_action}"
+
+    emit_error("INVALID_INPUT", message, json_output,
+               suggested_action=suggested_action)
 
 
 def _is_combo(key_str: str) -> bool:
@@ -288,6 +350,14 @@ def press(keys: tuple[str, ...], count: int, delay: float, hold_duration: float 
             if idx < len(keys) - 1 and delay > 0:
                 time.sleep(delay / 1000.0)
     except Exception as exc:
+        # An unrecognized key name reaches us as NaturoCoreError(code=-1)
+        # ("Invalid argument") — bad input, not a runtime action failure.
+        # Re-map it to a clean INVALID_INPUT envelope (#991); ``key_spec`` is
+        # the key the loop was processing when the core rejected it.
+        from naturo.bridge import NaturoCoreError
+        if isinstance(exc, NaturoCoreError) and exc.code == -1:
+            _emit_unknown_key_error(key_spec, json_output)
+            return
         _common._json_err(str(exc), json_output, exc=exc)
         return
     finally:

--- a/tests/test_cli_press.py
+++ b/tests/test_cli_press.py
@@ -8,6 +8,7 @@ import click
 import pytest
 from click.testing import CliRunner
 
+from naturo.bridge import NaturoCoreError
 from naturo.cli.interaction._press import (
     _is_combo, _is_standalone_modifier, _normalize_modifier, press, hotkey,
 )
@@ -382,6 +383,112 @@ class TestPressErrors:
         assert result.exit_code == 0
         backend.focus_window.assert_called_once_with(hwnd=12345)
         backend.press_key.assert_called_once()
+
+
+# ── press command — invalid key name (#991) ─────
+
+
+class TestPressInvalidKey:
+    """#991: an unknown key name must surface as an agent-friendly INVALID_INPUT
+    envelope (clean message + suggested_action), not a raw ACTION_ERROR that
+    leaks the internal ``key_press('...')`` function name.
+
+    The native core is the sole authority on key validity: it rejects an
+    unknown key with ``NaturoCoreError(code=-1)`` ("Invalid argument"). The CLI
+    translates *only* that code into INVALID_INPUT — a genuine runtime failure
+    (code=-2, System/COM error) must keep its ACTION_ERROR categorization.
+    """
+
+    @patch("naturo.cli.interaction._common._auto_route", return_value=None)
+    @patch("naturo.cli.interaction._common._get_backend")
+    @patch("naturo.cli.interaction._common._resolve_app_id", return_value=(None, None, None))
+    def test_unknown_single_key_is_invalid_input(self, mock_resolve, mock_get_backend, mock_route, runner):
+        backend = MagicMock()
+        backend.press_key.side_effect = NaturoCoreError(-1, "key_press('entr')")
+        mock_get_backend.return_value = backend
+
+        result = runner.invoke(press, ["entr", "--json", "--no-verify"], catch_exceptions=False)
+        assert result.exit_code != 0
+        err = json.loads(result.output)["error"]
+        assert err["code"] == "INVALID_INPUT"
+        assert err["category"] == "validation"
+        # Clean, user-facing message — names the offending key, hides internals.
+        assert err["message"] == "Unknown key: 'entr'"
+        assert "key_press(" not in result.output
+        assert "Invalid argument" not in result.output
+        # Recovery guidance is present (unlike the old null suggested_action).
+        assert err["suggested_action"]
+        assert "press --help" in err["suggested_action"]
+
+    @patch("naturo.cli.interaction._common._auto_route", return_value=None)
+    @patch("naturo.cli.interaction._common._get_backend")
+    @patch("naturo.cli.interaction._common._resolve_app_id", return_value=(None, None, None))
+    def test_unknown_single_key_fuzzy_did_you_mean(self, mock_resolve, mock_get_backend, mock_route, runner):
+        backend = MagicMock()
+        backend.press_key.side_effect = NaturoCoreError(-1, "key_press('entr')")
+        mock_get_backend.return_value = backend
+
+        result = runner.invoke(press, ["entr", "--json", "--no-verify"], catch_exceptions=False)
+        err = json.loads(result.output)["error"]
+        assert "Did you mean 'enter'?" in err["suggested_action"]
+
+    @patch("naturo.cli.interaction._common._auto_route", return_value=None)
+    @patch("naturo.cli.interaction._common._get_backend")
+    @patch("naturo.cli.interaction._common._resolve_app_id", return_value=(None, None, None))
+    def test_unknown_key_in_combo_is_invalid_input(self, mock_resolve, mock_get_backend, mock_route, runner):
+        backend = MagicMock()
+        backend.hotkey.side_effect = NaturoCoreError(-1, "key_hotkey(('ctrl', 'notakey'))")
+        mock_get_backend.return_value = backend
+
+        result = runner.invoke(press, ["ctrl+notakey", "--json", "--no-verify"], catch_exceptions=False)
+        assert result.exit_code != 0
+        err = json.loads(result.output)["error"]
+        assert err["code"] == "INVALID_INPUT"
+        assert err["message"] == "Unknown key: 'ctrl+notakey'"
+        assert "key_hotkey(" not in result.output
+
+    @patch("naturo.cli.interaction._common._auto_route", return_value=None)
+    @patch("naturo.cli.interaction._common._get_backend")
+    @patch("naturo.cli.interaction._common._resolve_app_id", return_value=(None, None, None))
+    def test_empty_key_is_invalid_input(self, mock_resolve, mock_get_backend, mock_route, runner):
+        backend = MagicMock()
+        backend.press_key.side_effect = NaturoCoreError(-1, "key_press('')")
+        mock_get_backend.return_value = backend
+
+        result = runner.invoke(press, ["", "--json", "--no-verify"], catch_exceptions=False)
+        assert result.exit_code != 0
+        err = json.loads(result.output)["error"]
+        assert err["code"] == "INVALID_INPUT"
+        assert err["message"] == "Empty key name."
+        assert "key_press(" not in result.output
+
+    @patch("naturo.cli.interaction._common._auto_route", return_value=None)
+    @patch("naturo.cli.interaction._common._get_backend")
+    @patch("naturo.cli.interaction._common._resolve_app_id", return_value=(None, None, None))
+    def test_system_error_stays_action_error(self, mock_resolve, mock_get_backend, mock_route, runner):
+        """A genuine runtime failure (code=-2) must NOT be remapped to INVALID_INPUT."""
+        backend = MagicMock()
+        backend.press_key.side_effect = NaturoCoreError(-2, "key_press('enter')")
+        mock_get_backend.return_value = backend
+
+        result = runner.invoke(press, ["enter", "--json", "--no-verify"], catch_exceptions=False)
+        assert result.exit_code != 0
+        err = json.loads(result.output)["error"]
+        assert err["code"] == "ACTION_ERROR"
+        assert "System/COM error" in err["message"]
+
+    @patch("naturo.cli.interaction._common._auto_route", return_value=None)
+    @patch("naturo.cli.interaction._common._get_backend")
+    @patch("naturo.cli.interaction._common._resolve_app_id", return_value=(None, None, None))
+    def test_unknown_key_plain_text(self, mock_resolve, mock_get_backend, mock_route, runner):
+        backend = MagicMock()
+        backend.press_key.side_effect = NaturoCoreError(-1, "key_press('entr')")
+        mock_get_backend.return_value = backend
+
+        result = runner.invoke(press, ["entr", "--no-verify"], catch_exceptions=False)
+        assert result.exit_code != 0
+        assert "Unknown key: 'entr'" in result.output
+        assert "key_press(" not in result.output
 
 
 # ── press command — --on element ────────────────


### PR DESCRIPTION
## What
`naturo press <bad-key>` returned a low-quality error: a generic `ACTION_ERROR` whose message leaked the internal function name (`key_press('entr'): Invalid argument`), `category: unknown`, and `suggested_action: null` — unlike every other command's recovery-guiding envelope (#991).

Now an unrecognized key surfaces as the canonical agent-friendly envelope:
```json
{"code": "INVALID_INPUT", "message": "Unknown key: 'entr'", "category": "validation",
 "suggested_action": "Did you mean 'enter'? Valid keys include enter, tab, esc, space, up/down/left/right, f1-f12, and combos like 'ctrl+c'. Run 'naturo press --help' for examples.", "recoverable": false}
```

## How
The native core is the sole authority on key validity: it rejects an unknown key with `NaturoCoreError(code=-1)` ("Invalid argument"). The press error path now re-maps **only** that code to `INVALID_INPUT` via a small `_emit_unknown_key_error` helper — clean `Unknown key: '<spec>'` message (or `Empty key name.`), a `suggested_action` listing valid keys, and a `difflib` "did you mean" hint for single near-miss keys (#149). A genuine runtime failure (`code=-2`, System/COM error) keeps its `ACTION_ERROR` categorization.

Validity is **never** decided in the CLI — no hardcoded key list can wrongly reject a key the core would accept (false-negative-safe per SOUL 'Never Lie'). Continues the error-envelope quality theme (#1004/#1006/#1007).

## How tested
- Added `TestPressInvalidKey` (6 tests) in `tests/test_cli_press.py`: unknown single key → INVALID_INPUT/validation + clean message + no leaked internals; fuzzy 'did you mean enter'; unknown key in combo; empty key → 'Empty key name.'; **code=-2 stays ACTION_ERROR** (guards against over-broad remapping); plain-text mode.
- `ruff` + `mypy` clean on changed file.
- 432 passed across press/phase2/consistency/keyboard/strategies/error-envelope-contract suites — no regressions (existing plain-`RuntimeError` test unaffected, since only `NaturoCoreError(code=-1)` is remapped).
- Live on real desktop (input-safe — invalid keys send no keystroke): `-j press entr`/`ctrl+notakey`/`""` and plain-text all emit the new envelope, exit 1.