### PR TITLE
feat: add --file/stdin input to clipboard set (fixes #888)

### DIFF
--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -1478,19 +1478,25 @@ Write text to the clipboard.
 
 | Name | Type | Required |
 |------|------|----------|
-| `TEXT` | text | yes |
+| `TEXT` | text | no — supply via `TEXT`, `--file`, or stdin (`-`) |
 
 **Options:**
 
 | Flag | Type | Description |
 |------|------|-------------|
+| `--file PATH` | path | Read text from a file (mirrors `naturo type --file`) |
 | `--json`, `-j` | boolean | JSON output |
+
+Exactly one source must be supplied. `--file` and stdin avoid the shell
+ARG_MAX limit (~32 KB) that caps a positional argument, and preserve real
+newlines without shell-specific quoting.
 
 **Examples:**
 
 ```bash
-naturo clipboard set "hello world"      # Set clipboard text
-naturo clipboard set "line1\nline2"     # Multi-line text
+naturo clipboard set "hello world"      # Literal text
+naturo clipboard set --file notes.txt   # Read text from a file
+naturo see -j | naturo clipboard set -  # Read text from stdin
 ```
 
 ## `naturo config`

--- a/naturo/cli/system/_clipboard.py
+++ b/naturo/cli/system/_clipboard.py
@@ -17,7 +17,7 @@ import sys
 
 import click
 
-from naturo.cli.error_helpers import emit_exception_error
+from naturo.cli.error_helpers import emit_error, emit_exception_error
 from naturo.cli.fuzzy_group import FuzzyGroup
 
 
@@ -35,6 +35,59 @@ def _get_backend(json_output: bool = False):
             }))
             sys.exit(1)
         raise click.UsageError(str(exc))
+
+
+def _resolve_set_text(text: str | None, file_path: str | None, json_output: bool) -> str:
+    """Resolve the clipboard-set payload from the chosen input source.
+
+    Exactly one source must be supplied: the positional ``text``, a ``--file``
+    path, or stdin (signalled by passing ``-`` as ``text``, the jq/sed
+    convention). File and stdin sources sidestep the shell ARG_MAX limit that
+    caps a positional argument and preserve real newlines verbatim.
+
+    Args:
+        text: The positional ``TEXT`` argument, ``-`` for stdin, or ``None``.
+        file_path: Path supplied via ``--file``, or ``None``.
+        json_output: Whether errors should be emitted as JSON.
+
+    Returns:
+        The resolved payload string to write to the clipboard.
+
+    Raises:
+        SystemExit: Via :func:`emit_error` when no source, multiple sources, or a
+            missing/unreadable file is supplied. The process exits with code 1
+            and a canonical ``INVALID_INPUT`` error envelope.
+    """
+    if file_path is not None and text is not None:
+        emit_error(
+            "INVALID_INPUT",
+            "Provide the text either as the TEXT argument, via --file, or on "
+            "stdin ('-') — not more than one source.",
+            json_output,
+        )
+
+    if file_path is not None:
+        import os
+        if not os.path.exists(file_path):
+            emit_error("INVALID_INPUT", f"File not found: {file_path}", json_output)
+        try:
+            with open(file_path, "r", encoding="utf-8") as handle:
+                return handle.read()
+        except OSError as exc:
+            emit_error("INVALID_INPUT", f"Could not read file: {exc}", json_output)
+
+    if text == "-":
+        return sys.stdin.read()
+
+    if text is None:
+        emit_error(
+            "INVALID_INPUT",
+            "No text to set. Provide a TEXT argument, --file PATH, or '-' to "
+            "read from stdin.",
+            json_output,
+        )
+
+    return text
 
 
 @click.group(cls=FuzzyGroup)
@@ -92,18 +145,27 @@ def get(fmt: str, json_output: bool) -> None:
 
 
 @clipboard.command()
-@click.argument("text")
+@click.argument("text", required=False)
+@click.option("--file", "file_path", type=click.Path(),
+              help="Read text from a file (mirrors 'naturo type --file')")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def set(text: str, json_output: bool) -> None:
+def set(text: str | None, file_path: str | None, json_output: bool) -> None:
     """Write text to the clipboard.
 
-    Replaces the current clipboard content with the specified text.
+    Replaces the current clipboard content. The payload may come from a
+    positional TEXT argument, from a file via --file, or from stdin by passing
+    ``-`` as TEXT. --file and stdin avoid the shell ARG_MAX limit (~32 KB) that
+    caps a positional argument, and preserve real newlines without shell-specific
+    quoting. Exactly one source must be supplied.
 
     \b
     Examples:
-        naturo clipboard set "hello world"      # Set clipboard text
-        naturo clipboard set "line1\\nline2"     # Multi-line text
+        naturo clipboard set "hello world"      # Literal text
+        naturo clipboard set --file notes.txt   # Read text from a file
+        naturo see -j | naturo clipboard set -  # Read text from stdin
     """
