### PR TITLE
fix: route all CLI -j emit sites through json_dumps (fixes #1025)

### DIFF
--- a/naturo/cli/_browser/captcha.py
+++ b/naturo/cli/_browser/captcha.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import json as json_module
+from naturo.cli._jsonio import json_dumps
 from typing import Optional
 
 import click
@@ -33,7 +33,7 @@ def captcha_detect(ctx: click.Context, json_output: bool) -> None:
     captchas = manager.detect()
 
     if json_output:
-        click.echo(json_module.dumps({"captchas": captchas, "count": len(captchas)}))
+        click.echo(json_dumps({"captchas": captchas, "count": len(captchas)}))
     elif not captchas:
         click.echo("No captchas detected on this page.")
     else:
@@ -94,7 +94,7 @@ def captcha_solve(ctx: click.Context, solver: str, token: Optional[str],
     try:
         result_token = manager.solve(solver=solver_instance)
         if json_output:
-            click.echo(json_module.dumps({
+            click.echo(json_dumps({
                 "success": True,
                 "solver": solver,
                 "token_length": len(result_token),

--- a/naturo/cli/_browser/elements.py
+++ b/naturo/cli/_browser/elements.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import json as json_module
+from naturo.cli._jsonio import json_dumps
 from typing import Optional
 
 import click
@@ -59,7 +59,7 @@ def find_cmd(ctx: click.Context, selector: str, by: Optional[str],
                         "tag": el.tag_name,
                         "text": el.text[:200],
                     })
-                click.echo(json_module.dumps({"elements": items, "count": len(items)}, indent=2))
+                click.echo(json_dumps({"elements": items, "count": len(items)}, indent=2))
             else:
                 if not elements:
                     click.echo("No elements found.")
@@ -71,7 +71,7 @@ def find_cmd(ctx: click.Context, selector: str, by: Optional[str],
         else:
             el = page.find(selector)
             if json_output:
-                click.echo(json_module.dumps({
+                click.echo(json_dumps({
                     "ref": "e1",
                     "tag": el.tag_name,
                     "text": el.text[:200],
@@ -117,7 +117,7 @@ def click_cmd(ctx: click.Context, selector: str, by: Optional[str],
         el = page.find(selector)
         el.click(offset_x=offset_x, offset_y=offset_y)
         if json_output:
-            click.echo(json_module.dumps({"status": "ok", "selector": selector}))
+            click.echo(json_dumps({"status": "ok", "selector": selector}))
         else:
             click.echo(f"Clicked: {selector}")
     except RuntimeError as exc:
@@ -154,7 +154,7 @@ def type_cmd(ctx: click.Context, selector: str, text: str, by: Optional[str],
         el = page.find(selector)
         el.type(text, clear_first=clear_first)
         if json_output:
-            click.echo(json_module.dumps({"status": "ok", "selector": selector, "text": text}))
+            click.echo(json_dumps({"status": "ok", "selector": selector, "text": text}))
         else:
             click.echo(f"Typed into: {selector}")
     except RuntimeError as exc:
@@ -192,7 +192,7 @@ def select_cmd(ctx: click.Context, selector: str, value: str,
         el = page.find(selector)
         el.select(value)
         if json_output:
-            click.echo(json_module.dumps({
+            click.echo(json_dumps({
                 "status": "ok", "selector": selector, "value": value,
             }))
         else:
@@ -228,7 +228,7 @@ def text_cmd(ctx: click.Context, selector: str, by: Optional[str], json_output: 
         el = page.find(selector)
         content = el.text
         if json_output:
-            click.echo(json_module.dumps({"text": content, "selector": selector}))
+            click.echo(json_dumps({"text": content, "selector": selector}))
         else:
             click.echo(content)
     except RuntimeError as exc:
@@ -261,7 +261,7 @@ def attr_cmd(ctx: click.Context, selector: str, attribute: str,
         el = page.find(selector)
         value = el.attr(attribute)
         if json_output:
-            click.echo(json_module.dumps({
+            click.echo(json_dumps({
                 "attribute": attribute, "value": value, "selector": selector,
             }))
         else:
@@ -296,7 +296,7 @@ def html_cmd(ctx: click.Context, selector: str, by: Optional[str],
         el = page.find(selector)
         content = el.outer_html if outer else el.inner_html
         if json_output:
-            click.echo(json_module.dumps({"html": content, "selector": selector}))
+            click.echo(json_dumps({"html": content, "selector": selector}))
         else:
             click.echo(content)
     except RuntimeError as exc:
@@ -331,7 +331,7 @@ def hover_cmd(ctx: click.Context, selector: str, by: Optional[str],
         el = page.find(selector)
         el.hover()
         if json_output:
-            click.echo(json_module.dumps({"status": "ok", "selector": selector}))
+            click.echo(json_dumps({"status": "ok", "selector": selector}))
         else:
             click.echo(f"Hovered: {selector}")
     except RuntimeError as exc:

--- a/naturo/cli/_browser/frames.py
+++ b/naturo/cli/_browser/frames.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import json as json_module
+from naturo.cli._jsonio import json_dumps
 
 import click
 
@@ -26,7 +26,7 @@ def frames_cmd(ctx: click.Context, json_output: bool) -> None:
     try:
         frame_list = page.frames()
         if json_output:
-            click.echo(json_module.dumps({
+            click.echo(json_dumps({
                 "frames": frame_list,
                 "count": len(frame_list),
             }, indent=2))
@@ -76,7 +76,7 @@ def frame_eval_cmd(ctx: click.Context, frame_ref: str, expression: str,
 
         result = frame.evaluate(expression)
         if json_output:
-            click.echo(json_module.dumps({"result": result, "frame": frame_ref}))
+            click.echo(json_dumps({"result": result, "frame": frame_ref}))
         else:
             click.echo(result)
     except RuntimeError as exc:
@@ -122,7 +122,7 @@ def frame_find_cmd(ctx: click.Context, frame_ref: str, selector: str,
             if json_output:
                 items = [{"ref": f"e{i+1}", "tag": el.tag_name, "text": el.text[:200]}
                          for i, el in enumerate(elements)]
-                click.echo(json_module.dumps({"elements": items, "count": len(items)}, indent=2))
+                click.echo(json_dumps({"elements": items, "count": len(items)}, indent=2))
             else:
                 if not elements:
                     click.echo("No elements found in frame.")
@@ -134,7 +134,7 @@ def frame_find_cmd(ctx: click.Context, frame_ref: str, selector: str,
         else:
             el = frame.find(selector)
             if json_output:
-                click.echo(json_module.dumps({
+                click.echo(json_dumps({
                     "ref": "e1", "tag": el.tag_name,
                     "text": el.text[:200], "value": el.value,
                 }, indent=2))

--- a/naturo/cli/_browser/lifecycle.py
+++ b/naturo/cli/_browser/lifecycle.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import json as json_module
+from naturo.cli._jsonio import json_dumps
 from typing import Optional
 
 import click
@@ -66,7 +66,7 @@ def launch_cmd(ctx: click.Context, profile: Optional[str],
             timeout=timeout,
         )
         if json_output:
-            click.echo(json_module.dumps({
+            click.echo(json_dumps({
                 "success": True,
                 "action": "browser_launch",
                 "pid": proc.pid,
@@ -104,7 +104,7 @@ def profiles_cmd(user_data_dir: Optional[str], json_output: bool) -> None:
     profiles = _list_profiles(user_data_dir=user_data_dir)
 
     if json_output:
-        click.echo(json_module.dumps({"profiles": profiles, "count": len(profiles)}, indent=2))
+        click.echo(json_dumps({"profiles": profiles, "count": len(profiles)}, indent=2))
     elif not profiles:
         click.echo("No Chrome profiles found.")
         click.echo("Hint: profiles are read from Chrome's 'Local State' file.")
@@ -159,7 +159,7 @@ def download_cmd(
 
         if not wait:
             if json_output:
-                click.echo(json_module.dumps({
+                click.echo(json_dumps({
                     "success": True,
                     "download_dir": abs_dir,
                 }))
@@ -177,7 +177,7 @@ def download_cmd(
             emit_exception_error(exc, json_output, fallback_code="TIMEOUT")
 
         if json_output:
-            click.echo(json_module.dumps({
+            click.echo(json_dumps({
                 "success": True,
                 "download_dir": abs_dir,
                 "file": path,

--- a/naturo/cli/_browser/navigation.py
+++ b/naturo/cli/_browser/navigation.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import json as json_module
+from naturo.cli._jsonio import json_dumps
 from typing import Optional
 
 import click
@@ -33,7 +33,7 @@ def navigate(ctx: click.Context, url: str, wait_until: str, json_output: bool) -
     try:
         page.navigate(url, wait_until=wait_until)
         if json_output:
-            click.echo(json_module.dumps({
+            click.echo(json_dumps({
                 "url": page.url,
                 "title": page.title,
                 "status": "ok",
@@ -63,7 +63,7 @@ def eval_cmd(ctx: click.Context, expression: str, json_output: bool) -> None:
     try:
         result = page.evaluate(expression)
         if json_output:
-            click.echo(json_module.dumps({"result": result}))
+            click.echo(json_dumps({"result": result}))
         else:
             click.echo(result)
     finally:
@@ -79,7 +79,7 @@ def url_cmd(ctx: click.Context, json_output: bool) -> None:
     try:
         current_url = page.url
         if json_output:
-            click.echo(json_module.dumps({"url": current_url}))
+            click.echo(json_dumps({"url": current_url}))
         else:
             click.echo(current_url)
     finally:
@@ -95,7 +95,7 @@ def title_cmd(ctx: click.Context, json_output: bool) -> None:
     try:
         current_title = page.title
         if json_output:
-            click.echo(json_module.dumps({"title": current_title}))
+            click.echo(json_dumps({"title": current_title}))
         else:
             click.echo(current_title)
     finally:
@@ -114,7 +114,7 @@ def tabs_cmd(ctx: click.Context, json_output: bool) -> None:
     try:
         tab_list = page.tabs()
         if json_output:
-            click.echo(json_module.dumps(tab_list, indent=2))
+            click.echo(json_dumps(tab_list, indent=2))
         else:
             for i, tab in enumerate(tab_list):
                 click.echo(f"  {i + 1}. [{tab.get('id', '')[:8]}] {tab.get('title', '')} — {tab.get('url', '')}")
@@ -180,7 +180,7 @@ def scroll_cmd(ctx: click.Context, to_bottom: bool, to_top: bool,
             )
 
         if json_output:
-            click.echo(json_module.dumps({"status": "ok", "action": msg}))
+            click.echo(json_dumps({"status": "ok", "action": msg}))
         else:
             click.echo(msg)
     finally:

--- a/naturo/cli/_browser/network.py
+++ b/naturo/cli/_browser/network.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import json as json_module
+from naturo.cli._jsonio import json_dumps
 from typing import Optional
 
 import click
@@ -32,7 +32,7 @@ def requests_cmd(ctx: click.Context, pattern: Optional[str], json_output: bool) 
             snapshot = page.network.find_requests(pattern, snapshot=snapshot)
 
         if json_output:
-            click.echo(json_module.dumps({
+            click.echo(json_dumps({
                 "success": True,
                 "requests": snapshot,
                 "count": len(snapshot),
@@ -78,7 +78,7 @@ def intercept_cmd(ctx: click.Context, pattern: str, action: str,
             )
 
         if json_output:
-            click.echo(json_module.dumps({
+            click.echo(json_dumps({
                 "success": True,
                 "pattern": pattern,
                 "action": action,

--- a/naturo/cli/_browser/stealth.py
+++ b/naturo/cli/_browser/stealth.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import json as json_module
+from naturo.cli._jsonio import json_dumps
 
 import click
 
@@ -32,7 +32,7 @@ def stealth_cmd(ctx: click.Context, json_output: bool) -> None:
     try:
         count = apply_stealth_patches(page)
         if json_output:
-            click.echo(json_module.dumps({
+            click.echo(json_dumps({
                 "success": True,
                 "patches_applied": count,
             }))
@@ -60,7 +60,7 @@ def stealth_flags_cmd(json_output: bool) -> None:
     from naturo.browser._stealth import STEALTH_FLAGS
 
     if json_output:
-        click.echo(json_module.dumps({"flags": STEALTH_FLAGS}))
+        click.echo(json_dumps({"flags": STEALTH_FLAGS}))
     else:
         click.echo(" ".join(STEALTH_FLAGS))
 
@@ -89,7 +89,7 @@ def stealth_check_cmd(ctx: click.Context, json_output: bool) -> None:
         all_passed = all(results.values())
 
         if json_output:
-            click.echo(json_module.dumps({
+            click.echo(json_dumps({
                 "success": all_passed,
                 "checks": results,
             }))

--- a/naturo/cli/_browser/visual.py
+++ b/naturo/cli/_browser/visual.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import json as json_module
+from naturo.cli._jsonio import json_dumps
 from typing import Optional
 
 import click
@@ -31,7 +31,7 @@ def screenshot_cmd(ctx: click.Context, path: str, selector: Optional[str],
     try:
         saved_path = page.screenshot(path, full_page=full_page)
         if json_output:
-            click.echo(json_module.dumps({"path": saved_path, "status": "ok"}))
+            click.echo(json_dumps({"path": saved_path, "status": "ok"}))
         else:
             click.echo(f"Screenshot saved: {saved_path}")
     except RuntimeError as exc:

--- a/naturo/cli/_browser/waits.py
+++ b/naturo/cli/_browser/waits.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import json as json_module
+from naturo.cli._jsonio import json_dumps
 from typing import Optional
 
 import click
@@ -37,7 +37,7 @@ def wait_cmd(ctx: click.Context, selector: str, by: Optional[str],
     try:
         page.wait_for(selector, timeout=timeout, state=state)
         if json_output:
-            click.echo(json_module.dumps({"status": "ok", "selector": selector, "state": state}))
+            click.echo(json_dumps({"status": "ok", "selector": selector, "state": state}))
         else:
             click.echo(f"Element '{selector}' is {state}.")
     except TimeoutError as exc:
@@ -64,7 +64,7 @@ def wait_navigation_cmd(ctx: click.Context, timeout: float,
     try:
         new_url = page.wait_for_navigation(timeout=timeout)
         if json_output:
-            click.echo(json_module.dumps({"status": "ok", "url": new_url}))
+            click.echo(json_dumps({"status": "ok", "url": new_url}))
         else:
             click.echo(f"Navigation complete: {new_url}")
     except TimeoutError as exc:
@@ -95,7 +95,7 @@ def wait_url_cmd(ctx: click.Context, pattern: str, regex: bool,
     try:
         matched_url = page.wait_for_url(pattern, regex=regex, timeout=timeout)
         if json_output:
-            click.echo(json_module.dumps({"status": "ok", "url": matched_url}))
+            click.echo(json_dumps({"status": "ok", "url": matched_url}))
         else:
             click.echo(f"URL matched: {matched_url}")
     except TimeoutError as exc:
@@ -125,7 +125,7 @@ def wait_function_cmd(ctx: click.Context, expression: str,
     try:
         result = page.wait_for_function(expression, timeout=timeout)
         if json_output:
-            click.echo(json_module.dumps({"status": "ok", "result": str(result)}))
+            click.echo(json_dumps({"status": "ok", "result": str(result)}))
         else:
             click.echo(f"Expression truthy: {result}")
     except TimeoutError as exc:
@@ -154,7 +154,7 @@ def wait_network_idle_cmd(ctx: click.Context, idle_time: float,
     try:
         page.wait_for_network_idle(idle_time=idle_time, timeout=timeout)
         if json_output:
-            click.echo(json_module.dumps({"status": "ok"}))
+            click.echo(json_dumps({"status": "ok"}))
         else:
             click.echo("Network is idle.")
     except TimeoutError as exc:

--- a/naturo/cli/core/_capture.py
+++ b/naturo/cli/core/_capture.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import click
 
 import naturo.cli.core._common as _common
+from naturo.cli._jsonio import json_dumps
 
 
 @click.command("capture")
@@ -266,7 +267,6 @@ def capture(app: str | None, pid: int | None, window_title: str | None, hwnd: in
             mgr.store_screenshot(snapshot_id, result.path, metadata)
 
         if json_output:
-            import json as json_module
             out: dict = {
                 "success": True,
                 "path": result.path,
@@ -281,7 +281,7 @@ def capture(app: str | None, pid: int | None, window_title: str | None, hwnd: in
                 out["crop_source"] = "element" if element_ref else "region"
             if snapshot_id:
                 out["snapshot_id"] = snapshot_id
-            click.echo(json_module.dumps(out))
+            click.echo(json_dumps(out))
         else:
             import os
             full_path = os.path.abspath(result.path)

--- a/naturo/cli/core/_find.py
+++ b/naturo/cli/core/_find.py
@@ -1,7 +1,7 @@
 """Find command — search for UI elements matching a query."""
 from __future__ import annotations
 
-import json as json_module
+from naturo.cli._jsonio import json_dumps
 from typing import Any
 
 import click
@@ -202,7 +202,7 @@ def find_cmd(query: str | None, query_opt: str | None, find_all: bool, role: str
                 }
                 for r in results
             ]
-            click.echo(json_module.dumps({
+            click.echo(json_dumps({
                 "success": True,
                 "elements": data,
                 "count": len(data),
@@ -291,7 +291,7 @@ def _find_with_ai(
         elif "capture" in msg.lower():
             code = "CAPTURE_FAILED"
         if json_output:
-            click.echo(json_module.dumps({"success": False, "error": {"code": code, "message": msg}}))
+            click.echo(json_dumps({"success": False, "error": {"code": code, "message": msg}}))
         else:
             click.echo(f"Error: {msg}", err=True)
         raise SystemExit(1)
@@ -314,7 +314,7 @@ def _find_with_ai(
                 "code": "ELEMENT_NOT_FOUND",
                 "message": f"AI could not locate: {query}",
             }
-        click.echo(json_module.dumps(output, indent=2))
+        click.echo(json_dumps(output, indent=2))
     else:
         if not result.found:
             click.echo(f"Element not found: {query}")

--- a/naturo/cli/core/_list.py
+++ b/naturo/cli/core/_list.py
@@ -1,7 +1,7 @@
 """List command group — apps, windows, screens, permissions."""
 from __future__ import annotations
 
-import json as json_module
+from naturo.cli._jsonio import json_dumps
 import ntpath
 import platform
 
@@ -98,7 +98,7 @@ def windows(app, pid, json_output) -> None:
                 }
                 for w in win_list
             ]
-            click.echo(json_module.dumps({"success": True, "windows": data, "count": len(data)}, indent=2))
+            click.echo(json_dumps({"success": True, "windows": data, "count": len(data)}, indent=2))
         else:
             if not win_list:
                 click.echo("No windows found.")
@@ -149,7 +149,7 @@ def screens(json_output) -> None:
                 if m.work_area:
                     item["work_area"] = m.work_area
                 items.append(item)
-            click.echo(json_module.dumps({"success": True, "monitors": items, "count": len(items)}, indent=2))
+            click.echo(json_dumps({"success": True, "monitors": items, "count": len(items)}, indent=2))
         else:
             from naturo.cli.table import print_table
 

--- a/naturo/cli/core/_menu.py
+++ b/naturo/cli/core/_menu.py
@@ -1,7 +1,7 @@
 """Menu-inspect command — list menu bar structure."""
 from __future__ import annotations
 
-import json as json_module
+from naturo.cli._jsonio import json_dumps
 
 import click
 
@@ -91,9 +91,9 @@ def menu_inspect(app, app_id, flat, json_output) -> None:
                 flat_items = []
                 for item in items:
                     flat_items.extend(item.flatten())
-                click.echo(json_module.dumps({"success": True, "menu_items": flat_items}, indent=2))
+                click.echo(json_dumps({"success": True, "menu_items": flat_items}, indent=2))
             else:
-                click.echo(json_module.dumps({"success": True, "menu_items": [item.to_dict() for item in items]}, indent=2))
+                click.echo(json_dumps({"success": True, "menu_items": [item.to_dict() for item in items]}, indent=2))
         else:
             if flat:
                 for item in items:

--- a/naturo/cli/core/_see.py
+++ b/naturo/cli/core/_see.py
@@ -1,7 +1,7 @@
 """See command — capture screenshot and analyze UI elements."""
 from __future__ import annotations
 
-import json as json_module
+from naturo.cli._jsonio import json_dumps
 import re as _re_mod
 from typing import Any
 
@@ -456,7 +456,7 @@ def see(app: str | None, window_title: str | None, hwnd: int | None, pid: int | 
 
 
 
-            click.echo(json_module.dumps(out, indent=2))
+            click.echo(json_dumps(out, indent=2))
         else:
             # BUG-071: include short element IDs (e1, e2, ...) that can be
             # passed to ``naturo click e3`` for quick interaction.

--- a/naturo/cli/extensions.py
+++ b/naturo/cli/extensions.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from typing import Any
 
 import click
+from naturo.cli._jsonio import json_dumps
 from naturo.cli.fuzzy_group import FuzzyGroup
 
 
@@ -39,7 +40,6 @@ def excel_open_cmd(path, visible, read_only, json_output) -> None:
 
       naturo excel open "C:\\Data\\sales.xlsx" --visible --json
     """
-    import json as json_module
     from naturo.cli.error_helpers import emit_exception_error
 
     try:
@@ -50,7 +50,7 @@ def excel_open_cmd(path, visible, read_only, json_output) -> None:
         return
 
     if json_output:
-        click.echo(json_module.dumps({"success": True, **result}))
+        click.echo(json_dumps({"success": True, **result}))
     else:
         click.echo(f"Opened: {result['path']}")
         click.echo(f"Sheets ({result['sheet_count']}): {', '.join(result['sheets'])}")
@@ -74,7 +74,6 @@ def read(path, cell, sheet, json_output) -> None:
 
       naturo excel read data.xlsx "A1:D100" --sheet "Sales" --json
     """
-    import json as json_module
     from naturo.cli.error_helpers import emit_exception_error
 
     try:
@@ -85,7 +84,7 @@ def read(path, cell, sheet, json_output) -> None:
         return
 
     if json_output:
-        click.echo(json_module.dumps({"success": True, **result}))
+        click.echo(json_dumps({"success": True, **result}))
     else:
         value = result["value"]
         if isinstance(value, list):
@@ -116,7 +115,6 @@ def write(path: str, cell: str, value: str, sheet: str | None, create: bool, jso
 
       naturo excel write data.xlsx B2 42 --sheet "Numbers" --json
     """
-    import json as json_module
     from naturo.cli.error_helpers import emit_exception_error
 
     # Try to convert numeric values
@@ -137,7 +135,7 @@ def write(path: str, cell: str, value: str, sheet: str | None, create: bool, jso
         return
 
     if json_output:
-        click.echo(json_module.dumps({"success": True, **result}))
+        click.echo(json_dumps({"success": True, **result}))
     else:
         click.echo(f"Wrote to {result['cell']} ({result['sheet']}): {write_value}")
 
@@ -155,7 +153,6 @@ def list_sheets(path, json_output) -> None:
 
       naturo excel list-sheets data.xlsx --json
     """
-    import json as json_module
     from naturo.cli.error_helpers import emit_exception_error
 
     try:
@@ -166,7 +163,7 @@ def list_sheets(path, json_output) -> None:
         return
 
     if json_output:
-        click.echo(json_module.dumps({"success": True, **result}))
+        click.echo(json_dumps({"success": True, **result}))
     else:
         click.echo(f"Workbook: {result['path']}")
         for i, name in enumerate(result["sheets"], 1):
@@ -191,7 +188,6 @@ def run_macro(path, macro_name, macro_args, json_output) -> None:
 
       naturo excel run-macro data.xlsm "UpdateData" --arg "2024" --arg "Q1" --json
     """
-    import json as json_module
     from naturo.cli.error_helpers import emit_exception_error
 
     try:
@@ -202,7 +198,7 @@ def run_macro(path, macro_name, macro_args, json_output) -> None:
         return
 
     if json_output:
-        click.echo(json_module.dumps({"success": True, **result}))
+        click.echo(json_dumps({"success": True, **result}))
     else:
         click.echo(f"Macro '{result['macro']}' executed.")
         if result.get("result") is not None:
@@ -225,7 +221,6 @@ def excel_info(path, sheet, json_output) -> None:
 
       naturo excel info data.xlsx --sheet "Sales" --json
     """
-    import json as json_module
     from naturo.cli.error_helpers import emit_exception_error
 
     try:
@@ -236,7 +231,7 @@ def excel_info(path, sheet, json_output) -> None:
         return
 
     if json_output:
-        click.echo(json_module.dumps({"success": True, **result}))
+        click.echo(json_dumps({"success": True, **result}))
     else:
         click.echo(f"Sheet: {result['sheet']}")
         click.echo(f"Used range: {result['used_range']}")

--- a/naturo/cli/snapshot.py
+++ b/naturo/cli/snapshot.py
@@ -14,7 +14,7 @@ Commands
 
 from __future__ import annotations
 
-import json as json_module
+from naturo.cli._jsonio import json_dumps
 
 import click
 
@@ -63,7 +63,7 @@ def snapshot_list(session: str | None, json_output: bool) -> None:
             }
             for s in infos
         ]
-        click.echo(json_module.dumps({
+        click.echo(json_dumps({
             "success": True,
             "session": mgr.session,
             "snapshots": data,
@@ -107,7 +107,7 @@ def snapshot_sessions(json_output: bool) -> None:
                 sessions.append({"name": entry.name, "snapshot_count": count})
 
     if json_output:
-        click.echo(json_module.dumps({"success": True, "sessions": sessions}, indent=2))
+        click.echo(json_dumps({"success": True, "sessions": sessions}, indent=2))
     else:
         if not sessions:
             click.echo("No sessions found.")
@@ -138,7 +138,7 @@ def snapshot_clean(session: str | None, days: int | None, clean_all: bool, yes: 
     if not clean_all and days is None:
         msg = "Specify --days N or --all.  Run with --help for usage."
         if json_output:
-            click.echo(json_module.dumps({"success": False, "error": {"code": "INVALID_INPUT", "message": msg}}))
+            click.echo(json_dumps({"success": False, "error": {"code": "INVALID_INPUT", "message": msg}}))
         else:
             click.echo(f"Error: {msg}", err=True)
         raise SystemExit(1)
@@ -146,7 +146,7 @@ def snapshot_clean(session: str | None, days: int | None, clean_all: bool, yes: 
     if days is not None and days < 0:
         msg = f"--days must be >= 0, got {days}"
         if json_output:
-            click.echo(json_module.dumps({"success": False, "error": {"code": "INVALID_INPUT", "message": msg}}))
+            click.echo(json_dumps({"success": False, "error": {"code": "INVALID_INPUT", "message": msg}}))
         else:
             click.echo(f"Error: {msg}", err=True)
         raise SystemExit(1)
@@ -157,7 +157,7 @@ def snapshot_clean(session: str | None, days: int | None, clean_all: bool, yes: 
         base = DEFAULT_STORAGE_ROOT
         if not base.exists():
             if json_output:
-                click.echo(json_module.dumps({"success": True, "deleted": 0}))
+                click.echo(json_dumps({"success": True, "deleted": 0}))
             else:
                 click.echo("No snapshots found.")
             return
@@ -179,7 +179,7 @@ def snapshot_clean(session: str | None, days: int | None, clean_all: bool, yes: 
                 total += mgr.clean_older_than(days)  # type: ignore[arg-type]
 
         if json_output:
-            click.echo(json_module.dumps({"success": True, "deleted": total, "sessions": "all"}))
+            click.echo(json_dumps({"success": True, "deleted": total, "sessions": "all"}))
         else:
             click.echo(f"Deleted {total} snapshot(s) across all sessions.")
         return
@@ -203,7 +203,7 @@ def snapshot_clean(session: str | None, days: int | None, clean_all: bool, yes: 
         count = mgr.clean_older_than(days)  # type: ignore[arg-type]
 
     if json_output:
-        click.echo(json_module.dumps({"success": True, "deleted": count, "session": mgr.session}))
+        click.echo(json_dumps({"success": True, "deleted": count, "session": mgr.session}))
     else:
         click.echo(f"Deleted {count} snapshot(s) from session '{mgr.session}'.")
 

--- a/naturo/cli/table.py
+++ b/naturo/cli/table.py
@@ -5,7 +5,7 @@ across all ``naturo list`` and ``naturo app list`` commands.
 """
 from __future__ import annotations
 
-import json as json_module
+from naturo.cli._jsonio import json_dumps
 
 import click
 
@@ -45,7 +45,7 @@ def print_table(
         out: dict = {"success": True, json_key: items, "count": len(items)}
         if json_extra:
             out.update(json_extra)
-        click.echo(json_module.dumps(out, indent=2))
+        click.echo(json_dumps(out, indent=2))
         return
 
     if not rows:

--- a/naturo/cli/values/_get.py
+++ b/naturo/cli/values/_get.py
@@ -4,7 +4,7 @@ Reads the current value of a UI element by querying UIAutomation
 patterns: ValuePattern, TogglePattern, SelectionPattern,
 RangeValuePattern, and TextPattern.
 """
-import json as json_module
+from naturo.cli._jsonio import json_dumps
 import platform
 import sys
 
@@ -193,7 +193,7 @@ def get_cmd(ctx, target, ref, automation_id, role, name, get_all, prop, app,
                         "width": el.width,
                         "height": el.height,
                     })
-                click.echo(json_module.dumps(output))
+                click.echo(json_dumps(output))
             else:
                 if not matches:
                     filters = []
@@ -286,7 +286,7 @@ def get_cmd(ctx, target, ref, automation_id, role, name, get_all, prop, app,
                 "width": result.get("width"),
                 "height": result.get("height"),
             }
-            click.echo(json_module.dumps(element_data))
+            click.echo(json_dumps(element_data))
         elif prop:
             # Return just the requested property
             val = result.get(prop)

--- a/naturo/cli/values/_set.py
+++ b/naturo/cli/values/_set.py
@@ -5,7 +5,7 @@ ValuePattern (text fields), TogglePattern (checkboxes),
 SelectionItemPattern (list/radio items), and ExpandCollapsePattern
 (combo boxes).
 """
-import json as json_module
+from naturo.cli._jsonio import json_dumps
 import platform
 
 import click
@@ -301,7 +301,7 @@ def _do_set_value(backend, hwnd, automation_id, role, name, ref, value,
         )
 
     if json_output:
-        click.echo(json_module.dumps({
+        click.echo(json_dumps({
             "status": "ok",
             "action": "set_value",
             "ref": ref,
@@ -345,7 +345,7 @@ def _do_toggle(backend, hwnd, automation_id, role, name, ref, json_output) -> No
         )
 
     if json_output:
-        click.echo(json_module.dumps({
+        click.echo(json_dumps({
             "status": "ok",
             "action": "toggle",
             "ref": ref,
@@ -390,7 +390,7 @@ def _do_select(backend, hwnd, automation_id, role, name, ref, json_output) -> No
         )
 
     if json_output:
-        click.echo(json_module.dumps({
+        click.echo(json_dumps({
             "status": "ok",
             "action": "select",
             "ref": ref,
@@ -438,7 +438,7 @@ def _do_expand_collapse(backend, hwnd, automation_id, role, name, ref,
         )
 
     if json_output:
-        click.echo(json_module.dumps({
+        click.echo(json_dumps({
             "status": "ok",
             "action": action,
             "ref": ref,

--- a/tests/test_json_unicode_894.py
+++ b/tests/test_json_unicode_894.py
@@ -11,10 +11,19 @@ literal Unicode is safe on every platform.
 These tests pin the contract: the shared :func:`naturo.cli._jsonio.json_dumps` helper
 defaults to ``ensure_ascii=False``, the canonical error envelope preserves literal
 Unicode, and an end-to-end command echoes CJK input without escaping.
+
+#1025 is an incomplete-fix regression of #894: a large set of ``-j`` emit sites were
+missed because they call the raw stdlib ``json`` (often aliased as
+``import json as json_module``) instead of :func:`json_dumps`, so ``see`` / ``find`` /
+``menu-inspect`` / ``list windows`` / ``get`` / ``set`` still emitted ``\\uXXXX``. The
+:class:`TestNoRawJsonDumpsInCliOutput` AST guard pins the whole class shut: every CLI
+emit site must route through :func:`json_dumps`, never the stdlib ``json.dumps``.
 """
 from __future__ import annotations
 
+import ast
 import json
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -126,3 +135,114 @@ class TestCliEndToEnd:
         finally:
             for p in patches:
                 p.stop()
+
+
+def _stdlib_json_names(tree: ast.Module) -> set[str]:
+    """Return the names the stdlib ``json`` module is bound to in a module.
+
+    Handles ``import json`` (name ``json``), ``import json as json_module``
+    (the alias used by the modules #1025 missed), and module-level
+    ``from json import dumps`` (name ``dumps``).
+
+    Args:
+        tree: Parsed AST of a Python module.
+
+    Returns:
+        The set of identifiers that refer to the stdlib ``json`` module, plus
+        ``"dumps"`` if it was imported directly from ``json``.
+    """
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "json":
+                    names.add(alias.asname or "json")
+        elif isinstance(node, ast.ImportFrom) and node.module == "json":
+            for alias in node.names:
+                if alias.name == "dumps":
+                    names.add(alias.asname or "dumps")
+    return names
+
+
+def _raw_json_dumps_callsites(path: Path) -> list[int]:
+    """Find line numbers in ``path`` that call the stdlib ``json.dumps``.
+
+    Detects both ``<json-alias>.dumps(...)`` (e.g. ``json_module.dumps``) and a
+    bare ``dumps(...)`` imported via ``from json import dumps`` — the patterns
+    that bypass :func:`naturo.cli._jsonio.json_dumps` and re-introduce the #894
+    ``\\uXXXX`` escaping regression (#1025).
+
+    Args:
+        path: Path to the Python source file to scan.
+
+    Returns:
+        Sorted line numbers of offending callsites (empty if the file is clean).
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    json_names = _stdlib_json_names(tree)
+    hits: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if (isinstance(func, ast.Attribute) and func.attr == "dumps"
+                and isinstance(func.value, ast.Name)
+                and func.value.id in json_names):
+            hits.append(node.lineno)
+        elif (isinstance(func, ast.Name) and func.id == "dumps"
+                and "dumps" in json_names):
+            hits.append(node.lineno)
+    return sorted(hits)
+
+
+class TestNoRawJsonDumpsInCliOutput:
+    """Every CLI ``-j`` emit site must route through :func:`json_dumps` (#1025).
+
+    The original #894 fix added the helper but missed many callsites that use
+    the raw stdlib ``json`` (frequently aliased ``import json as json_module``),
+    which kept emitting ``\\uXXXX`` escapes. A grep audit missed them because of
+    the alias; this AST scan does not.
+    """
+
+    def test_no_module_uses_stdlib_json_dumps(self):
+        cli_dir = Path(__file__).resolve().parent.parent / "naturo" / "cli"
+        # The shared helper is the one and only sanctioned ``json.dumps`` call.
+        sanctioned = cli_dir / "_jsonio.py"
+
+        offenders: dict[str, list[int]] = {}
+        for path in sorted(cli_dir.rglob("*.py")):
+            if path == sanctioned:
+                continue
+            lines = _raw_json_dumps_callsites(path)
+            if lines:
+                offenders[str(path.relative_to(cli_dir.parent.parent))] = lines
+
+        assert not offenders, (
+            "CLI modules must serialize -j output via "
+            "naturo.cli._jsonio.json_dumps (ensure_ascii=False), not the "
+            "stdlib json.dumps which escapes non-ASCII as \\uXXXX (#1025). "
+            f"Offending callsites: {offenders}"
+        )
+
+
+class TestElementTreeSurfacesKeepCjkLiteral:
+    """The element-tree ``-j`` surfaces #1025 called out echo CJK literally."""
+
+    def test_find_ai_error_envelope_keeps_cjk_literal(self, runner):
+        """``find --ai`` JSON error envelope (``_find.py:294``) stays literal.
+
+        This callsite — one of the raw ``json_module.dumps`` sites #1025
+        flagged — echoes the underlying failure message; a CJK message must
+        survive without ``\\uXXXX`` escaping.
+        """
+        with patch("naturo.ai_find.ai_find_element",
+                   side_effect=RuntimeError(f"detector crashed: {_CJK}")):
+            from naturo.cli.core._find import find_cmd
+            result = runner.invoke(
+                find_cmd, ["the close button", "--ai", "--json"],
+            )
+
+        assert result.exit_code != 0
+        assert "AI_FIND_FAILED" in result.output
+        assert _CJK in result.output
+        assert "\\u" not in result.output


### PR DESCRIPTION
## What
Fixes #1025 — an incomplete-fix regression of #894. PR #1013 added the central `naturo.cli._jsonio.json_dumps()` helper (`ensure_ascii=False`) but missed a large set of `-j` emit sites that still call the raw stdlib `json` via `import json as json_module` / `json_module.dumps(...)`. Those surfaces — `see`, `find`, `menu-inspect`, `list windows`, `get`, `set`, `capture`, `snapshot`, `table`, `extensions` (excel), and all of `_browser/*` — still emitted `\uXXXX` escapes for CJK/emoji. The alias hid them from a `grep "json.dumps("` audit.

This repoints every missed callsite at `json_dumps`, so non-ASCII round-trips **literally and consistently** across all `-j` surfaces (matching `clipboard get -j` and the non-`-j` path). No public-API/CLI change: `json.loads` decodes both forms to identical values. Stale `import json as json_module` aliases are dropped where now unused; the one re-export in `core/_common.py` (not an emit site) is left untouched.

19 source files touched; every `json_module.dumps` callsite from the issue's source map is converted.

## How tested
- **New regression tests** (extending `tests/test_json_unicode_894.py`):
  - `TestNoRawJsonDumpsInCliOutput` — an **AST scan** of `naturo/cli/**/*.py` asserting *no* module calls the stdlib `json.dumps` (only the sanctioned `_jsonio.py` wrapper may). Pins the entire bug class shut and can't be evaded by aliasing. Confirmed **red before / green after**.
  - `TestElementTreeSurfacesKeepCjkLiteral::test_find_ai_error_envelope_keeps_cjk_literal` — functional check that `find --ai`'s JSON error envelope (`_find.py:294`) keeps CJK literal (no `\uXXXX`). Red before / green after.
- `ruff check naturo/` — clean.
- `mypy` — changed files clean (the only error is a pre-existing third-party `mcp` py3.10 match-statement syntax error, identical with changes stashed).
- Full non-desktop suite: **2110 passed**; the 2 failures + 270 errors are pre-existing and environment-only (non-Windows platform tests on Windows; worktree filesystem `PermissionError`) — confirmed identical with changes stashed.
- CI-style `--collect-only` on the new tests: 9 collected, no import issues.
- **Real-desktop runtime**: `naturo list windows -j` → 46 windows, 35 non-ASCII titles, **0 `\u` escapes** (literal UTF-8, parses via `json.loads`).