### PR TITLE
fix: classify find's missing window/app as recoverable WINDOW_NOT_FOUND (fixes #1047)

### DIFF
--- a/naturo/cli/core/_find.py
+++ b/naturo/cli/core/_find.py
@@ -244,6 +244,19 @@ def find_cmd(query: str | None, query_opt: str | None, find_all: bool, role: str
             click.echo(f"Snapshot: {snapshot_id}")
             click.echo("Tip: use 'naturo click e<N>' to interact with a found element.")
 
+    except _common.WindowNotFoundError as e:
+        # (#1047) The backend raises WindowNotFoundError (message "Window not
+        # found: <target>") rather than returning None, so the not-found path
+        # never reaches the ``tree is None`` branch above.  Classify it as a
+        # recoverable WINDOW_NOT_FOUND with remediation guidance — matching the
+        # envelope its siblings (see/menu-inspect/highlight) emit for the same
+        # condition — instead of flattening it into an unrecoverable
+        # UNKNOWN_ERROR via the broad handler below.
+        if json_output:
+            click.echo(_common._json_error_str("WINDOW_NOT_FOUND", str(e)))
+        else:
+            click.echo(f"Error: {e}", err=True)
+        raise SystemExit(1)
     except Exception as e:
         if json_output:
             click.echo(_common._json_error_str("UNKNOWN_ERROR", str(e)))

--- a/tests/test_find_window_not_found_1047.py
+++ b/tests/test_find_window_not_found_1047.py
@@ -1,0 +1,105 @@
+"""Tests for find's window/app-not-found error classification (fixes #1047).
+
+When the backend cannot locate the target window/app, ``naturo find`` used to
+report the condition as a generic, *unrecoverable* ``UNKNOWN_ERROR`` with no
+remediation hint — diverging from its sibling element-targeting commands
+(``see``/``menu-inspect``/``highlight``), which return a recoverable
+``WINDOW_NOT_FOUND`` envelope with a ``suggested_action``.
+
+The backend's ``get_element_tree`` *raises* a :class:`WindowNotFoundError`
+(message ``"Window not found: <target>"``) rather than returning ``None``, so
+the dedicated ``WINDOW_NOT_FOUND`` branch (which only fires when ``tree is
+None``) was dead for the raise path, and the broad ``except Exception``
+flattened the structured error into ``UNKNOWN_ERROR``.
+
+These tests pin the corrected contract: a not-found target yields a recoverable
+``WINDOW_NOT_FOUND`` envelope, identical in shape to what ``see`` emits.
+"""
+
+import json
+
+import pytest
+from unittest.mock import patch, MagicMock
+from click.testing import CliRunner
+
+from naturo.cli.core import find_cmd
+from naturo.errors import WindowNotFoundError
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def _backend_raising(exc):
+    """Build a mocked backend whose get_element_tree raises ``exc``."""
+    mock_be = MagicMock()
+    mock_be.get_element_tree.side_effect = exc
+    return mock_be
+
+
+class TestFindWindowNotFound:
+    """find must classify a missing window/app as recoverable WINDOW_NOT_FOUND."""
+
+    def test_window_not_found_emits_recoverable_envelope(self, runner):
+        """A raised WindowNotFoundError → WINDOW_NOT_FOUND, recoverable, with a hint."""
+        mock_be = _backend_raising(WindowNotFoundError("NaturoNoSuchApp_QA_PROBE"))
+        with patch("naturo.cli.core._common._platform_supports_gui", return_value=True), \
+             patch("naturo.cli.core._common._get_backend", return_value=mock_be):
+            result = runner.invoke(find_cmd, ["button", "--app", "NaturoNoSuchApp_QA_PROBE", "--json"])
+
+        assert result.exit_code == 1
+        payload = json.loads(result.output)
+        assert payload["success"] is False
+        error = payload["error"]
+        # The defining regression: no longer an unknown/unrecoverable failure.
+        assert error["code"] == "WINDOW_NOT_FOUND"
+        assert error["code"] != "UNKNOWN_ERROR"
+        assert error["category"] == "automation"
+        assert error["recoverable"] is True
+        assert error["suggested_action"]  # non-null, non-empty guidance
+        assert "NaturoNoSuchApp_QA_PROBE" in error["message"]
+
+    def test_window_not_found_matches_see_envelope(self, runner):
+        """find's not-found envelope is identical in shape to see's (#1047 sibling parity)."""
+        from naturo.cli.core import see
+
+        exc = WindowNotFoundError("BogusWindowTitle")
+
+        def _run(cmd, args):
+            mock_be = _backend_raising(exc)
+            with patch("naturo.cli.core._common._platform_supports_gui", return_value=True), \
+                 patch("naturo.cli.core._common._get_backend", return_value=mock_be):
+                return runner.invoke(cmd, args)
+
+        find_err = json.loads(_run(find_cmd, ["x", "--window", "BogusWindowTitle", "--json"]).output)["error"]
+        see_err = json.loads(_run(see, ["--window", "BogusWindowTitle", "--json"]).output)["error"]
+
+        # Same keys, same code/category/recoverable classification across siblings.
+        assert set(find_err) == set(see_err)
+        assert find_err["code"] == see_err["code"] == "WINDOW_NOT_FOUND"
+        assert find_err["category"] == see_err["category"]
+        assert find_err["recoverable"] == see_err["recoverable"] is True
+
+    def test_window_not_found_text_mode(self, runner):
+        """Without --json, the not-found path stays a clean 'Error:' line, exit 1."""
+        mock_be = _backend_raising(WindowNotFoundError("BogusWindowTitle"))
+        with patch("naturo.cli.core._common._platform_supports_gui", return_value=True), \
+             patch("naturo.cli.core._common._get_backend", return_value=mock_be):
+            result = runner.invoke(find_cmd, ["x", "--window", "BogusWindowTitle"])
+
+        assert result.exit_code == 1
+        assert "Window not found: BogusWindowTitle" in result.output
+        assert "UNKNOWN_ERROR" not in result.output
+
+    def test_unexpected_error_still_unknown(self, runner):
+        """A genuinely unexpected backend failure is still reported as UNKNOWN_ERROR."""
+        mock_be = _backend_raising(RuntimeError("disk on fire"))
+        with patch("naturo.cli.core._common._platform_supports_gui", return_value=True), \
+             patch("naturo.cli.core._common._get_backend", return_value=mock_be):
+            result = runner.invoke(find_cmd, ["x", "--app", "Whatever", "--json"])
+
+        assert result.exit_code == 1
+        error = json.loads(result.output)["error"]
+        assert error["code"] == "UNKNOWN_ERROR"
+        assert error["recoverable"] is False


### PR DESCRIPTION
## What
`naturo find` misclassified a missing target window/app as an **unrecoverable** `UNKNOWN_ERROR` (category `unknown`, `recoverable: false`, `suggested_action: null`) — diverging from every sibling element-targeting command (`see`/`menu-inspect`/`highlight`), which return a recoverable `WINDOW_NOT_FOUND`/`APP_NOT_FOUND` envelope with remediation guidance.

## Root cause
The backend `get_element_tree` **raises** `WindowNotFoundError` (message `"Window not found: <target>"`) rather than returning `None`, so the not-found path never reached the dedicated `tree is None` → `WINDOW_NOT_FOUND` branch. The raise fell through to the broad `except Exception`, which flattened it into `UNKNOWN_ERROR`. That dedicated branch was effectively dead for the raise path.

## Fix
Add a dedicated `except _common.WindowNotFoundError` handler ahead of the broad one — mirroring the proven pattern already in `see` (`_see.py:569`). A missing target now yields `WINDOW_NOT_FOUND` (category `automation`, `recoverable: true`, with a `suggested_action` pointing at `naturo list windows` / launching the app). Genuinely unexpected failures still surface as `UNKNOWN_ERROR`.

Part of the error-envelope-consistency series (#865 / #882 / #897).

## How tested
- New `tests/test_find_window_not_found_1047.py` (4 tests): recoverable envelope, sibling-envelope parity with `see`, clean text-mode output, and that unexpected errors stay `UNKNOWN_ERROR`. All pass.
- `ruff check` clean; full local suite green for the affected paths.