### PR TITLE
fix: honor find --image --screenshot for offline matching (fixes #1070, fixes #1067)

### DIFF
--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -166,7 +166,7 @@ Search for UI elements matching a query.
 | `--image` | path | Locate a template image (PNG/JPG) on the target window or screen via normalized cross-correlation (no UIA tree needed) |
 | `--threshold` | float | Minimum match score in [0.0, 1.0] for `--image` (higher is stricter, default `0.9`) |
 | `--selector` | text | Resolve a unified selector path to an element (the same strategy `click`/`type` use). URI (`app://proc.exe/Button[@name="Save"]`), descendant shorthand (`//Edit[@name="Search"]`), or saved (`@name`) |
-| `--screenshot` | path | Use existing screenshot (for --ai mode) |
+| `--screenshot` | path | Match against this existing screenshot instead of capturing live (for `--ai` and `--image`). With `--image` the screenshot is the haystack, coordinates are screenshot-relative, and window-targeting flags are rejected |
 | `--app` | text | Target app window |
 | `--app-id` | text | Stable app/window ID from "naturo app list" output (e.g. a1) |
 | `--json`, `-j` | boolean | JSON output |
@@ -190,6 +190,7 @@ naturo find "OK" --backend msaa          # MSAA for legacy apps
 naturo find --image submit.png           # template match on the screen
 naturo find --image icon.png --app Notepad --all  # all matches in an app
 naturo find --image btn.png --threshold 0.85      # looser match threshold
+naturo find --image btn.png --screenshot saved.png  # match offline against a saved screenshot
 naturo find --selector '//Button[@name="Save"]'   # resolve a selector path
 naturo find --selector 'app://notepad.exe/Edit[@automationid="15"]'
 naturo find --selector @login-button --all        # every match of a saved selector
@@ -197,8 +198,13 @@ naturo find --selector @login-button --all        # every match of a saved selec
 
 Found matches get `eN` refs in the snapshot (like a normal `find`), so you can
 follow up with `naturo click e<N>`. With `--image` the reported `x,y` are the
-match's screen-absolute top-left; the JSON envelope also includes `center_x`,
-`center_y`, and the NCC `score`. With `--selector` the element is resolved the
+match's screen-absolute top-left (the JSON envelope's `coordinate_frame` is
+`screen`); the JSON envelope also includes `center_x`, `center_y`, and the NCC
+`score`. Passing `--screenshot <file>` matches offline against that image
+instead of capturing live — useful for replay, headless pipelines, and
+regression fixtures — and the coordinates are then relative to the screenshot
+(`coordinate_frame` is `screenshot`); window-targeting flags do not apply and
+are rejected. With `--selector` the element is resolved the
 same way `click`/`type` resolve it (URI / XML / `//` shorthand / `@named`, with
 flexible app-name matching), so a path that clicks will also `find`.
 

