### PR TITLE
fix: stop 'Did you mean' suggesting unrelated commands for short verbs (fixes #889)

### DIFF
--- a/naturo/cli/fuzzy_group.py
+++ b/naturo/cli/fuzzy_group.py
@@ -6,6 +6,16 @@ import difflib
 
 import click
 
+# Minimum ``difflib`` similarity ratio for a typo to earn a "Did you mean"
+# hint. Click's default of 0.6 is too lax for short verbs: a 2–3 char query
+# crosses it on incidental character overlap alone (``ai``→``wait``,
+# ``tap``→``app`` both score 0.667), aiming an authoritative-sounding hint at a
+# semantically unrelated command (#889). Genuine one-character typos of real
+# commands score noticeably higher (``apps``→``app`` 0.857, ``mvoe``→``move``
+# 0.750), so 0.7 sits in the empirical gap — it drops the spurious short-query
+# matches while preserving every real near-miss.
+_SUGGESTION_CUTOFF = 0.7
+
 
 class FuzzyGroup(click.Group):
     """Click Group subclass that suggests the closest command on typos.
@@ -109,7 +119,10 @@ class FuzzyGroup(click.Group):
                     f"No such command '{cmd_name}'. Did you mean '{alias_target}'?"
                 )
             matches = difflib.get_close_matches(
-                cmd_name, self._suggestable_commands(ctx), n=1, cutoff=0.6
+                cmd_name,
+                self._suggestable_commands(ctx),
+                n=1,
+                cutoff=_SUGGESTION_CUTOFF,
             )
             if matches:
                 ctx.fail(

--- a/tests/test_fuzzy_group.py
+++ b/tests/test_fuzzy_group.py
@@ -226,3 +226,96 @@ class TestRealCliHiddenSuggestions:
         result = CliRunner().invoke(main, ["captur"])
         assert result.exit_code != 0
         assert "Did you mean 'capture'?" in result.output
+
+
+class TestFuzzyGroupShortQueryPrecision:
+    """A short query that is only an edit-distance neighbor — sharing no real
+    intent — must not produce an authoritative "Did you mean" hint (#889).
+
+    Click's default ``cutoff=0.6`` lets random character overlaps in 2–3 char
+    queries cross the bar (``ai``→``wait``, ``tap``→``app``, both ratio 0.667).
+    Genuine one-character typos of real commands score markedly higher
+    (≥ 0.75), so a tighter cutoff cleanly separates the two.
+    """
+
+    @pytest.fixture
+    def cli(self):
+        @click.group(cls=FuzzyGroup)
+        def app_group():
+            pass
+
+        @app_group.command(name="app")
+        def app_cmd():
+            click.echo("app")
+
+        @app_group.command(name="wait")
+        def wait_cmd():
+            click.echo("wait")
+
+        @app_group.command(name="list")
+        def list_cmd():
+            click.echo("list")
+
+        return app_group
+
+    def test_spurious_short_neighbor_not_suggested(self, cli):
+        """``ai`` is a 0.667-ratio neighbor of ``wait`` but shares no intent."""
+        result = CliRunner().invoke(cli, ["ai"])
+        assert result.exit_code != 0
+        assert "Did you mean" not in result.output
+
+    def test_spurious_short_neighbor_not_aimed_at_app(self, cli):
+        """``tap`` is a 0.667-ratio neighbor of ``app`` but means ``click``."""
+        result = CliRunner().invoke(cli, ["tap"])
+        assert result.exit_code != 0
+        assert "Did you mean" not in result.output
+
+    def test_genuine_short_typo_still_suggested(self, cli):
+        """``lis`` is a genuine one-char-short typo of ``list`` (ratio 0.857)."""
+        result = CliRunner().invoke(cli, ["lis"])
+        assert result.exit_code != 0
+        assert "Did you mean 'list'?" in result.output
+
+
+class TestRealCliSpuriousSuggestions:
+    """#889 — short verbs must not be nudged toward unrelated commands.
+
+    The hint reads as authoritative ("Did you mean ...?"), so aiming it at the
+    wrong command is worse than emitting nothing: a user who types ``naturo ai``
+    and is pointed at ``wait`` concludes naturo has no AI surface.
+    """
+
+    @pytest.mark.parametrize(
+        "verb,wrong_target",
+        [
+            ("ai", "wait"),
+            ("tap", "app"),
+        ],
+    )
+    def test_short_spurious_verb_gives_no_wrong_suggestion(self, verb, wrong_target):
+        from naturo.cli import main
+
+        result = CliRunner().invoke(main, [verb])
+        assert result.exit_code != 0
+        assert f"Did you mean '{wrong_target}'?" not in result.output
+
+    @pytest.mark.parametrize(
+        "typo,target",
+        [
+            ("apps", "app"),
+            ("clik", "click"),
+            ("lis", "list"),
+            ("typ", "type"),
+            ("mov", "move"),
+            ("fnd", "find"),
+            ("dif", "diff"),
+            ("scrol", "scroll"),
+        ],
+    )
+    def test_genuine_near_miss_still_suggested(self, typo, target):
+        """A real one-character typo still surfaces its command (ratio ≥ 0.75)."""
+        from naturo.cli import main
+
+        result = CliRunner().invoke(main, [typo])
+        assert result.exit_code != 0
+        assert f"Did you mean '{target}'?" in result.output


### PR DESCRIPTION
## What

The top-level CLI's `Did you mean '<x>'?` hint was firing on edit-distance neighbors that share no semantic relationship with the user's intent (#889):

```text
$ naturo ai    → Error: No such command 'ai'.  Did you mean 'wait'?   # zero shared intent
$ naturo tap   → Error: No such command 'tap'. Did you mean 'app'?    # 'tap' means 'click'
```

Both score a `difflib` ratio of only 0.667, but Click's default `cutoff=0.6` let them through. For short verbs (2–3 chars) incidental character overlap alone crosses that bar, and the hint reads as authoritative — a first-time user who types `naturo ai`, is pointed at `wait`, and tries it concludes naturo has no AI surface.

## How

Raise the `FuzzyGroup` suggestion cutoff from `0.6` to `0.7` (extracted as a named, documented `_SUGGESTION_CUTOFF` constant). An empirical survey of the real command set shows a clean gap:

| input | match | ratio | category |
|-------|-------|-------|----------|
| `ai` | wait | 0.667 | spurious → now dropped |
| `tap` | app | 0.667 | spurious → now dropped |
| `cap` | mcp | 0.667 | spurious → now dropped |
| `apps` | app | 0.857 | genuine → preserved |
| `clik` | click | 0.889 | genuine → preserved |
| `lis` | list | 0.857 | genuine → preserved |
| `mvoe` | move | 0.750 | genuine → preserved |

All spurious short-query matches sit at ≤0.667; every genuine one-character typo sits at ≥0.75. `0.7` separates them cleanly — spurious hints vanish, real near-misses survive. Subgroup/renamed intent aliases from #880 (`launch`→`app launch`, `screenshot`→`capture`) are unaffected (checked before difflib).

## How tested

- New `TestFuzzyGroupShortQueryPrecision` (generic group) + `TestRealCliSpuriousSuggestions` (real CLI): assert `ai`/`tap` emit no suggestion, and that `apps`/`clik`/`lis`/`typ`/`mov`/`fnd`/`dif`/`scrol` still suggest their command.
- `pytest tests/test_fuzzy_group.py` → 37 passed.
- `ruff check naturo/` clean; `mypy naturo/` clean (only the pre-existing third-party `mcp` match-statement artifact).
- `--collect-only` succeeds with no Windows/optional deps (cross-platform CI-safe).

Fixes #889.
