### PR TITLE
feat: naturo find --selector path resolution (part of #809)

### DIFF
--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -165,6 +165,7 @@ Search for UI elements matching a query.
 | `--ai` | boolean | Use AI vision to find element by natural language |
 | `--image` | path | Locate a template image (PNG/JPG) on the target window or screen via normalized cross-correlation (no UIA tree needed) |
 | `--threshold` | float | Minimum match score in [0.0, 1.0] for `--image` (higher is stricter, default `0.9`) |
+| `--selector` | text | Resolve a unified selector path to an element (the same strategy `click`/`type` use). URI (`app://proc.exe/Button[@name="Save"]`), descendant shorthand (`//Edit[@name="Search"]`), or saved (`@name`) |
 | `--screenshot` | path | Use existing screenshot (for --ai mode) |
 | `--app` | text | Target app window |
 | `--app-id` | text | Stable app/window ID from "naturo app list" output (e.g. a1) |
@@ -189,12 +190,17 @@ naturo find "OK" --backend msaa          # MSAA for legacy apps
 naturo find --image submit.png           # template match on the screen
 naturo find --image icon.png --app Notepad --all  # all matches in an app
 naturo find --image btn.png --threshold 0.85      # looser match threshold
+naturo find --selector '//Button[@name="Save"]'   # resolve a selector path
+naturo find --selector 'app://notepad.exe/Edit[@automationid="15"]'
+naturo find --selector @login-button --all        # every match of a saved selector
 ```
 
 Found matches get `eN` refs in the snapshot (like a normal `find`), so you can
 follow up with `naturo click e<N>`. With `--image` the reported `x,y` are the
 match's screen-absolute top-left; the JSON envelope also includes `center_x`,
-`center_y`, and the NCC `score`.
+`center_y`, and the NCC `score`. With `--selector` the element is resolved the
+same way `click`/`type` resolve it (URI / XML / `//` shorthand / `@named`, with
+flexible app-name matching), so a path that clicks will also `find`.
 
 ## `naturo get`
 

--- a/naturo/cli/core/_find.py
+++ b/naturo/cli/core/_find.py
@@ -25,6 +25,12 @@ import naturo.cli.core._common as _common
                    "via normalized cross-correlation (no UIA tree needed)")
 @click.option("--threshold", type=float, default=0.9, show_default=True,
               help="Minimum match score in [0.0, 1.0] for --image (higher is stricter)")
+@click.option("--selector", default=None,
+              help="Resolve a unified selector path to an element (the strategy "
+                   "click/type use). "
+                   'URI: app://notepad.exe/Button[@name="Save"]. '
+                   'Short: //Edit[@name="Search"] (any app, descendant search). '
+                   "Saved: @name. App names are flexible: chrome, chrome.exe, Chrome.")
 @click.option("--screenshot", type=click.Path(), default=None,
               help="Use existing screenshot (for --ai mode)")
 @click.option("--app", default=None, help="Target app window")
