### PR TITLE
test: align test_report_no_baselines with non-zero exit contract (fixes #1016)

### DIFF
--- a/tests/test_visual.py
+++ b/tests/test_visual.py
@@ -844,12 +844,14 @@ class TestVisualReportCLI:
         assert "FAIL" in result.output
 
     def test_report_no_baselines(self, runner, tmp_dirs, tmp_path):
+        """#1016: plain-output report must exit non-zero with no baselines, matching
+        the JSON path (#781) and the #993 report-errors-exit-non-zero contract."""
         current_dir = tmp_path / "current"
         current_dir.mkdir()
         result = runner.invoke(main, [
             "visual", "report", "--current-dir", str(current_dir),
         ])
-        assert result.exit_code == 0
+        assert result.exit_code != 0
         assert "No baselines" in result.output
 
     def test_report_named_report(self, runner, tmp_dirs, red_image, tmp_path):


### PR DESCRIPTION
## What
`tests/test_visual.py::TestVisualReportCLI::test_report_no_baselines` asserted `exit_code == 0`, but `visual report` correctly exits **1** when there are no baselines to compare. The test failed on a clean `develop` (reproduced on pristine HEAD).

This resolves #1016 as **option 2**: the source behavior is correct, the test was stale.

## Why exit non-zero is the contract
- The JSON path is already contracted to exit non-zero for the same condition: `test_report_no_baselines_json_exit_code` and `test_report_no_baselines_json_exits_nonzero` (#781) both assert `exit_code != 0`.
- It matches the #993 "report errors exit non-zero" direction (`test_report_errors_exit_nonzero`).
- `visual_cmd.py` already `sys.exit(1)` on the no-baselines branch in both plain and JSON modes — no source change needed; only the plain-output test assertion was out of sync.

## How tested
- `python -m pytest tests/test_visual.py` → **74 passed** (was 1 failed / 73 passed).
- `python -m ruff check naturo/ tests/test_visual.py` → clean.
- `python -m pytest tests/ --collect-only` → 6482 tests collected, no collection break.
- Pure exit-code assertion, platform-independent.