### PR TITLE
test: mock _is_hwnd_alive in test_valid_app_id_returns_handle_and_pid (fixes #944)

### DIFF
--- a/tests/test_interaction_common.py
+++ b/tests/test_interaction_common.py
@@ -264,7 +264,11 @@ class TestResolveAppId:
         entry = MagicMock(handle=999, pid=111)
         fake_map = MagicMock()
         fake_map.resolve.return_value = entry
-        with patch("naturo.app_ids.get_app_id_map", return_value=fake_map):
+        # The handle (999) is a fixture value, not a real window, so the #788
+        # stale-HWND guard must be mocked alive; otherwise IsWindow(999) returns
+        # 0 on Windows and _resolve_app_id raises APP_ID_STALE (see #944).
+        with patch("naturo.app_ids.get_app_id_map", return_value=fake_map), \
+             patch("naturo.cli.interaction._common._is_hwnd_alive", return_value=True):
             result = _resolve_app_id("a1", "notepad", None, None, False)
         assert result == (None, 999, 111)
 


### PR DESCRIPTION
## What
`tests/test_interaction_common.py::TestResolveAppId::test_valid_app_id_returns_handle_and_pid` fails on Windows. The test supplies a fixture handle (`MagicMock(handle=999, pid=111)`) but does not mock the #788 stale-HWND guard. On Windows, `_resolve_app_id` calls `_is_hwnd_alive(999)` → `user32.IsWindow(999)` returns 0 → the code raises `APP_ID_STALE` and `sys.exit(1)` instead of returning `(None, 999, 111)`.

This is the same class of breakage #870 (PR #918) fixed for three sibling tests; this fourth test was missed. It stays green on Linux/macOS (no `IsWindow`, `_is_hwnd_alive` returns `True`), and the windows-latest CI lane is `continue-on-error`, so the failure is invisible to CI gating.

## How
Mock `naturo.cli.interaction._common._is_hwnd_alive` to `True` inside the test — the canonical pattern already used by `test_stale_pid_routing.py` and `test_cli_interaction_common.py`. This isolates the live-handle path under test from the real Win32 liveness check. Test-only change; production code is correct.

## How tested
- `pytest tests/test_interaction_common.py` → 39 passed (was 1 failing on this Windows host).
- Reproduced the failure on `origin/develop` before the fix; confirmed fixed after.
- `ruff check` clean; `--collect-only` on the affected files succeeds.