### PR TITLE
fix: auto-create --path parent dir for capture/see (fixes #1022)

### DIFF
--- a/naturo/cli/core/_capture.py
+++ b/naturo/cli/core/_capture.py
@@ -89,6 +89,10 @@ def capture(app: str | None, pid: int | None, window_title: str | None, hwnd: in
         app_label = (app or window_title or "screen").lower().replace(" ", "-")
         path = f"naturo-{app_label}-{timestamp}.{fmt}"
 
+    # (#1022) Auto-create the parent directory so a missing folder doesn't
+    # surface as a raw [Errno 2] mislabeled as a capture failure.
+    _common._ensure_output_dir(path, json_output)
+
     try:
         backend = _common._get_backend(json_output)
         if hwnd or app or window_title or pid:

--- a/naturo/cli/core/_common.py
+++ b/naturo/cli/core/_common.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import functools
 import json as json_module  # noqa: F401 — re-exported for submodules
 import logging
+import os
 import platform
 from collections.abc import Callable
 from typing import TypeVar
@@ -148,3 +149,40 @@ def _platform_error_msg(feature: str) -> str:
     if system == "Linux":
         return f"{feature} is not yet supported on Linux. See https://github.com/AcePeak/naturo#platform-support"
     return f"{feature} is not supported on {system}."
+
+
+def _ensure_output_dir(path: str, json_output: bool) -> None:
+    """Ensure the parent directory of an output file path exists.
+
+    Auto-creates the parent directory (and any missing ancestors) so that
+    writing an image to a not-yet-existing folder succeeds, instead of letting
+    the backend raise a raw ``FileNotFoundError`` that downstream code
+    mislabels as a capture failure (issue #1022).
+
+    Args:
+        path: The output file path the caller is about to write to.
+        json_output: Whether the caller emits JSON error envelopes; controls
+            the format of the error reported on failure.
+
+    Raises:
+        SystemExit: With exit code 1 if the parent directory cannot be created
+            (e.g. permission denied, or a file occupies the path). The emitted
+            error is a clear ``INVALID_INPUT`` naming the directory rather than
+            a raw OS errno.
+    """
+    parent = os.path.dirname(os.path.abspath(path))
+    if not parent or os.path.isdir(parent):
+        return
+    try:
+        os.makedirs(parent, exist_ok=True)
+    except OSError as exc:
+        reason = exc.strerror or str(exc)
+        msg = (
+            f"Cannot create output directory '{parent}': {reason}. "
+            "Choose a writable --path or create the directory first."
+        )
+        if json_output:
+            click.echo(_json_error_str("INVALID_INPUT", msg))
+        else:
+            click.echo(f"Error: {msg}", err=True)
+        raise SystemExit(1)

--- a/naturo/cli/core/_see.py
+++ b/naturo/cli/core/_see.py
@@ -132,6 +132,11 @@ def see(app: str | None, window_title: str | None, hwnd: int | None, pid: int | 
             click.echo(f"Error: {msg}", err=True)
         raise SystemExit(1)
 
+    # (#1022) Auto-create the parent directory for --path so a missing folder
+    # doesn't surface as a raw [Errno 2] mislabeled as UNKNOWN_ERROR on save.
+    if path:
+        _common._ensure_output_dir(path, json_output)
+
     try:
         be = _common._get_backend(json_output)
 

--- a/tests/test_output_dir_1022.py
+++ b/tests/test_output_dir_1022.py
@@ -1,0 +1,157 @@
+"""Tests for #1022 — output `--path` parent-directory handling.
+
+`capture` and `see` write a screenshot to a user-supplied ``--path``. When the
+parent directory did not exist, the underlying ``FileNotFoundError`` leaked out
+as a raw ``[Errno 2]`` string and the JSON envelope was mislabeled
+(``CAPTURE_ERROR`` with minimized-window guidance for ``capture``,
+``UNKNOWN_ERROR`` with no guidance for ``see``).
+
+The fix (option A in the issue) auto-creates the parent directory before the
+backend write. If the directory genuinely cannot be created, a clear
+``INVALID_INPUT`` error is emitted instead of a raw OS errno.
+"""
+from __future__ import annotations
+
+import inspect
+import json
+from dataclasses import dataclass
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+import naturo.cli.core._common as _common
+from naturo.cli.core._capture import capture
+from naturo.cli.core._see import see
+
+
+@dataclass
+class FakeCaptureResult:
+    path: str = "/tmp/test.png"
+    width: int = 1920
+    height: int = 1080
+    format: str = "png"
+    scale_factor: float = 1.0
+    dpi: int = 96
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def _patch_backend(mock_backend):
+    return patch("naturo.cli.core._common._get_backend", return_value=mock_backend)
+
+
+def _patch_platform(supports=True):
+    return patch("naturo.cli.core._common._platform_supports_gui", return_value=supports)
+
+
+# ── Shared helper: _ensure_output_dir ─────────────────────────────────────────
+
+
+class TestEnsureOutputDir:
+    """Unit tests for the shared parent-directory helper."""
+
+    def test_creates_missing_nested_parent(self, tmp_path):
+        target = tmp_path / "a" / "b" / "c" / "shot.png"
+        assert not target.parent.exists()
+        _common._ensure_output_dir(str(target), json_output=False)
+        assert target.parent.is_dir()
+
+    def test_noop_when_parent_exists(self, tmp_path):
+        target = tmp_path / "shot.png"  # tmp_path already exists
+        _common._ensure_output_dir(str(target), json_output=False)
+        assert tmp_path.is_dir()
+
+    def test_bare_filename_does_not_raise(self):
+        # No directory component → nothing to create, must not error.
+        _common._ensure_output_dir("shot.png", json_output=False)
+
+    def test_uncreatable_dir_raises_invalid_input_json(self, tmp_path):
+        # A file occupies what would have to be a directory → makedirs fails.
+        blocker = tmp_path / "blocker"
+        blocker.write_text("x")
+        target = blocker / "sub" / "shot.png"
+        with pytest.raises(SystemExit) as exc:
+            _common._ensure_output_dir(str(target), json_output=True)
+        assert exc.value.code == 1
+
+    def test_uncreatable_dir_plain_message(self, tmp_path, capsys):
+        blocker = tmp_path / "blocker"
+        blocker.write_text("x")
+        target = blocker / "sub" / "shot.png"
+        with pytest.raises(SystemExit):
+            _common._ensure_output_dir(str(target), json_output=False)
+        err = capsys.readouterr().err
+        assert "Error:" in err
+
+
+# ── capture auto-creates the parent directory ─────────────────────────────────
+
+
+class TestCaptureAutoCreate:
+
+    def test_capture_creates_missing_parent_dir(self, runner, tmp_path):
+        target = tmp_path / "no_such_subdir" / "shot.png"
+        backend = MagicMock()
+        backend.list_monitors.return_value = [MagicMock(index=0)]
+        backend.capture_screen.return_value = FakeCaptureResult(path=str(target))
+        with _patch_platform(), _patch_backend(backend):
+            result = runner.invoke(
+                capture, ["-p", str(target), "--no-snapshot"],
+                catch_exceptions=False,
+            )
+        assert result.exit_code == 0
+        assert target.parent.is_dir()
+
+    def test_capture_json_success_after_autocreate(self, runner, tmp_path):
+        target = tmp_path / "deep" / "nested" / "out.png"
+        backend = MagicMock()
+        backend.list_monitors.return_value = [MagicMock(index=0)]
+        backend.capture_screen.return_value = FakeCaptureResult(path=str(target))
+        with _patch_platform(), _patch_backend(backend):
+            result = runner.invoke(
+                capture, ["-p", str(target), "--json", "--no-snapshot"],
+                catch_exceptions=False,
+            )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["success"] is True
+        assert target.parent.is_dir()
+
+    def test_capture_uncreatable_dir_is_invalid_input_not_capture_error(
+        self, runner, tmp_path,
+    ):
+        # Regression: a save-path failure must NOT be mislabeled as a
+        # CAPTURE_ERROR with misleading minimized-window guidance.
+        blocker = tmp_path / "blocker"
+        blocker.write_text("x")
+        target = blocker / "sub" / "shot.png"
+        backend = MagicMock()
+        backend.capture_screen.return_value = FakeCaptureResult(path=str(target))
+        with _patch_platform(), _patch_backend(backend):
+            result = runner.invoke(
+                capture, ["-p", str(target), "--json", "--no-snapshot"],
+                catch_exceptions=False,
+            )
+        assert result.exit_code != 0
+        data = json.loads(result.output)
+        assert data["error"]["code"] == "INVALID_INPUT"
+        assert "minimized" not in json.dumps(data).lower()
+        assert "[errno" not in data["error"]["message"].lower()
+
+
+# ── Source guard: both commands invoke the helper before the backend write ────
+
+
+class TestBothCommandsGuardOutputDir:
+
+    @pytest.mark.parametrize("command", [capture, see])
+    def test_command_calls_ensure_output_dir(self, command):
+        source = inspect.getsource(command.callback)
+        assert "_ensure_output_dir" in source, (
+            f"{command.name} must call _ensure_output_dir to auto-create the "
+            "parent directory of --path (#1022)"
+        )


### PR DESCRIPTION
## What
`capture` and `see` write a screenshot to a user-supplied `--path` but never validated or created the parent directory. When the parent dir did not exist, the underlying `FileNotFoundError` leaked out as a raw `[Errno 2]` string and the JSON envelope was **mislabeled**:
- `capture` → `CAPTURE_ERROR` with misleading "ensure the target window is not minimized" guidance
- `see` → `UNKNOWN_ERROR` with no guidance

…even though the capture itself succeeded — only the *save* failed.

## How
- Add a shared `_common._ensure_output_dir(path, json_output)` helper that **auto-creates** the parent directory (and ancestors) before the backend write — option A in the issue, least-surprise for agents building output paths.
- On a genuine failure (e.g. a file occupies the path, permission denied), emit a clear `INVALID_INPUT` naming the directory instead of a raw OS errno — no more mislabeled capture failure.
- Wire it into both `capture` (after path resolution) and `see` (when `--path` is given), before any capture work runs.
- No new flags / no CLI-interface change: a previously-failing case now succeeds.

Lateral audit: `capture` and `see` are the only `--path` image-writing commands in `cli/core` (grep-confirmed); `visual`/`record`/`diff` have no such output-path write.

## How tested
- New `tests/test_output_dir_1022.py` (10 tests): helper unit tests (nested create, no-op when present, bare filename, uncreatable-dir → `INVALID_INPUT` in JSON + plain), `capture` auto-create + JSON success, regression that an uncreatable dir is `INVALID_INPUT` (not `CAPTURE_ERROR`, no "minimized" text, no raw errno), and a source guard that both commands call the helper.
- 100 related capture/see tests pass; ruff clean; full suite collects (6524) with no break.
- Real-desktop runtime: `capture -j --path missing/shot.png` → `success: true` + file created; `see --path missing/s.png` → dir auto-created + 155KB PNG written; blocked path → clean `INVALID_INPUT`.