### PR TITLE
test: pin utf-8 on visual report reads + drop dead assertion (fixes #999)

### DIFF
--- a/tests/test_visual.py
+++ b/tests/test_visual.py
@@ -88,7 +88,7 @@ class TestSaveBaseline:
     def test_save_metadata(self, tmp_dirs, red_image):
         bd, _ = tmp_dirs
         visual_mod.save_baseline(red_image, "test_screen", bd)
-        meta = json.loads((bd / "test_screen.json").read_text())
+        meta = json.loads((bd / "test_screen.json").read_text(encoding="utf-8"))
         assert meta["name"] == "test_screen"
         assert meta["size"] == [100, 100]
 
@@ -218,7 +218,7 @@ class TestHTMLReport:
         report.add_result(result)
         html_path = visual_mod.generate_html_report(report, rd / "report.html")
         assert html_path.exists()
-        content = html_path.read_text()
+        content = html_path.read_text(encoding="utf-8")
         assert "Test Report" in content
         assert "FAILED" in content
         assert "test" in content
@@ -672,8 +672,6 @@ class TestEnterpriseCLI:
         ])
         assert result.exit_code != 0
 
-        assert data["name"] == "screen1"
-
     def test_list_json(self, runner, tmp_dirs, red_image):
         runner.invoke(main, ["visual", "baseline", "s1", "--from", str(red_image)])
         result = runner.invoke(main, ["visual", "list", "--json"])
@@ -867,5 +865,5 @@ class TestVisualReportCLI:
             "-o", str(html_out),
         ])
         assert result.exit_code == 0
-        content = html_out.read_text()
+        content = html_out.read_text(encoding="utf-8")
         assert "Sprint 42 Regression" in content


### PR DESCRIPTION
## What
Fixes #999 — two latent, CI-invisible test defects in `tests/test_visual.py`:

1. **Locale fragility:** the visual HTML report (and baseline metadata JSON) was read back via `Path.read_text()` with the **platform default codec**. The report contains non-ASCII bytes (curly quotes, byte `0x94`), so on a non-UTF-8 host (zh-CN / gbk Windows desktop) `read_text()` raised `UnicodeDecodeError`. CI's UTF-8 Linux/macOS lanes never triggered it — a silent host-vs-CI divergence. Pinned `encoding="utf-8"` on the three affected reads. The report is already written as UTF-8 (`naturo/visual.py:454`), so this is a test-only round-trip fix; no source/public-API change.

2. **Dead assertion:** `TestEnterpriseCLI::test_report_errors_exit_nonzero` ended with `assert data["name"] == "screen1"` where `data` was never assigned — a copy-paste leftover that raised `NameError` whenever the preceding `exit_code != 0` assertion passed. Removed it (the command is invoked without `-j`, so there is no JSON envelope to assert on).

## How tested
- Reproduced all three failures RED on this gbk-locale Windows host (two `UnicodeDecodeError`, one dead-`data`).
- After the fix: the three named tests + `test_save_metadata` pass; full `tests/test_visual.py` GREEN except one **pre-existing, unrelated** failure (`test_report_no_baselines`, exit-code drift) confirmed RED on pristine `develop` and filed separately.
- `ruff check` clean, `mypy` clean, `--collect-only` clean (no Windows/optional-dep import at collection → CI-safe).

Test-only change. No behavior, CLI, or JSON-schema impact.
