### PR TITLE
fix: warn on empty Win11 taskbar/tray listing instead of silent success (fixes #916)

### DIFF
--- a/naturo/cli/core/_common.py
+++ b/naturo/cli/core/_common.py
@@ -16,6 +16,7 @@ import json as json_module  # noqa: F401 — re-exported for submodules
 import logging
 import os
 import platform
+import sys
 from collections.abc import Callable
 from typing import TypeVar
 
@@ -130,6 +131,48 @@ def _platform_supports_gui() -> bool:
         import shutil
         return shutil.which("peekaboo") is not None
     return False
+
+
+def _is_windows_11_or_later() -> bool:
+    """Return True when running on Windows 11 (build 22000) or later.
+
+    Windows 11 replaced the classic Win32 taskbar and notification-area
+    toolbars (``MSTaskListWClass`` and ``TrayNotifyWnd`` under
+    ``Shell_TrayWnd``) with a XAML shell host. The legacy UI Automation
+    enumeration that drives ``taskbar list`` / ``tray list`` therefore returns
+    zero elements on Windows 11 even when the taskbar and tray are populated
+    (#916). Callers use this to warn that an empty listing may be incomplete
+    rather than genuinely empty.
+
+    Returns:
+        True only on Windows with an OS build number of 22000 or higher; False
+        on Windows 10 and earlier, and on every non-Windows platform.
+    """
+    if platform.system() != "Windows":
+        return False
+    try:
+        return sys.getwindowsversion().build >= 22000  # type: ignore[attr-defined]
+    except (AttributeError, OSError):
+        return False
+
+
+def _win11_shell_enumeration_warning(surface: str) -> str:
+    """Build the Windows 11 shell-enumeration warning for an empty read.
+
+    Args:
+        surface: Human-readable name of the surface being enumerated, e.g.
+            ``"taskbar"`` or ``"system tray"``.
+
+    Returns:
+        A single-line English warning explaining that the empty result may be
+        incomplete because Windows 11 renders the surface with a XAML shell
+        host that the legacy Win32 enumeration cannot read (#916).
+    """
+    return (
+        f"Windows 11 renders the {surface} with a XAML shell host that the "
+        "legacy Win32 enumeration cannot read, so this empty result may be "
+        "incomplete rather than genuinely empty."
+    )
 
 
 def _platform_error_msg(feature: str) -> str:

--- a/naturo/cli/system/_taskbar.py
+++ b/naturo/cli/system/_taskbar.py
@@ -18,7 +18,11 @@ from naturo.cli._jsonio import json_dumps
 
 import click as _click
 
-from naturo.cli.core._common import _enforce_desktop_session
+from naturo.cli.core._common import (
+    _enforce_desktop_session,
+    _is_windows_11_or_later,
+    _win11_shell_enumeration_warning,
+)
 from naturo.cli.error_helpers import emit_error, emit_exception_error
 
 
@@ -61,14 +65,28 @@ def taskbar_list(json_output) -> None:
         backend = get_backend()
         items = backend.taskbar_list()
 
+        # (#916) An empty result on Windows 11 is almost certainly the XAML
+        # shell host defeating the legacy Win32 enumeration, not a truly empty
+        # taskbar. Surface that explicitly instead of silently reporting an
+        # empty success — empty-but-successful reads are a silent-failure shape.
+        empty_on_win11 = not items and _is_windows_11_or_later()
+
         if json_output:
-            _click.echo(json_dumps({
+            payload = {
                 "success": True,
                 "items": items,
                 "count": len(items),
-            }))
+            }
+            if empty_on_win11:
+                payload["warning"] = _win11_shell_enumeration_warning("taskbar")
+            _click.echo(json_dumps(payload))
         else:
             if not items:
+                if empty_on_win11:
+                    _click.echo(
+                        f"Warning: {_win11_shell_enumeration_warning('taskbar')}",
+                        err=True,
+                    )
                 _click.echo("No taskbar items found.")
             else:
                 for item in items:

--- a/naturo/cli/system/_tray.py
+++ b/naturo/cli/system/_tray.py
@@ -19,7 +19,11 @@ from naturo.cli._jsonio import json_dumps
 
 import click as _click
 
-from naturo.cli.core._common import _enforce_desktop_session
+from naturo.cli.core._common import (
+    _enforce_desktop_session,
+    _is_windows_11_or_later,
+    _win11_shell_enumeration_warning,
+)
 from naturo.cli.error_helpers import emit_error, emit_exception_error
 
 
@@ -62,14 +66,29 @@ def tray_list(json_output) -> None:
         backend = get_backend()
         icons = backend.tray_list()
 
+        # (#916) An empty result on Windows 11 is almost certainly the XAML
+        # shell host defeating the legacy Win32 enumeration, not a truly empty
+        # notification area. Surface that explicitly instead of silently
+        # reporting an empty success — empty-but-successful reads are a
+        # silent-failure shape.
+        empty_on_win11 = not icons and _is_windows_11_or_later()
+
         if json_output:
-            _click.echo(json_dumps({
+            payload = {
                 "success": True,
                 "icons": icons,
                 "count": len(icons),
-            }))
+            }
+            if empty_on_win11:
+                payload["warning"] = _win11_shell_enumeration_warning("system tray")
+            _click.echo(json_dumps(payload))
         else:
             if not icons:
+                if empty_on_win11:
+                    _click.echo(
+                        f"Warning: {_win11_shell_enumeration_warning('system tray')}",
+                        err=True,
+                    )
                 _click.echo("No tray icons found.")
             else:
                 for icon in icons:

--- a/tests/test_shell_win11_warning_916.py
+++ b/tests/test_shell_win11_warning_916.py
@@ -1,0 +1,120 @@
+"""Tests for the Windows 11 shell-enumeration warning on empty taskbar/tray reads.
+
+Regression coverage for #916: on Windows 11 the classic Win32 taskbar/tray
+toolbars (``MSTaskListWClass`` / ``TrayNotifyWnd`` under ``Shell_TrayWnd``) were
+replaced by a XAML shell host that the legacy UI Automation enumeration cannot
+read. ``taskbar list`` / ``tray list`` therefore returned an empty result while
+reporting ``success: true`` — a silent failure that violates the project's
+"never lie" contract. An empty listing on Windows 11 must now carry an explicit
+warning (additive ``warning`` key in JSON, a loud stderr note in human mode)
+while keeping the existing ``success``/``items``/``count`` envelope and exit
+code unchanged.
+
+All tests are mock-based (no DLL/desktop/input) so they run on Linux/macOS CI.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from naturo.cli.system import taskbar, tray
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_backend():
+    return MagicMock()
+
+
+class TestTaskbarWin11Warning:
+    """`naturo taskbar list` must warn on an empty Windows 11 result (#916)."""
+
+    def test_json_empty_on_win11_carries_warning(self, runner, mock_backend):
+        mock_backend.taskbar_list.return_value = []
+        with patch("naturo.backends.base.get_backend", return_value=mock_backend), \
+                patch("naturo.cli.system._taskbar._is_windows_11_or_later", return_value=True):
+            result = runner.invoke(taskbar, ["list", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        # Existing envelope keys are preserved (additive change only).
+        assert data["success"] is True
+        assert data["items"] == []
+        assert data["count"] == 0
+        # The new, additive warning explains the silent-empty cause.
+        assert "warning" in data
+        assert "Windows 11" in data["warning"]
+
+    def test_json_empty_off_win11_has_no_warning(self, runner, mock_backend):
+        mock_backend.taskbar_list.return_value = []
+        with patch("naturo.backends.base.get_backend", return_value=mock_backend), \
+                patch("naturo.cli.system._taskbar._is_windows_11_or_later", return_value=False):
+            result = runner.invoke(taskbar, ["list", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["success"] is True
+        assert data["count"] == 0
+        assert "warning" not in data
+
+    def test_json_nonempty_on_win11_has_no_warning(self, runner, mock_backend):
+        mock_backend.taskbar_list.return_value = [
+            {"name": "Notepad", "is_active": True, "is_pinned": False},
+        ]
+        with patch("naturo.backends.base.get_backend", return_value=mock_backend), \
+                patch("naturo.cli.system._taskbar._is_windows_11_or_later", return_value=True):
+            result = runner.invoke(taskbar, ["list", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["count"] == 1
+        assert "warning" not in data
+
+    def test_human_empty_on_win11_prints_warning(self, runner, mock_backend):
+        mock_backend.taskbar_list.return_value = []
+        with patch("naturo.backends.base.get_backend", return_value=mock_backend), \
+                patch("naturo.cli.system._taskbar._is_windows_11_or_later", return_value=True):
+            result = runner.invoke(taskbar, ["list"])
+        assert result.exit_code == 0
+        assert "Warning" in result.output
+        assert "Windows 11" in result.output
+
+
+class TestTrayWin11Warning:
+    """`naturo tray list` must warn on an empty Windows 11 result (#916)."""
+
+    def test_json_empty_on_win11_carries_warning(self, runner, mock_backend):
+        mock_backend.tray_list.return_value = []
+        with patch("naturo.backends.base.get_backend", return_value=mock_backend), \
+                patch("naturo.cli.system._tray._is_windows_11_or_later", return_value=True):
+            result = runner.invoke(tray, ["list", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["success"] is True
+        assert data["icons"] == []
+        assert data["count"] == 0
+        assert "warning" in data
+        assert "Windows 11" in data["warning"]
+
+    def test_json_empty_off_win11_has_no_warning(self, runner, mock_backend):
+        mock_backend.tray_list.return_value = []
+        with patch("naturo.backends.base.get_backend", return_value=mock_backend), \
+                patch("naturo.cli.system._tray._is_windows_11_or_later", return_value=False):
+            result = runner.invoke(tray, ["list", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["success"] is True
+        assert data["count"] == 0
+        assert "warning" not in data
+
+    def test_human_empty_on_win11_prints_warning(self, runner, mock_backend):
+        mock_backend.tray_list.return_value = []
+        with patch("naturo.backends.base.get_backend", return_value=mock_backend), \
+                patch("naturo.cli.system._tray._is_windows_11_or_later", return_value=True):
+            result = runner.invoke(tray, ["list"])
+        assert result.exit_code == 0
+        assert "Warning" in result.output
+        assert "Windows 11" in result.output


### PR DESCRIPTION
## What
On a populated **Windows 11** desktop, `naturo taskbar list` and `naturo tray list` returned `{"success": true, "items": [], "count": 0}` (and `No taskbar items found.`) — a **silent failure**. Win11 replaced the classic Win32 taskbar/notification-area toolbars (`MSTaskListWClass` / `TrayNotifyWnd` under `Shell_TrayWnd`) with a XAML shell host that the existing legacy UI Automation enumeration cannot read, so it comes back empty even when the taskbar/tray are full. An empty-but-successful read is exactly the silent-failure shape the project's "never lie" contract forbids (#916).

This makes the empty result **honest** without changing the machine contract:
- **JSON mode**: when the listing is empty *and* the OS is Windows 11 (build ≥ 22000), an **additive** `"warning"` key is included. `success` / `items`/`icons` / `count` and the exit code (0) are unchanged — existing scripts that check `.success` / `.count` are unaffected.
- **Human mode**: a loud `Warning: …` line is printed to **stderr** before `No taskbar items found.` on stdout.

This is option (b) ("fail loudly / warn rather than return `success:true []`") from the issue. Fully enumerating the Win11 XAML taskbar/tray is a larger native effort and is intentionally left as a follow-up; this change stops the *silent* part of the failure now.

### Scope
- `naturo/cli/core/_common.py`: add `_is_windows_11_or_later()` (build ≥ 22000, False off-Windows) and `_win11_shell_enumeration_warning(surface)` message builder.
- `naturo/cli/system/_taskbar.py` / `_tray.py`: emit the warning only when the result is empty on Win11. Purely additive; no key removed/renamed, exit code unchanged.

## How tested
- **Live, real Windows 11 desktop** (build 26200): `taskbar list -j`, `taskbar list`, `tray list -j` all now carry the explicit warning (additive `warning` key in JSON, loud stderr note in human mode); `success`/`count`/exit-0 unchanged.
- New `tests/test_shell_win11_warning_916.py` (7 cases, all mock-based — no DLL/desktop/input → Linux/macOS CI-safe): warning present when empty+Win11; absent when off-Win11 or non-empty; additive-envelope guard; human-mode warning. `--collect-only` clean without optional deps (#936 lesson).
- `ruff check` PASS, `mypy --follow-imports=silent` PASS on all changed files. Existing `test_taskbar*`/`test_tray*` suites: 78 passed.

Sibling in spirit to the JSON-envelope honesty/consistency series (#876/#977/#980/#1043). Continues SOUL's "Never Lie" architecture rule.