### PR TITLE
fix: highlight reads newest snapshot, not oldest (fixes #1038)

### DIFF
--- a/naturo/bridge/_highlight.py
+++ b/naturo/bridge/_highlight.py
@@ -369,7 +369,9 @@ def highlight_elements_uia(
         try:
             snaps = mgr.list_snapshots()
             if snaps:
-                snap = mgr.get_snapshot(snaps[-1].id)
+                # list_snapshots() is newest-first, so index 0 is the most
+                # recent snapshot (the one a preceding ``see`` just stored).
+                snap = mgr.get_snapshot(snaps[0].id)
         except Exception as exc:
             logger.debug("Snapshot retrieval for highlight failed: %s", exc)
 
@@ -406,7 +408,8 @@ def highlight_elements_uia(
     try:
         snaps = mgr.list_snapshots()
         if snaps:
-            latest = snaps[-1]
+            # list_snapshots() is newest-first; index 0 is the latest snapshot.
+            latest = snaps[0]
             snap = mgr.get_snapshot(latest.id)
             if snap.ui_map:
                 _found_snapshot = True

--- a/naturo/cli/core/_highlight.py
+++ b/naturo/cli/core/_highlight.py
@@ -163,7 +163,12 @@ def highlight(positional_refs, on_ref, ref_option, app, window_title, hwnd, app_
                         click.echo(f"Annotated screenshot saved: {result_path}")
                     return
                 else:
-                    msg = "No snapshot with screenshot available for --annotate. Run 'naturo see' first."
+                    msg = (
+                        "No snapshot with a stored screenshot is available for "
+                        "--annotate. Run 'naturo see --path <file>' first: a "
+                        "screenshot is only persisted into the snapshot when "
+                        "'see' is given --path."
+                    )
                     if json_output:
                         click.echo(_common._json_error_str("NO_SNAPSHOT", msg))
                         raise SystemExit(1)

--- a/tests/test_highlight_snapshot_order_1038.py
+++ b/tests/test_highlight_snapshot_order_1038.py
@@ -1,0 +1,78 @@
+"""Regression tests for #1038 — highlight reads newest snapshot, not oldest.
+
+``naturo.snapshot.SnapshotManager.list_snapshots()`` returns snapshots
+**newest-first** (``infos.sort(..., reverse=True)``), so index ``0`` is the
+most recent and index ``-1`` is the oldest.  ``highlight_elements_uia`` must
+select the newest snapshot in both its annotate and live-overlay paths.
+
+Before the fix it used ``snaps[-1]`` (the oldest snapshot), which typically
+has no stored screenshot — causing ``highlight --annotate`` to always fail
+with ``NO_SNAPSHOT`` even right after a successful ``see``.  These tests are
+mock-based and CI-safe (no DLL / desktop required).
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from naturo.bridge import _highlight
+
+
+def _snapshot_info(snapshot_id: str) -> MagicMock:
+    """Build a minimal ``SnapshotInfo``-like stub exposing only ``.id``."""
+    info = MagicMock()
+    info.id = snapshot_id
+    return info
+
+
+def _make_manager() -> MagicMock:
+    """Manager whose newest snapshot has a screenshot and the oldest does not.
+
+    ``list_snapshots()`` returns newest-first, mirroring the real
+    implementation: ``["new", "old"]``.
+    """
+    newest = MagicMock()
+    newest.ui_map = {"e1": MagicMock()}
+    newest.screenshot_path = "C:/snaps/new/raw.png"
+
+    oldest = MagicMock()
+    oldest.ui_map = None
+    oldest.screenshot_path = None  # the symptom: oldest never has a screenshot
+
+    mgr = MagicMock()
+    mgr.list_snapshots.return_value = [_snapshot_info("new"), _snapshot_info("old")]
+    mgr.get_snapshot.side_effect = lambda sid: {"new": newest, "old": oldest}[sid]
+    return mgr
+
+
+def test_annotate_uses_newest_snapshot() -> None:
+    """Annotate mode must read the newest snapshot (``snaps[0]``), not oldest."""
+    mgr = _make_manager()
+    with patch("naturo.snapshot.get_snapshot_manager", return_value=mgr), \
+            patch("naturo.annotate.highlight_annotate", return_value="out.png") as mock_ann:
+        result = _highlight.highlight_elements_uia(
+            backend=MagicMock(),
+            app="notepad",
+            annotate_path="out.png",
+        )
+
+    assert result == "out.png"
+    mgr.get_snapshot.assert_called_once_with("new")
+    # The newest snapshot's screenshot must be the one annotated.
+    assert mock_ann.call_args.kwargs["screenshot_path"] == "C:/snaps/new/raw.png"
+
+
+def test_live_overlay_uses_newest_snapshot() -> None:
+    """Live-overlay mode must also resolve the newest snapshot (``snaps[0]``)."""
+    mgr = _make_manager()
+    backend = MagicMock()
+    backend.get_element_tree.return_value = None
+    with patch("naturo.snapshot.get_snapshot_manager", return_value=mgr), \
+            patch.object(_highlight.platform, "system", return_value="Windows"), \
+            patch.object(_highlight, "_draw_gdi_overlay"):
+        _highlight.highlight_elements_uia(
+            backend=backend,
+            app="notepad",
+            duration=0.0,
+        )
+
+    mgr.get_snapshot.assert_called_once_with("new")


### PR DESCRIPTION
## What
`naturo highlight --annotate/-A` always failed with `NO_SNAPSHOT` even right after a successful `see`. Root cause: `highlight_elements_uia()` read `snaps[-1]` in **both** the annotate and live-overlay paths, but `snapshot.list_snapshots()` returns snapshots **newest-first** (`sort(..., reverse=True)`). So index `-1` is the *oldest* snapshot — which typically has no stored screenshot, tripping the guard and surfacing the misleading `NO_SNAPSHOT`. The live overlay could likewise redraw stale boxes from an unrelated old snapshot.

### Changes
- `naturo/bridge/_highlight.py`: use `snaps[0]` (newest) in both the annotate path (~L372) and the live-overlay path (~L409).
- `naturo/cli/core/_highlight.py`: clarify the `NO_SNAPSHOT` message to name the exact prerequisite — `see --path <file>` — because a screenshot is only persisted into the snapshot when `see` is given `--path` (addresses acceptance criterion 2).
- `tests/test_highlight_snapshot_order_1038.py`: CI-safe, mock-based regression tests for both the annotate and live-overlay ordering.

## How tested
- New regression tests fail before the fix (annotate returns `None`) and pass after.
- `ruff` clean; `mypy` clean on changed files (`--follow-imports=skip`; repo-wide mypy halts on a pre-existing 3rd-party `mcp` 3.10-syntax issue on this runner — CI Lint & Type Check is the source of truth).
- Mock-based suites green: `test_highlight_snapshot_order_1038`, `test_cli_highlight`, `test_highlight`, `test_annotate` (68 passed). Pre-existing `PermissionError` ERRORs on this runner come from the temp-dir / `tmp_path` fixture and are unrelated (present on develop).
- **Runtime verification on a real desktop (Windows 11, DLL build):** `see --app notepad --path s.png` then `highlight --app notepad --all -A out.png` → `{"success": true, "annotate_path": ".../out.png"}` and a 164 KB annotated PNG was produced. This exact flow returned `NO_SNAPSHOT` before the fix.

Closes #1038.