### PR TITLE
fix: batch process info in detect_electron_app to avoid ~23s cascade stall (fixes #1023)

### DIFF
--- a/naturo/electron.py
+++ b/naturo/electron.py
@@ -358,6 +358,15 @@ def detect_electron_app(app_name: str) -> Dict[str, Any]:
             "main_pid": None,
         }
 
+    # Bulk-fetch command lines and exe paths in a single wmic call to avoid
+    # per-PID subprocess overhead. Apps that match many processes (UWP apps,
+    # Chrome/Edge/Teams) would otherwise pay ~0.86 s per PID for the two wmic
+    # calls in each helper, stalling the see/find cascade for 20+ s. This
+    # mirrors list_electron_apps, which already applies the BUG-007 batching
+    # fix that detect_electron_app — the function the cascade actually calls —
+    # was missing (#1023).
+    proc_info = _bulk_get_process_info()
+
     # Check each process for Electron characteristics
     is_electron = False
     debug_port = None
@@ -365,11 +374,11 @@ def detect_electron_app(app_name: str) -> Dict[str, Any]:
 
     for proc in processes:
         pid = proc["pid"]
-        if _is_electron_process(pid):
+        if _is_electron_process(pid, proc_info=proc_info):
             is_electron = True
             if main_pid is None:
                 main_pid = pid
-            port = _find_debug_port_from_cmdline(pid)
+            port = _find_debug_port_from_cmdline(pid, proc_info=proc_info)
             if port is not None:
                 debug_port = port
                 break

--- a/tests/test_electron.py
+++ b/tests/test_electron.py
@@ -85,6 +85,46 @@ class TestDetectElectronApp:
         assert result["debug_port"] is None
         assert result["app_name"] == "Slack"
 
+    @patch("naturo.electron._get_process_exe_path")
+    @patch("naturo.electron._get_process_command_line")
+    @patch("naturo.electron._bulk_get_process_info")
+    @patch("naturo.electron._find_processes_by_name")
+    def test_uses_single_bulk_query_for_many_pids(
+        self, mock_find, mock_bulk, mock_cmdline, mock_exe,
+    ):
+        """detect_electron_app batches process info into one bulk query.
+
+        Regression for #1023: with many matching PIDs the old code issued
+        two ``wmic`` subprocesses per PID (~0.86 s each), causing a ~23 s
+        stall on the ``see``/``find`` cascade for multi-process apps (e.g.
+        Calculator spawns ~27 processes). The fix mirrors
+        ``list_electron_apps``: fetch ``_bulk_get_process_info`` once and pass
+        it through to the per-PID helpers, which must therefore never fall
+        back to their per-PID ``wmic`` calls.
+        """
+        from naturo.electron import detect_electron_app
+
+        pids = list(range(1000, 1027))  # 27 processes, like a UWP/Electron app
+        mock_find.return_value = [
+            {"pid": pid, "name": "App.exe"} for pid in pids
+        ]
+        mock_bulk.return_value = {
+            pid: {
+                "command_line": '"C:\\App.exe" --type=renderer',
+                "exe_path": "",
+            }
+            for pid in pids
+        }
+
+        result = detect_electron_app("App")
+
+        # Exactly one bulk query, and zero per-PID wmic fallbacks.
+        assert mock_bulk.call_count == 1
+        mock_cmdline.assert_not_called()
+        mock_exe.assert_not_called()
+        # Functional result is unchanged: the renderer marker confirms Electron.
+        assert result["is_electron"] is True
+
 
 # ── list_electron_apps ──────────────────────────
 


### PR DESCRIPTION
## What

`naturo see`/`find` (the `auto` cascade) stalled **~23 s** on plain non-browser apps that match many running processes (UWP apps, Chrome/Edge/Teams — 10-30 procs). The entire delay was wasted Electron debug-port detection in `detect_electron_app()`, which probed each matching PID by spawning **two `wmic` subprocesses** (`_is_electron_process` + `_find_debug_port_from_cmdline`, ~0.86 s each). Calculator matches ~27 processes → ~23 s, even though UIA already returned a full tree (`coverage_estimate: 1.0`).

This is the same hang class as **BUG-007**, already fixed for `list_electron_apps` by batching into a single `wmic` call via `_bulk_get_process_info()` — but the fix was never applied to `detect_electron_app`, the function the cascade actually calls.

## How

Fetch `_bulk_get_process_info()` **once** at the top of `detect_electron_app()` and pass `proc_info=` through to `_is_electron_process(...)` and `_find_debug_port_from_cmdline(...)` (both already accept it). This removes the per-PID `wmic` fan-out. The returned value of `get_debug_port` is unchanged — a port for Electron apps, `None` otherwise; only the redundant subprocess spawns are eliminated.

Issue's prototyped measurement: `get_debug_port('CalculatorApp')` 23.09 s → 1.15 s (same result, ~20× faster).

## How tested

- New regression test `test_uses_single_bulk_query_for_many_pids` (27-PID app): asserts exactly **one** bulk query and **zero** per-PID `wmic` fallbacks, with the functional result unchanged.
- `python -m ruff check naturo/` → clean.
- `mypy naturo/electron.py` → clean (only pre-existing 3rd-party `mcp` error on local Win box, present on develop too).
- `pytest tests/test_electron.py` → 34 passed, 4 skipped. Full non-desktop suite: only pre-existing platform/env failures (non-Windows tests on Windows, DLL version, config-file access), identical with this change stashed.

Closes #1023.