### PR TITLE
fix: guard tomllib import for Python 3.9 test lane (fixes #910)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,9 @@ dev = [
     "pyyaml>=6.0",
     "ruff>=0.4.0",
     "mypy>=1.10",
+    # ``tomllib`` is stdlib only on Python 3.11+; tests read pyproject.toml on
+    # 3.9/3.10 via the ``tomli`` backport (#910).
+    "tomli>=2.0; python_version < '3.11'",
 ]
 ai = [
     "anthropic>=0.20,<2.0",

--- a/tests/test_builtin_selectors.py
+++ b/tests/test_builtin_selectors.py
@@ -6,6 +6,7 @@ formatted, loadable, and integrate with the selector CLI commands.
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 
 import pytest
@@ -141,7 +142,12 @@ class TestPackageData:
     """Ensure built-in templates are included in package distribution."""
 
     def test_pyproject_includes_json_templates(self):
-        import tomllib
+        # ``tomllib`` is stdlib only on Python 3.11+; fall back to the ``tomli``
+        # backport (declared as a dev dependency) on 3.9/3.10 (#910).
+        if sys.version_info >= (3, 11):
+            import tomllib
+        else:
+            import tomli as tomllib
         pyproject = Path(__file__).parent.parent / "pyproject.toml"
         with open(pyproject, "rb") as f:
             config = tomllib.load(f)

--- a/tests/test_python_compat.py
+++ b/tests/test_python_compat.py
@@ -20,6 +20,16 @@ def _get_python_files():
     return list(pkg_dir.rglob("*.py"))
 
 
+def _get_test_files():
+    """Get all .py files in the tests directory.
+
+    Tests run on the full 3.9-3.13 matrix too, so they must not use stdlib
+    features newer than the lowest supported version without a fallback (#910).
+    """
+    test_dir = Path(__file__).parent
+    return list(test_dir.rglob("*.py"))
+
+
 def _check_file_for_310_syntax(filepath):
     """Check a file for Python 3.10+ syntax patterns.
 
@@ -123,8 +133,12 @@ class TestPython39Compatibility:
                     )
 
     def test_no_tomllib_without_fallback(self):
-        """R-DEV-011: tomllib usage must have fallback for Python < 3.11."""
-        for filepath in _get_python_files():
+        """R-DEV-011: tomllib usage must have fallback for Python < 3.11.
+
+        Scans both the package and the test suite, since tests also run on the
+        3.9/3.10 lanes where ``tomllib`` is absent from the stdlib (#910).
+        """
+        for filepath in (*_get_python_files(), *_get_test_files()):
             source = filepath.read_text(encoding="utf-8")
             if "import tomllib" in source and "sys.version_info" not in source:
                 if "tomli" not in source:


### PR DESCRIPTION
## What
The Python **3.9/3.10** test lanes were red on develop: `tests/test_builtin_selectors.py` imported the stdlib `tomllib` (3.11+) unconditionally → `ModuleNotFoundError: No module named 'tomllib'`. The 3.9 matrix entry is `continue-on-error: true`, so the aggregate "Build & Test" run stayed green and masked the failure — while the project advertises Python 3.9+ support.

## How
- **Guard the import** in `test_builtin_selectors.py` with a `tomli` fallback, matching the existing pattern in `test_version.py`:
  ```python
  if sys.version_info >= (3, 11):
      import tomllib
  else:
      import tomli as tomllib
  ```
- **Declare the backport**: `tomli>=2.0; python_version < '3.11'` in the `dev` extra, so the 3.9/3.10 CI lanes (which `pip install -e .[dev]`) actually have `tomli` available to read `pyproject.toml`.
- **Prevent recurrence**: extend the `R-DEV-011` compat check (`test_python_compat.py::test_no_tomllib_without_fallback`) to scan `tests/` in addition to `naturo/` — previously it only scanned the package, so an unguarded `tomllib` in a test slipped through.

## How tested
- `pytest tests/test_python_compat.py tests/test_builtin_selectors.py tests/test_version.py` → 82 passed locally (Python 3.12); the extended `tests/` scan trips on no existing file.
- `pyproject.toml` validated as parseable TOML; `ruff check` clean on the changed files.
- The decisive check is the **Python Tests (Ubuntu/macOS, 3.9)** lane on this PR going green.

Closes #910.