### PR TITLE
test: skip MCP surface-coverage test when mcp package is absent (#912)

### DIFF
--- a/tests/test_surface_guard_coverage_912.py
+++ b/tests/test_surface_guard_coverage_912.py
@@ -63,6 +63,17 @@ import pytest
 
 from naturo.cli import main
 
+# The ``mcp`` package requires Python >= 3.10, so it is absent on the 3.9 CI
+# lane.  Detect it once at import time and skip the MCP-enumeration test there,
+# mirroring ``test_no_desktop_guard_885.py``.  The CLI coverage and the
+# data-only behavioral cross-check do not need ``mcp`` and always run.
+try:
+    from naturo.mcp_server import create_server as _create_server
+
+    _MCP_AVAILABLE = True
+except ImportError:  # pragma: no cover - mcp optional, absent on Python 3.9
+    _MCP_AVAILABLE = False
+
 
 # ── Runtime surface enumeration ──────────────────────────────────────────────
 
@@ -128,9 +139,7 @@ def _all_mcp_tools() -> set[str]:
     """
     import asyncio
 
-    from naturo.mcp_server import create_server
-
-    server = create_server()
+    server = _create_server()
     loop = asyncio.new_event_loop()
     try:
         tools = loop.run_until_complete(server.list_tools())
@@ -266,6 +275,7 @@ def test_cli_classification_sets_are_disjoint() -> None:
     assert not overlap, f"CLI commands classified both ways: {sorted(overlap)}"
 
 
+@pytest.mark.skipif(not _MCP_AVAILABLE, reason="mcp package not installed")
 def test_every_mcp_tool_is_classified() -> None:
     """Every MCP tool is classified; desktop-required = all minus the allow-list.
 


### PR DESCRIPTION
## What
Follow-up CI fix for #912 (PR #1040). The new `test_every_mcp_tool_is_classified` enumerates MCP tools via `create_server()`, which imports the `mcp` package. `mcp` requires Python >= 3.10 and is **not** installed on the Python 3.9 CI lane, so the test failed there with `ModuleNotFoundError: No module named 'mcp'` (Ubuntu 3.9 + macOS 3.9).

Detect `mcp` availability at import time and `@pytest.mark.skipif` the MCP-enumeration test when it is absent — mirroring the exact pattern already used in `test_no_desktop_guard_885.py`. The CLI coverage test and the data-only behavioral cross-check need no `mcp` and keep running on 3.9.

## How tested
- Local (mcp present): `pytest tests/test_surface_guard_coverage_912.py` → 4 passed.
- Simulated 3.9 (mcp import blocked): 3 passed, 1 skipped — no error.
- `ruff check` clean; `mypy` clean.

Part of #912.