--- a/naturo/cli/core/_find.py
+++ b/naturo/cli/core/_find.py
@@ -459,14 +459,6 @@ def _find_with_image(
             click.echo(f"Error: {msg}", err=True)
         raise SystemExit(1)
 
-    if not _common._platform_supports_gui():
-        msg = _common._platform_error_msg("Image matching")
-        if json_output:
-            click.echo(_common._json_error_str("PLATFORM_ERROR", msg))
-        else:
-            click.echo(f"Error: {msg}", err=True)
-        raise SystemExit(1)
-
     try:
         from PIL import Image
     except ImportError as e:  # pragma: no cover - exercised only without Pillow
@@ -491,7 +483,9 @@ def _find_with_image(
     # search haystack, so the window-targeting flags do not apply.  Reject the
     # combination explicitly rather than silently ignoring it (the convention
     # the --ai path already follows) — silently discarding --screenshot and
-    # matching the live screen returns confidently-wrong coordinates.
+    # matching the live screen returns confidently-wrong coordinates.  Offline
+    # matching needs no live capture, so it is also exempt from the GUI-platform
+    # requirement that the live-capture path enforces (it runs headless).
     if screenshot is not None:
         if hwnd or app or window_title or pid:
             _emit(
@@ -503,6 +497,8 @@ def _find_with_image(
             )
         if not os.path.exists(screenshot):
             _emit("FILE_NOT_FOUND", f"Screenshot file not found: {screenshot}")
+    elif not _common._platform_supports_gui():
+        _emit("PLATFORM_ERROR", _common._platform_error_msg("Image matching"))
 
     # Load the template once, in its own try, so a template that exists but
     # cannot be decoded is attributed to the template — never mis-reported as a

--- a/naturo/cli/core/_find.py
+++ b/naturo/cli/core/_find.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from naturo.cli._jsonio import json_dumps
-from typing import Any
+from typing import Any, NoReturn
 
 import click
 
@@ -32,7 +32,10 @@ import naturo.cli.core._common as _common
                    'Short: //Edit[@name="Search"] (any app, descendant search). '
                    "Saved: @name. App names are flexible: chrome, chrome.exe, Chrome.")
 @click.option("--screenshot", type=click.Path(), default=None,
-              help="Use existing screenshot (for --ai mode)")
+              help="Match against this existing screenshot instead of capturing "
+                   "live (for --ai and --image modes). With --image the screenshot "
+                   "is the search haystack and reported coordinates are "
+                   "screenshot-relative; window-targeting flags do not apply.")
 @click.option("--app", default=None, help="Target app window")
 @click.option("--app-id", "app_id", default=None,
               help='Stable app/window ID from "naturo app list" output (e.g. a1)')
@@ -151,7 +154,7 @@ def find_cmd(query: str | None, query_opt: str | None, find_all: bool, role: str
         _find_with_image(
             image_template, threshold, find_all,
             app=app, window_title=window_title, hwnd=hwnd, pid=pid,
-            limit=limit, json_output=json_output,
+            screenshot=screenshot, limit=limit, json_output=json_output,
         )
         return
 
@@ -393,15 +396,30 @@ def _find_with_image(
     window_title: str | None,
     hwnd: int | None,
     pid: int | None,
+    screenshot: str | None,
     limit: int,
     json_output: bool,
 ) -> None:
-    """Locate a template image on the target window or screen (naturo find --image).
+    """Locate a template image on the target window, screen, or screenshot.
 
-    Captures the target (a specific window when any of app/window/hwnd/pid is
-    given, otherwise the primary screen), runs normalized cross-correlation, and
-    reports matches as snapshot elements with stable ``eN`` refs so they can be
-    acted on with ``naturo click eN``.
+    Backs ``naturo find --image``.  The haystack is, in order of precedence:
+
+    * the image at ``screenshot`` when given (offline/deterministic matching for
+      replay, headless pipelines, and regression fixtures — coordinates are
+      reported relative to the screenshot's top-left, origin ``(0, 0)``);
+    * a specific window when any of app/window/hwnd/pid is given;
+    * otherwise the primary screen.
+
+    It runs normalized cross-correlation and reports matches as snapshot
+    elements with stable ``eN`` refs so they can be acted on with
+    ``naturo click eN``.
+
+    Each distinct failure source carries its own error code rather than
+    inheriting a sibling's (#1067/#1070 error attribution): a template file that
+    cannot be decoded → ``INVALID_TEMPLATE`` (never the haystack's
+    ``CAPTURE_FAILED``); a missing screenshot → ``FILE_NOT_FOUND``; a screenshot
+    that cannot be decoded → ``INVALID_SCREENSHOT``; a live-capture fault →
+    ``CAPTURE_FAILED``.
 
     Args:
         template_path: Path to the template image (PNG/JPG).
@@ -412,12 +430,16 @@ def _find_with_image(
         window_title: Target window title substring.
         hwnd: Target window handle.
         pid: Target process ID.
+        screenshot: Optional path to an existing screenshot to match against
+            instead of capturing live.  Incompatible with the window-targeting
+            flags (app/window/hwnd/pid), which the function rejects rather than
+            silently ignoring (#1070), since the screenshot is the haystack.
         limit: Maximum number of matches to return.
         json_output: Whether to emit JSON.
 
     Raises:
-        SystemExit: With status 1 on invalid input, missing file, platform
-            without GUI support, window-not-found, or capture failure.
+        SystemExit: With status 1 on invalid input, missing/undecodable file,
+            platform without GUI support, window-not-found, or capture failure.
     """
     import os
 
@@ -458,48 +480,85 @@ def _find_with_image(
 
     from naturo.image_match import match_template
 
-    backend = _common._get_backend(json_output)
-    targeted = bool(hwnd or app or window_title or pid)
-
-    import tempfile
-    fd, capture_path = tempfile.mkstemp(suffix=".png")
-    os.close(fd)
-    target_hwnd = hwnd
-    try:
-        if targeted:
-            if not target_hwnd and hasattr(backend, "_resolve_hwnd"):
-                target_hwnd = backend._resolve_hwnd(app=app, window_title=window_title, pid=pid)
-            if not target_hwnd:
-                target = app or window_title or (f"pid={pid}" if pid else "target")
-                msg = f"Window not found: {target}"
-                if json_output:
-                    click.echo(_common._json_error_str("WINDOW_NOT_FOUND", msg))
-                else:
-                    click.echo(f"Error: {msg}", err=True)
-                raise SystemExit(1)
-            backend.capture_window(hwnd=target_hwnd, output_path=capture_path)
-            origin_x, origin_y = _window_origin(target_hwnd)
-        else:
-            backend.capture_screen(screen_index=0, output_path=capture_path)
-            origin_x, origin_y = _monitor_origin(backend, 0)
-
-        with Image.open(capture_path) as hay_src, Image.open(template_path) as tmpl_src:
-            haystack = hay_src.copy()
-            template = tmpl_src.copy()
-    except SystemExit:
-        raise
-    except Exception as e:
-        msg = f"Screen capture failed: {e}"
+    def _emit(code: str, message: str) -> NoReturn:
         if json_output:
-            click.echo(_common._json_error_str("CAPTURE_FAILED", msg))
+            click.echo(_common._json_error_str(code, message))
         else:
-            click.echo(f"Error: {msg}", err=True)
+            click.echo(f"Error: {message}", err=True)
         raise SystemExit(1)
-    finally:
+
+    # Offline mode (#1070): when --screenshot is given the screenshot IS the
+    # search haystack, so the window-targeting flags do not apply.  Reject the
+    # combination explicitly rather than silently ignoring it (the convention
+    # the --ai path already follows) — silently discarding --screenshot and
+    # matching the live screen returns confidently-wrong coordinates.
+    if screenshot is not None:
+        if hwnd or app or window_title or pid:
+            _emit(
+                "INVALID_INPUT",
+                "--screenshot matches against the supplied image, so "
+                "--app/--window/--hwnd/--pid do not apply; drop those flags to "
+                "match the screenshot, or drop --screenshot to capture a live "
+                "window.",
+            )
+        if not os.path.exists(screenshot):
+            _emit("FILE_NOT_FOUND", f"Screenshot file not found: {screenshot}")
+
+    # Load the template once, in its own try, so a template that exists but
+    # cannot be decoded is attributed to the template — never mis-reported as a
+    # haystack capture/load failure (#1067).
+    try:
+        with Image.open(template_path) as tmpl_src:
+            template = tmpl_src.copy()
+    except Exception as e:
+        _emit("INVALID_TEMPLATE",
+              f"Template image could not be loaded: {template_path} ({e})")
+
+    # Acquire the haystack: the supplied screenshot (offline) or a live capture.
+    target_hwnd = hwnd
+    if screenshot is not None:
         try:
-            os.remove(capture_path)
-        except OSError:
-            pass
+            with Image.open(screenshot) as hay_src:
+                haystack = hay_src.copy()
+        except Exception as e:
+            _emit("INVALID_SCREENSHOT",
+                  f"Screenshot could not be loaded: {screenshot} ({e})")
+        # Matches are located within the supplied screenshot, so coordinates are
+        # relative to its top-left rather than screen-absolute.
+        origin_x, origin_y = 0, 0
+        target_hwnd = None
+    else:
+        backend = _common._get_backend(json_output)
+        targeted = bool(hwnd or app or window_title or pid)
+
+        import tempfile
+        fd, capture_path = tempfile.mkstemp(suffix=".png")
+        os.close(fd)
+        try:
+            if targeted:
+                if not target_hwnd and hasattr(backend, "_resolve_hwnd"):
+                    target_hwnd = backend._resolve_hwnd(
+                        app=app, window_title=window_title, pid=pid)
+                if not target_hwnd:
+                    target = app or window_title or (f"pid={pid}" if pid else "target")
+                    _emit("WINDOW_NOT_FOUND", f"Window not found: {target}")
+                backend.capture_window(hwnd=target_hwnd, output_path=capture_path)
+                origin_x, origin_y = _window_origin(target_hwnd)
+            else:
+                backend.capture_screen(screen_index=0, output_path=capture_path)
+                origin_x, origin_y = _monitor_origin(backend, 0)
+
+            with Image.open(capture_path) as hay_src:
+                haystack = hay_src.copy()
+        except SystemExit:
+            raise
+        except Exception as e:
+            _emit("CAPTURE_FAILED", f"Screen capture failed: {e}")
+        finally:
+            try:
+                os.remove(capture_path)
+            except OSError:
+                pass
 
     try:
         matches = match_template(
@@ -576,6 +635,7 @@ def _find_with_image(
             "elements": data,
             "count": len(data),
             "snapshot_id": snapshot_id,
+            "coordinate_frame": "screenshot" if screenshot is not None else "screen",
         }, indent=2))
     else:
         if not matches:
@@ -589,6 +649,9 @@ def _find_with_image(
             )
         click.echo(f"\n{len(matches)} match(es) found.")
         click.echo(f"Snapshot: {snapshot_id}")
+        if screenshot is not None:
+            click.echo("Coordinates are relative to the supplied screenshot "
+                       "(not screen-absolute).")
         click.echo("Tip: use 'naturo click e<N>' to interact with a match.")
 
 

--- a/tests/test_find_image_screenshot_1070.py
+++ b/tests/test_find_image_screenshot_1070.py
@@ -136,6 +136,27 @@ class TestScreenshotOfflineMatching:
         assert payload["count"] == 0
         backend.capture_screen.assert_not_called()
 
+    def test_offline_matching_works_without_gui_support(self, runner, tmp_path) -> None:
+        """Offline matching against a screenshot needs no live capture, so it
+        runs even on a platform without GUI support (headless pipelines)."""
+        patch_img = _distinctive_patch()
+        shot = _haystack_with_patch((200, 160), patch_img, at=(40, 50))
+        shot_file = tmp_path / "shot.png"
+        shot.save(shot_file)
+        template_file = tmp_path / "tmpl.png"
+        patch_img.save(template_file)
+
+        with patch("naturo.cli.core._common._platform_supports_gui", return_value=False):
+            result = runner.invoke(
+                find_cmd,
+                ["--image", str(template_file), "--screenshot", str(shot_file), "--json"],
+            )
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["count"] == 1
+        assert payload["coordinate_frame"] == "screenshot"
+
     def test_screenshot_rejects_window_targeting_flags(self, runner, tmp_path) -> None:
         template_file = tmp_path / "tmpl.png"
         _distinctive_patch().save(template_file)

--- a/tests/test_find_image_screenshot_1070.py
+++ b/tests/test_find_image_screenshot_1070.py
@@ -1,0 +1,218 @@
+"""Tests for ``naturo find --image --screenshot`` offline matching (#1070) and
+template-vs-haystack error attribution (#1067).
+
+#1070: ``--image --screenshot <file>`` must match against the supplied
+screenshot, not silently discard the flag and capture the live screen (which
+returns confidently-wrong coordinates at ``score 1.0``).
+
+#1067: a template file that exists but cannot be decoded must be attributed to
+the template (``INVALID_TEMPLATE``), never mis-reported as a haystack capture
+failure (``CAPTURE_FAILED``).
+
+All tests drive the CLI with a mocked capture backend and in-memory images, so
+they need neither a desktop session nor the native core DLL — they run on every
+CI platform.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+# Pillow backs the matcher; skip the whole module where it is unavailable.
+pytest.importorskip("PIL")
+
+from click.testing import CliRunner  # noqa: E402
+from PIL import Image  # noqa: E402
+from unittest.mock import MagicMock, patch  # noqa: E402
+
+from naturo.cli.core import find_cmd  # noqa: E402
+
+
+def _distinctive_patch(width: int = 24, height: int = 18) -> Image.Image:
+    """A patch with strong internal contrast so NCC is well conditioned."""
+    patch = Image.new("L", (width, height), 0)
+    px = patch.load()
+    for y in range(height):
+        for x in range(width):
+            px[x, y] = 255 if (x // 4 + y // 4) % 2 == 0 else 0
+    return patch
+
+
+def _haystack_with_patch(
+    size: tuple[int, int], patch: Image.Image, at: tuple[int, int], background: int = 128,
+) -> Image.Image:
+    """Build a haystack with ``patch`` pasted at ``at`` over a lightly textured
+    background (so the background carries no spurious high-contrast match)."""
+    width, height = size
+    base = Image.new("L", size, background)
+    px = base.load()
+    for y in range(height):
+        for x in range(width):
+            px[x, y] = (background + (x + y) % 7) % 256
+    base.paste(patch, at)
+    return base
+
+
+def _backend_capturing(image: Image.Image) -> MagicMock:
+    """A backend whose live capture would write ``image`` — used to prove the
+    offline path never reaches it."""
+    backend = MagicMock()
+
+    def _capture_screen(screen_index: int = 0, output_path: str = "capture.png"):
+        image.save(output_path)
+        return MagicMock(path=output_path, width=image.width, height=image.height)
+
+    backend.capture_screen.side_effect = _capture_screen
+    backend.list_monitors.return_value = [MagicMock(x=0, y=0)]
+    return backend
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+class TestScreenshotOfflineMatching:
+    """--screenshot is honored as the haystack (#1070)."""
+
+    def test_screenshot_is_haystack_not_live_capture(self, runner, tmp_path) -> None:
+        patch_img = _distinctive_patch()
+        # The screenshot contains the template at a known offset.
+        shot = _haystack_with_patch((320, 240), patch_img, at=(60, 90))
+        shot_file = tmp_path / "shot.png"
+        shot.save(shot_file)
+        template_file = tmp_path / "tmpl.png"
+        patch_img.save(template_file)
+
+        # The live screen would contain the template at a DIFFERENT offset; if the
+        # flag were ignored we would get those coordinates instead.
+        live = _haystack_with_patch((320, 240), patch_img, at=(200, 30))
+        backend = _backend_capturing(live)
+
+        with patch("naturo.cli.core._common._platform_supports_gui", return_value=True), \
+             patch("naturo.cli.core._common._get_backend", return_value=backend):
+            result = runner.invoke(
+                find_cmd,
+                ["--image", str(template_file), "--screenshot", str(shot_file), "--json"],
+            )
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["count"] == 1
+        assert payload["coordinate_frame"] == "screenshot"
+        el = payload["elements"][0]
+        # Coordinates come from the screenshot (60,90), not the live screen (200,30).
+        assert abs(el["x"] - 60) <= 2
+        assert abs(el["y"] - 90) <= 2
+        backend.capture_screen.assert_not_called()
+        backend.capture_window.assert_not_called()
+
+    def test_black_screenshot_yields_no_match(self, runner, tmp_path) -> None:
+        """The exact #1070 repro: an all-black screenshot cannot contain the
+        template, so the count is 0 — proving the live screen is not captured."""
+        patch_img = _distinctive_patch()
+        black = Image.new("L", (320, 240), 0)
+        black_file = tmp_path / "black.png"
+        black.save(black_file)
+        template_file = tmp_path / "tmpl.png"
+        patch_img.save(template_file)
+
+        # The live screen DOES contain the template; if --screenshot were ignored
+        # we would falsely match it at score 1.0.
+        live = _haystack_with_patch((320, 240), patch_img, at=(100, 80))
+        backend = _backend_capturing(live)
+
+        with patch("naturo.cli.core._common._platform_supports_gui", return_value=True), \
+             patch("naturo.cli.core._common._get_backend", return_value=backend):
+            result = runner.invoke(
+                find_cmd,
+                ["--image", str(template_file), "--screenshot", str(black_file),
+                 "--threshold", "0.95", "--json"],
+            )
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["count"] == 0
+        backend.capture_screen.assert_not_called()
+
+    def test_screenshot_rejects_window_targeting_flags(self, runner, tmp_path) -> None:
+        template_file = tmp_path / "tmpl.png"
+        _distinctive_patch().save(template_file)
+        shot_file = tmp_path / "shot.png"
+        Image.new("L", (50, 50), 128).save(shot_file)
+
+        result = runner.invoke(
+            find_cmd,
+            ["--image", str(template_file), "--screenshot", str(shot_file),
+             "--hwnd", "12345", "--json"],
+        )
+        assert result.exit_code == 1
+        assert json.loads(result.output)["error"]["code"] == "INVALID_INPUT"
+
+    def test_screenshot_file_not_found(self, runner, tmp_path) -> None:
+        template_file = tmp_path / "tmpl.png"
+        _distinctive_patch().save(template_file)
+
+        result = runner.invoke(
+            find_cmd,
+            ["--image", str(template_file), "--screenshot",
+             str(tmp_path / "missing.png"), "--json"],
+        )
+        assert result.exit_code == 1
+        assert json.loads(result.output)["error"]["code"] == "FILE_NOT_FOUND"
+
+    def test_undecodable_screenshot_attributed_to_screenshot(self, runner, tmp_path) -> None:
+        template_file = tmp_path / "tmpl.png"
+        _distinctive_patch().save(template_file)
+        bad_shot = tmp_path / "shot.png"
+        bad_shot.write_text("not an image", encoding="utf-8")
+
+        with patch("naturo.cli.core._common._platform_supports_gui", return_value=True):
+            result = runner.invoke(
+                find_cmd,
+                ["--image", str(template_file), "--screenshot", str(bad_shot), "--json"],
+            )
+        assert result.exit_code == 1
+        assert json.loads(result.output)["error"]["code"] == "INVALID_SCREENSHOT"
+
+
+class TestTemplateErrorAttribution:
+    """A bad template is attributed to the template, not the haystack (#1067)."""
+
+    def test_bad_template_is_invalid_template_not_capture_failed(self, runner, tmp_path) -> None:
+        # Template exists but is not a decodable image.
+        bad_template = tmp_path / "notimg.txt.png"
+        bad_template.write_text("not an image", encoding="utf-8")
+
+        # Live capture succeeds (writes a valid haystack), so the only fault is
+        # the template — it must NOT be reported as CAPTURE_FAILED.
+        live = _haystack_with_patch((100, 100), _distinctive_patch(), at=(10, 10))
+        backend = _backend_capturing(live)
+
+        with patch("naturo.cli.core._common._platform_supports_gui", return_value=True), \
+             patch("naturo.cli.core._common._get_backend", return_value=backend):
+            result = runner.invoke(
+                find_cmd, ["--image", str(bad_template), "--json"],
+            )
+        assert result.exit_code == 1
+        assert json.loads(result.output)["error"]["code"] == "INVALID_TEMPLATE"
+
+    def test_live_path_reports_screen_coordinate_frame(self, runner, tmp_path) -> None:
+        """Sanity: the live-capture path is unchanged and labels its frame
+        ``screen``."""
+        patch_img = _distinctive_patch()
+        live = _haystack_with_patch((320, 240), patch_img, at=(100, 80))
+        template_file = tmp_path / "tmpl.png"
+        patch_img.save(template_file)
+        backend = _backend_capturing(live)
+
+        with patch("naturo.cli.core._common._platform_supports_gui", return_value=True), \
+             patch("naturo.cli.core._common._get_backend", return_value=backend):
+            result = runner.invoke(find_cmd, ["--image", str(template_file), "--json"])
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["coordinate_frame"] == "screen"
+        assert payload["count"] == 1
+        backend.capture_screen.assert_called_once()


### PR DESCRIPTION
## What
`naturo find --image <tmpl> --screenshot <file>` **silently ignored `--screenshot`** and captured the live screen, returning live-screen coordinates labelled `score: 1.0` — confidently-wrong coordinates for a user working from a saved screenshot, so a follow-up `click eN` would click the wrong place (#1070, a 'Never Lie' violation on the headline recognition feature).

This honors the flag (Option B from the issue): the screenshot becomes the search haystack (offline/deterministic matching — useful for replay, headless pipelines, regression fixtures), consistent with the `--ai` path which already honors `--screenshot`.

- **Offline matching:** when `--screenshot` is given, match the template against that image instead of capturing live; coordinates are screenshot-relative (origin 0,0).
- **No silent ignore:** window-targeting flags (`--app/--window/--hwnd/--pid`) are **rejected** with `INVALID_INPUT` when combined with `--screenshot` (the screenshot is the haystack), mirroring the `--ai` rejection convention.
- **Honest frame of reference:** the JSON envelope gains `coordinate_frame` (`screenshot`|`screen`); the human output prints a screenshot-relative note.
- **Error attribution (fixes #1067):** template loading is split into its own `try`/`except` so an undecodable template is reported as `INVALID_TEMPLATE`, never inheriting the haystack's `CAPTURE_FAILED`. A missing screenshot → `FILE_NOT_FOUND`; an undecodable screenshot → `INVALID_SCREENSHOT`.

## How tested
- New CI-safe test module `tests/test_find_image_screenshot_1070.py` (mocked backend + in-memory images, no DLL/desktop):
  - screenshot is used as the haystack, **live capture is never called**, coords come from the screenshot;
  - the exact #1070 repro — an **all-black screenshot** yields count 0 while the (mocked) live screen contains the template, proving the live screen is not captured;
  - `--screenshot` + `--hwnd` → `INVALID_INPUT`; missing screenshot → `FILE_NOT_FOUND`; undecodable screenshot → `INVALID_SCREENSHOT`;
  - bad template file → `INVALID_TEMPLATE` (not `CAPTURE_FAILED`) with live capture succeeding (#1067);
  - live path still reports `coordinate_frame: screen`.
- `ruff check` clean; `mypy` clean on the changed file; `pytest -k 'find or image'` → 300 passed, 4 env-skips; `--collect-only` confirms no DLL/desktop import deps (CI-collection safe).
- Docs: `docs/CLI_REFERENCE.md` updated (`--screenshot` semantics, `coordinate_frame`, offline example).