### PR TITLE
fix: route selector/record/visual -o writes through _ensure_output_dir (fixes #1029)

### DIFF
--- a/naturo/cli/recording_cmd.py
+++ b/naturo/cli/recording_cmd.py
@@ -12,6 +12,7 @@ from datetime import datetime
 
 import click
 
+from naturo.cli.core._common import _ensure_output_dir
 from naturo.cli.error_helpers import collection_read, json_error, success_envelope
 from naturo.cli.fuzzy_group import FuzzyGroup
 from naturo.errors import ErrorCode
@@ -342,6 +343,7 @@ def record_export(recording_id: str, fmt: str, output_path: str | None,
     content = _export_recording(rec, fmt)
 
     if output_path:
+        _ensure_output_dir(output_path, json_output)
         with open(output_path, "w", encoding="utf-8") as f:
             f.write(content)
         if json_output:

--- a/naturo/cli/selector_cmd.py
+++ b/naturo/cli/selector_cmd.py
@@ -13,6 +13,7 @@ from typing import Optional
 
 import click
 
+from naturo.cli.core._common import _ensure_output_dir
 from naturo.cli.error_helpers import collection_read, json_error, success_envelope
 from naturo.cli.fuzzy_group import FuzzyGroup
 from naturo.errors import ErrorCode
@@ -442,6 +443,7 @@ def selector_export(app_name: str, output_path: str | None, json_output: bool):
     content = json_dumps(export_data, indent=2, ensure_ascii=False)
 
     if output_path:
+        _ensure_output_dir(output_path, json_output)
         with open(output_path, "w", encoding="utf-8") as f:
             f.write(content)
         if json_output:

--- a/naturo/cli/visual_cmd.py
+++ b/naturo/cli/visual_cmd.py
@@ -14,6 +14,7 @@ from typing import Optional
 
 import click
 
+from naturo.cli.core._common import _ensure_output_dir
 from naturo.cli.error_helpers import collection_read, json_error, success_envelope
 from naturo.cli.fuzzy_group import FuzzyGroup
 from naturo.errors import ErrorCode
@@ -154,6 +155,13 @@ def visual_diff(image1: str, image2: str, output: Optional[str],
         naturo visual diff before.png after.png
         naturo visual diff before.png after.png -o diff.png
     """
+    if output:
+        # Auto-create a missing parent dir (and emit a clean INVALID_INPUT
+        # envelope for an uncreatable one) before compare_images writes the
+        # diff, so a missing/uncreatable -o never leaks a raw traceback or
+        # bypasses the -j contract (#1029).
+        _ensure_output_dir(output, json_output)
+
     try:
         result = compare_images(
             image1, image2, name="diff",

--- a/tests/test_output_dir_1029.py
+++ b/tests/test_output_dir_1029.py
@@ -1,0 +1,214 @@
+"""Tests for #1029 — `--output`/`-o` parent-directory handling for export commands.
+
+Follow-on to #1022 (capture/see ``--path``). The output-writing commands
+``selector export``, ``record export`` and ``visual diff`` opened the
+``--output`` file with a bare ``open()`` (selector/record) or let
+``visual.compare_images`` create the directory unguarded. When the parent
+directory was missing or uncreatable they leaked a raw Python traceback to
+stderr and — fatally for an agent — ignored the ``-j`` JSON contract, emitting
+no error envelope at all.
+
+The fix routes every ``--output`` write through
+:func:`naturo.cli.core._common._ensure_output_dir` *before* opening the file,
+mirroring #1022's option A: a normally-missing parent is auto-created, and a
+genuinely uncreatable parent yields a clean ``INVALID_INPUT`` envelope (``-j``)
+or a one-line ``Error:`` (otherwise) — never a raw traceback or ``[Errno 2]``.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from naturo import recording as rec_mod
+from naturo.cli import main, selector_cmd
+from naturo.recording import ActionStep, Recording, save_recording
+
+
+@pytest.fixture()
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture()
+def tmp_selectors(tmp_path):
+    """Patch SELECTORS_DIR so selector writes/reads stay in a temp dir."""
+    with patch.object(selector_cmd, "SELECTORS_DIR", tmp_path):
+        yield tmp_path
+
+
+@pytest.fixture()
+def tmp_recordings(tmp_path):
+    """Patch RECORDINGS_DIR so recording reads stay in a temp dir."""
+    with patch.object(rec_mod, "RECORDINGS_DIR", tmp_path):
+        yield tmp_path
+
+
+def _save_sample_recording() -> str:
+    """Persist a small recording and return its id."""
+    rec = Recording(
+        name="Export Flow",
+        recording_id="rec_20260401_120000",
+        created_at="2026-04-01T12:00:00",
+    )
+    rec.steps = [ActionStep("click", {"x": 1, "y": 2}, 1000.0)]
+    save_recording(rec)
+    return rec.recording_id
+
+
+def _assert_no_raw_traceback(result) -> None:
+    """A handled error must never surface a Python traceback or raw OS errno."""
+    combined = result.output + (str(result.exception) if result.exception else "")
+    assert "Traceback (most recent call last)" not in result.output
+    assert "[Errno 2]" not in combined
+    assert "No such file or directory" not in combined
+
+
+# ── selector export ───────────────────────────────────────────────────────────
+
+
+class TestSelectorExportOutputDir:
+    def test_missing_parent_is_auto_created(self, runner, tmp_selectors, tmp_path):
+        runner.invoke(main, ["selector", "save", "notepad", "btn", "app://notepad/btn"])
+        out = tmp_path / "missing_sub" / "sel.json"
+        assert not out.parent.exists()
+
+        result = runner.invoke(main, [
+            "-j", "selector", "export", "notepad", "-o", str(out),
+        ])
+
+        assert result.exit_code == 0, result.output
+        assert out.exists()
+        data = json.loads(result.output)
+        assert data["success"] is True
+        assert data["path"] == str(out)
+
+    def test_uncreatable_parent_yields_invalid_input_envelope(
+        self, runner, tmp_selectors, tmp_path,
+    ):
+        runner.invoke(main, ["selector", "save", "notepad", "btn", "app://notepad/btn"])
+        blocker = tmp_path / "afile"
+        blocker.write_text("not a directory")
+        out = blocker / "sub" / "sel.json"  # parent path traverses a file
+
+        result = runner.invoke(main, [
+            "-j", "selector", "export", "notepad", "-o", str(out),
+        ])
+
+        assert result.exit_code == 1
+        _assert_no_raw_traceback(result)
+        data = json.loads(result.output)
+        assert data["error"]["code"] == "INVALID_INPUT"
+        assert not out.exists()
+
+    def test_uncreatable_parent_plain_text_error(
+        self, runner, tmp_selectors, tmp_path,
+    ):
+        runner.invoke(main, ["selector", "save", "notepad", "btn", "app://notepad/btn"])
+        blocker = tmp_path / "afile"
+        blocker.write_text("not a directory")
+        out = blocker / "sub" / "sel.json"
+
+        result = runner.invoke(main, [
+            "selector", "export", "notepad", "-o", str(out),
+        ])
+
+        assert result.exit_code == 1
+        _assert_no_raw_traceback(result)
+        assert "Error:" in result.output
+
+
+# ── record export ─────────────────────────────────────────────────────────────
+
+
+class TestRecordExportOutputDir:
+    def test_missing_parent_is_auto_created(self, runner, tmp_recordings, tmp_path):
+        _save_sample_recording()
+        out = tmp_path / "missing_sub" / "script.json"
+        assert not out.parent.exists()
+
+        result = runner.invoke(main, [
+            "-j", "record", "export", "rec_20260401_120000",
+            "--format", "json", "-o", str(out),
+        ])
+
+        assert result.exit_code == 0, result.output
+        assert out.exists()
+        data = json.loads(result.output)
+        assert data["success"] is True
+        assert data["path"] == str(out)
+
+    def test_uncreatable_parent_yields_invalid_input_envelope(
+        self, runner, tmp_recordings, tmp_path,
+    ):
+        _save_sample_recording()
+        blocker = tmp_path / "afile"
+        blocker.write_text("not a directory")
+        out = blocker / "sub" / "script.json"
+
+        result = runner.invoke(main, [
+            "-j", "record", "export", "rec_20260401_120000",
+            "--format", "json", "-o", str(out),
+        ])
+
+        assert result.exit_code == 1
+        _assert_no_raw_traceback(result)
+        data = json.loads(result.output)
+        assert data["error"]["code"] == "INVALID_INPUT"
+        assert not out.exists()
+
+
+# ── visual diff ───────────────────────────────────────────────────────────────
+
+
+class TestVisualDiffOutputDir:
+    """``visual diff`` pre-validates the ``-o`` parent before comparing.
+
+    ``compare_images`` is patched so the test exercises only the CLI-layer
+    directory handling and does not require the imaging dependencies.
+    """
+
+    @pytest.fixture()
+    def images(self, tmp_path):
+        img1 = tmp_path / "a.png"
+        img2 = tmp_path / "b.png"
+        img1.write_bytes(b"\x89PNG\r\n\x1a\n")
+        img2.write_bytes(b"\x89PNG\r\n\x1a\n")
+        return str(img1), str(img2)
+
+    def test_missing_parent_is_auto_created(self, runner, tmp_path, images):
+        img1, img2 = images
+        out = tmp_path / "missing_sub" / "diff.png"
+        fake = MagicMock()
+        fake.to_dict.return_value = {"match": True, "similarity": 1.0}
+
+        with patch("naturo.cli.visual_cmd.compare_images", return_value=fake) as cmp_mock:
+            result = runner.invoke(main, [
+                "-j", "visual", "diff", img1, img2, "-o", str(out),
+            ])
+
+        assert result.exit_code == 0, result.output
+        assert out.parent.is_dir()
+        cmp_mock.assert_called_once()
+
+    def test_uncreatable_parent_yields_invalid_input_envelope(
+        self, runner, tmp_path, images,
+    ):
+        img1, img2 = images
+        blocker = tmp_path / "afile"
+        blocker.write_text("not a directory")
+        out = blocker / "sub" / "diff.png"
+
+        with patch("naturo.cli.visual_cmd.compare_images") as cmp_mock:
+            result = runner.invoke(main, [
+                "-j", "visual", "diff", img1, img2, "-o", str(out),
+            ])
+
+        assert result.exit_code == 1
+        _assert_no_raw_traceback(result)
+        data = json.loads(result.output)
+        assert data["error"]["code"] == "INVALID_INPUT"
+        cmp_mock.assert_not_called()  # fail fast, before the comparison runs


### PR DESCRIPTION
## What
Follow-on to #1022 / PR #1028. The output-writing commands `selector export`, `record export` and `visual diff` did not guard their `--output`/`-o` parent directory:

- `selector export` and `record export` opened the file with a bare `open(output_path, "w")` — a **missing parent dir** (the common, benign case) raised an uncaught `FileNotFoundError`, leaking a raw Python traceback and, when `-j` was set, emitting **no JSON envelope at all** (contract violation).
- `visual diff` let `visual.compare_images` create the dir unguarded, so an **uncreatable** parent surfaced a raw `FileExistsError`/`[WinError 183]` traceback with no `-j` envelope.

This routes every `-o` write through the existing `naturo.cli.core._common._ensure_output_dir` helper (shipped in #1028) **before** the write, matching #1022's option A:

1. A normally-missing parent dir is **auto-created**.
2. A genuinely uncreatable parent yields a clean `INVALID_INPUT` envelope naming the directory (`-j`) or a one-line `Error:` (otherwise) — **never** a raw traceback or `[Errno 2]`/`[WinError]`.
3. `-j` always produces a JSON envelope.

`visual report` already wrapped its write in `try/except` and emitted an envelope, so it was left unchanged.

## How tested
New `tests/test_output_dir_1029.py` (7 tests, parametrized over the three commands):
- missing parent → auto-created, exit 0, valid success envelope, file written;
- uncreatable parent (path traverses a file) → exit 1, `INVALID_INPUT` envelope, no traceback / no raw errno, output **not** written; `visual diff` fails fast before `compare_images` runs;
- plain-text (non-`-j`) path → one-line `Error:`, exit 1.

Gate: `ruff check naturo/` clean; affected suites green (`test_output_dir_1029`, `test_output_dir_1022`, `test_selector_cmd`, `test_recording_cmd`, `test_visual`, `test_selector_cli`, `test_recording_cli` — 266 passed); `--collect-only` clean (no Windows/optional-dep collection break).

Fixes #1029.