+    text = _resolve_set_text(text, file_path, json_output)
+
     backend = _get_backend(json_output)
     try:
         backend.clipboard_set(text)

--- a/tests/test_clipboard_set_input_888.py
+++ b/tests/test_clipboard_set_input_888.py
@@ -1,0 +1,140 @@
+"""Tests for 'naturo clipboard set' file/stdin input sources (issue #888).
+
+`naturo type` accepts ``--file PATH`` for large/multi-line payloads; `clipboard
+set` historically only took a positional ``TEXT`` argument bounded by the shell
+ARG_MAX limit. These tests pin the symmetric input paths added in #888:
+
+* ``--file PATH`` reads the clipboard payload from a file (mirrors ``type --file``)
+* ``-`` reads the payload from stdin (jq/sed convention)
+* mutually-exclusive sources and a missing file fail with a clean error envelope
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from naturo.cli.system import clipboard
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_backend():
+    return MagicMock()
+
+
+class TestClipboardSetFromFile:
+    """'naturo clipboard set --file PATH' reads the payload from a file."""
+
+    def test_set_from_file(self, runner, mock_backend, tmp_path):
+        payload = "line1\nline2\nline3"
+        src = tmp_path / "note.txt"
+        src.write_text(payload, encoding="utf-8")
+        with patch("naturo.backends.base.get_backend", return_value=mock_backend):
+            result = runner.invoke(clipboard, ["set", "--file", str(src)])
+        assert result.exit_code == 0
+        mock_backend.clipboard_set.assert_called_once_with(payload)
+
+    def test_set_from_file_json_length(self, runner, mock_backend, tmp_path):
+        payload = "x" * 51200  # exceeds the shell ARG_MAX positional cap
+        src = tmp_path / "big.txt"
+        src.write_text(payload, encoding="utf-8")
+        with patch("naturo.backends.base.get_backend", return_value=mock_backend):
+            result = runner.invoke(clipboard, ["set", "--file", str(src), "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["success"] is True
+        assert data["length"] == 51200
+        mock_backend.clipboard_set.assert_called_once_with(payload)
+
+    def test_set_from_file_preserves_real_newlines(self, runner, mock_backend, tmp_path):
+        # A real newline in the file must reach the backend as a real newline,
+        # not a literal backslash-n (the misleading-help case from #888).
+        src = tmp_path / "multi.txt"
+        src.write_text("a\nb", encoding="utf-8")
+        with patch("naturo.backends.base.get_backend", return_value=mock_backend):
+            result = runner.invoke(clipboard, ["set", "--file", str(src)])
+        assert result.exit_code == 0
+        (stored,), _ = mock_backend.clipboard_set.call_args
+        assert stored == "a\nb"
+        assert "\\n" not in stored
+
+    def test_set_missing_file(self, runner, mock_backend, tmp_path):
+        missing = tmp_path / "does_not_exist.txt"
+        with patch("naturo.backends.base.get_backend", return_value=mock_backend):
+            result = runner.invoke(clipboard, ["set", "--file", str(missing), "--json"])
+        assert result.exit_code != 0
+        data = json.loads(result.output)
+        assert data["success"] is False
+        assert data["error"]["code"] == "INVALID_INPUT"
+        mock_backend.clipboard_set.assert_not_called()
+
+
+class TestClipboardSetFromStdin:
+    """'naturo clipboard set -' reads the payload from stdin."""
+
+    def test_set_from_stdin(self, runner, mock_backend):
+        with patch("naturo.backends.base.get_backend", return_value=mock_backend):
+            result = runner.invoke(clipboard, ["set", "-"], input="piped text")
+        assert result.exit_code == 0
+        mock_backend.clipboard_set.assert_called_once_with("piped text")
+
+    def test_set_from_stdin_json(self, runner, mock_backend):
+        with patch("naturo.backends.base.get_backend", return_value=mock_backend):
+            result = runner.invoke(clipboard, ["set", "-", "--json"], input="hello\nworld")
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["success"] is True
+        assert data["length"] == len("hello\nworld")
+        mock_backend.clipboard_set.assert_called_once_with("hello\nworld")
+
+
+class TestClipboardSetSourceValidation:
+    """Source selection is mutually exclusive and at least one is required."""
+
+    def test_text_and_file_conflict(self, runner, mock_backend, tmp_path):
+        src = tmp_path / "note.txt"
+        src.write_text("from file", encoding="utf-8")
+        with patch("naturo.backends.base.get_backend", return_value=mock_backend):
+            result = runner.invoke(
+                clipboard, ["set", "literal", "--file", str(src), "--json"]
+            )
+        assert result.exit_code != 0
+        data = json.loads(result.output)
+        assert data["success"] is False
+        assert data["error"]["code"] == "INVALID_INPUT"
+        mock_backend.clipboard_set.assert_not_called()
+
+    def test_no_source(self, runner, mock_backend):
+        # No positional TEXT, no --file, no stdin marker -> clean error.
+        with patch("naturo.backends.base.get_backend", return_value=mock_backend):
+            result = runner.invoke(clipboard, ["set", "--json"])
+        assert result.exit_code != 0
+        data = json.loads(result.output)
+        assert data["success"] is False
+        assert data["error"]["code"] == "INVALID_INPUT"
+        mock_backend.clipboard_set.assert_not_called()
+
+    def test_literal_text_still_works(self, runner, mock_backend):
+        # Regression: the plain positional path is unchanged.
+        with patch("naturo.backends.base.get_backend", return_value=mock_backend):
+            result = runner.invoke(clipboard, ["set", "hello world"])
+        assert result.exit_code == 0
+        mock_backend.clipboard_set.assert_called_once_with("hello world")
+
+
+class TestClipboardSetHelp:
+    """Help text documents the new sources and drops the misleading example."""
+
+    def test_help_mentions_file_and_stdin(self, runner):
+        result = runner.invoke(clipboard, ["set", "--help"])
+        assert result.exit_code == 0
+        assert "--file" in result.output
+        # The old example implied naturo interprets a literal '\n' as a newline,
+        # which it never did (#888). It must be gone.
+        assert "line1\\nline2" not in result.output

--- a/tests/test_subcommand_usage_error_json_872.py
+++ b/tests/test_subcommand_usage_error_json_872.py
@@ -77,8 +77,12 @@ class TestSubcommandUsageErrorJson:
         return data
 
     def test_missing_required_argument(self, monkeypatch, capsys):
+        # ``app find`` requires a positional NAME and defines ``-j``, so omitting
+        # the argument is a parse-time "Missing argument" error. (``clipboard
+        # set`` used to be the exemplar here but gained optional --file/stdin
+        # sources in #888, so its TEXT argument is no longer required.)
         data = self._assert_envelope(
-            monkeypatch, capsys, ["clipboard", "set", "-j"], "INVALID_INPUT"
+            monkeypatch, capsys, ["app", "find", "-j"], "INVALID_INPUT"
         )
         assert "Missing argument" in data["error"]["message"]
 
@@ -147,10 +151,12 @@ class TestFlagPositionVariants:
 
 class TestPlainTextUnchanged:
     def test_missing_arg_plain_text_exit_2(self, monkeypatch, capsys):
-        code = _run(monkeypatch, ["clipboard", "set"])
+        # See test_missing_required_argument: ``app find`` is the missing-arg
+        # exemplar now that ``clipboard set`` accepts --file/stdin (#888).
+        code = _run(monkeypatch, ["app", "find"])
         captured = capsys.readouterr()
         assert code == 2  # Click's UsageError exit code, unchanged
-        assert "Usage: naturo clipboard set" in captured.err
+        assert "Usage: naturo app find" in captured.err
         assert captured.out == ""  # nothing on stdout — no stray JSON
 
     def test_invalid_value_plain_text_exit_2(self, monkeypatch, capsys):


### PR DESCRIPTION
## What
`naturo clipboard set` only accepted a positional `TEXT` argument, bounded by the shell ARG_MAX limit (~32 KB), with no naturo-native way to set a large or multi-line payload. This adds the symmetric input paths that `naturo type --file` already has:

- `--file PATH` — read the payload from a file (UTF-8), mirroring `type --file`.
- `-` as `TEXT` — read the payload from stdin (jq/sed convention).
- Exactly one source is enforced; missing/unreadable file and no-source cases emit the canonical `INVALID_INPUT` error envelope.

Also removes the misleading help/docs example `clipboard set "line1\nline2"`, which implied naturo interprets a literal `\n` as a newline — it never did (SOUL: never lie). Both new sources preserve real newlines verbatim, so an AI agent can place >32 KB content on the clipboard from the CLI.

## How tested
- New `tests/test_clipboard_set_input_888.py` (10 tests, desktop-independent — backend mocked): `--file` read, large (51 200-char) payload length, real-newline preservation, missing file, stdin read (+`-j`), text/file conflict, no-source error, literal-text regression, help-text contract.
- `ruff check` clean; `mypy` clean on the changed file (`--follow-imports=silent`; the local full run hits the known third-party `mcp` 3.10-`match` env mismatch, green on CI).
- Regression: `test_clipboard_cmd.py`, `test_clipboard.py`, `test_mcp_clipboard.py`, `test_cli_type.py`, `test_cli_reference_gen.py`, `test_help_command.py` all green.
- `--collect-only` succeeds (no Windows/optional-dep imports → CI-safe).

Closes #888 on merge.