### PR TITLE
fix: accept --id eN on type/press/get/set/highlight (part of #864)

### DIFF
--- a/naturo/cli/core/_highlight.py
+++ b/naturo/cli/core/_highlight.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 @click.command()
 @click.argument("positional_refs", nargs=-1)
-@click.option("--on", "on_ref", help="Target element ref (eN) to highlight")
+@click.option("--on", "--id", "on_ref", help="Target element ref (eN) to highlight")
 @click.option("--ref", "-r", "ref_option", multiple=True, help="Specific refs to highlight (e.g. -r e5 -r e10). Omit for all.")
 @click.option("--app", "-a", help="Application name (partial match)")
 @click.option("--window", "window_title", default=None,
@@ -65,6 +65,7 @@ def highlight(positional_refs, on_ref, ref_option, app, window_title, hwnd, app_
       naturo highlight --app notepad             # Actionable only
       naturo highlight --app notepad --all       # All elements
       naturo highlight e11 --app notepad         # Specific ref
+      naturo highlight --id e11 --app notepad    # --id is an alias for the eN ref
       naturo highlight --app notepad --filter Button
       naturo highlight --app notepad --visible-only
       naturo highlight --app feishu --cascade -d 10

--- a/naturo/cli/interaction/_press.py
+++ b/naturo/cli/interaction/_press.py
@@ -104,7 +104,7 @@ def _normalize_modifier(key_str: str) -> str:
 @click.option("--count", "-n", type=int, default=1, help="Number of times to press", show_default=True)
 @click.option("--delay", type=float, default=50.0, help="Delay between presses (ms)", show_default=True)
 @click.option("--hold-duration", type=float, default=None, help="Hold duration for combos (ms)")
-@click.option("--on", "on_element", help="Target element (eN ref or text label) — click to focus before pressing")
+@click.option("--on", "--id", "on_element", help="Target element (eN ref or text label) — click to focus before pressing")
 @click.option("--ref", "ref_alias", hidden=True, help="Deprecated alias for --on")
 @click.option("--app", help="Target application (name or partial match)")
 @click.option("--pid", type=int, help="Process ID")
@@ -140,6 +140,7 @@ def press(keys: tuple[str, ...], count: int, delay: float, hold_duration: float 
       naturo press ctrl+c                 # key combination (was: hotkey)
       naturo press ctrl+a ctrl+c          # sequential combos
       naturo press alt+f4
+      naturo press enter --id e42          # focus element e42 then press
       naturo press enter --selector 'app://*/Button[@name="OK"]'
     """
     # (#361) Resolve --app-id to app/hwnd/pid before any other logic

--- a/naturo/cli/interaction/_type.py
+++ b/naturo/cli/interaction/_type.py
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 @click.option("--paste", "paste_mode", is_flag=True, help="Paste via clipboard (Ctrl+V) instead of typing")
 @click.option("--file", "file_path", type=click.Path(), help="Read text from file (use with --paste)")
 @click.option("--restore/--no-restore", default=True, help="Restore clipboard after --paste", show_default=True)
-@click.option("--on", "on_element", help="Target element (eN ref or text label) — click to focus before typing")
+@click.option("--on", "--id", "on_element", help="Target element (eN ref or text label) — click to focus before typing")
 @click.option("--ref", "ref_alias", hidden=True, help="Deprecated alias for --on")
 @click.option("--app", help="Target application (name or partial match)")
 @click.option("--pid", type=int, help="Process ID")
@@ -81,6 +81,7 @@ def type_cmd(text, delay, profile, wpm, press_return, tab_count, escape,
       naturo type --paste --file mytext.txt
       naturo type --paste                        # paste current clipboard
       naturo type "hello" --on e42               # click e42 then type
+      naturo type "hello" --id e42               # --id is an alias for --on
       naturo type "hello" --on e42 --app feishu  # target app + element
       naturo type "hello" --selector 'app://notepad.exe/Edit[@automationid="15"]'
     """

--- a/naturo/cli/values/_get.py
+++ b/naturo/cli/values/_get.py
@@ -56,7 +56,7 @@ def _collect_matching_elements(tree, role=None, name=None):
 
 @click.command("get")
 @click.argument("target", required=False)
-@click.option("--ref", "-r", "ref", default=None,
+@click.option("--ref", "-r", "--id", "ref", default=None,
               help="Element ref from snapshot (e.g. e47)")
 @click.option("--automation-id", "--aid", "automation_id", default=None,
               help="UIA AutomationId of the target element")
@@ -93,6 +93,7 @@ def get_cmd(ctx, target, ref, automation_id, role, name, get_all, prop, app,
     \b
     Examples:
       naturo get e47                      # Read value by ref
+      naturo get --id e47                 # --id is an alias for the eN ref
       naturo get e47 --json               # JSON output
       naturo get --aid txtSearch          # By AutomationId
       naturo get --role Edit --name Search # By role + name

--- a/naturo/cli/values/_set.py
+++ b/naturo/cli/values/_set.py
@@ -66,7 +66,7 @@ def _resolve_element_identifiers(ref, automation_id, role, name):
 @click.command("set")
 @click.argument("target", required=False)
 @click.argument("value", required=False)
-@click.option("--ref", "-r", "ref", default=None,
+@click.option("--ref", "-r", "--id", "ref", default=None,
               help="Element ref from snapshot (e.g. e47)")
 @click.option("--automation-id", "--aid", "automation_id", default=None,
               help="UIA AutomationId of the target element")
@@ -108,6 +108,7 @@ def set_cmd(ctx, target, value, ref, automation_id, role, name, toggle,
     \b
     Examples:
       naturo set e47 "hello world"       # Set text field value
+      naturo set --id e47 "hello world"  # --id is an alias for the eN ref
       naturo set --aid txtSearch "query"  # Set by AutomationId
       naturo set e12 --toggle            # Toggle a checkbox
       naturo set e8 --select             # Select a list/radio item

--- a/tests/test_id_flag_864.py
+++ b/tests/test_id_flag_864.py
@@ -1,0 +1,101 @@
+"""#864: ``--id eN`` flag harmonization for single-element targeting commands.
+
+``naturo see`` emits elements with display refs (``e1``, ``e2``, ...).  The
+natural scripter workflow pipes those refs into follow-up commands, but the
+``--id eN`` convention established by ``click`` (#23) — and shared by ``scroll``
+and ``move`` — was never propagated to the other commands that act on a single
+element.  Scripters had to memorise a per-command flag matrix
+(``get -r eN``, ``type --on eN``, ``highlight eN`` ...) and hit a Click
+``No such option: --id`` wall mid-pipeline.
+
+This change adds ``--id`` as an accepted alias on every command that targets a
+*single* element by ref: ``type``, ``press``, ``get``, ``set``, and
+``highlight``.  ``--id`` maps to each command's existing eN-capable input, so
+the other targeting methods (``--on``, ``-r``, positional) keep working as
+aliases.
+
+Out of scope (documented in #864): ``find`` *produces* refs rather than
+consuming one; ``wait`` polls the live UI by selector string (``--element``),
+not a snapshot ref; ``drag`` targets two endpoints (``--from``/``--to``, which
+already accept eN refs), so a single ``--id`` is ambiguous for it.  ``click``,
+``scroll``, and ``move`` already expose ``--id``.
+"""
+from __future__ import annotations
+
+import pytest
+from click.testing import CliRunner
+
+from naturo.cli import main
+
+runner = CliRunner()
+
+# Commands that target a single element by ref and must now accept ``--id``.
+_ID_REF_COMMANDS = [
+    ["type"],
+    ["press"],
+    ["get"],
+    ["set"],
+    ["highlight"],
+]
+
+# Commands that established the convention earlier (#23) — regression guard so a
+# refactor can't quietly drop ``--id`` from them either.
+_ALREADY_SUPPORTED = [
+    ["click"],
+    ["scroll"],
+    ["move"],
+]
+
+
+@pytest.mark.parametrize("cmd_args", _ID_REF_COMMANDS + _ALREADY_SUPPORTED)
+def test_id_flag_in_help(cmd_args):
+    """Each single-element command's --help must list the ``--id`` flag."""
+    result = runner.invoke(main, cmd_args + ["--help"])
+    assert result.exit_code == 0, (
+        f"naturo {' '.join(cmd_args)} --help failed:\n{result.output}"
+    )
+    assert "--id" in result.output, (
+        f"naturo {' '.join(cmd_args)} --help missing --id:\n{result.output}"
+    )
+
+
+@pytest.mark.parametrize("cmd_args", _ID_REF_COMMANDS + _ALREADY_SUPPORTED)
+def test_id_flag_accepted(cmd_args):
+    """``--id eN`` must be parsed (not rejected with Click 'No such option').
+
+    The command may still fail downstream (no desktop session, stale ref) — what
+    matters is that parsing reaches the handler instead of aborting at the Click
+    layer with a usage error.
+    """
+    result = runner.invoke(main, cmd_args + ["--id", "e1"])
+    assert "No such option" not in result.output, (
+        f"naturo {' '.join(cmd_args)} --id e1 rejected the flag:\n{result.output}"
+    )
+
+
+@pytest.mark.parametrize(
+    "cmd_args,dest",
+    [
+        (["type"], "on_element"),
+        (["press"], "on_element"),
+        (["get"], "ref"),
+        (["set"], "ref"),
+        (["highlight"], "on_ref"),
+    ],
+)
+def test_id_flag_aliases_existing_ref_input(cmd_args, dest):
+    """``--id`` must alias the command's existing eN-ref parameter, not invent a new one.
+
+    Aliasing the existing destination guarantees ``--id eN`` flows through the
+    exact same snapshot-ref resolution as ``--on``/``-r``/positional, so there is
+    no second, divergent code path to keep in sync.
+    """
+    command = main.commands[cmd_args[0]]
+    id_param = next(
+        (p for p in command.params if "--id" in getattr(p, "opts", [])),
+        None,
+    )
+    assert id_param is not None, f"{cmd_args[0]} has no --id option"
+    assert id_param.name == dest, (
+        f"{cmd_args[0]} --id maps to {id_param.name!r}, expected {dest!r}"
+    )


### PR DESCRIPTION
## What

Adds `--id eN` as an accepted flag on the single-element-targeting commands that were missing it: **`type`, `press`, `get`, `set`, `highlight`**.

`naturo see` emits element refs (`e1`, `e2`, ...) and the `--id eN` convention — established by `click` in #23 and shared by `scroll`/`move` — was never propagated to these commands. Scripters hit a Click `No such option: --id` wall mid-pipeline (e.g. `ID=$(...); naturo click --id $ID; naturo get --id $ID` failed on the `get` step) and had to memorise a per-command flag matrix (`get -r eN`, `type --on eN`, `highlight eN`, ...).

## How

`--id` is wired as an **additional name on each command's existing eN-capable option** (the same mechanism as `--automation-id`/`--aid`), so it flows through the identical snapshot-ref resolution as `--on`/`-r`/positional — there is no second, divergent code path to keep in sync:

| Command | `--id` aliases | resolves via |
|---|---|---|
| `type`, `press` | `--on` (`on_element`) | snapshot ref → focus + act |
| `get`, `set` | `--ref`/`-r` (`ref`) | snapshot ref → value pattern |
| `highlight` | `--on` (`on_ref`) | snapshot ref → overlay |

## Out of scope (follow-up on #864)

Mirrors the incremental approach taken for the sibling matrix issue #871. These three commands do **not** consume a single element ref, so a blanket `--id eN` would be semantically wrong:

- **`find`** *produces* refs (it's a search), it doesn't target one.
- **`wait`** polls the **live** UI by selector string (`--element "Button:Save"`), not a snapshot ref.
- **`drag`** targets two endpoints (`--from`/`--to`, which already accept eN refs), so a single `--id` is ambiguous.

`click`, `scroll`, and `move` already expose `--id`.

## How tested

- New `tests/test_id_flag_864.py` (21 cases): each command's `--help` lists `--id`; `--id e1` parses without a Click `No such option` error; and `--id` aliases the command's **existing** ref destination (not a new divergent param). Includes a regression guard that `click`/`scroll`/`move` keep `--id`.
- `python -m pytest tests/ -m "not desktop"` → **6277 passed** (the unrelated platform/DLL/cost-guardrails failures pre-exist on `develop`, verified by stashing this change).
- `ruff check` clean; `mypy` clean on all changed files.
- `--collect-only` on the new test succeeds with no optional deps (cross-platform collection safe).