### PR TITLE
fix: emit English-only reason from _ensure_output_dir (fixes #1031)

### DIFF
--- a/naturo/cli/core/_common.py
+++ b/naturo/cli/core/_common.py
@@ -10,6 +10,7 @@ This gives a single consistent mock-patch path:
 """
 from __future__ import annotations
 
+import errno
 import functools
 import json as json_module  # noqa: F401 — re-exported for submodules
 import logging
@@ -151,6 +152,45 @@ def _platform_error_msg(feature: str) -> str:
     return f"{feature} is not supported on {system}."
 
 
+# Stable, English-only reasons keyed by ``errno``. ``OSError.strerror`` is
+# rendered by the OS in the system locale, so interpolating it leaks non-English
+# text into naturo's English-only CLI/``-j`` contract on a localized Windows
+# (#1031). Map the errno to a fixed phrase instead; the numeric errno is kept for
+# diagnostics, but never the localized string.
+_OSERROR_REASONS: dict[int, str] = {
+    errno.ENOENT: "a path component is missing or is not a directory",
+    errno.ENOTDIR: "a path component is not a directory",
+    errno.EACCES: "permission denied",
+    errno.EPERM: "operation not permitted",
+    errno.EEXIST: "a file already exists at that path",
+    errno.EROFS: "the filesystem is read-only",
+    errno.ENOSPC: "no space left on the device",
+    errno.ENAMETOOLONG: "the path is too long",
+}
+
+
+def _oserror_reason(exc: OSError) -> str:
+    """Return a stable, English-only reason describing an :class:`OSError`.
+
+    Avoids ``exc.strerror``, which the OS renders in the system locale and would
+    otherwise leak non-English text into naturo's English-only error contract
+    (#1031). Falls back to the numeric errno (still English) for codes that are
+    not explicitly mapped.
+
+    Args:
+        exc: The ``OSError`` raised while creating the output directory.
+
+    Returns:
+        An ASCII/English-only phrase suitable for interpolating into a
+        user-facing message.
+    """
+    if exc.errno in _OSERROR_REASONS:
+        return f"{_OSERROR_REASONS[exc.errno]} (errno {exc.errno})"
+    if exc.errno is not None:
+        return f"OS error {exc.errno}"
+    return "the directory could not be created"
+
+
 def _ensure_output_dir(path: str, json_output: bool) -> None:
     """Ensure the parent directory of an output file path exists.
 
@@ -176,7 +216,7 @@ def _ensure_output_dir(path: str, json_output: bool) -> None:
     try:
         os.makedirs(parent, exist_ok=True)
     except OSError as exc:
-        reason = exc.strerror or str(exc)
+        reason = _oserror_reason(exc)
         msg = (
             f"Cannot create output directory '{parent}': {reason}. "
             "Choose a writable --path or create the directory first."

--- a/tests/test_output_dir_1031.py
+++ b/tests/test_output_dir_1031.py
@@ -1,0 +1,93 @@
+"""Tests for #1031 — `_ensure_output_dir` must not leak localized OS text.
+
+The shared :func:`naturo.cli.core._common._ensure_output_dir` helper (used by
+``capture``, ``see``, ``selector export``, ``record export`` and
+``visual diff`` for the uncreatable ``--path``/``-o`` parent-dir case) built an
+English error message but interpolated the raw OS ``strerror``, which the
+platform renders in the **system locale**. On a non-English Windows that leaked
+a verbatim localized substring (e.g. the zh-CN "系统找不到指定的路径。") into the
+otherwise all-English ``INVALID_INPUT`` message / ``-j`` contract.
+
+The fix maps the ``OSError`` to a stable English reason by ``errno`` (keeping
+the numeric errno for diagnostics, never the localized text), so the
+user-facing message is ASCII/English-only regardless of system locale.
+"""
+from __future__ import annotations
+
+import errno
+import json
+from unittest.mock import patch
+
+import pytest
+
+import naturo.cli.core._common as _common
+
+# A deliberately non-ASCII (zh-CN) OS strerror, as produced on a localized
+# Windows for ERROR_PATH_NOT_FOUND. This is exactly what used to leak.
+_LOCALIZED_STRERROR = "系统找不到指定的路径。"
+
+
+def _run_ensure_output_dir(capsys, *, json_output: bool, exc: OSError):
+    """Drive ``_ensure_output_dir`` against a forced ``makedirs`` failure.
+
+    Returns the captured ``(stdout, stderr)`` produced by the helper before it
+    raised ``SystemExit``.
+    """
+    # A parent that does not exist yet, so the helper attempts ``makedirs``.
+    path = "no_such_dir_1031/sub/out.png"
+    with patch.object(_common.os.path, "isdir", return_value=False), \
+            patch.object(_common.os, "makedirs", side_effect=exc):
+        with pytest.raises(SystemExit) as excinfo:
+            _common._ensure_output_dir(path, json_output)
+    assert excinfo.value.code == 1
+    return capsys.readouterr()
+
+
+def _message_is_english_only(message: str) -> None:
+    """A user-facing message must be ASCII/English-only (no localized OS text)."""
+    assert message.isascii(), f"non-ASCII text leaked into message: {message!r}"
+    assert _LOCALIZED_STRERROR not in message
+
+
+class TestEnsureOutputDirEnglishOnly:
+    def test_json_envelope_has_no_localized_text(self, capsys):
+        exc = OSError(errno.ENOENT, _LOCALIZED_STRERROR)
+        out, _err = _run_ensure_output_dir(capsys, json_output=True, exc=exc)
+
+        data = json.loads(out)
+        assert data["success"] is False
+        assert data["error"]["code"] == "INVALID_INPUT"
+        _message_is_english_only(data["error"]["message"])
+        # The mapped English reason for a missing path component is surfaced.
+        assert "missing" in data["error"]["message"]
+        # errno is preserved for diagnostics (the number, not localized text).
+        assert "errno 2" in data["error"]["message"]
+
+    def test_plain_text_error_has_no_localized_text(self, capsys):
+        exc = OSError(errno.ENOENT, _LOCALIZED_STRERROR)
+        _out, err = _run_ensure_output_dir(capsys, json_output=False, exc=exc)
+
+        assert err.startswith("Error:")
+        _message_is_english_only(err)
+
+    def test_permission_denied_maps_to_english(self, capsys):
+        exc = OSError(errno.EACCES, _LOCALIZED_STRERROR)
+        out, _err = _run_ensure_output_dir(capsys, json_output=True, exc=exc)
+
+        message = json.loads(out)["error"]["message"]
+        _message_is_english_only(message)
+        assert "permission denied" in message
+
+    def test_unknown_errno_falls_back_to_english(self, capsys):
+        # An OSError carrying only a localized strerror and an errno we do not
+        # map must still produce English-only output (never the raw strerror).
+        exc = OSError(errno.EBUSY, _LOCALIZED_STRERROR)
+        out, _err = _run_ensure_output_dir(capsys, json_output=True, exc=exc)
+
+        _message_is_english_only(json.loads(out)["error"]["message"])
+
+    def test_errno_none_falls_back_to_english(self, capsys):
+        exc = OSError()  # no errno, no strerror
+        out, _err = _run_ensure_output_dir(capsys, json_output=True, exc=exc)
+
+        _message_is_english_only(json.loads(out)["error"]["message"])


### PR DESCRIPTION
## What
`_ensure_output_dir` (shared by `capture`, `see`, `selector export`, `record export`, `visual diff`) built an English `INVALID_INPUT` message but interpolated the raw OS `strerror`, which the platform renders in the **system locale**. On a non-English Windows that leaked a verbatim localized substring (e.g. the zh-CN `系统找不到指定的路径。`) into naturo's English-only CLI/`-j` contract — found by QA during #1029 verification (pre-existing cosmetic/i18n gap, not a regression).

## How
- New `_oserror_reason(OSError) -> str` maps `errno` to a stable English phrase (`ENOENT`, `ENOTDIR`, `EACCES`, `EPERM`, `EEXIST`, `EROFS`, `ENOSPC`, `ENAMETOOLONG`), appending the numeric errno for diagnostics — never the localized `strerror`.
- Unmapped errnos fall back to `OS error <n>`; an errno-less `OSError` to a generic English phrase.
- Single shared fix point covers all five commands.

## How tested
- New `tests/test_output_dir_1031.py` (5 cases): forces an `OSError` carrying a non-ASCII zh-CN `strerror` and asserts the user-facing message (both `-j` envelope and plain `Error:`) is ASCII/English-only, that the mapped English reason + `errno N` appear, and that permission-denied / unknown-errno / errno-`None` all stay English.
- `ruff check` clean; existing `test_output_dir_1029.py` / `test_output_dir_1022.py` / `test_cli_core_common.py` still pass (34 passed locally). Collection-only check passes with no Windows/desktop deps.

Closes #1031.