### PR TITLE
feat: wire 'naturo info' as a hidden alias for 'naturo doctor' (fixes #1048)

### DIFF
--- a/naturo/cli/__init__.py
+++ b/naturo/cli/__init__.py
@@ -49,7 +49,7 @@ from naturo.cli.selector_cmd import selector
 from naturo.cli.visual_cmd import visual
 from naturo.cli.recording_cmd import record
 from naturo.cli.config_cmd import config_cmd as _config_cmd_group
-from naturo.cli.doctor_cmd import doctor
+from naturo.cli.doctor_cmd import doctor, info
 
 
 # Accept ``-h`` as the POSIX synonym for ``--help`` (#899). Declaring it on the
@@ -222,6 +222,7 @@ main.add_command(browser)
 
 # ── Diagnostics ────────────────────────────────
 main.add_command(doctor)
+main.add_command(info)  # hidden alias for `doctor` (#1048)
 
 
 

--- a/naturo/cli/doctor_cmd.py
+++ b/naturo/cli/doctor_cmd.py
@@ -410,6 +410,35 @@ def _emit_human(checks: list[Check], success: bool) -> None:
         )
 
 
+def _run_doctor(ctx, check_updates: bool, json_output: bool) -> None:
+    """Gather the diagnostics, emit the report, and exit with the status code.
+
+    Shared by the ``doctor`` command and its ``info`` alias so the two stay
+    byte-for-byte identical (same report, same JSON envelope, same exit code).
+
+    Args:
+        ctx: The Click context, used to inherit the group-level ``--json`` flag.
+        check_updates: Whether to query PyPI for a newer release.
+        json_output: Whether the command-level ``-j`` flag was passed.
+    """
+    json_output = json_output or (ctx.obj or {}).get("json", False)
+
+    checks = _gather_checks(check_updates)
+    success = not any(c.status == STATUS_FAIL and c.required for c in checks)
+
+    if json_output:
+        payload = {
+            "success": success,
+            "checks": [c.to_dict() for c in checks],
+            "count": len(checks),
+        }
+        click.echo(json_dumps(payload, indent=2))
+    else:
+        _emit_human(checks, success)
+
+    sys.exit(0 if success else 1)
+
+
 @click.command("doctor")
 @click.option(
     "--check-updates",
@@ -432,19 +461,24 @@ def doctor(ctx, check_updates: bool, json_output: bool) -> None:
       naturo doctor -j
       naturo doctor --check-updates
     """
-    json_output = json_output or (ctx.obj or {}).get("json", False)
+    _run_doctor(ctx, check_updates, json_output)
 
-    checks = _gather_checks(check_updates)
-    success = not any(c.status == STATUS_FAIL and c.required for c in checks)
 
-    if json_output:
-        payload = {
-            "success": success,
-            "checks": [c.to_dict() for c in checks],
-            "count": len(checks),
-        }
-        click.echo(json_dumps(payload, indent=2))
-    else:
-        _emit_human(checks, success)
+@click.command("info", hidden=True)
+@click.option(
+    "--check-updates",
+    is_flag=True,
+    help="Query PyPI to report whether a newer naturo release is available.",
+)
+@click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
+@click.pass_context
+def info(ctx, check_updates: bool, json_output: bool) -> None:
+    """Alias for ``naturo doctor`` — run the environment self-check.
 
-    sys.exit(0 if success else 1)
+    A first-time user following the docs or the #898 proposal naturally reaches
+    for ``naturo info``; this alias makes it behave identically to
+    ``naturo doctor`` (same report, same ``-j`` envelope, same ``--check-updates``
+    flag) instead of failing with "no such command". Hidden from the top-level
+    help so ``doctor`` stays the single advertised name.
+    """
+    _run_doctor(ctx, check_updates, json_output)

--- a/tests/test_info_alias_1048.py
+++ b/tests/test_info_alias_1048.py
@@ -1,0 +1,83 @@
+"""Tests for ``naturo info`` as an alias of ``naturo doctor`` (#1048).
+
+The ``doctor`` proposal (#898) advertised ``naturo info`` as an alias, but the
+command was never wired — ``naturo info`` exited 2 with "no such command". These
+tests pin the alias contract: ``info`` produces the same envelope, exit code, and
+flag behaviour as ``doctor``, and stays hidden from the top-level help so
+``doctor`` remains the single advertised name. Every test is mock-based so it
+runs identically on Linux/macOS CI where no desktop session or native DLL exists.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from naturo.cli import main
+from naturo.cli import doctor_cmd
+from naturo.cli.doctor_cmd import Check, STATUS_FAIL, STATUS_OK, STATUS_WARN
+from naturo.version import __version__
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _ok_checks() -> list[Check]:
+    """A minimal all-passing check set (both required checks ok)."""
+    return [
+        Check("naturo version", STATUS_OK, __version__),
+        Check("Desktop session", STATUS_OK, "interactive", required=True),
+        Check("Native core (naturo_core.dll)", STATUS_OK, "loaded", required=True),
+        Check("AI providers", STATUS_WARN, "no key", "set ANTHROPIC_API_KEY"),
+    ]
+
+
+class TestInfoAlias:
+    def test_info_command_is_registered(self):
+        assert "info" in main.commands
+
+    def test_info_hidden_doctor_visible(self):
+        """`info` must not clutter the top-level help; `doctor` stays advertised."""
+        assert main.commands["info"].hidden is True
+        assert main.commands["doctor"].hidden is False
+
+    def test_info_json_matches_doctor_json(self, runner: CliRunner):
+        with patch.object(doctor_cmd, "_gather_checks", return_value=_ok_checks()):
+            doctor_result = runner.invoke(main, ["doctor", "-j"])
+            info_result = runner.invoke(main, ["info", "-j"])
+        assert doctor_result.exit_code == 0
+        assert info_result.exit_code == doctor_result.exit_code
+        assert json.loads(info_result.output) == json.loads(doctor_result.output)
+
+    def test_info_human_matches_doctor_human(self, runner: CliRunner):
+        with patch.object(doctor_cmd, "_gather_checks", return_value=_ok_checks()):
+            doctor_result = runner.invoke(main, ["doctor"])
+            info_result = runner.invoke(main, ["info"])
+        assert info_result.output == doctor_result.output
+        assert info_result.exit_code == doctor_result.exit_code == 0
+
+    def test_info_propagates_failure_exit_code(self, runner: CliRunner):
+        checks = _ok_checks()
+        checks[1] = Check(
+            "Desktop session", STATUS_FAIL, "no session", "connect via RDP", required=True
+        )
+        with patch.object(doctor_cmd, "_gather_checks", return_value=checks):
+            result = runner.invoke(main, ["info", "-j"])
+        assert result.exit_code == 1
+        assert json.loads(result.output)["success"] is False
+
+    def test_info_forwards_check_updates_flag(self, runner: CliRunner):
+        """`--check-updates` must reach `_gather_checks` through the alias too."""
+        seen: dict[str, bool] = {}
+
+        def _fake_gather(check_updates: bool) -> list[Check]:
+            seen["check_updates"] = check_updates
+            return _ok_checks()
+
+        with patch.object(doctor_cmd, "_gather_checks", _fake_gather):
+            runner.invoke(main, ["info", "--check-updates", "-j"])
+        assert seen["check_updates"] is True

--- a/tests/test_surface_guard_coverage_912.py
+++ b/tests/test_surface_guard_coverage_912.py
@@ -204,8 +204,9 @@ _CLI_SESSION_INDEPENDENT = frozenset(
         # Diagnostic self-check -- probes session/DPI/deps defensively and
         # reports availability (e.g. "Desktop session: no") instead of
         # acquiring the desktop backend, so it never routes through
-        # require_desktop_session / the guarded _get_backend.
-        "doctor",
+        # require_desktop_session / the guarded _get_backend. ``info`` is a
+        # hidden alias of ``doctor`` (#1048) sharing the same code path.
+        "doctor", "info",
         # Excel COM automation -- its own backend, not desktop UIA.
         "excel info", "excel list-sheets", "excel open", "excel read",
         "excel run-macro", "excel write",


### PR DESCRIPTION
## What
`naturo info` was advertised as an alias of `naturo doctor` in the #898 proposal but was never registered, so it exited 2 with "no such command". This wires `info` as a **hidden** Click alias that shares `doctor`'s exact code path.

- Extracted the doctor body into a shared `_run_doctor()` helper.
- Added a hidden `info` command reusing it → byte-for-byte identical report, `-j` envelope, exit code, and `--check-updates` flag.
- `doctor` stays the single advertised name (top-level help unchanged).
- Classified the new `info` leaf as session-independent in the surface guard (#912), matching `doctor`'s defensive, backend-free path.

Additive, low-risk CLI change. No public-API break.

## How tested
- New `tests/test_info_alias_1048.py` (6 tests): registration, hidden-vs-visible, JSON parity, human-output parity, failure exit-code propagation, `--check-updates` forwarding. All mock-based → runs on Linux/macOS CI.
- Surface-guard suite (#912) updated and green.
- Live on real desktop: `naturo info -j` and `naturo doctor -j` produce **byte-identical** output (both exit 0); `info` absent from `naturo -h`.
- `ruff check naturo/` clean; new tests collect cleanly (CI-style).

Closes #1048