### PR TITLE
fix: capture --region off-screen error echoes user input, not clamped box (fixes #1050)

### DIFF
--- a/naturo/cli/core/_capture.py
+++ b/naturo/cli/core/_capture.py
@@ -131,6 +131,10 @@ def capture(app: str | None, pid: int | None, window_title: str | None, hwnd: in
 
         # ── Element / region crop (issue #160) ───────────────────────────────
         crop_box = None  # (left, top, right, bottom) in image coordinates
+        # The user's raw --region request (x, y, w, h), kept so an off-screen
+        # error can echo what the user typed rather than the clamped PIL box
+        # (issue #1050).  None for the --element path.
+        requested_region: tuple[int, int, int, int] | None = None
 
         # Track whether the capture is window-relative (for element crop offset)
         _is_window_capture = bool(hwnd or app or window_title or pid)
@@ -213,6 +217,7 @@ def capture(app: str | None, pid: int | None, window_title: str | None, hwnd: in
                 if len(parts) != 4:
                     raise ValueError("need 4 values")
                 rx, ry, rw, rh = parts
+                requested_region = (rx, ry, rw, rh)
                 crop_box = (
                     max(0, rx - padding),
                     max(0, ry - padding),
@@ -239,9 +244,41 @@ def capture(app: str | None, pid: int | None, window_title: str | None, hwnd: in
                 right = min(iw, crop_box[2])
                 bottom = min(ih, crop_box[3])
                 if right <= left or bottom <= top:
-                    msg = f"Crop region ({left},{top},{right},{bottom}) has zero size."
+                    # Echo the user's *requested* region, not the clamped PIL
+                    # crop box — the clamped (left, top, right, bottom) reads
+                    # like an X,Y,W,H the user never typed (issue #1050).
+                    if requested_region is not None:
+                        rx, ry, rw, rh = requested_region
+                        if rw <= 0 or rh <= 0:
+                            msg = (
+                                f"Crop region X,Y,W,H ({rx},{ry},{rw},{rh}) has "
+                                "non-positive width/height; W and H must both be > 0."
+                            )
+                        else:
+                            msg = (
+                                f"Crop region X,Y,W,H ({rx},{ry},{rw},{rh}) is entirely "
+                                f"outside the captured image bounds ({iw}x{ih}). "
+                                "Reduce X/Y or W/H so the region overlaps the screen."
+                            )
+                        context = {
+                            "requested_region": [rx, ry, rw, rh],
+                            "image_size": [iw, ih],
+                        }
+                    else:
+                        # --element path: the resolved bounds fall outside the
+                        # captured image after the window-origin offset.
+                        msg = (
+                            f"Crop bounds fall entirely outside the captured image "
+                            f"bounds ({iw}x{ih}); the element may be off-screen."
+                        )
+                        context = {
+                            "clamped_crop_box": [left, top, right, bottom],
+                            "image_size": [iw, ih],
+                        }
                     if json_output:
-                        click.echo(_common._json_error_str("INVALID_INPUT", msg))
+                        click.echo(
+                            _common._json_error_str("INVALID_INPUT", msg, context=context)
+                        )
                     else:
                         click.echo(f"Error: {msg}", err=True)
                     raise SystemExit(1)

--- a/tests/test_capture_region_offscreen_1050.py
+++ b/tests/test_capture_region_offscreen_1050.py
@@ -1,0 +1,124 @@
+"""Tests for issue #1050 — capture --region off-screen error clarity.
+
+When ``naturo capture --region X,Y,W,H`` targets a region that lies entirely
+off-screen, the zero-size error used to echo the internal *clamped* PIL crop
+box ``(left, top, right, bottom)``, which reads like an ``X,Y,W,H`` the user
+never typed (the W/H columns silently became the image's right/bottom edges).
+
+These tests pin the corrected behaviour:
+- the message echoes the user's requested ``X,Y,W,H``;
+- it names the captured image bounds separately;
+- ``error.context`` carries ``requested_region`` and ``image_size``;
+- a non-positive width/height is reported as such rather than as "off-screen".
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from naturo.cli import main
+
+
+@pytest.fixture()
+def png_200x100(tmp_path) -> str:
+    """200×100 PNG used as the mock capture result."""
+    try:
+        from PIL import Image
+    except ImportError:
+        pytest.skip("Pillow not installed")
+    img = Image.new("RGB", (200, 100), color=(128, 128, 128))
+    p = tmp_path / "screen_200x100.png"
+    img.save(str(p))
+    return str(p)
+
+
+def _mock_capture_result(path: str, w: int = 200, h: int = 100):
+    @dataclass
+    class MockCaptureResult:
+        path: str
+        width: int
+        height: int
+        format: str = "png"
+        scale_factor: float = 1.0
+        dpi: int = 96
+
+    return MockCaptureResult(path=path, width=w, height=h)
+
+
+def _run(args, capture_path: str):
+    mock_result = _mock_capture_result(capture_path, 200, 100)
+    runner = CliRunner()
+    with patch("naturo.cli.core._common._platform_supports_gui", return_value=True), \
+         patch("naturo.cli.core._common._get_backend") as mock_be:
+        be = MagicMock()
+        be.capture_screen.return_value = mock_result
+        be.capture_window.return_value = mock_result
+        be.list_monitors.return_value = []
+        mock_be.return_value = be
+        return runner.invoke(main, args)
+
+
+class TestOffScreenRegionMessage:
+    def test_message_echoes_requested_region_not_clamped_box(self, png_200x100):
+        result = _run(
+            ["capture", "--region", "5000,5000,50,50", "--no-snapshot", "--json"],
+            png_200x100,
+        )
+        data = json.loads(result.output)
+        assert data["success"] is False
+        assert data["error"]["code"] == "INVALID_INPUT"
+        message = data["error"]["message"]
+        # Echoes the user's actual X,Y,W,H ...
+        assert "5000,5000,50,50" in message
+        # ... and never the misleading clamped box that reads as W=200,H=100.
+        assert "5000,5000,200,100" not in message
+        # Names the image bounds explicitly so "off-screen" is obvious.
+        assert "200x100" in message
+
+    def test_context_carries_requested_region_and_image_size(self, png_200x100):
+        result = _run(
+            ["capture", "--region", "9999,9999,100,100", "--no-snapshot", "--json"],
+            png_200x100,
+        )
+        data = json.loads(result.output)
+        ctx = data["error"]["context"]
+        assert ctx["requested_region"] == [9999, 9999, 100, 100]
+        assert ctx["image_size"] == [200, 100]
+
+    def test_non_positive_size_reported_distinctly(self, png_200x100):
+        result = _run(
+            ["capture", "--region", "10,10,0,0", "--no-snapshot", "--json"],
+            png_200x100,
+        )
+        data = json.loads(result.output)
+        assert data["success"] is False
+        message = data["error"]["message"]
+        assert "non-positive" in message
+        assert "10,10,0,0" in message
+        assert data["error"]["context"]["requested_region"] == [10, 10, 0, 0]
+
+    def test_plain_text_error_echoes_user_input(self, png_200x100):
+        result = _run(
+            ["capture", "--region", "5000,5000,50,50", "--no-snapshot"],
+            png_200x100,
+        )
+        # Non-JSON path writes to stderr; CliRunner merges it into output.
+        assert "5000,5000,50,50" in result.output
+        assert "200x100" in result.output
+
+    def test_valid_onscreen_region_still_succeeds(self, png_200x100):
+        """Guard: the fix must not regress the valid crop path."""
+        result = _run(
+            ["capture", "--region", "10,10,80,40", "--no-snapshot", "--json"],
+            png_200x100,
+        )
+        if "MISSING_DEPENDENCY" in result.output:
+            pytest.skip("Pillow not installed")
+        data = json.loads(result.output)
+        assert data["success"] is True
+        assert data["width"] == 80
+        assert data["height"] == 40


### PR DESCRIPTION
## What
`naturo capture --region X,Y,W,H` reported a misleading zero-size error when the region was off-screen. The message interpolated the internal **clamped PIL crop box** `(left, top, right, bottom)`, so the image's right/bottom edges showed up where the user expected their W,H:

```
$ naturo capture --region 5000,5000,50,50 -j
... "message": "Crop region (5000,5000,1920,1080) has zero size." ...   # 1920,1080 = image bounds, NOT the typed 50,50
```

`error.context` was also empty, so nothing helped the user debug.

## How
- Track the user's raw `--region` request `(rx, ry, rw, rh)` so the error echoes what was typed.
- Off-screen regions now report: `Crop region X,Y,W,H (5000,5000,50,50) is entirely outside the captured image bounds (1920x1080). Reduce X/Y or W/H so the region overlaps the screen.`
- A non-positive width/height is reported distinctly (`W and H must both be > 0`).
- `error.context` carries `{requested_region: [x,y,w,h], image_size: [iw,ih]}`.
- The `--element` crop path gets an equivalent bounds-aware message (`clamped_crop_box` + `image_size` context).

Root cause was `naturo/cli/core/_capture.py` zero-size branch interpolating the clamped box. No behavior change for valid on-screen regions (still crop correctly).

## How tested
- New `tests/test_capture_region_offscreen_1050.py` (5 tests): off-screen message echoes user input not the clamped box, names image bounds, populates `error.context`, non-positive size reported distinctly, plain-text path, and a regression guard that valid on-screen crops still succeed.
- Full capture suite green: `test_capture* + test_cli_capture` -> **54 passed**. ruff clean; changed file mypy-clean (the `mcp` site-package match-stmt error is a pre-existing local-env artifact, handled by CI).
- Live desktop verify on real 1920x1080: off-screen, non-positive, and valid (200x150) paths all produce the expected output.