### PR TITLE
test: assert browser user-data-dir paths by parts, not slash substrings (fixes #946)

### DIFF
--- a/tests/test_browser_launcher.py
+++ b/tests/test_browser_launcher.py
@@ -193,25 +193,32 @@ class TestResolveProfileDirectory:
 
 
 class TestDefaultUserDataDir:
-    """Tests for OS-specific default user data directory."""
+    """Tests for OS-specific default user data directory.
+
+    Assertions compare ``Path.parts`` (OS-agnostic components) rather than
+    slash-joined substrings: ``_default_user_data_dir`` builds the path with
+    ``pathlib.Path``, which renders with the *host* separator, so a
+    ``"a/b"`` substring check never matches when the suite runs on Windows
+    (backslash separators). See #946.
+    """
 
     @patch("platform.system", return_value="Linux")
     def test_linux_path(self, mock_system):
         result = _default_user_data_dir()
         assert result is not None
-        assert ".config/google-chrome" in str(result)
+        assert result.parts[-2:] == (".config", "google-chrome")
 
     @patch("platform.system", return_value="Darwin")
     def test_macos_path(self, mock_system):
         result = _default_user_data_dir()
         assert result is not None
-        assert "Application Support/Google/Chrome" in str(result)
+        assert result.parts[-3:] == ("Application Support", "Google", "Chrome")
 
     @patch("platform.system", return_value="Windows")
     def test_windows_path(self, mock_system):
         result = _default_user_data_dir()
         assert result is not None
-        assert "Google" in str(result) and "Chrome" in str(result)
+        assert result.parts[-3:] == ("Google", "Chrome", "User Data")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What
`tests/test_browser_launcher.py::TestDefaultUserDataDir::test_linux_path` and `::test_macos_path` failed on a **Windows** host. Same class as #944: a test-portability defect masked in CI because the windows-latest lane is `continue-on-error`. Production code is correct.

## Root cause
The tests `@patch("platform.system")` to force an OS branch, but `_default_user_data_dir()` builds the result with `pathlib.Path`, which renders using the **host** separator. On Windows the path uses backslashes, so the forward-slash substring assertions (`.config/google-chrome`, `Application Support/Google/Chrome`) never matched. `test_windows_path` only passed because its substring check (`Google`/`Chrome`) is separator-agnostic.

## Fix (test-only, no source change)
Assert on OS-agnostic `Path.parts` components instead of slash-joined substrings:
- linux: `result.parts[-2:] == (".config", "google-chrome")`
- macos: `result.parts[-3:] == ("Application Support", "Google", "Chrome")`
- windows: `result.parts[-3:] == ("Google", "Chrome", "User Data")` (aligned for consistency; was a loose substring)

This is portable across hosts and also makes the assertions stricter (exact trailing components + order).

## How tested
- `python -m pytest tests/test_browser_launcher.py` on the Windows host: **55 passed** (was 2 failed / 53 passed). Run with a fresh `--basetemp` to avoid the unrelated shared-tmp `PermissionError` noise from concurrent worktrees (#935).
- `python -m pytest tests/test_browser_launcher.py --collect-only`: 55 collected, no import/collection errors.
- `ruff check`: clean. No source touched, so `mypy naturo/` is unaffected.