### PR TITLE
fix: suggest correct command for subgroup/renamed intent verbs (fixes #880)

### DIFF
--- a/naturo/cli/__init__.py
+++ b/naturo/cli/__init__.py
@@ -119,7 +119,25 @@ def _patch_all_commands(group: click.Command) -> None:
     _apply_short_help(group)
 
 
-@click.group(cls=FuzzyGroup, context_settings=CONTEXT_SETTINGS)
+# Common first-run intents that no edit-distance match can reach: the verb
+# either lives inside a subgroup (``launch`` → ``app launch``) or the real
+# command is named differently (``screenshot`` → ``capture``). FuzzyGroup
+# surfaces these as "Did you mean" hints so an intuitive verb is not a dead
+# end on a fresh install (#880).
+_COMMAND_INTENT_ALIASES = {
+    "launch": "app launch",
+    "open": "app launch",
+    "run": "app launch",
+    "start": "app launch",
+    "screenshot": "capture",
+}
+
+
+@click.group(
+    cls=FuzzyGroup,
+    context_settings=CONTEXT_SETTINGS,
+    aliases=_COMMAND_INTENT_ALIASES,
+)
 @click.version_option(__version__, prog_name="naturo")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.option("--verbose", "-v", is_flag=True, help="Verbose logging")

--- a/naturo/cli/fuzzy_group.py
+++ b/naturo/cli/fuzzy_group.py
@@ -1,5 +1,7 @@
 """FuzzyGroup — Click Group with typo-correcting command suggestions."""
 
+from __future__ import annotations
+
 import difflib
 
 import click
@@ -22,7 +24,29 @@ class FuzzyGroup(click.Group):
     (:class:`click.exceptions.NoSuchCommand`) which matches against *all*
     commands, including ``hidden=True`` ones — so delegating would re-introduce
     the leak this class exists to prevent.
+
+    An optional ``aliases`` map handles intuitive verbs that edit-distance
+    matching cannot discover — either because the real command lives inside a
+    subgroup (``launch`` → ``app launch``) or because it is named differently
+    (``screenshot`` → ``capture``). These curated intents are checked before
+    the fuzzy match and may point at a multi-word command path (see #880).
     """
+
+    def __init__(
+        self, *args: object, aliases: dict[str, str] | None = None, **kwargs: object
+    ) -> None:
+        """Initialize the group, capturing the optional intent-alias map.
+
+        Args:
+            *args: Positional arguments forwarded to :class:`click.Group`.
+            aliases: Optional mapping of an unrecognized command name to the
+                canonical command path to suggest (e.g. ``{"launch": "app
+                launch"}``). The path may contain spaces to reference a
+                subgroup command.
+            **kwargs: Keyword arguments forwarded to :class:`click.Group`.
+        """
+        super().__init__(*args, **kwargs)
+        self.aliases: dict[str, str] = aliases or {}
 
     def _suggestable_commands(self, ctx: click.Context) -> list[str]:
         """Return command names eligible to appear as typo suggestions.
@@ -76,6 +100,14 @@ class FuzzyGroup(click.Group):
         # ``resilient_parsing`` is set during shell completion, where failing
         # would break completion — defer to the base class there too.
         if cmd is None and not ctx.resilient_parsing and not cmd_name.startswith("-"):
+            # Curated intents win over fuzzy guesses: they target the command a
+            # first-time user actually means, which edit distance cannot reach
+            # (subgroup commands or differently-named ones).
+            alias_target = self.aliases.get(cmd_name)
+            if alias_target:
+                ctx.fail(
+                    f"No such command '{cmd_name}'. Did you mean '{alias_target}'?"
+                )
             matches = difflib.get_close_matches(
                 cmd_name, self._suggestable_commands(ctx), n=1, cutoff=0.6
             )

--- a/tests/test_fuzzy_group.py
+++ b/tests/test_fuzzy_group.py
@@ -97,6 +97,104 @@ class TestFuzzyGroup:
         assert "Did you mean 'capture'?" in result.output
 
 
+class TestFuzzyGroupAliases:
+    """Tests for the curated intent-alias suggestions (#880).
+
+    Some intuitive verbs do not match any top-level command by edit distance —
+    either because the real command lives inside a subgroup (``launch`` →
+    ``app launch``) or because it is named differently (``screenshot`` →
+    ``capture``). A curated ``aliases`` map lets a group point such intents at
+    the right command, which ``difflib`` alone cannot discover.
+    """
+
+    @pytest.fixture
+    def cli(self):
+        """Create a FuzzyGroup CLI with a subgroup and an intent-alias map."""
+        @click.group(
+            cls=FuzzyGroup,
+            aliases={"launch": "app launch", "screenshot": "capture"},
+        )
+        def app():
+            pass
+
+        @app.command()
+        def capture():
+            click.echo("captured")
+
+        @click.group()
+        def app_group():
+            pass
+
+        @app_group.command("launch")
+        def app_launch():
+            click.echo("launched")
+
+        app.add_command(app_group, "app")
+        return app
+
+    def test_subgroup_intent_suggests_full_path(self, cli):
+        result = CliRunner().invoke(cli, ["launch"])
+        assert result.exit_code != 0
+        assert "Did you mean 'app launch'?" in result.output
+
+    def test_renamed_intent_suggests_real_name(self, cli):
+        result = CliRunner().invoke(cli, ["screenshot"])
+        assert result.exit_code != 0
+        assert "Did you mean 'capture'?" in result.output
+
+    def test_alias_does_not_break_exact_command(self, cli):
+        result = CliRunner().invoke(cli, ["capture"])
+        assert result.exit_code == 0
+        assert "captured" in result.output
+
+    def test_no_alias_falls_back_to_no_suggestion(self, cli):
+        result = CliRunner().invoke(cli, ["zzzzzzz"])
+        assert result.exit_code != 0
+        assert "Did you mean" not in result.output
+
+
+class TestRealCliIntentAliases:
+    """The first-run verbs from #880 should suggest the correct command.
+
+    A first-time user typing an intuitive English verb must be pointed at the
+    real command instead of hitting a dead ``No such command`` wall.
+    """
+
+    @pytest.mark.parametrize(
+        "verb,target",
+        [
+            ("launch", "app launch"),
+            ("open", "app launch"),
+            ("run", "app launch"),
+            ("start", "app launch"),
+            ("screenshot", "capture"),
+        ],
+    )
+    def test_intent_verb_suggests_command(self, verb, target):
+        from naturo.cli import main
+
+        result = CliRunner().invoke(main, [verb])
+        assert result.exit_code != 0
+        assert f"Did you mean '{target}'?" in result.output
+
+    def test_alias_targets_resolve_to_real_commands(self):
+        """Every alias target must be a real command path (drift guard)."""
+        from naturo.cli import _COMMAND_INTENT_ALIASES, main
+
+        ctx = click.Context(main, info_name="naturo")
+        for target in set(_COMMAND_INTENT_ALIASES.values()):
+            group = main
+            *groups, leaf = target.split()
+            for name in groups:
+                group = group.get_command(ctx, name)
+                assert isinstance(group, click.Group), (
+                    f"alias target '{target}': '{name}' is not a group"
+                )
+            assert group.get_command(ctx, leaf) is not None, (
+                f"alias target '{target}' does not resolve to a command"
+            )
+
+
 class TestRealCliHiddenSuggestions:
     """Regression tests against the real naturo CLI (#867).
 


### PR DESCRIPTION
## What
A first-time user typing an intuitive English verb hit a dead `No such command` wall with no useful hint, because the real command either lives inside a subgroup (`launch` → `app launch`) or is named differently (`screenshot` → `capture`). Edit-distance matching (`difflib`) cannot bridge that gap — `launch` is not a top-level command name, and `screenshot` is not close to `capture`.

Fixes #880. Now:

```
$ naturo launch notepad      → Error: No such command 'launch'. Did you mean 'app launch'?
$ naturo open notepad         → Did you mean 'app launch'?
$ naturo run notepad          → Did you mean 'app launch'?
$ naturo start notepad        → Did you mean 'app launch'?
$ naturo screenshot           → Did you mean 'capture'?
```

## How
- `FuzzyGroup` gains an optional `aliases` map (intent verb → canonical command path), checked **before** the fuzzy match. Targets may be multi-word to reference a subgroup command. The generic class stays decoupled from product command names.
- The naturo-specific intent map (`launch/open/run/start → app launch`, `screenshot → capture`) is wired into the top-level `main` group in `cli/__init__.py`.
- Added `from __future__ import annotations` to `fuzzy_group.py` so the new PEP 604 union annotation stays importable on Python 3.9.

The change is purely additive to the not-found branch — it cannot regress any working command, and `screenshot` still does **not** surface the hidden `snapshot` (#867); it now points at `capture` instead.

## How tested
- New `TestFuzzyGroupAliases` (generic alias behaviour: subgroup path, renamed command, exact command unaffected, no-alias fallback).
- New `TestRealCliIntentAliases` against the real CLI: all five #880 verbs suggest the right command, plus a drift guard asserting every alias target resolves to a real command path.
- `ruff check naturo/` clean; `mypy naturo/` clean relative to baseline; `tests/test_python_compat.py` (Python 3.9 guard), `test_fuzzy_group.py`, `test_fuzzy_command.py`, `test_cli.py`, `test_cli_consistency.py` all pass.
