### PR TITLE
fix: initialize Java Access Bridge via Windows_run + pumped settle (#932)

### DIFF
--- a/benchmarks/recognition/fixtures/java/.gitignore
+++ b/benchmarks/recognition/fixtures/java/.gitignore
@@ -1,0 +1,2 @@
+# Compiled Java fixture classes — rebuilt on demand by the benchmark harness.
+*.class

--- a/benchmarks/recognition/fixtures/java/SwingControlsFixture.java
+++ b/benchmarks/recognition/fixtures/java/SwingControlsFixture.java
@@ -1,0 +1,113 @@
+/*
+ * Naturo owned Java Swing recognition fixture (issue #932).
+ *
+ * A deliberately small, self-contained Swing application that exposes a known
+ * set of accessible controls — buttons, a text field, a checkbox, a label, a
+ * table and a tree. It exists to prove naturo's Java Access Bridge (JAB)
+ * recognition against ground truth: the Windows UI Automation tree collapses a
+ * Swing window into opaque window chrome, while JAB recovers every control
+ * below.
+ *
+ * The control names are stable and unique so tests can assert exact ground
+ * truth. The window title is also stable so the harness can locate the window.
+ *
+ * Build and run with the JDK directly — no Maven/Gradle required:
+ *
+ *     javac SwingControlsFixture.java
+ *     java  SwingControlsFixture
+ *
+ * Java Access Bridge must be enabled for naturo to see the controls
+ * (`jabswitch -enable`, then restart the JVM).
+ */
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.JTextField;
+import javax.swing.JTree;
+import javax.swing.SwingUtilities;
+import javax.swing.WindowConstants;
+import javax.swing.table.DefaultTableModel;
+import javax.swing.tree.DefaultMutableTreeNode;
+import java.awt.BorderLayout;
+import java.awt.GridLayout;
+
+public final class SwingControlsFixture {
+
+    /** Stable window title used by the recognition harness to find this window. */
+    public static final String WINDOW_TITLE = "Naturo Swing Recognition Fixture";
+
+    private SwingControlsFixture() {
+    }
+
+    /**
+     * Build the fixture window on the Swing event-dispatch thread.
+     *
+     * @return the fully populated, visible {@link JFrame}.
+     */
+    private static JFrame buildFrame() {
+        JFrame frame = new JFrame(WINDOW_TITLE);
+        frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
+
+        JPanel controls = new JPanel(new GridLayout(0, 1, 4, 4));
+
+        JButton submitButton = new JButton("Submit Order");
+        submitButton.getAccessibleContext().setAccessibleName("Submit Order");
+        controls.add(submitButton);
+
+        JButton cancelButton = new JButton("Cancel Order");
+        cancelButton.getAccessibleContext().setAccessibleName("Cancel Order");
+        controls.add(cancelButton);
+
+        JTextField customerField = new JTextField("Ada Lovelace");
+        customerField.getAccessibleContext().setAccessibleName("Customer Name");
+        controls.add(customerField);
+
+        JCheckBox expressCheck = new JCheckBox("Express Shipping");
+        expressCheck.getAccessibleContext().setAccessibleName("Express Shipping");
+        controls.add(expressCheck);
+
+        JLabel statusLabel = new JLabel("Order Status: Pending");
+        statusLabel.getAccessibleContext().setAccessibleName("Order Status: Pending");
+        controls.add(statusLabel);
+
+        DefaultTableModel tableModel = new DefaultTableModel(
+                new Object[][] {
+                        {"Widget", "2"},
+                        {"Gadget", "5"},
+                },
+                new Object[] {"Item", "Quantity"});
+        JTable itemsTable = new JTable(tableModel);
+        itemsTable.getAccessibleContext().setAccessibleName("Order Items");
+
+        DefaultMutableTreeNode root = new DefaultMutableTreeNode("Catalog");
+        DefaultMutableTreeNode hardware = new DefaultMutableTreeNode("Hardware");
+        hardware.add(new DefaultMutableTreeNode("Widget"));
+        hardware.add(new DefaultMutableTreeNode("Gadget"));
+        root.add(hardware);
+        JTree catalogTree = new JTree(root);
+        catalogTree.getAccessibleContext().setAccessibleName("Catalog Tree");
+
+        frame.setLayout(new BorderLayout(8, 8));
+        frame.add(controls, BorderLayout.NORTH);
+        frame.add(new JScrollPane(itemsTable), BorderLayout.CENTER);
+        frame.add(new JScrollPane(catalogTree), BorderLayout.SOUTH);
+
+        frame.setSize(420, 460);
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+        return frame;
+    }
+
+    /**
+     * Launch the fixture window.
+     *
+     * @param args ignored.
+     */
+    public static void main(String[] args) {
+        SwingUtilities.invokeLater(SwingControlsFixture::buildFrame);
+    }
+}

--- a/benchmarks/recognition/harness.py
+++ b/benchmarks/recognition/harness.py
@@ -664,6 +664,215 @@ class ElectronFixtureApp:
         self.stop()
 
 
+def _find_java_tool(tool: str) -> Optional[str]:
+    """Locate a JDK tool (``java``/``javac``) via ``JAVA_HOME`` then ``PATH``.
+
+    Args:
+        tool: Bare tool name without extension (e.g. ``"javac"``).
+
+    Returns:
+        Absolute path to the executable, or ``None`` if it cannot be found.
+    """
+    import os
+    import shutil
+
+    java_home = os.environ.get("JAVA_HOME")
+    if java_home:
+        candidate = Path(java_home) / "bin" / f"{tool}.exe"
+        if candidate.is_file():
+            return str(candidate)
+        candidate = Path(java_home) / "bin" / tool
+        if candidate.is_file():
+            return str(candidate)
+    return shutil.which(tool)
+
+
+class JavaSwingFixtureApp:
+    """Launch and control naturo's *owned* Java Swing recognition fixture.
+
+    This compiles ``fixtures/java/SwingControlsFixture.java`` with ``javac`` (no
+    Maven/Gradle) and runs it on the JVM.  The window's Swing controls
+    (buttons, a text field, a checkbox, a label, a table and a tree) are
+    invisible to the Windows UIA tree — which collapses the frame into opaque
+    window chrome — but fully recovered by naturo's Java Access Bridge (JAB)
+    provider.  The measured delta is therefore the literal Java/Swing case.
+
+    Java Access Bridge must be enabled in the JVM (``jabswitch -enable``) and
+    ``WindowsAccessBridge-64.dll`` must be on ``PATH`` (it ships in the JDK's
+    ``bin`` directory) for the JAB provider to recognize the controls.
+
+    Use as a context manager::
+
+        with JavaSwingFixtureApp() as app:
+            result = app.measure()
+    """
+
+    #: Window title set by ``SwingControlsFixture.java`` (used to find the HWND).
+    WINDOW_TITLE_SUBSTRING = "Naturo Swing Recognition Fixture"
+    #: Fully-qualified class name / source stem of the fixture.
+    MAIN_CLASS = "SwingControlsFixture"
+
+    def __init__(
+        self,
+        *,
+        javac_path: Optional[str] = None,
+        java_path: Optional[str] = None,
+    ) -> None:
+        """Initialise the controller.
+
+        Args:
+            javac_path: Override the auto-detected ``javac`` executable.
+            java_path: Override the auto-detected ``java`` executable.
+        """
+        self.app_dir = FIXTURES_DIR / "java"
+        self.source_path = self.app_dir / f"{self.MAIN_CLASS}.java"
+        self.javac_path = javac_path or _find_java_tool("javac")
+        self.java_path = java_path or _find_java_tool("java")
+        self._process: Optional[subprocess.Popen] = None
+
+    @property
+    def available(self) -> bool:
+        """Whether a JDK (``javac`` + ``java``) and the fixture source exist."""
+        return (
+            self.javac_path is not None
+            and self.java_path is not None
+            and self.source_path.is_file()
+        )
+
+    def _ensure_compiled(self) -> None:
+        """Compile the fixture with ``javac`` if the class file is missing or stale.
+
+        Raises:
+            RuntimeError: If ``javac`` is unavailable or compilation fails.
+        """
+        if self.javac_path is None:
+            raise RuntimeError("javac not found; install a JDK or set JAVA_HOME.")
+        class_path = self.app_dir / f"{self.MAIN_CLASS}.class"
+        if (
+            class_path.is_file()
+            and class_path.stat().st_mtime >= self.source_path.stat().st_mtime
+        ):
+            return
+        logger.info("Compiling Java fixture: %s", self.source_path)
+        result = subprocess.run(
+            [self.javac_path, self.source_path.name],
+            cwd=str(self.app_dir),
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"javac failed for {self.source_path}:\n{result.stderr}"
+            )
+
+    def start(self, ready_timeout: float = 30.0) -> None:
+        """Compile, launch the Swing fixture, and wait for its window.
+
+        Args:
+            ready_timeout: Maximum seconds to wait for the fixture window to
+                appear after launching the JVM.
+
+        Raises:
+            RuntimeError: If the JDK is unavailable, or the window does not
+                appear within ``ready_timeout``.
+        """
+        if not self.available or self.java_path is None:
+            raise RuntimeError(
+                "Java Swing fixture unavailable: "
+                f"javac={self.javac_path!r}, java={self.java_path!r}, "
+                f"source={self.source_path!r}. Install a JDK (JAVA_HOME)."
+            )
+
+        self._ensure_compiled()
+        logger.info("Launching Java Swing fixture: %s", self.MAIN_CLASS)
+        self._process = subprocess.Popen(
+            [self.java_path, self.MAIN_CLASS],
+            cwd=str(self.app_dir),
+        )
+
+        deadline = time.monotonic() + ready_timeout
+        while time.monotonic() < deadline:
+            if self.find_window() is not None:
+                time.sleep(1.0)  # settle the render and the JAB attach
+                return
+            if self._process.poll() is not None:
+                self.stop()
+                raise RuntimeError(
+                    "Java fixture process exited before its window appeared."
+                )
+            time.sleep(0.5)
+        self.stop()
+        raise RuntimeError(
+            f"Java Swing fixture window did not appear within {ready_timeout:.0f}s."
+        )
+
+    def find_window(self):
+        """Find the Swing fixture window via the backend.
+
+        Returns:
+            A window-info object (with ``hwnd``/``pid``) for the fixture
+            window, or ``None`` if it cannot be located.
+        """
+        backend = get_backend()
+        for window in backend.list_windows():
+            if self.WINDOW_TITLE_SUBSTRING in (window.title or ""):
+                return window
+        return None
+
+    def measure(self, depth: int = 15) -> CoverageResult:
+        """Measure recognition coverage on the Swing fixture window.
+
+        Args:
+            depth: Maximum accessibility-tree depth to walk.
+
+        Returns:
+            A :class:`CoverageResult` for the owned Java Swing app.
+
+        Raises:
+            RuntimeError: If the fixture window cannot be found.
+        """
+        window = self.find_window()
+        if window is None:
+            raise RuntimeError(
+                "Could not locate the Java Swing fixture window. "
+                "Did the JVM launch and render the fixture?"
+            )
+        return measure_window(
+            app="Owned Java Swing fixture (real Swing app)",
+            framework="Java Access Bridge",
+            hwnd=window.hwnd,
+            pid=window.pid,
+            depth=depth,
+            notes=(
+                "A real Swing process: its buttons, text field, checkbox, "
+                "label, table and tree live below a SunAwtFrame that the UIA "
+                "tree collapses into opaque window chrome. Only the Java Access "
+                "Bridge provider recovers them — the literal Java/Swing case. "
+                "Requires JAB enabled and WindowsAccessBridge-64.dll on PATH."
+            ),
+        )
+
+    def stop(self) -> None:
+        """Terminate the JVM process."""
+        if self._process is not None:
+            try:
+                self._process.terminate()
+                self._process.wait(timeout=10)
+            except (OSError, subprocess.TimeoutExpired):
+                try:
+                    self._process.kill()
+                except OSError:
+                    pass
+            self._process = None
+
+    def __enter__(self) -> "JavaSwingFixtureApp":
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        self.stop()
+
+
 def measure_running_app(
     *,
     app: str,

--- a/benchmarks/recognition/run_benchmark.py
+++ b/benchmarks/recognition/run_benchmark.py
@@ -35,6 +35,7 @@ from benchmarks.recognition.harness import (
     ChromiumFixtureApp,
     CoverageResult,
     ElectronFixtureApp,
+    JavaSwingFixtureApp,
     measure_running_app,
 )
 
@@ -93,7 +94,18 @@ def collect_results() -> tuple[List[CoverageResult], List[str]]:
             "install` in benchmarks/recognition/fixtures/electron/."
         )
 
-    # 3. Optional real desktop apps (included only when actually open).
+    # 3. Owned, real Java Swing fixture (the literal Java/Swing JAB case).
+    swing = JavaSwingFixtureApp()
+    if swing.available:
+        with swing:
+            results.append(swing.measure())
+    else:
+        gaps.append(
+            "Java Swing fixture skipped: no JDK found. Install a JDK (set "
+            "JAVA_HOME) and enable Java Access Bridge (`jabswitch -enable`)."
+        )
+
+    # 4. Optional real desktop apps (included only when actually open).
     for spec in OPTIONAL_APPS:
         result = measure_running_app(
             app=spec["app"],
@@ -108,7 +120,7 @@ def collect_results() -> tuple[List[CoverageResult], List[str]]:
                 f"desktop — no window titled '*{spec['title_substring']}*'."
             )
 
-    # 4. SAP GUI is not available in this environment.
+    # 5. SAP GUI is not available in this environment.
     gaps.append(
         "SAP GUI (SAP scripting/COM): not installed in this environment — "
         "future work."

--- a/core/src/jab.cpp
+++ b/core/src/jab.cpp
@@ -12,9 +12,10 @@
  * - IsJavaWindow(HWND) detects Java windows
  * - AccessibleContextInfo provides role, name, bounds, states etc.
  *
- * JAB must be initialized before use (initializeAccessBridge) and all
- * AccessibleContext handles must be released (ReleaseJavaObject) to
- * prevent memory leaks in the JVM.
+ * JAB must be started before use (Windows_run, the AT-side entry point the
+ * WindowsAccessBridge DLL actually exports) with its message queue pumped so
+ * the asynchronous JVM handshake completes, and all AccessibleContext handles
+ * must be released (ReleaseJavaObject) to prevent memory leaks in the JVM.
  */
 
 #ifdef _WIN32
@@ -62,7 +63,11 @@ typedef struct {
 
 /* ── JAB Function Pointer Types ───────────────────── */
 
-typedef BOOL  (__cdecl *FN_initializeAccessBridge)(void);
+// The assistive-technology entry point exported by the shipped
+// WindowsAccessBridge-<bits>.dll is `Windows_run` (declared
+// `void Windows_run(void)`), NOT `initializeAccessBridge` — that symbol is not
+// exported by the DLL, so looking it up returns NULL and JAB never starts.
+typedef void  (__cdecl *FN_Windows_run)(void);
 typedef BOOL  (__cdecl *FN_shutdownAccessBridge)(void);
 typedef BOOL  (__cdecl *FN_IsJavaWindow)(HWND window);
 typedef BOOL  (__cdecl *FN_GetAccessibleContextFromHWND)(HWND target, long* vmID, AccessibleContext* ac);
@@ -78,7 +83,7 @@ struct JABState {
     bool initialized = false;
     bool init_failed = false;
 
-    FN_initializeAccessBridge    pInitialize = nullptr;
+    FN_Windows_run               pInitialize = nullptr;
     FN_shutdownAccessBridge      pShutdown = nullptr;
     FN_IsJavaWindow              pIsJavaWindow = nullptr;
     FN_GetAccessibleContextFromHWND pGetContextFromHWND = nullptr;
@@ -89,6 +94,37 @@ struct JABState {
 };
 
 static JABState g_jab;
+
+/// Milliseconds to pump the message queue after starting the bridge, giving the
+/// asynchronous JVM-discovery handshake time to complete before the first query.
+static const DWORD JAB_INIT_SETTLE_MS = 1000;
+
+/**
+ * @brief Pump this thread's Windows message queue for up to @p budget_ms.
+ *
+ * The Java Access Bridge answers from the JVM are delivered as window messages
+ * to the assistive-technology thread and are only processed while that thread
+ * drains its message loop. A bare Sleep() blocks without draining the queue, so
+ * the bridge never finishes attaching and every subsequent query fails. This
+ * drains all pending messages in a bounded loop.
+ *
+ * @param budget_ms Maximum time to spend pumping, in milliseconds.
+ */
+static void jab_pump_messages(DWORD budget_ms) {
+    DWORD start = GetTickCount();
+    MSG msg;
+    for (;;) {
+        while (PeekMessageW(&msg, nullptr, 0, 0, PM_REMOVE)) {
+            TranslateMessage(&msg);
+            DispatchMessageW(&msg);
+        }
+        // Unsigned subtraction is wrap-safe across the GetTickCount rollover.
+        if (GetTickCount() - start >= budget_ms) {
+            break;
+        }
+        Sleep(10);
+    }
+}
 
 /**
  * @brief Attempt to load and initialize the Java Access Bridge.
@@ -116,7 +152,7 @@ static bool jab_ensure_init() {
     }
 
     // Load function pointers
-    g_jab.pInitialize     = (FN_initializeAccessBridge)GetProcAddress(g_jab.dll, "initializeAccessBridge");
+    g_jab.pInitialize     = (FN_Windows_run)GetProcAddress(g_jab.dll, "Windows_run");
     g_jab.pShutdown       = (FN_shutdownAccessBridge)GetProcAddress(g_jab.dll, "shutdownAccessBridge");
     g_jab.pIsJavaWindow   = (FN_IsJavaWindow)GetProcAddress(g_jab.dll, "isJavaWindow");
     g_jab.pGetContextFromHWND = (FN_GetAccessibleContextFromHWND)GetProcAddress(g_jab.dll, "getAccessibleContextFromHWND");
@@ -135,17 +171,18 @@ static bool jab_ensure_init() {
         return false;
     }
 
-    // Initialize the bridge — this triggers message pump handshake with JVMs
-    BOOL ok = g_jab.pInitialize();
-    if (!ok) {
-        FreeLibrary(g_jab.dll);
-        g_jab.dll = nullptr;
-        g_jab.init_failed = true;
-        return false;
-    }
+    // Start the bridge. `Windows_run` registers this process as an assistive
+    // technology and kicks off JVM discovery; it returns void, so its result
+    // must not be treated as a success flag (the previous code did, gating
+    // initialization on indeterminate stack garbage).
+    g_jab.pInitialize();
 
-    // Give bridge time to discover JVMs (JAB uses async window messages)
-    Sleep(250);
+    // Discovery and every later accessibility query are answered
+    // asynchronously over window messages delivered to this thread, so the
+    // message queue must be pumped for the handshake to complete — a bare
+    // Sleep() starves it and isJavaWindow()/getAccessibleContextFromHWND()
+    // then always fail. Pump for a bounded settle window.
+    jab_pump_messages(JAB_INIT_SETTLE_MS);
 
     g_jab.initialized = true;
     return true;

--- a/tests/test_jab_recognition_932.py
+++ b/tests/test_jab_recognition_932.py
@@ -1,0 +1,123 @@
+"""Live Java Access Bridge recognition tests against the owned Swing fixture (#932).
+
+These prove that naturo recognizes Java/Swing controls through the Java Access
+Bridge (JAB) where a UIA-only baseline sees only opaque window chrome — the
+recognition moat for Java desktop apps.
+
+They are ``@pytest.mark.desktop`` because they launch a real JVM window and call
+the native DLL, so they run on an interactive Windows desktop that has a JDK
+with Java Access Bridge enabled (``jabswitch -enable`` and
+``WindowsAccessBridge-64.dll`` on ``PATH``) — not on the headless CI runners.
+When that environment is absent the whole module is skipped.
+"""
+from __future__ import annotations
+
+import platform
+
+import pytest
+
+from benchmarks.recognition.harness import JavaSwingFixtureApp
+from naturo.backends.base import get_backend
+
+#: Accessible control names defined by ``SwingControlsFixture.java`` — the
+#: ground truth that JAB must recover and UIA cannot see.
+EXPECTED_CONTROLS = {
+    "Submit Order",
+    "Cancel Order",
+    "Customer Name",
+    "Express Shipping",
+    "Catalog Tree",
+}
+
+pytestmark = pytest.mark.desktop
+
+
+def _fixture_available() -> bool:
+    """Whether this host can build and run the Java Swing fixture."""
+    return platform.system() == "Windows" and JavaSwingFixtureApp().available
+
+
+requires_fixture = pytest.mark.skipif(
+    not _fixture_available(),
+    reason="requires an interactive Windows desktop with a JDK (JAVA_HOME)",
+)
+
+
+def _names_in_tree(tree) -> set:
+    """Collect every non-empty element name in an element tree.
+
+    Args:
+        tree: Root :class:`~naturo.backends.base.ElementInfo`, or ``None``.
+
+    Returns:
+        Set of stripped, non-empty element names found anywhere in the tree.
+    """
+    names: set = set()
+    stack = [tree]
+    while stack:
+        node = stack.pop()
+        if node is None:
+            continue
+        if node.name and node.name.strip():
+            names.add(node.name.strip())
+        stack.extend(node.children or [])
+    return names
+
+
+@pytest.fixture(scope="module")
+def swing_app():
+    """Launch the owned Swing fixture once for the module and tear it down."""
+    app = JavaSwingFixtureApp()
+    if not _fixture_available():
+        pytest.skip("Java Swing fixture unavailable on this host")
+    with app:
+        window = app.find_window()
+        assert window is not None, "fixture window did not appear"
+        yield app, window
+
+
+@requires_fixture
+def test_uia_only_is_blind_to_swing_controls(swing_app):
+    """A UIA-only walk sees window chrome but none of the Swing controls.
+
+    This establishes the moat premise: the controls genuinely live outside the
+    UIA tree, so any recognition of them must come from JAB.
+    """
+    _app, window = swing_app
+    backend = get_backend()
+    tree = backend.get_element_tree(hwnd=window.hwnd, depth=15, backend="uia")
+    uia_names = _names_in_tree(tree)
+    assert EXPECTED_CONTROLS.isdisjoint(uia_names), (
+        "UIA unexpectedly saw Swing controls: "
+        f"{sorted(EXPECTED_CONTROLS & uia_names)}"
+    )
+
+
+@requires_fixture
+def test_jab_recognizes_swing_controls(swing_app):
+    """The JAB backend recovers every named Swing control.
+
+    Fails against a core DLL whose Java Access Bridge never initializes (the
+    pre-#932 defect) and passes once JAB attaches to the JVM.
+    """
+    _app, window = swing_app
+    backend = get_backend()
+    tree = backend.get_element_tree(hwnd=window.hwnd, depth=15, backend="jab")
+    assert tree is not None, "JAB returned no tree for a live Swing window"
+    jab_names = _names_in_tree(tree)
+    missing = EXPECTED_CONTROLS - jab_names
+    assert not missing, f"JAB did not recognize controls: {sorted(missing)}"
+
+
+@requires_fixture
+def test_cascade_shows_positive_jab_delta(swing_app):
+    """The full cascade recognizes more than UIA alone, with JAB as the source."""
+    app, _window = swing_app
+    result = app.measure()
+    assert result.delta > 0, (
+        f"expected a positive JAB delta, got UIA={result.uia_only_count} "
+        f"cascade={result.cascade_count}"
+    )
+    assert "jab" in result.extra_sources, (
+        f"expected JAB to contribute extra elements, got {result.extra_sources}"
+    )


### PR DESCRIPTION
## What

Fixes the root-cause defect that has prevented **Java Access Bridge (JAB)** recognition from ever working, and lands the owned Swing fixture + harness the moat proof needs (part of #932, the v0.3.2 recognition moat).

### The bug
`core/src/jab.cpp` loaded `WindowsAccessBridge-64.dll` but resolved the AT entry point as **`initializeAccessBridge`** — a symbol the shipped DLL **does not export**. `GetProcAddress` returned `NULL`, the required-symbol check failed, and every JAB call returned "not available". So `naturo see/find --backend jab` (and the `auto` cascade) saw nothing in Java/Swing windows beyond the opaque UIA window chrome.

Two issues, both proven against the installed `WindowsAccessBridge-64.dll`:
1. The exported entry point is **`Windows_run`** (`void`, no args), not `initializeAccessBridge`. The old code also gated success on its `BOOL` return — indeterminate stack garbage for a void function.
2. After starting the bridge, JVM discovery and every later query are answered **asynchronously over window messages** delivered to the AT thread. The old `Sleep(250)` blocked **without pumping** the queue, so the handshake never completed.

### The fix (`core/src/jab.cpp`)
- Resolve and call `Windows_run`; don't treat its result as a success flag.
- Replace the bare `Sleep` with a bounded **message-pump settle** (`jab_pump_messages`) so the handshake completes.

### Supporting artifacts (part of #932)
- `benchmarks/recognition/fixtures/java/SwingControlsFixture.java` — owned Swing app with known accessible controls (buttons, text field, checkbox, label, table, tree); compiles with `javac` directly (no Maven/Gradle).
- `JavaSwingFixtureApp` harness controller + `run_benchmark` wiring, mirroring the existing Chromium/Electron fixtures (UIA-only vs full-cascade delta).
- `tests/test_jab_recognition_932.py` (`@pytest.mark.desktop`) — asserts UIA is blind to the controls while JAB recovers them, with a positive cascade delta.

## How tested
- **Root cause + fix proven**: replicating the corrected sequence (`Windows_run` + pump + `getAccessibleContextFromHWND` + tree walk) in Python against the **exact same** `WindowsAccessBridge-64.dll` walks the full Swing tree — **41 elements incl. every named control** (Submit Order, Cancel Order, Customer Name, Express Shipping, Order Items, Catalog Tree) — where a UIA-only walk sees ~7 chrome nodes.
- **Fixture verified**: compiles with `javac`, launches, and the harness controller (`JavaSwingFixtureApp`) builds → launches → finds → measures cleanly. With the current pre-fix DLL the cascade delta reads 0 (expected); it jumps to the JAB tree once the rebuilt DLL ships.
- **Gates**: `ruff` clean; `mypy` clean on changed files; new desktop test collects cross-platform (`--collect-only` OK); non-desktop suite unaffected (the two pre-existing local `test_jab`/`test_cascade` env failures reproduce on clean `develop` without this change).

## Verification status & scope
The native change is **compile-verified by the required `build-dll` CI job**. End-to-end runtime verification with naturo's own pipeline needs the **rebuilt core DLL** (gitignored; produced by CI) and runs on the self-hosted desktop runner. Because that distribution + the `RECOGNITION.md` benchmark numbers and click/type-via-JAB are follow-up slices, **#932 stays open**.

Progresses #932.