### PR TITLE
fix: harmonize window-targeting flags on find/highlight/menu-inspect (part of #871)

### DIFF
--- a/naturo/cli/core/_find.py
+++ b/naturo/cli/core/_find.py
@@ -25,6 +25,10 @@ import naturo.cli.core._common as _common
 @click.option("--app", default=None, help="Target app window")
 @click.option("--app-id", "app_id", default=None,
               help='Stable app/window ID from "naturo app list" output (e.g. a1)')
+@click.option("--window", "window_title", default=None,
+              help="Window title pattern (substring match)")
+@click.option("--hwnd", default=None, type=int, help="Window handle (HWND)")
+@click.option("--pid", default=None, type=int, help="Process ID")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.option(
     "--backend", "--method", "-b", "-m",
@@ -43,6 +47,7 @@ def find_cmd(query: str | None, query_opt: str | None, find_all: bool, role: str
              actionable: bool, depth: int, limit: int, ai: bool,
              ai_provider: str, ai_model: str | None, ai_api_key: str | None,
              screenshot: str | None, app: str | None, app_id: str | None,
+             window_title: str | None, hwnd: int | None, pid: int | None,
              json_output: bool, backend: str) -> None:
     """Search for UI elements matching a query.
 
@@ -67,8 +72,8 @@ def find_cmd(query: str | None, query_opt: str | None, find_all: bool, role: str
     from naturo.cli.options import maybe_promote_app_to_app_id
     app, app_id = maybe_promote_app_to_app_id(app, app_id)
 
-    # (#593) Resolve --app-id to hwnd before any other logic
-    hwnd = None
+    # (#593) Resolve --app-id to hwnd before any other logic.
+    # An explicit --app-id takes precedence over a raw --hwnd value.
     if app_id is not None:
         from naturo.app_ids import get_app_id_map
         id_map = get_app_id_map()
@@ -107,6 +112,18 @@ def find_cmd(query: str | None, query_opt: str | None, find_all: bool, role: str
 
     # AI vision mode — natural language element finding
     if ai:
+        # AI vision operates on a screenshot, not the UIA tree, so window-handle
+        # targeting does not apply.  Reject it explicitly rather than silently
+        # ignoring the flags — use --app to scope the captured app instead.
+        if window_title is not None or hwnd is not None or pid is not None:
+            msg = ("--window/--hwnd/--pid are not supported with --ai "
+                   "(vision mode operates on a screenshot); use --app to scope "
+                   "the target application.")
+            if json_output:
+                click.echo(_common._json_error_str("INVALID_INPUT", msg))
+            else:
+                click.echo(f"Error: {msg}", err=True)
+            raise SystemExit(1)
         _find_with_ai(query, ai_provider, screenshot, app, json_output,
                       model=ai_model, api_key=ai_api_key)
         return
@@ -130,7 +147,8 @@ def find_cmd(query: str | None, query_opt: str | None, find_all: bool, role: str
 
     try:
         be = _common._get_backend(json_output)
-        tree = be.get_element_tree(app=app, hwnd=hwnd, depth=depth, backend=backend)
+        tree = be.get_element_tree(app=app, window_title=window_title, hwnd=hwnd,
+                                   pid=pid, depth=depth, backend=backend)
         if tree is None:
             msg = "No window found or UI tree is empty."
             if json_output:

--- a/naturo/cli/core/_highlight.py
+++ b/naturo/cli/core/_highlight.py
@@ -16,6 +16,8 @@ logger = logging.getLogger(__name__)
 @click.option("--on", "on_ref", help="Target element ref (eN) to highlight")
 @click.option("--ref", "-r", "ref_option", multiple=True, help="Specific refs to highlight (e.g. -r e5 -r e10). Omit for all.")
 @click.option("--app", "-a", help="Application name (partial match)")
+@click.option("--window", "window_title", default=None,
+              help="Window title pattern (substring match)")
 @click.option("--hwnd", type=int, help="Direct window handle")
 @click.option("--app-id", "app_id", default=None,
               help='Stable app/window ID from "naturo app list" output (e.g. a1)')
@@ -40,9 +42,9 @@ logger = logging.getLogger(__name__)
 @click.option("--fill-gaps", "fill_gaps", is_flag=True,
               help="Use AI vision to fill uncovered regions (requires --cascade)")
 @click.option("--pid", type=int, default=None, help="Process ID")
-def highlight(positional_refs, on_ref, ref_option, app, hwnd, app_id, depth, duration,
-              json_output, backend, show_all, annotate_path, role_filter,
-              visible_only, cascade, fill_gaps, pid) -> None:
+def highlight(positional_refs, on_ref, ref_option, app, window_title, hwnd, app_id,
+              depth, duration, json_output, backend, show_all, annotate_path,
+              role_filter, visible_only, cascade, fill_gaps, pid) -> None:
     """Highlight UI elements on screen with colored borders and labels.
 
     By default highlights only actionable elements (Button, Edit, ComboBox,
@@ -91,7 +93,7 @@ def highlight(positional_refs, on_ref, ref_option, app, hwnd, app_id, depth, dur
 
     be = _common._get_backend(json_output)
     try:
-        handle = be._resolve_hwnd(app=app, hwnd=hwnd, pid=pid)
+        handle = be._resolve_hwnd(app=app, window_title=window_title, hwnd=hwnd, pid=pid)
     except Exception as exc:
         if json_output:
             click.echo(_common._json_error_str("WINDOW_NOT_FOUND", str(exc)))

--- a/naturo/cli/core/_menu.py
+++ b/naturo/cli/core/_menu.py
@@ -12,18 +12,25 @@ import naturo.cli.core._common as _common
 @click.option("--app", help="Application name")
 @click.option("--app-id", "app_id", default=None,
               help='Stable app/window ID from "naturo app list" output (e.g. a1)')
+@click.option("--window", "window_title", default=None,
+              help="Window title pattern (substring match)")
+@click.option("--hwnd", default=None, type=int, help="Window handle (HWND)")
+@click.option("--pid", default=None, type=int, help="Process ID")
 @click.option("--flat", is_flag=True, help="Flatten menu tree into paths")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def menu_inspect(app, app_id, flat, json_output) -> None:
-    """List the menu bar structure of the foreground application.
+def menu_inspect(app, app_id, window_title, hwnd, pid, flat, json_output) -> None:
+    """List the menu bar structure of a window.
 
     Traverses the application's MenuBar via UIAutomation and displays
-    all menu items with their keyboard shortcuts.
+    all menu items with their keyboard shortcuts.  Targets the foreground
+    window by default, or a specific window via --app/--window/--hwnd/--pid.
 
     \b
     Examples:
       naturo menu-inspect                     # Foreground app
       naturo menu-inspect --app notepad       # Specific app
+      naturo menu-inspect --window Untitled   # By window title
+      naturo menu-inspect --pid 4321          # By process ID
       naturo menu-inspect --flat              # Flat path list
       naturo menu-inspect --app notepad --json # JSON output
     """
@@ -31,8 +38,8 @@ def menu_inspect(app, app_id, flat, json_output) -> None:
     from naturo.cli.options import maybe_promote_app_to_app_id
     app, app_id = maybe_promote_app_to_app_id(app, app_id)
 
-    # (#593) Resolve --app-id to hwnd before any other logic
-    hwnd = None
+    # (#593) Resolve --app-id to hwnd before any other logic.
+    # An explicit --app-id takes precedence over a raw --hwnd value.
     if app_id is not None:
         from naturo.app_ids import get_app_id_map
         id_map = get_app_id_map()
@@ -76,7 +83,23 @@ def menu_inspect(app, app_id, flat, json_output) -> None:
             except Exception:
                 pass  # find_process failed for other reasons, fall through
 
-        items = backend.get_menu_items(window_title=app, hwnd=hwnd)
+        # Resolve the full window-targeting flag set (--app/--window/--hwnd/--pid)
+        # to a single handle via the shared resolver, then inspect that window's
+        # menu.  Resolving here (rather than passing --app through as a window
+        # title) keeps targeting consistent with see/click/highlight (#871).
+        from naturo.errors import WindowNotFoundError
+        try:
+            handle = backend._resolve_hwnd(
+                app=app, window_title=window_title, hwnd=hwnd, pid=pid,
+            )
+        except WindowNotFoundError as exc:
+            if json_output:
+                click.echo(_common._json_error_str("WINDOW_NOT_FOUND", str(exc)))
+            else:
+                click.echo(f"Error: {exc}", err=True)
+            raise SystemExit(1)
+
+        items = backend.get_menu_items(hwnd=handle)
 
         if not items:
             msg = "No menu items found."

--- a/tests/test_cli_menu.py
+++ b/tests/test_cli_menu.py
@@ -125,11 +125,19 @@ class TestNoMenuItems:
 class TestAppFilter:
 
     def test_app_passed_to_backend(self, runner, mock_backend):
+        # (#871) --app is resolved to a concrete handle via the shared
+        # _resolve_hwnd resolver, then that handle is inspected.  This keeps
+        # window targeting consistent with see/click/highlight and avoids the
+        # old conflation of passing the app name as a window title.
+        mock_backend._resolve_hwnd.return_value = 12345
         with _patch_platform(), _patch_backend(mock_backend), \
              patch("naturo.process.find_process", return_value={"name": "notepad"}):
             result = runner.invoke(menu_inspect, ["--app", "notepad"], catch_exceptions=False)
         assert result.exit_code == 0
-        mock_backend.get_menu_items.assert_called_once_with(window_title="notepad", hwnd=None)
+        mock_backend._resolve_hwnd.assert_called_once_with(
+            app="notepad", window_title=None, hwnd=None, pid=None,
+        )
+        mock_backend.get_menu_items.assert_called_once_with(hwnd=12345)
 
 
 # ── Platform check ───────────────────────────────────────────────────

--- a/tests/test_window_targeting_flags_871.py
+++ b/tests/test_window_targeting_flags_871.py
@@ -1,0 +1,65 @@
+"""#871: window-targeting flag harmonization for element/menu discovery commands.
+
+The window-targeting flag family (``--app``, ``--window``, ``--hwnd``, ``--pid``,
+``--app-id``) was exposed inconsistently across subcommands, forcing scripters to
+memorise a per-command matrix.  The "gold standard" commands
+(``see``/``click``/``type``/...) accept the full set; the element/menu *discovery*
+commands ``find``, ``highlight``, and ``menu-inspect`` had gaps.
+
+These three commands all resolve their target window through the same DLL-backed
+``_resolve_hwnd`` / ``get_element_tree`` / ``get_menu_items`` path, so the full
+flag set can be threaded uniformly.  These tests assert the flags are now
+accepted (no Click ``No such option`` rejection) and visible in ``--help``.
+
+Commands that route through other resolution paths (``get``/``set`` value
+patterns, ``list windows`` enumeration, ``app focus``/``quit`` lifecycle) are
+tracked separately in #871 and are out of scope here.
+"""
+from __future__ import annotations
+
+import pytest
+from click.testing import CliRunner
+
+from naturo.cli import main
+
+runner = CliRunner()
+
+# Element/menu discovery commands harmonised by this change and the full
+# window-targeting flag set each must expose.
+_DISCOVERY_COMMANDS = [
+    ["find"],
+    ["highlight"],
+    ["menu-inspect"],
+]
+_WINDOW_TARGET_FLAGS = ["--app", "--window", "--hwnd", "--pid", "--app-id"]
+
+
+@pytest.mark.parametrize("cmd_args", _DISCOVERY_COMMANDS)
+@pytest.mark.parametrize("flag", _WINDOW_TARGET_FLAGS)
+def test_window_target_flag_in_help(cmd_args, flag):
+    """Each discovery command's --help must list the full window-targeting flag set."""
+    result = runner.invoke(main, cmd_args + ["--help"])
+    assert result.exit_code == 0, (
+        f"naturo {' '.join(cmd_args)} --help failed:\n{result.output}"
+    )
+    assert flag in result.output, (
+        f"naturo {' '.join(cmd_args)} --help missing {flag}:\n{result.output}"
+    )
+
+
+@pytest.mark.parametrize("cmd_args", _DISCOVERY_COMMANDS)
+@pytest.mark.parametrize(
+    "flag_with_value",
+    [["--window", "Untitled"], ["--hwnd", "12345"], ["--pid", "4321"]],
+)
+def test_window_target_flag_accepted(cmd_args, flag_with_value):
+    """The flag must be parsed (not rejected with Click 'No such option').
+
+    The command may still fail for other reasons (no desktop session, window
+    not found) — what matters is that argument parsing reaches the handler
+    rather than aborting at the Click layer.
+    """
+    result = runner.invoke(main, cmd_args + flag_with_value)
+    assert "No such option" not in result.output, (
+        f"naturo {' '.join(cmd_args + flag_with_value)} rejected the flag:\n{result.output}"
+    )


### PR DESCRIPTION
## What

Part of #871 — window-targeting flags (`--app`/`--window`/`--hwnd`/`--pid`/`--app-id`) are exposed inconsistently across subcommands. This harmonizes the **DLL-backed element/menu discovery commands** so they accept the full set, matching the `see`/`click`/`type` "gold standard":

| Command | Added flags |
|---|---|
| `find` | `--window`, `--hwnd`, `--pid` |
| `highlight` | `--window` |
| `menu-inspect` | `--window`, `--hwnd`, `--pid` |

These three all resolve their target window through the same `_resolve_hwnd` / `get_element_tree` / `get_menu_items` path, so the flags thread uniformly **with no backend signature changes**.

Notable behavior choices:
- `find --ai` with `--window`/`--hwnd`/`--pid` is now **rejected with a clear `INVALID_INPUT` error** rather than silently ignored — AI vision operates on a screenshot, not the UIA tree (use `--app` to scope). Avoids the silent-failure shape.
- `menu-inspect` now resolves `--app` to a concrete handle via the shared resolver instead of conflating the app name with the window title.

## Scope / remaining work

This is a **focused subset** of #871, consistent with how `--app-id` was rolled out incrementally (#584/#593). The remaining commands named in the issue — `get`/`set` (value patterns), `list windows` (enumeration filtering), `app focus`/`app quit` (process lifecycle) — route through **different resolution paths** that require cross-platform backend method signature changes (and the comtypes UIA path). They are intentionally left for a follow-up. #871 stays open.

## How tested

- New `tests/test_window_targeting_flags_871.py`: parametrized — asserts the full flag set is accepted (no Click "No such option") and present in `--help` for all three commands (CI-safe, no desktop).
- Updated `tests/test_cli_menu.py` to the new resolve-then-inspect contract.
- Local quality gate: `ruff` clean, `mypy` clean on changed files (`--follow-imports=skip`; the repo-wide mypy halts on a pre-existing third-party `mcp` 3.10-syntax issue on this runner). `pytest -m "not desktop"` across the CLI blast radius: all relevant tests pass; full-suite collection clean (6587 tests).
- Live smoke (Win11 + DLL): `find --pid <bad>` reaches the handler and fails with a real "Window not found" (no longer "No such option"); `find --ai --pid` correctly rejected; `menu-inspect --help` lists the new flags.