### PR TITLE
fix: reject unknown MCP tool arguments instead of silently dropping them (fixes #891)

### DIFF
--- a/naturo/mcp_server.py
+++ b/naturo/mcp_server.py
@@ -115,6 +115,22 @@ class _SanitizingFastMCP(FastMCP):
                 :func:`_format_tool_validation_error`; all other errors
                 propagate unchanged so genuine failures stay diagnosable.
         """
+        # (#891) Reject unknown arguments *before* dispatch.  FastMCP builds
+        # each tool's argument model from the function signature with Pydantic's
+        # default config, which silently discards undeclared arguments — so a
+        # mistyped parameter name (e.g. ``window_title`` for ``focus_window``)
+        # runs with default behaviour instead of failing, focusing the wrong
+        # window with no signal to the agent.  Surfacing this as a ToolError
+        # keeps it on the same ``isError: true`` "Invalid parameters" path as
+        # the Pydantic wrong-type/missing-field validation (#844).
+        allowed = self._allowed_argument_names(name)
+        if allowed is not None and arguments:
+            unknown = sorted(key for key in arguments if key not in allowed)
+            if unknown:
+                raise ToolError(
+                    _format_unknown_arguments_error(name, unknown, allowed)
+                )
+
         try:
             return await super().call_tool(name, arguments)
         except ToolError as exc:
@@ -122,6 +138,37 @@ class _SanitizingFastMCP(FastMCP):
             if cause is not None and hasattr(cause, "errors"):
                 raise ToolError(_format_tool_validation_error(name, cause)) from None
             raise
+
+    def _allowed_argument_names(self, name: str) -> set[str] | None:
+        """Return the argument names tool *name* declares, or ``None``.
+
+        ``None`` signals "do not enforce an allow-list" and is returned when the
+        tool is unknown (so dispatch surfaces the canonical "Unknown tool"
+        error rather than an unknown-argument one) or when its schema explicitly
+        permits additional properties.  The set is drawn from the tool's
+        generated JSON-Schema ``properties``; FastMCP omits the injected
+        ``Context`` parameter from that schema, so it is re-added when present.
+
+        Args:
+            name: Name of the MCP tool being invoked.
+
+        Returns:
+            The set of accepted argument names, or ``None`` when no allow-list
+            should be enforced.
+        """
+        try:
+            tool = self._tool_manager.get_tool(name)
+        except Exception:
+            return None
+        if tool is None:
+            return None
+        schema = tool.parameters or {}
+        if schema.get("additionalProperties") is True:
+            return None
+        allowed = set(schema.get("properties", {}).keys())
+        if tool.context_kwarg:
+            allowed.add(tool.context_kwarg)
+        return allowed
 
 
 def create_server(host: str = "localhost", port: int = 3100) -> FastMCP:
@@ -271,6 +318,36 @@ def _format_tool_validation_error(tool_name: str, cause: BaseException) -> str:
         return f"Invalid parameters for {tool_name}: {'; '.join(parts)}"
     except Exception:
         return f"Invalid parameters for {tool_name}"
+
+
+def _format_unknown_arguments_error(
+    tool_name: str, unknown: Sequence[str], allowed: Sequence[str],
+) -> str:
+    """Build a clean error message for unknown MCP tool arguments (#891).
+
+    Names the offending argument(s) and lists the valid ones so an AI agent can
+    self-correct, mirroring the ``Invalid parameters for <tool>`` phrasing used
+    for the Pydantic wrong-type/missing-field path (#844).  Leaks no Pydantic
+    internals.
+
+    Args:
+        tool_name: Name of the MCP tool that was called.
+        unknown: Argument names supplied by the client but not declared by the
+            tool.
+        allowed: The tool's declared argument names.
+
+    Returns:
+        A human-readable error string, e.g. ``"Invalid parameters for
+        focus_window: unexpected argument 'window_title'. Valid arguments: app,
+        hwnd, title."``
+    """
+    unknown_str = ", ".join(f"'{arg}'" for arg in sorted(unknown))
+    noun = "argument" if len(unknown) == 1 else "arguments"
+    valid = ", ".join(sorted(allowed)) if allowed else "(none)"
+    return (
+        f"Invalid parameters for {tool_name}: unexpected {noun} {unknown_str}. "
+        f"Valid arguments: {valid}."
+    )
 
 
 def run_server(transport: str = "stdio", host: str = "localhost", port: int = 3100):

--- a/tests/test_mcp_unknown_args_891.py
+++ b/tests/test_mcp_unknown_args_891.py
@@ -1,0 +1,142 @@
+"""Tests for MCP rejection of unknown tool arguments (#891).
+
+FastMCP generates each tool's argument model from the function signature with
+Pydantic's default config, which *silently discards* arguments not declared in
+the schema.  A client that mistypes a parameter name (e.g. ``window_title``
+instead of ``title`` for ``focus_window``) — or one targeting a schema that
+drifted between naturo versions — then gets a call that runs with default
+behaviour instead of a validation error.  That is a silent failure: the wrong
+window is focused, the wrong text is typed, and the agent has no signal.
+
+These tests pin the fix: unknown arguments are rejected before dispatch with a
+clean ``Invalid parameters for <tool>`` message (``isError: true``), consistent
+with the existing Pydantic wrong-type/missing-field path (#844).  They run
+through the *real* low-level JSON-RPC dispatch path a live MCP client hits, plus
+unit-level coverage of the allow-list and the message formatter.  All are
+desktop-independent: the rejection happens before any backend call.
+"""
+from __future__ import annotations
+
+import pytest
+
+mcp_available = True
+try:
+    from naturo.mcp_server import _format_unknown_arguments_error
+except ImportError:
+    mcp_available = False
+
+pytestmark = pytest.mark.skipif(not mcp_available, reason="mcp package not installed")
+
+
+def _dispatch(tool_name: str, arguments: dict):
+    """Drive a tools/call request through the registered handler.
+
+    Returns the resulting ``CallToolResult`` (``ServerResult.root``).  Mirrors
+    the dispatch helper in ``test_mcp_pydantic_leak.py`` so the test exercises
+    the same path a real client triggers.
+    """
+    import asyncio
+    from unittest.mock import patch
+
+    from mcp.types import CallToolRequest, CallToolRequestParams
+    from naturo.mcp_server import create_server
+
+    with patch("naturo.mcp_server.get_backend"):
+        server = create_server()
+
+    handler = server._mcp_server.request_handlers[CallToolRequest]
+    request = CallToolRequest(
+        method="tools/call",
+        params=CallToolRequestParams(name=tool_name, arguments=arguments),
+    )
+    result = asyncio.run(handler(request))
+    return result.root
+
+
+class TestFormatUnknownArgumentsError:
+    """Unit tests for the _format_unknown_arguments_error helper."""
+
+    def test_single_unknown_argument(self):
+        msg = _format_unknown_arguments_error(
+            "focus_window", ["window_title"], ["app", "hwnd", "title"],
+        )
+        assert msg == (
+            "Invalid parameters for focus_window: unexpected argument "
+            "'window_title'. Valid arguments: app, hwnd, title."
+        )
+        assert "pydantic" not in msg.lower()
+
+    def test_multiple_unknown_arguments_pluralised_and_sorted(self):
+        msg = _format_unknown_arguments_error(
+            "click", ["zeta", "alpha"], ["x", "y"],
+        )
+        assert "unexpected arguments 'alpha', 'zeta'" in msg
+        assert msg.startswith("Invalid parameters for click:")
+
+    def test_no_valid_arguments_renders_none(self):
+        msg = _format_unknown_arguments_error("list_monitors", ["foo"], [])
+        assert "Valid arguments: (none)." in msg
+
+
+class TestAllowedArgumentNames:
+    """Unit tests for the per-tool allow-list lookup."""
+
+    @staticmethod
+    def _server():
+        from unittest.mock import patch
+        from naturo.mcp_server import create_server
+
+        with patch("naturo.mcp_server.get_backend"):
+            return create_server()
+
+    def test_known_tool_allows_declared_params_only(self):
+        allowed = self._server()._allowed_argument_names("focus_window")
+        assert allowed is not None
+        assert {"title", "app", "hwnd"} <= allowed
+        assert "window_title" not in allowed
+
+    def test_unknown_tool_returns_none(self):
+        # None signals "no enforceable allow-list" so dispatch surfaces the
+        # canonical "Unknown tool" error instead of an unknown-argument one.
+        assert self._server()._allowed_argument_names("not_a_real_tool") is None
+
+
+class TestDispatchRejection:
+    """End-to-end rejection through the real JSON-RPC dispatch path."""
+
+    def test_mistyped_param_name_rejected(self):
+        """The #891 repro: focus_window with ``window_title`` must fail loudly.
+
+        Previously this silently dropped ``window_title``, fell back to the
+        foreground window, and leaked the ``foreground`` sentinel in a
+        downstream WINDOW_NOT_FOUND message.
+        """
+        result = _dispatch("focus_window", {"window_title": "claude"})
+
+        assert result.isError is True
+        text = result.content[0].text
+        assert "Invalid parameters for focus_window" in text
+        assert "window_title" in text
+        # No silent success and no Pydantic leakage.
+        assert '"success": true' not in text.lower()
+        assert "pydantic" not in text.lower()
+
+    def test_extra_arg_alongside_valid_rejected(self):
+        """An unknown arg next to a valid one must not pass as success (#891)."""
+        result = _dispatch(
+            "focus_window", {"title": "claude", "bogus_extra_param": "foo"},
+        )
+
+        assert result.isError is True
+        text = result.content[0].text
+        assert "bogus_extra_param" in text
+        assert "Invalid parameters for focus_window" in text
+
+    def test_unknown_tool_still_reports_unknown_tool(self):
+        """A genuinely unknown tool keeps its canonical error, not ours."""
+        result = _dispatch("definitely_not_a_real_tool", {"title": "x"})
+
+        assert result.isError is True
+        text = result.content[0].text
+        assert "definitely_not_a_real_tool" in text
+        assert "unexpected argument" not in text


### PR DESCRIPTION
## What
MCP tool calls silently dropped arguments not declared in the schema. A mistyped or drifted parameter name (e.g. `focus_window {window_title: ...}` instead of `{title: ...}`) was discarded by FastMCP's Pydantic argument model, so the call ran with default behaviour — focusing the *foreground* window and leaking the internal `foreground` sentinel in a downstream `WINDOW_NOT_FOUND` message — instead of failing loudly. An extra unknown arg next to a valid one was accepted as `success: true`. This is a silent-failure / 'never lie' violation (#891).

## How
`_SanitizingFastMCP.call_tool` now checks supplied argument names against the tool's declared JSON-Schema `properties` **before** dispatch. Unknown args raise a clean `ToolError` — `"Invalid parameters for <tool>: unexpected argument '<name>'. Valid arguments: ..."` — placing them on the same `isError: true` 'Invalid parameters' path as the existing Pydantic wrong-type/missing-field validation (#844), with no Pydantic leakage. The allow-list lookup returns `None` (no enforcement) for unknown tools (so the canonical 'Unknown tool' error still surfaces) and for schemas that explicitly permit additional properties; the injected FastMCP `Context` param is re-added when present. No tool uses `**kwargs`, so forbidding extras is uniformly safe across all 64 tools.

## How tested
- New `tests/test_mcp_unknown_args_891.py` (8 tests, desktop-independent — rejection precedes any backend call): message formatter (single/plural/empty), per-tool allow-list lookup, and end-to-end rejection through the real low-level JSON-RPC dispatch path for the #891 repro (`window_title`) and the extra-arg-alongside-valid case; plus a guard that genuinely unknown tools keep their canonical error.
- Existing #844 sanitization suite (`test_mcp_pydantic_leak.py`) still green — the `launch_app {app_name}` case now flows through the unknown-arg path with an equivalent clean `isError: true` message.
- `ruff` clean; `mypy` clean on changed file (the only local mypy error is a pre-existing 3.10 `match` syntax issue inside the third-party `mcp` package; CI Lint passes).
- Full MCP suite: 322 passed (56 errors are a pre-existing local `tmp_path` WinError5 env issue, unrelated; CI's fresh tmp is unaffected).