@@ -50,7 +56,7 @@ import naturo.cli.core._common as _common
               help="AI provider API key (overrides env var)")
 def find_cmd(query: str | None, query_opt: str | None, find_all: bool, role: str | None,
              actionable: bool, depth: int, limit: int, ai: bool,
-             image_template: str | None, threshold: float,
+             image_template: str | None, threshold: float, selector: str | None,
              ai_provider: str, ai_model: str | None, ai_api_key: str | None,
              screenshot: str | None, app: str | None, app_id: str | None,
              window_title: str | None, hwnd: int | None, pid: int | None,
@@ -75,6 +81,8 @@ def find_cmd(query: str | None, query_opt: str | None, find_all: bool, role: str
         naturo find "OK" --backend msaa          # MSAA for legacy apps
         naturo find --image submit.png           # template match on screen
         naturo find --image icon.png --app Notepad --all  # all matches in app
+        naturo find --selector '//Button[@name="Save"]'   # resolve a selector path
+        naturo find --selector 'app://notepad.exe/Edit[@automationid="15"]'
     """
     # (#752) Auto-detect app ID pattern (a1, a2, ...) in --app flag
     from naturo.cli.options import maybe_promote_app_to_app_id
@@ -94,6 +102,32 @@ def find_cmd(query: str | None, query_opt: str | None, find_all: bool, role: str
                 click.echo(f"Error: {msg}", err=True)
             raise SystemExit(1)
         hwnd = entry.handle
+
+    # Selector resolution mode — resolve a saved/inline selector path to an
+    # element (the third unified-find strategy, #1061 / #809).  Dispatched
+    # before query resolution since --selector carries its own target path, not
+    # a text query.
+    if selector is not None:
+        conflict = None
+        if ai:
+            conflict = "--selector and --ai are mutually exclusive; choose one find strategy."
+        elif image_template is not None:
+            conflict = "--selector and --image are mutually exclusive; choose one find strategy."
+        elif query is not None or query_opt is not None:
+            conflict = ("--selector takes no text query; it resolves a selector path, "
+                        "not a named element.")
+        if conflict is not None:
+            if json_output:
+                click.echo(_common._json_error_str("INVALID_INPUT", conflict))
+            else:
+                click.echo(f"Error: {conflict}", err=True)
+            raise SystemExit(1)
+        _find_with_selector(
+            selector, find_all,
+            app=app, window_title=window_title, hwnd=hwnd, pid=pid,
+            limit=limit, json_output=json_output,
+        )
+        return
 
     # Image template matching mode — locate a picture on the window/screen.
     # Dispatched before query resolution since --image needs no text query
@@ -556,6 +590,185 @@ def _find_with_image(
         click.echo(f"\n{len(matches)} match(es) found.")
         click.echo(f"Snapshot: {snapshot_id}")
         click.echo("Tip: use 'naturo click e<N>' to interact with a match.")
+
+
+def _find_with_selector(
+    selector_str: str,
+    find_all: bool,
+    *,
+    app: str | None,
+    window_title: str | None,
+    hwnd: int | None,
+    pid: int | None,
+    limit: int,
+    json_output: bool,
+) -> None:
+    """Resolve a unified selector path to element(s) (naturo find --selector).
+
+    Mirrors the click/type family's ``_resolve_selector_target`` so the
+    ``--selector`` flag resolves the SAME way across commands — same selector
+    grammar, ``@named`` dereferencing, app-name normalization, and
+    ``SelectorResolver`` — then reports the match(es) as snapshot elements with
+    stable ``eN`` refs (the contract the text and image strategies share), so
+    they can be acted on with ``naturo click eN``.
+
+    Each distinct failure source carries its own error code (#1047/#1067 error
+    attribution): a bad ``@name`` ref → ``SELECTOR_REF_ERROR``, a malformed
+    selector → ``INVALID_SELECTOR``, a missing window → ``WINDOW_NOT_FOUND``, a
+    tree-fetch fault → ``TREE_ERROR``, and a no-match → ``SELECTOR_NOT_FOUND``.
+
+    Args:
+        selector_str: Selector path (URI / XML / ``//`` shorthand / ``@named``).
+        find_all: When True, return every exact match; otherwise the single best
+            (with the resolver's relaxed/fuzzy fallback).
+        app: Target app name/partial match (overridden by the selector's app
+            when not given explicitly).
+        window_title: Target window title substring.
+        hwnd: Target window handle.
+        pid: Target process ID.
+        limit: Maximum number of matches to return.
+        json_output: Whether to emit JSON.
+
+    Raises:
+        SystemExit: With status 1 on any of the failure sources above or on a
+            platform without GUI support.
+    """
+    from naturo.selector import (
+        parse, SelectorParseError, SelectorResolver, normalize_app_name,
+    )
+
+    def _emit_error(code: str, message: str) -> None:
+        if json_output:
+            click.echo(_common._json_error_str(code, message))
+        else:
+            click.echo(f"Error: {message}", err=True)
+        raise SystemExit(1)
+
+    # Dereference a saved @name selector to its stored path (#105), matching the
+    # click family's behavior exactly.
+    if selector_str.startswith("@"):
+        from naturo.cli.selector_cmd import resolve_named_selector
+        try:
+            selector_str = resolve_named_selector(selector_str)
+        except (KeyError, ValueError) as exc:
+            _emit_error("SELECTOR_REF_ERROR", str(exc))
+
+    try:
+        ast = parse(selector_str)
+    except SelectorParseError as exc:
+        _emit_error("INVALID_SELECTOR", f"Invalid selector: {exc}")
+
+    # The selector's app scopes the search when no explicit --app was given.
+    if ast.app and ast.app != "*" and not app:
+        app = normalize_app_name(ast.app)
+
+    if not _common._platform_supports_gui():
+        _emit_error("PLATFORM_ERROR", _common._platform_error_msg("Selector resolution"))
+
+    backend = _common._get_backend(json_output)
+
+    try:
+        tree = backend.get_element_tree(
+            app=app, window_title=window_title, hwnd=hwnd, pid=pid, depth=20,
+        )
+    except _common.WindowNotFoundError as exc:
+        _emit_error("WINDOW_NOT_FOUND", str(exc))
+    except Exception as exc:
+        _emit_error("TREE_ERROR", f"Failed to get UI tree for selector resolution: {exc}")
+
+    if tree is None:
+        _emit_error(
+            "WINDOW_NOT_FOUND",
+            "No window found for selector resolution. Check that the target "
+            "application is running and visible.",
+        )
+
+    # Reuse the click family's ElementInfo→dict conversion so both commands feed
+    # the resolver an identically-shaped tree (no semantic drift).
+    from naturo.cli.interaction._common import _elementinfo_to_dict
+    tree_dict = [_elementinfo_to_dict(tree)]
+
+    resolver = SelectorResolver()
+    if find_all:
+        resolved = [r.element for r in resolver.resolve_all(ast, tree_dict)][:limit]
+    else:
+        result = resolver.resolve(ast, tree_dict)
+        resolved = [result.element] if result is not None else []
+
+    if not resolved:
+        _emit_error("SELECTOR_NOT_FOUND", f"Selector matched no elements: {selector_str}")
+
+    from naturo.bridge import ElementInfo as BridgeElementInfo
+    from naturo.snapshot import get_snapshot_manager
+    from naturo.models.snapshot import UIElement
+    from naturo.refs import assign_stable_refs
+
+    children = [
+        BridgeElementInfo(
+            id=str(i),
+            role=el.get("role", ""),
+            name=el.get("name", ""),
+            value=el.get("value", "") or None,
+            x=el.get("x", 0),
+            y=el.get("y", 0),
+            width=el.get("width", 0),
+            height=el.get("height", 0),
+            parent_id="0",
+            hwnd=hwnd or 0,
+        )
+        for i, el in enumerate(resolved, start=1)
+    ]
+    root = BridgeElementInfo(
+        id="0",
+        role="Pane",
+        name="selector-match",
+        value=None,
+        x=0,
+        y=0,
+        width=0,
+        height=0,
+        children=children,
+        hwnd=hwnd or 0,
+    )
+
+    mgr = get_snapshot_manager()
+    snapshot_id = mgr.create_snapshot()
+    element_id_to_ref: dict[int, str] = {}
+    ui_map, ref_map = assign_stable_refs(root, UIElement, element_obj_to_ref=element_id_to_ref)
+    mgr.store_detection_result(snapshot_id, ui_map)
+    mgr.store_ref_map(snapshot_id, ref_map)
+
+    if json_output:
+        data = [
+            {
+                "ref": element_id_to_ref.get(id(child), child.id),
+                "role": child.role,
+                "name": child.name,
+                "value": child.value,
+                "x": child.x,
+                "y": child.y,
+                "width": child.width,
+                "height": child.height,
+                "center_x": child.x + child.width // 2,
+                "center_y": child.y + child.height // 2,
+            }
+            for child in children
+        ]
+        click.echo(json_dumps({
+            "success": True,
+            "elements": data,
+            "count": len(data),
+            "snapshot_id": snapshot_id,
+        }, indent=2))
+    else:
+        for child in children:
+            ref = element_id_to_ref.get(id(child), "?")
+            name_str = f' "{child.name}"' if child.name else ""
+            pos_str = f"({child.x},{child.y} {child.width}x{child.height})"
+            click.echo(f"  {ref}. [{child.role}]{name_str} {pos_str}")
+        click.echo(f"\n{len(children)} element(s) found.")
+        click.echo(f"Snapshot: {snapshot_id}")
+        click.echo("Tip: use 'naturo click e<N>' to interact with a resolved element.")
 
 
 def _find_with_ai(

--- a/tests/test_find_selector_1061.py
+++ b/tests/test_find_selector_1061.py
@@ -1,0 +1,208 @@
+"""Tests for ``naturo find --selector`` path resolution (feature #1061).
+
+The third locator strategy of the unified find engine (#809): resolve an
+existing selector path (URI / XML / ``@named`` / ``//`` shorthand) against the
+live UI tree and report the matched element(s) as snapshot elements with stable
+``eN`` refs — the same contract the text and image strategies emit.
+
+These tests stub ``backend.get_element_tree`` with an in-memory element tree, so
+they need neither a desktop session nor the native core DLL and run on every CI
+platform.
+
+A cross-command parity test pins the key invariant: ``find --selector`` resolves
+a selector to the SAME element the click family's ``_resolve_selector_target``
+targets — harmonizing the *accepted* flag is not enough; the *semantics* must
+match the gold-standard resolver (lesson of #1058/#1065).
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+
+import pytest
+from click.testing import CliRunner
+from unittest.mock import MagicMock, patch
+
+from naturo.cli.core import find_cmd
+
+
+@dataclass
+class _FakeElement:
+    """Minimal stand-in for a backend ``ElementInfo`` node.
+
+    Carries exactly the attributes ``_elementinfo_to_dict`` reads so the real
+    ``SelectorResolver`` runs unchanged.
+    """
+
+    role: str
+    name: str = ""
+    id: str = ""
+    value: str = ""
+    x: int = 0
+    y: int = 0
+    width: int = 0
+    height: int = 0
+    children: list = field(default_factory=list)
+    properties: dict = field(default_factory=dict)
+
+
+def _sample_tree() -> _FakeElement:
+    """A small Notepad-like tree with two buttons and an edit area."""
+    return _FakeElement(
+        role="Window", name="Untitled - Notepad", x=0, y=0, width=800, height=600,
+        children=[
+            _FakeElement(role="Edit", name="Text Editor", id="15",
+                         x=10, y=40, width=780, height=520),
+            _FakeElement(role="Button", name="Save", x=700, y=8, width=60, height=24),
+            _FakeElement(role="Button", name="Cancel", x=620, y=8, width=60, height=24),
+        ],
+    )
+
+
+def _backend_returning(tree) -> MagicMock:
+    backend = MagicMock()
+    backend.get_element_tree.return_value = tree
+    return backend
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _invoke(runner, backend, args):
+    with patch("naturo.cli.core._common._platform_supports_gui", return_value=True), \
+         patch("naturo.cli.core._common._get_backend", return_value=backend):
+        return runner.invoke(find_cmd, args)
+
+
+class TestFindSelectorMutualExclusion:
+    def test_selector_and_ai_mutually_exclusive(self, runner) -> None:
+        result = runner.invoke(
+            find_cmd, ["--selector", "//Button[@name=\"Save\"]", "--ai", "--json"],
+        )
+        assert result.exit_code == 1
+        assert json.loads(result.output)["error"]["code"] == "INVALID_INPUT"
+
+    def test_selector_and_image_mutually_exclusive(self, runner) -> None:
+        # The conflict is detected before any file access, so the (absent) image
+        # path need not exist.
+        result = runner.invoke(
+            find_cmd,
+            ["--selector", "//Button[@name=\"Save\"]", "--image", "anything.png", "--json"],
+        )
+        assert result.exit_code == 1
+        assert json.loads(result.output)["error"]["code"] == "INVALID_INPUT"
+
+    def test_selector_rejects_text_query(self, runner) -> None:
+        result = runner.invoke(
+            find_cmd, ["Save", "--selector", "//Button[@name=\"Save\"]", "--json"],
+        )
+        assert result.exit_code == 1
+        assert json.loads(result.output)["error"]["code"] == "INVALID_INPUT"
+
+
+class TestFindSelectorResolution:
+    def test_valid_selector_resolves_to_element(self, runner) -> None:
+        backend = _backend_returning(_sample_tree())
+        result = _invoke(
+            runner, backend,
+            ["--selector", "//Button[@name=\"Save\"]", "--json"],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["success"] is True
+        assert payload["count"] == 1
+        el = payload["elements"][0]
+        assert el["role"] == "Button"
+        assert el["name"] == "Save"
+        assert el["x"] == 700 and el["y"] == 8
+        assert el["ref"].startswith("e")
+
+    def test_uri_selector_with_app_resolves(self, runner) -> None:
+        backend = _backend_returning(_sample_tree())
+        result = _invoke(
+            runner, backend,
+            ["--selector", "app://notepad.exe/Edit[@automationid=\"15\"]", "--json"],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["count"] == 1
+        assert payload["elements"][0]["role"] == "Edit"
+
+    def test_no_match_returns_selector_not_found(self, runner) -> None:
+        backend = _backend_returning(_sample_tree())
+        result = _invoke(
+            runner, backend,
+            ["--selector", "//Button[@name=\"Nonexistent\"]", "--json"],
+        )
+        assert result.exit_code == 1
+        assert json.loads(result.output)["error"]["code"] == "SELECTOR_NOT_FOUND"
+
+    def test_all_flag_returns_every_match(self, runner) -> None:
+        backend = _backend_returning(_sample_tree())
+        result = _invoke(
+            runner, backend,
+            ["--selector", "//Button", "--all", "--json"],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["count"] == 2
+        names = sorted(e["name"] for e in payload["elements"])
+        assert names == ["Cancel", "Save"]
+
+    def test_invalid_selector_syntax_recoverable_error(self, runner) -> None:
+        backend = _backend_returning(_sample_tree())
+        # "app://" with an empty body is a parse error.
+        result = _invoke(runner, backend, ["--selector", "app://", "--json"])
+        assert result.exit_code == 1
+        assert json.loads(result.output)["error"]["code"] == "INVALID_SELECTOR"
+
+    def test_window_not_found(self, runner) -> None:
+        backend = _backend_returning(None)
+        result = _invoke(
+            runner, backend,
+            ["--selector", "//Button[@name=\"Save\"]", "--json"],
+        )
+        assert result.exit_code == 1
+        assert json.loads(result.output)["error"]["code"] == "WINDOW_NOT_FOUND"
+
+    def test_unresolvable_named_selector(self, runner) -> None:
+        backend = _backend_returning(_sample_tree())
+        with patch("naturo.cli.selector_cmd.resolve_named_selector",
+                   side_effect=KeyError("no such saved selector: @ghost")):
+            result = _invoke(runner, backend, ["--selector", "@ghost", "--json"])
+        assert result.exit_code == 1
+        assert json.loads(result.output)["error"]["code"] == "SELECTOR_REF_ERROR"
+
+    def test_plain_text_output(self, runner) -> None:
+        backend = _backend_returning(_sample_tree())
+        result = _invoke(runner, backend, ["--selector", "//Button[@name=\"Save\"]"])
+        assert result.exit_code == 0, result.output
+        assert "Save" in result.output
+        assert "Button" in result.output
+
+
+class TestSelectorCrossCommandParity:
+    """``find --selector`` must target the SAME element the click family does."""
+
+    def test_find_selector_matches_click_resolution(self, runner) -> None:
+        from naturo.cli.interaction._common import _resolve_selector_target
+
+        selector = "//Button[@name=\"Save\"]"
+        tree = _sample_tree()
+
+        # Gold standard: what the click family would target.
+        click_backend = _backend_returning(tree)
+        click_xy = _resolve_selector_target(
+            selector, click_backend, None, None, None, None, json_output=True,
+        )
+        assert click_xy is not None
+
+        # find --selector must land on the same element's center.
+        find_backend = _backend_returning(tree)
+        result = _invoke(runner, find_backend, ["--selector", selector, "--json"])
+        assert result.exit_code == 0, result.output
+        el = json.loads(result.output)["elements"][0]
+        find_xy = (el["x"] + el["width"] // 2, el["y"] + el["height"] // 2)
+        assert find_xy == click_xy


### PR DESCRIPTION
## What

Adds the third locator strategy of the unified find engine (#809): `naturo find --selector "<path>"` resolves an existing selector path against the live UI tree and reports the matched element(s) as snapshot elements with stable `eN` refs — the same contract the text (`find Save`) and image (`find --image`) strategies already emit. Until now selector resolution lived only in `click`/`type`.

Supports the full selector grammar: URI (`app://notepad.exe/Button[@name="Save"]`), XML, descendant shorthand (`//Edit[@name="Search"]`), and saved `@named` selectors. `--all` returns every exact match.

## Cross-command parity

Resolution mirrors the click/type family's gold-standard `_resolve_selector_target` — same `parse`, same `@named` dereferencing, same `normalize_app_name` app scoping, and the same `SelectorResolver` over an identically-shaped tree (reuses `_elementinfo_to_dict`). A path that `click` targets will also `find` to the same element. Pinned by a cross-command parity test asserting `find --selector`'s resolved element center equals the coordinates `_resolve_selector_target` returns for the same selector + tree.

## Error attribution

Each distinct failure source gets its own code (per the #1047/#1067 self-review rule): bad `@name` → `SELECTOR_REF_ERROR`, malformed selector → `INVALID_SELECTOR`, missing window → `WINDOW_NOT_FOUND`, tree-fetch fault → `TREE_ERROR`, no match → `SELECTOR_NOT_FOUND`. `--selector` is mutually exclusive with `--ai`, `--image`, and a text query (`INVALID_INPUT`).

## How tested

- `tests/test_find_selector_1061.py` — 12 tests: mutual-exclusion (×3), valid URI/descendant resolution, `--all`, no-match, invalid syntax, window-not-found, unresolvable `@named`, plain-text output, and the cross-command parity test. All pass; collection is desktop/DLL-free (runs on every CI platform).
- Quality gate: `ruff check` clean, `mypy` clean on changed file.
- **Live desktop validation** against Calculator: `find --selector //Button` resolves to the real minimize button at its true coords (702,34); `--all` returns all 34 buttons; not-found path returns `SELECTOR_NOT_FOUND` exit 1. Read-only — no input injection.

Acceptance (#1061): a valid selector resolves to the element; invalid returns a clear recoverable error; `-j` envelope. ✓