### PR TITLE
feat: harmonize window-targeting flags on `app` window-state commands (#871)

### DIFF
--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -680,6 +680,7 @@ Close an application window (graceful or forced).
 | `--app` | text | Application name (alternative to positional NAME) |
 | `--window` | text | Window title pattern (substring match) |
 | `--hwnd` | integer | Window handle (HWND) |
+| `--pid` | integer | Process ID |
 | `--force` | boolean | Force terminate the process |
 | `--json`, `-j` | boolean | JSON output |
 
@@ -690,6 +691,7 @@ naturo app close notepad
 naturo app close --app notepad
 naturo app close feishu --window "Chat"
 naturo app close --hwnd 12345 --force
+naturo app close --pid 1234
 ```
 
 ### `naturo app find`
@@ -726,6 +728,7 @@ Focus an application window (bring to foreground).
 | `--app` | text | Application name (alternative to positional NAME) |
 | `--window` | text | Window title pattern (substring match) |
 | `--hwnd` | integer | Window handle (HWND) |
+| `--pid` | integer | Process ID |
 | `--json`, `-j` | boolean | JSON output |
 
 **Examples:**
@@ -734,8 +737,8 @@ Focus an application window (bring to foreground).
 naturo app focus feishu
 naturo app focus --app feishu
 naturo app focus feishu --window "Chat"
-naturo app focus --app feishu
 naturo app focus --hwnd 12345
+naturo app focus --pid 1234
 ```
 
 ### `naturo app inspect`
@@ -815,15 +818,19 @@ Maximize an application window.
 
 | Flag | Type | Description |
 |------|------|-------------|
+| `--app` | text | Application name (alternative to positional NAME) |
 | `--window` | text | Window title pattern (substring match) |
 | `--hwnd` | integer | Window handle (HWND) |
+| `--pid` | integer | Process ID |
 | `--json`, `-j` | boolean | JSON output |
 
 **Examples:**
 
 ```bash
 naturo app maximize feishu
+naturo app maximize --app feishu
 naturo app maximize --hwnd 12345
+naturo app maximize --pid 1234
 ```
 
 ### `naturo app minimize`
@@ -840,15 +847,19 @@ Minimize an application window.
 
 | Flag | Type | Description |
 |------|------|-------------|
+| `--app` | text | Application name (alternative to positional NAME) |
 | `--window` | text | Window title pattern (substring match) |
 | `--hwnd` | integer | Window handle (HWND) |
+| `--pid` | integer | Process ID |
 | `--json`, `-j` | boolean | JSON output |
 
 **Examples:**
 
 ```bash
 naturo app minimize feishu
+naturo app minimize --app feishu
 naturo app minimize --hwnd 12345
+naturo app minimize --pid 1234
 ```
 
 ### `naturo app move`
@@ -865,8 +876,10 @@ Move and/or resize an application window.
 
 | Flag | Type | Description |
 |------|------|-------------|
+| `--app` | text | Application name (alternative to positional NAME) |
 | `--window` | text | Window title pattern (substring match) |
 | `--hwnd` | integer | Window handle (HWND) |
+| `--pid` | integer | Process ID |
 | `--x` | integer | Target X position |
 | `--y` | integer | Target Y position |
 | `--width` | integer | New width in pixels (optional) |
@@ -878,7 +891,7 @@ Move and/or resize an application window.
 ```bash
 naturo app move feishu --x 100 --y 100
 naturo app move feishu --x 100 --y 100 --width 800 --height 600
-naturo app move feishu --width 800 --height 600
+naturo app move --pid 1234 --width 800 --height 600
 ```
 
 ### `naturo app quit`
@@ -942,15 +955,19 @@ Restore a minimized or maximized window to normal state.
 
 | Flag | Type | Description |
 |------|------|-------------|
+| `--app` | text | Application name (alternative to positional NAME) |
 | `--window` | text | Window title pattern (substring match) |
 | `--hwnd` | integer | Window handle (HWND) |
+| `--pid` | integer | Process ID |
 | `--json`, `-j` | boolean | JSON output |
 
 **Examples:**
 
 ```bash
 naturo app restore feishu
+naturo app restore --app feishu
 naturo app restore --hwnd 12345
+naturo app restore --pid 1234
 ```
 
 ### `naturo app windows`

--- a/naturo/cli/_app/_common.py
+++ b/naturo/cli/_app/_common.py
@@ -86,34 +86,48 @@ def _resolve_app_id(name, json_output):
     return entry
 
 
-def _resolve_window_target(name, window_title=None, hwnd=None):
+def _resolve_window_target(backend, name, window_title=None, hwnd=None, pid=None):
     """Build keyword arguments for backend window methods.
 
-    Accepts the unified app command style: positional NAME with optional
-    --window title filter and --hwnd.
+    Accepts the unified window-targeting flag set: positional NAME / ``--app``
+    (*name*), ``--window`` (*window_title*), ``--hwnd``, and ``--pid``.
+
+    When ``--pid`` is supplied without an explicit ``--hwnd``, the PID is
+    resolved to a concrete window handle through the backend's canonical
+    ``_resolve_hwnd`` resolver — the same path ``see``/``capture``/``click``
+    use — so PID targeting works without a backend method-signature change
+    (#871).  *name*/*window_title* further narrow the PID match when supplied
+    alongside it.  An explicit ``--hwnd`` always wins (most specific target).
 
     Args:
-        name: Application/process name (positional).
+        backend: Active backend instance (provides ``_resolve_hwnd``).
+        name: Application/process name (positional NAME or ``--app``).
         window_title: Optional title substring to pick a specific window.
-        hwnd: Optional direct window handle.
+        hwnd: Optional direct window handle (takes priority over *pid*).
+        pid: Optional process ID to target.
 
     Returns:
-        Dict with title and/or hwnd keys for backend calls.
+        Dict with ``title`` and/or ``hwnd`` keys for backend calls.
+
+    Raises:
+        WindowNotFoundError: When *pid* matches no resolvable window
+            (propagated from ``_resolve_hwnd``).
     """
-    effective_title = name
-    if window_title:
-        effective_title = window_title
+    if pid is not None and hwnd is None and hasattr(backend, "_resolve_hwnd"):
+        hwnd = backend._resolve_hwnd(app=name, window_title=window_title, pid=pid)
+        return {"title": None, "hwnd": hwnd}
+    effective_title = window_title or name
     return {"title": effective_title, "hwnd": hwnd}
 
 
-def _require_target(name, window_title, hwnd, json_output):
+def _require_target(name, window_title, hwnd, pid, json_output):
     """Validate that at least one target identifier is provided.
 
     Returns:
         True if valid, False if error was emitted.
     """
-    if not name and not window_title and not hwnd:
-        msg = "Specify an app name, --window, or --hwnd"
+    if not name and not window_title and not hwnd and not pid:
+        msg = "Specify an app name, --window, --hwnd, or --pid"
         if json_output:
             click.echo(_json_error_str("INVALID_INPUT", msg))
         else:

--- a/naturo/cli/_app/window_ops.py
+++ b/naturo/cli/_app/window_ops.py
@@ -23,9 +23,10 @@ from naturo.cli._app._common import (
 @click.option("--app", "app_name", default=None, help="Application name (alternative to positional NAME)")
 @click.option("--window", "window_title", default=None, help="Window title pattern (substring match)")
 @click.option("--hwnd", type=int, default=None, help="Window handle (HWND)")
+@click.option("--pid", type=int, default=None, help="Process ID")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def app_focus(ctx, name, app_name, window_title, hwnd, json_output) -> None:
+def app_focus(ctx, name, app_name, window_title, hwnd, pid, json_output) -> None:
     """Focus an application window (bring to foreground).
 
     \b
@@ -33,8 +34,8 @@ def app_focus(ctx, name, app_name, window_title, hwnd, json_output) -> None:
       naturo app focus feishu
       naturo app focus --app feishu
       naturo app focus feishu --window "Chat"
-      naturo app focus --app feishu
       naturo app focus --hwnd 12345
+      naturo app focus --pid 1234
     """
     json_output = json_output or (ctx.obj or {}).get("json", False)
     # --app flag overrides positional NAME when both absent
@@ -52,13 +53,13 @@ def app_focus(ctx, name, app_name, window_title, hwnd, json_output) -> None:
 
     from naturo.errors import NaturoError
 
-    if not _require_target(name, window_title, hwnd, json_output):
+    if not _require_target(name, window_title, hwnd, pid, json_output):
         return
 
     try:
         from naturo.backends.base import get_backend
         backend = get_backend()
-        backend.focus_window(**_resolve_window_target(name, window_title, hwnd))
+        backend.focus_window(**_resolve_window_target(backend, name, window_title, hwnd, pid))
         if json_output:
             click.echo(json_dumps({"success": True, "action": "focus"}))
         else:
@@ -74,10 +75,11 @@ def app_focus(ctx, name, app_name, window_title, hwnd, json_output) -> None:
 @click.option("--app", "app_name", default=None, help="Application name (alternative to positional NAME)")
 @click.option("--window", "window_title", default=None, help="Window title pattern (substring match)")
 @click.option("--hwnd", type=int, default=None, help="Window handle (HWND)")
+@click.option("--pid", type=int, default=None, help="Process ID")
 @click.option("--force", is_flag=True, help="Force terminate the process")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def app_close(ctx, name, app_name, window_title, hwnd, force, json_output) -> None:
+def app_close(ctx, name, app_name, window_title, hwnd, pid, force, json_output) -> None:
     """Close an application window (graceful or forced).
 
     \b
@@ -86,6 +88,7 @@ def app_close(ctx, name, app_name, window_title, hwnd, force, json_output) -> No
       naturo app close --app notepad
       naturo app close feishu --window "Chat"
       naturo app close --hwnd 12345 --force
+      naturo app close --pid 1234
     """
     json_output = json_output or (ctx.obj or {}).get("json", False)
     if not name and app_name:
@@ -102,13 +105,13 @@ def app_close(ctx, name, app_name, window_title, hwnd, force, json_output) -> No
 
     from naturo.errors import NaturoError
 
-    if not _require_target(name, window_title, hwnd, json_output):
+    if not _require_target(name, window_title, hwnd, pid, json_output):
         return
 
     try:
         from naturo.backends.base import get_backend
         backend = get_backend()
-        kwargs = _resolve_window_target(name, window_title, hwnd)
+        kwargs = _resolve_window_target(backend, name, window_title, hwnd, pid)
         kwargs["force"] = force
         backend.close_window(**kwargs)
         if json_output:
@@ -123,19 +126,25 @@ def app_close(ctx, name, app_name, window_title, hwnd, force, json_output) -> No
 
 @click.command("minimize")
 @click.argument("name", required=False, default=None)
+@click.option("--app", "app_name", default=None, help="Application name (alternative to positional NAME)")
 @click.option("--window", "window_title", default=None, help="Window title pattern (substring match)")
 @click.option("--hwnd", type=int, default=None, help="Window handle (HWND)")
+@click.option("--pid", type=int, default=None, help="Process ID")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def app_minimize(ctx, name, window_title, hwnd, json_output) -> None:
+def app_minimize(ctx, name, app_name, window_title, hwnd, pid, json_output) -> None:
     """Minimize an application window.
 
     \b
     Examples:
       naturo app minimize feishu
+      naturo app minimize --app feishu
       naturo app minimize --hwnd 12345
+      naturo app minimize --pid 1234
     """
     json_output = json_output or (ctx.obj or {}).get("json", False)
+    if not name and app_name:
+        name = app_name
 
     # (#776) Resolve app ID (a1, a2, …) to window handle
     entry = _resolve_app_id(name, json_output)
@@ -148,13 +157,13 @@ def app_minimize(ctx, name, window_title, hwnd, json_output) -> None:
 
     from naturo.errors import NaturoError
 
-    if not _require_target(name, window_title, hwnd, json_output):
+    if not _require_target(name, window_title, hwnd, pid, json_output):
         return
 
     try:
         from naturo.backends.base import get_backend
         backend = get_backend()
-        backend.minimize_window(**_resolve_window_target(name, window_title, hwnd))
+        backend.minimize_window(**_resolve_window_target(backend, name, window_title, hwnd, pid))
         if json_output:
             click.echo(json_dumps({"success": True, "action": "minimize"}))
         else:
@@ -167,19 +176,25 @@ def app_minimize(ctx, name, window_title, hwnd, json_output) -> None:
 
 @click.command("maximize")
 @click.argument("name", required=False, default=None)
+@click.option("--app", "app_name", default=None, help="Application name (alternative to positional NAME)")
 @click.option("--window", "window_title", default=None, help="Window title pattern (substring match)")
 @click.option("--hwnd", type=int, default=None, help="Window handle (HWND)")
+@click.option("--pid", type=int, default=None, help="Process ID")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def app_maximize(ctx, name, window_title, hwnd, json_output) -> None:
+def app_maximize(ctx, name, app_name, window_title, hwnd, pid, json_output) -> None:
     """Maximize an application window.
 
     \b
     Examples:
       naturo app maximize feishu
+      naturo app maximize --app feishu
       naturo app maximize --hwnd 12345
+      naturo app maximize --pid 1234
     """
     json_output = json_output or (ctx.obj or {}).get("json", False)
+    if not name and app_name:
+        name = app_name
 
     # (#776) Resolve app ID (a1, a2, …) to window handle
     entry = _resolve_app_id(name, json_output)
@@ -192,13 +207,13 @@ def app_maximize(ctx, name, window_title, hwnd, json_output) -> None:
 
     from naturo.errors import NaturoError
 
-    if not _require_target(name, window_title, hwnd, json_output):
+    if not _require_target(name, window_title, hwnd, pid, json_output):
         return
 
     try:
         from naturo.backends.base import get_backend
         backend = get_backend()
-        backend.maximize_window(**_resolve_window_target(name, window_title, hwnd))
+        backend.maximize_window(**_resolve_window_target(backend, name, window_title, hwnd, pid))
         if json_output:
             click.echo(json_dumps({"success": True, "action": "maximize"}))
         else:
@@ -211,19 +226,25 @@ def app_maximize(ctx, name, window_title, hwnd, json_output) -> None:
 
 @click.command("restore")
 @click.argument("name", required=False, default=None)
+@click.option("--app", "app_name", default=None, help="Application name (alternative to positional NAME)")
 @click.option("--window", "window_title", default=None, help="Window title pattern (substring match)")
 @click.option("--hwnd", type=int, default=None, help="Window handle (HWND)")
+@click.option("--pid", type=int, default=None, help="Process ID")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def app_restore(ctx, name, window_title, hwnd, json_output) -> None:
+def app_restore(ctx, name, app_name, window_title, hwnd, pid, json_output) -> None:
     """Restore a minimized or maximized window to normal state.
 
     \b
     Examples:
       naturo app restore feishu
+      naturo app restore --app feishu
       naturo app restore --hwnd 12345
+      naturo app restore --pid 1234
     """
     json_output = json_output or (ctx.obj or {}).get("json", False)
+    if not name and app_name:
+        name = app_name
 
     # (#776) Resolve app ID (a1, a2, …) to window handle
     entry = _resolve_app_id(name, json_output)
@@ -236,13 +257,13 @@ def app_restore(ctx, name, window_title, hwnd, json_output) -> None:
 
     from naturo.errors import NaturoError
 
-    if not _require_target(name, window_title, hwnd, json_output):
+    if not _require_target(name, window_title, hwnd, pid, json_output):
         return
 
     try:
         from naturo.backends.base import get_backend
         backend = get_backend()
-        backend.restore_window(**_resolve_window_target(name, window_title, hwnd))
+        backend.restore_window(**_resolve_window_target(backend, name, window_title, hwnd, pid))
         if json_output:
             click.echo(json_dumps({"success": True, "action": "restore"}))
         else:
@@ -255,15 +276,17 @@ def app_restore(ctx, name, window_title, hwnd, json_output) -> None:
 
 @click.command("move")
 @click.argument("name", required=False, default=None)
+@click.option("--app", "app_name", default=None, help="Application name (alternative to positional NAME)")
 @click.option("--window", "window_title", default=None, help="Window title pattern (substring match)")
 @click.option("--hwnd", type=int, default=None, help="Window handle (HWND)")
+@click.option("--pid", type=int, default=None, help="Process ID")
 @click.option("--x", type=int, default=None, help="Target X position")
 @click.option("--y", type=int, default=None, help="Target Y position")
 @click.option("--width", type=int, default=None, help="New width in pixels (optional)")
 @click.option("--height", type=int, default=None, help="New height in pixels (optional)")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def app_move(ctx, name, window_title, hwnd, x, y, width, height, json_output) -> None:
+def app_move(ctx, name, app_name, window_title, hwnd, pid, x, y, width, height, json_output) -> None:
     """Move and/or resize an application window.
 
     Combines move, resize, and set-bounds into one command.
@@ -273,9 +296,11 @@ def app_move(ctx, name, window_title, hwnd, x, y, width, height, json_output) ->
     Examples:
       naturo app move feishu --x 100 --y 100
       naturo app move feishu --x 100 --y 100 --width 800 --height 600
-      naturo app move feishu --width 800 --height 600
+      naturo app move --pid 1234 --width 800 --height 600
     """
     json_output = json_output or (ctx.obj or {}).get("json", False)
+    if not name and app_name:
+        name = app_name
 
     # (#776) Resolve app ID (a1, a2, …) to window handle
     entry = _resolve_app_id(name, json_output)
@@ -288,7 +313,7 @@ def app_move(ctx, name, window_title, hwnd, x, y, width, height, json_output) ->
 
     from naturo.errors import NaturoError
 
-    if not _require_target(name, window_title, hwnd, json_output):
+    if not _require_target(name, window_title, hwnd, pid, json_output):
         return
 
     has_position = x is not None and y is not None
@@ -335,7 +360,7 @@ def app_move(ctx, name, window_title, hwnd, x, y, width, height, json_output) ->
     try:
         from naturo.backends.base import get_backend
         backend = get_backend()
-        kwargs = _resolve_window_target(name, window_title, hwnd)
+        kwargs = _resolve_window_target(backend, name, window_title, hwnd, pid)
 
         if has_position and has_size:
             backend.set_bounds(x=x, y=y, width=width, height=height, **kwargs)

--- a/tests/test_app_window_targeting_871.py
+++ b/tests/test_app_window_targeting_871.py
@@ -1,0 +1,166 @@
+"""#871: window-targeting flag harmonization for the ``app`` window-state subgroup.
+
+Sibling to :mod:`test_window_targeting_flags_871` (which covers the element/menu
+*discovery* commands ``find``/``highlight``/``menu-inspect``).  This module covers
+the ``app`` window-state subgroup — ``focus``, ``close``, ``minimize``,
+``maximize``, ``restore``, ``move`` — which previously exposed an inconsistent
+flag matrix (per QA round 132): ``--app`` was missing from
+``minimize``/``maximize``/``restore``/``move`` and ``--pid`` was missing from the
+whole subgroup.
+
+The gold standard for these commands is ``{--app, --window, --hwnd, --pid}`` plus
+positional NAME (app-id ``aN`` resolves through the positional argument).  Because
+the backend window methods accept only ``title``/``hwnd``, ``--pid`` is resolved
+to a concrete handle in the CLI via the canonical ``_resolve_hwnd`` resolver —
+the same path ``see``/``capture``/``click`` use — so no backend method-signature
+change is required.
+
+``app quit`` (process-lifecycle path) and ``get``/``set`` (value-pattern path)
+route through different resolution and are tracked as follow-ups on #871.
+"""
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from naturo.cli.app_cmd import (
+    app_close,
+    app_focus,
+    app_maximize,
+    app_minimize,
+    app_move,
+    app_restore,
+)
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def mock_backend():
+    backend = MagicMock()
+    # Canonical resolver returns a concrete handle for --pid resolution.
+    backend._resolve_hwnd.return_value = 999
+    return backend
+
+
+# Window-state commands harmonised by this change and the backend method each
+# delegates to.  ``move`` is exercised separately (it needs --x/--y).
+_STATE_COMMANDS = [
+    (app_focus, "focus_window"),
+    (app_close, "close_window"),
+    (app_minimize, "minimize_window"),
+    (app_maximize, "maximize_window"),
+    (app_restore, "restore_window"),
+]
+_GOLD_STANDARD_FLAGS = ["--app", "--window", "--hwnd", "--pid"]
+
+
+@pytest.mark.parametrize("cmd,_backend_method", _STATE_COMMANDS)
+@pytest.mark.parametrize("flag", _GOLD_STANDARD_FLAGS)
+def test_state_command_help_lists_flag(cmd, _backend_method, flag):
+    """Each window-state command's --help must list the full flag set."""
+    result = runner.invoke(cmd, ["--help"])
+    assert result.exit_code == 0, result.output
+    assert flag in result.output, f"{cmd.name} --help missing {flag}:\n{result.output}"
+
+
+@pytest.mark.parametrize("cmd,_backend_method", _STATE_COMMANDS)
+@pytest.mark.parametrize(
+    "flag_with_value",
+    [["--app", "Notepad"], ["--window", "Untitled"], ["--hwnd", "12345"], ["--pid", "4321"]],
+)
+def test_state_command_flag_not_rejected(cmd, _backend_method, mock_backend, flag_with_value):
+    """No flag may be rejected at the Click layer with 'No such option'."""
+    with patch("naturo.backends.base.get_backend", return_value=mock_backend):
+        result = runner.invoke(cmd, flag_with_value)
+    assert "No such option" not in result.output, (
+        f"{cmd.name} {' '.join(flag_with_value)} rejected the flag:\n{result.output}"
+    )
+
+
+@pytest.mark.parametrize("cmd,backend_method", _STATE_COMMANDS)
+def test_pid_resolves_to_hwnd(cmd, backend_method, mock_backend):
+    """--pid is resolved to a concrete hwnd via _resolve_hwnd, then passed on."""
+    with patch("naturo.backends.base.get_backend", return_value=mock_backend):
+        result = runner.invoke(cmd, ["--pid", "4321"])
+    assert result.exit_code == 0, result.output
+    mock_backend._resolve_hwnd.assert_called_once_with(app=None, window_title=None, pid=4321)
+    # ``close`` additionally threads ``force`` — assert the target kwargs only.
+    call_kwargs = getattr(mock_backend, backend_method).call_args.kwargs
+    assert call_kwargs["title"] is None
+    assert call_kwargs["hwnd"] == 999
+
+
+@pytest.mark.parametrize("cmd,backend_method", _STATE_COMMANDS)
+def test_app_flag_targets_by_name(cmd, backend_method, mock_backend):
+    """--app is accepted on every window-state command and targets by title."""
+    with patch("naturo.backends.base.get_backend", return_value=mock_backend):
+        result = runner.invoke(cmd, ["--app", "Notepad"])
+    assert result.exit_code == 0, result.output
+    mock_backend._resolve_hwnd.assert_not_called()
+    call_kwargs = getattr(mock_backend, backend_method).call_args.kwargs
+    assert call_kwargs["title"] == "Notepad"
+    assert call_kwargs["hwnd"] is None
+
+
+@pytest.mark.parametrize("cmd,backend_method", _STATE_COMMANDS)
+def test_pid_not_found_exits_nonzero(cmd, backend_method, mock_backend):
+    """An unresolvable --pid surfaces the WindowNotFoundError loudly (exit 1)."""
+    from naturo.errors import WindowNotFoundError
+
+    mock_backend._resolve_hwnd.side_effect = WindowNotFoundError("PID 4321")
+    with patch("naturo.backends.base.get_backend", return_value=mock_backend):
+        result = runner.invoke(cmd, ["--pid", "4321"])
+    assert result.exit_code != 0
+    getattr(mock_backend, backend_method).assert_not_called()
+
+
+def test_move_accepts_app_and_pid(mock_backend):
+    """app move gains --app and --pid alongside its geometry flags."""
+    help_result = runner.invoke(app_move, ["--help"])
+    assert "--app" in help_result.output
+    assert "--pid" in help_result.output
+
+    with patch("naturo.backends.base.get_backend", return_value=mock_backend):
+        result = runner.invoke(app_move, ["--pid", "4321", "--x", "10", "--y", "20"])
+    assert result.exit_code == 0, result.output
+    mock_backend._resolve_hwnd.assert_called_once_with(app=None, window_title=None, pid=4321)
+    mock_backend.move_window.assert_called_once_with(x=10, y=20, title=None, hwnd=999)
+
+
+def test_move_app_flag_targets_by_name(mock_backend):
+    """app move --app targets by title (parity with the other state commands)."""
+    with patch("naturo.backends.base.get_backend", return_value=mock_backend):
+        result = runner.invoke(app_move, ["--app", "Notepad", "--x", "10", "--y", "20"])
+    assert result.exit_code == 0, result.output
+    mock_backend.move_window.assert_called_once_with(x=10, y=20, title="Notepad", hwnd=None)
+
+
+def test_pid_combined_with_window_filter(mock_backend):
+    """--pid + --window narrows the PID match through the resolver."""
+    with patch("naturo.backends.base.get_backend", return_value=mock_backend):
+        result = runner.invoke(app_focus, ["--pid", "4321", "--window", "Chat"])
+    assert result.exit_code == 0, result.output
+    mock_backend._resolve_hwnd.assert_called_once_with(app=None, window_title="Chat", pid=4321)
+
+
+def test_explicit_hwnd_wins_over_pid(mock_backend):
+    """An explicit --hwnd short-circuits PID resolution (most specific wins)."""
+    with patch("naturo.backends.base.get_backend", return_value=mock_backend):
+        result = runner.invoke(app_focus, ["--hwnd", "555", "--pid", "4321"])
+    assert result.exit_code == 0, result.output
+    mock_backend._resolve_hwnd.assert_not_called()
+    mock_backend.focus_window.assert_called_once_with(title=None, hwnd=555)
+
+
+def test_pid_json_success_envelope(mock_backend):
+    """--pid path still emits the standard JSON success envelope."""
+    with patch("naturo.backends.base.get_backend", return_value=mock_backend):
+        result = runner.invoke(app_minimize, ["--pid", "4321", "--json"])
+    data = json.loads(result.output)
+    assert data["success"] is True
+    assert data["action"] == "minimize"


### PR DESCRIPTION
## What

Continues the **#871** window-targeting matrix harmonization (after **#1037** for `find`/`highlight`/`menu-inspect` and **#1053** for `list windows`).

Brings the `app` **window-state subgroup** — `focus`, `close`, `minimize`, `maximize`, `restore`, `move` — to the gold-standard window-targeting flag set `{--app, --window, --hwnd, --pid}` plus positional NAME.

Closes these matrix gaps (QA round 132):
- `--app` was missing from `minimize`/`maximize`/`restore`/`move` → **added** (parity with `focus`/`close`).
- `--pid` was missing from the **entire** subgroup → **added** to all six.

```bash
# Previously failed with "No such option"; now work:
naturo app focus    --pid 1234
naturo app minimize --app notepad
naturo app minimize --pid 1234
naturo app move     --pid 1234 --width 800 --height 600
```

## How

`--pid` is resolved to a concrete window handle **in the CLI** via the canonical `backend._resolve_hwnd(...)` — the same path `see`/`capture`/`click` use — so **no backend method-signature change** is required (the backend window methods still take only `title`/`hwnd`). Resolution lives in the shared `_resolve_window_target` helper:

- An unresolvable `--pid` fails **loudly** (`WINDOW_NOT_FOUND`, exit 1) rather than silently acting on the wrong window (SOUL "never lie").
- An explicit `--hwnd` still wins over `--pid` (most specific target).
- `--pid` may be combined with `--app`/`--window` to narrow the match.

Purely additive — no existing behavior changes.

## Scope

`app quit` (process-lifecycle path) and `get`/`set` (value-pattern path) route through different resolution and remain tracked as follow-ups on #871 — **issue stays open.**

## How tested

- New `tests/test_app_window_targeting_871.py` (60 cases): help lists the full flag set; no flag rejected at the Click layer; `--pid`→`_resolve_hwnd`→handle wiring; `--app` targets by title; unresolvable `--pid` exits non-zero; `--hwnd` beats `--pid`; JSON success envelope preserved.
- `ruff check naturo/` clean; changed files mypy-clean (pre-existing local `mcp` match-stmt artifact only; CI Lint & Type Check covers it on 3.10+).
- Targeted suites green: `test_app_window_targeting_871` + `test_app_cmd` + `test_window_targeting_flags_871` + `test_list_windows_targeting_871` → 212 passed. New test `--collect-only` clean (cross-platform safe).
- **Live (real desktop + DLL):** `app minimize --pid <Calculator>` → `{"success": true}` (exit 0); `app restore --pid` → success (reversible); unresolvable `--pid 999999` → loud `WINDOW_NOT_FOUND` exit 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)