### PR TITLE
test: build offline browser migration fixtures (fixes #1062)

### DIFF
--- a/tests/browser/conftest.py
+++ b/tests/browser/conftest.py
@@ -1,0 +1,54 @@
+"""Shared fixtures for the browser migration acceptance suite (#766).
+
+The migration matrix (#766/#1063) compares *Before* (DrissionPage/Selenium/
+pywinauto) against *After* (naturo) on deterministic, fully-offline pages.
+This module provides the local HTTP server those tests serve the fixtures
+from — the exact same serving model #1063 will point Chrome at, so any
+fixture that loads here is guaranteed loadable there.
+"""
+
+from __future__ import annotations
+
+import functools
+import http.server
+import threading
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+class _QuietHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
+    """Static-file handler that does not spam stderr with per-request logs."""
+
+    def log_message(self, *args: object) -> None:  # noqa: D102 - silence logging
+        pass
+
+
+@pytest.fixture(scope="session")
+def fixtures_dir() -> Path:
+    """Absolute path to ``tests/browser/fixtures``."""
+    return FIXTURES_DIR
+
+
+@pytest.fixture(scope="session")
+def fixtures_server() -> Iterator[str]:
+    """Serve the fixtures directory over loopback HTTP for the test session.
+
+    Binds to port 0 so the OS assigns a free port (no collisions when CI runs
+    suites in parallel). Yields the base URL, e.g. ``http://127.0.0.1:54321``.
+    """
+    handler = functools.partial(_QuietHTTPRequestHandler, directory=str(FIXTURES_DIR))
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    # Host is the loopback literal we bound to; only the OS-assigned port varies.
+    port = server.server_address[1]
+    try:
+        yield f"http://127.0.0.1:{port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)

--- a/tests/browser/fixtures/api-dashboard.html
+++ b/tests/browser/fixtures/api-dashboard.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>naturo fixture: api-dashboard</title>
+</head>
+<body>
+  <h1 id="main-heading">API Dashboard</h1>
+  <p>Order data is fetched via XHR from a local JSON endpoint.</p>
+
+  <!-- Exercises: network interception. The page issues a GET for
+       api-data.json; that request/response is what a listener captures. -->
+  <ul id="api-output" data-loaded="false"></ul>
+  <p id="api-status">Loading...</p>
+
+  <script>
+    fetch("api-data.json")
+      .then(function (response) { return response.json(); })
+      .then(function (data) {
+        var list = document.getElementById("api-output");
+        data.orders.forEach(function (order) {
+          var item = document.createElement("li");
+          item.className = "order-row";
+          item.setAttribute("data-id", String(order.id));
+          item.textContent = order.id + ": " + order.item + " ($" + order.total + ")";
+          list.appendChild(item);
+        });
+        list.setAttribute("data-loaded", "true");
+        document.getElementById("api-status").textContent =
+          "Loaded " + data.orders.length + " orders.";
+      })
+      .catch(function (error) {
+        document.getElementById("api-status").textContent = "Error: " + error;
+      });
+  </script>
+</body>
+</html>

--- a/tests/browser/fixtures/api-data.json
+++ b/tests/browser/fixtures/api-data.json
@@ -1,0 +1,7 @@
+{
+  "orders": [
+    { "id": 1001, "item": "Wireless Mouse", "total": 24.99 },
+    { "id": 1002, "item": "Mechanical Keyboard", "total": 89.50 },
+    { "id": 1003, "item": "USB-C Hub", "total": 41.00 }
+  ]
+}

--- a/tests/browser/fixtures/basic.html
+++ b/tests/browser/fixtures/basic.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>naturo fixture: basic</title>
+</head>
+<body>
+  <h1 id="main-heading">naturo Migration Fixture</h1>
+  <p id="intro">A deterministic page for element finding and text extraction.</p>
+
+  <nav>
+    <ul>
+      <li><a class="nav-link" id="link-docs" href="form.html">Documentation</a></li>
+      <li><a class="nav-link" id="link-guide" href="tabs.html">Guide</a></li>
+      <li><a class="nav-link" id="link-api" href="api-dashboard.html">API</a></li>
+    </ul>
+  </nav>
+
+  <article>
+    <h2 class="section-title">Section One</h2>
+    <p class="body-text">First paragraph of stable, deterministic body text.</p>
+    <h2 class="section-title">Section Two</h2>
+    <p class="body-text">Second paragraph, also stable across loads.</p>
+  </article>
+
+  <footer>
+    <span id="item-count" data-count="2">2 sections</span>
+  </footer>
+</body>
+</html>

--- a/tests/browser/fixtures/captcha-image.html
+++ b/tests/browser/fixtures/captcha-image.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>naturo fixture: captcha-image</title>
+  <style>
+    #captcha-grid {
+      display: grid; grid-template-columns: repeat(3, 80px);
+      grid-template-rows: repeat(3, 80px); gap: 4px;
+    }
+    .captcha-cell {
+      border: 1px solid #888; display: flex; align-items: center;
+      justify-content: center; cursor: pointer; user-select: none;
+    }
+    .captcha-cell.selected { outline: 3px solid #1976d2; }
+  </style>
+</head>
+<body>
+  <h1 id="main-heading">Image Captcha</h1>
+  <p>Click the cell containing the target (cell index 4, the center).</p>
+
+  <!-- Exercises: click offset. The grid has a known target cell; clicking it
+       passes. Coordinates are deterministic (80px cells), so a click-offset
+       script can target the center reliably. -->
+  <div id="captcha-grid" data-target="4">
+    <div class="captcha-cell" data-index="0">0</div>
+    <div class="captcha-cell" data-index="1">1</div>
+    <div class="captcha-cell" data-index="2">2</div>
+    <div class="captcha-cell" data-index="3">3</div>
+    <div class="captcha-cell" data-index="4">★</div>
+    <div class="captcha-cell" data-index="5">5</div>
+    <div class="captcha-cell" data-index="6">6</div>
+    <div class="captcha-cell" data-index="7">7</div>
+    <div class="captcha-cell" data-index="8">8</div>
+  </div>
+  <p id="captcha-status" data-passed="false">Select the target cell.</p>
+
+  <script>
+    var grid = document.getElementById("captcha-grid");
+    var status = document.getElementById("captcha-status");
+    var target = grid.getAttribute("data-target");
+
+    grid.addEventListener("click", function (event) {
+      var cell = event.target.closest(".captcha-cell");
+      if (!cell) { return; }
+      var cells = grid.querySelectorAll(".captcha-cell");
+      for (var i = 0; i < cells.length; i++) {
+        cells[i].classList.remove("selected");
+      }
+      cell.classList.add("selected");
+      var passed = cell.getAttribute("data-index") === target;
+      status.setAttribute("data-passed", String(passed));
+      status.textContent = passed ? "Captcha passed." : "Wrong cell.";
+    });
+  </script>
+</body>
+</html>

--- a/tests/browser/fixtures/captcha-slider.html
+++ b/tests/browser/fixtures/captcha-slider.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>naturo fixture: captcha-slider</title>
+  <style>
+    #slider-track {
+      position: relative; width: 300px; height: 40px;
+      border: 1px solid #888; background: #eee; user-select: none;
+    }
+    #slider-target {
+      position: absolute; left: 260px; top: 0; width: 40px; height: 40px;
+      background: rgba(0, 160, 0, 0.2);
+    }
+    #slider-handle {
+      position: absolute; left: 0; top: 0; width: 40px; height: 40px;
+      background: #1976d2; cursor: grab;
+    }
+  </style>
+</head>
+<body>
+  <h1 id="main-heading">Slider Captcha</h1>
+
+  <!-- Exercises: slider drag trajectory. The handle must be dragged to within
+       a tolerance of the target offset (260px) to pass — deterministic, no
+       server round-trip. -->
+  <div id="slider-track">
+    <div id="slider-target"></div>
+    <div id="slider-handle" data-target="260" data-tolerance="8"></div>
+  </div>
+  <p id="slider-status" data-passed="false">Drag the handle to the target.</p>
+
+  <script>
+    var track = document.getElementById("slider-track");
+    var handle = document.getElementById("slider-handle");
+    var status = document.getElementById("slider-status");
+    var target = parseInt(handle.getAttribute("data-target"), 10);
+    var tolerance = parseInt(handle.getAttribute("data-tolerance"), 10);
+    var maxLeft = track.clientWidth - handle.offsetWidth;
+    var dragging = false;
+    var startX = 0;
+    var startLeft = 0;
+
+    function setLeft(px) {
+      var clamped = Math.max(0, Math.min(maxLeft, px));
+      handle.style.left = clamped + "px";
+      return clamped;
+    }
+
+    function validate(left) {
+      var passed = Math.abs(left - target) <= tolerance;
+      status.setAttribute("data-passed", String(passed));
+      status.textContent = passed ? "Captcha passed." : "Try again.";
+    }
+
+    handle.addEventListener("mousedown", function (event) {
+      dragging = true;
+      startX = event.clientX;
+      startLeft = parseInt(handle.style.left || "0", 10);
+      event.preventDefault();
+    });
+    document.addEventListener("mousemove", function (event) {
+      if (!dragging) { return; }
+      setLeft(startLeft + (event.clientX - startX));
+    });
+    document.addEventListener("mouseup", function () {
+      if (!dragging) { return; }
+      dragging = false;
+      validate(parseInt(handle.style.left || "0", 10));
+    });
+  </script>
+</body>
+</html>

--- a/tests/browser/fixtures/download-payload.txt
+++ b/tests/browser/fixtures/download-payload.txt
@@ -1,0 +1,1 @@
+naturo download fixture deterministic body

--- a/tests/browser/fixtures/download.html
+++ b/tests/browser/fixtures/download.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>naturo fixture: download</title>
+</head>
+<body>
+  <h1 id="main-heading">File Download</h1>
+  <p>The link below downloads a fixed file for download-management tests.</p>
+
+  <!-- Exercises: download management. The anchor's download attribute saves a
+       deterministic served file (download-payload.txt), so a polling/SHA256
+       check has a known target. -->
+  <a id="download-link" href="download-payload.txt" download="report.txt">
+    Download report.txt
+  </a>
+
+  <p id="download-note" data-size="42">Expected size: 42 bytes.</p>
+</body>
+</html>

--- a/tests/browser/fixtures/form.html
+++ b/tests/browser/fixtures/form.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>naturo fixture: form</title>
+</head>
+<body>
+  <h1 id="main-heading">Sign-up Form</h1>
+
+  <!-- Exercises: form filling, dropdown selection, file upload, submit.
+       action is a relative path so submission stays fully offline. -->
+  <form id="signup-form" method="post" action="submit" enctype="multipart/form-data">
+    <label>Username
+      <input type="text" name="username" id="username" value="">
+    </label>
+
+    <label>Email
+      <input type="email" name="email" id="email" value="">
+    </label>
+
+    <label>Biography
+      <textarea name="bio" id="bio" rows="4"></textarea>
+    </label>
+
+    <label>Country
+      <select name="country" id="country">
+        <option value="">-- choose --</option>
+        <option value="us">United States</option>
+        <option value="cn">China</option>
+        <option value="de">Germany</option>
+      </select>
+    </label>
+
+    <label>Avatar
+      <input type="file" name="avatar" id="avatar">
+    </label>
+
+    <label>
+      <input type="checkbox" name="subscribe" id="subscribe" value="yes"> Subscribe
+    </label>
+
+    <button type="submit" id="submit-button">Create account</button>
+  </form>
+
+  <p id="form-status" data-submitted="false">Not submitted.</p>
+
+  <script>
+    // Keep submission offline + deterministic: record state instead of
+    // navigating away, so the After/Before scripts observe the same effect.
+    document.getElementById("signup-form").addEventListener("submit", function (event) {
+      event.preventDefault();
+      var status = document.getElementById("form-status");
+      status.textContent = "Submitted: " + document.getElementById("username").value;
+      status.setAttribute("data-submitted", "true");
+    });
+  </script>
+</body>
+</html>

--- a/tests/browser/fixtures/hover-menu.html
+++ b/tests/browser/fixtures/hover-menu.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>naturo fixture: hover-menu</title>
+  <style>
+    #menu-dropdown { display: none; list-style: none; margin: 0; padding: 0; }
+    #menu-trigger:hover + #menu-dropdown,
+    #menu-dropdown:hover { display: block; }
+    .menu-item { padding: 6px 12px; cursor: pointer; }
+  </style>
+</head>
+<body>
+  <h1 id="main-heading">Hover Menu</h1>
+
+  <!-- Exercises: hover interaction. The dropdown is hidden until the trigger
+       is hovered; only then can its items be clicked. -->
+  <div id="menu-bar">
+    <button id="menu-trigger">Menu &#9662;</button>
+    <ul id="menu-dropdown">
+      <li class="menu-item" id="menu-item-profile">Profile</li>
+      <li class="menu-item" id="menu-item-settings">Settings</li>
+      <li class="menu-item" id="menu-item-logout">Log out</li>
+    </ul>
+  </div>
+
+  <p id="menu-status" data-selected="">No item selected.</p>
+
+  <script>
+    document.getElementById("menu-dropdown").addEventListener("click", function (event) {
+      var item = event.target.closest(".menu-item");
+      if (!item) { return; }
+      var status = document.getElementById("menu-status");
+      status.textContent = "Selected: " + item.textContent;
+      status.setAttribute("data-selected", item.id);
+    });
+  </script>
+</body>
+</html>

--- a/tests/browser/fixtures/iframe-level1.html
+++ b/tests/browser/fixtures/iframe-level1.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>naturo fixture: iframe-level1</title>
+</head>
+<body>
+  <h2 id="level1-heading">Level 1 frame</h2>
+  <iframe id="frame-level2" name="frame-level2" src="iframe-level2.html"
+          title="level 2" width="400" height="200"></iframe>
+</body>
+</html>

--- a/tests/browser/fixtures/iframe-level2.html
+++ b/tests/browser/fixtures/iframe-level2.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>naturo fixture: iframe-level2</title>
+</head>
+<body>
+  <h3 id="level2-heading">Level 2 frame</h3>
+
+  <!-- The deeply-nested form a frame-switching test must reach and fill. -->
+  <form id="deep-form" method="post" action="submit">
+    <label>Deep field
+      <input type="text" name="deep" id="deep-input" value="">
+    </label>
+    <button type="submit" id="deep-submit">Send</button>
+  </form>
+  <p id="deep-status" data-submitted="false">Not submitted.</p>
+
+  <script>
+    document.getElementById("deep-form").addEventListener("submit", function (event) {
+      event.preventDefault();
+      var status = document.getElementById("deep-status");
+      status.textContent = "Submitted: " + document.getElementById("deep-input").value;
+      status.setAttribute("data-submitted", "true");
+    });
+  </script>
+</body>
+</html>

--- a/tests/browser/fixtures/iframe-nested.html
+++ b/tests/browser/fixtures/iframe-nested.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>naturo fixture: iframe-nested</title>
+</head>
+<body>
+  <h1 id="main-heading">Nested iframes (2 levels)</h1>
+  <p id="intro">A form lives two iframe levels deep, for frame-switching tests.</p>
+
+  <!-- Exercises: iframe switching. Top -> frame-level1 -> frame-level2 -> form.
+       Children are served as real files so a frame-switch by name/src works. -->
+  <iframe id="frame-level1" name="frame-level1" src="iframe-level1.html"
+          title="level 1" width="500" height="300"></iframe>
+</body>
+</html>

--- a/tests/browser/fixtures/infinite-scroll.html
+++ b/tests/browser/fixtures/infinite-scroll.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>naturo fixture: infinite-scroll</title>
+  <style>
+    #feed { margin: 0; padding: 0; list-style: none; }
+    .note-card { height: 180px; border-bottom: 1px solid #ccc; padding: 8px; }
+    #sentinel { height: 1px; }
+  </style>
+</head>
+<body>
+  <h1 id="main-heading">Infinite Scroll Feed</h1>
+  <p id="status" data-loaded="0">Loaded 0 of 30 cards.</p>
+
+  <!-- Exercises: scraping loop + scroll. The feed deterministically grows to
+       a fixed total (30) as the page scrolls, so a scrape loop terminates. -->
+  <ul id="feed"></ul>
+  <div id="sentinel"></div>
+
+  <script>
+    var TOTAL = 30;
+    var BATCH = 6;
+    var loaded = 0;
+    var feed = document.getElementById("feed");
+    var status = document.getElementById("status");
+
+    function appendBatch() {
+      var remaining = Math.min(BATCH, TOTAL - loaded);
+      for (var i = 0; i < remaining; i++) {
+        var index = loaded + i;
+        var card = document.createElement("li");
+        card.className = "note-card";
+        card.id = "card-" + index;
+        card.setAttribute("data-index", String(index));
+        card.textContent = "Note card #" + index;
+        feed.appendChild(card);
+      }
+      loaded += remaining;
+      status.textContent = "Loaded " + loaded + " of " + TOTAL + " cards.";
+      status.setAttribute("data-loaded", String(loaded));
+    }
+
+    // First batch on load, then more each time the user nears the bottom.
+    appendBatch();
+    window.addEventListener("scroll", function () {
+      var nearBottom = window.innerHeight + window.scrollY >=
+        document.body.offsetHeight - 50;
+      if (nearBottom && loaded < TOTAL) {
+        appendBatch();
+      }
+    });
+  </script>
+</body>
+</html>

--- a/tests/browser/fixtures/stealth-check.html
+++ b/tests/browser/fixtures/stealth-check.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>naturo fixture: stealth-check</title>
+</head>
+<body>
+  <h1 id="main-heading">Automation Stealth Check</h1>
+  <p>Reports whether common automation markers are detectable.</p>
+
+  <!-- Exercises: anti-detection. Each vector renders PASS (looks human) or
+       FAIL (automation detected). A stealthy driver should PASS every row. -->
+  <table>
+    <tbody>
+      <tr><td>navigator.webdriver</td><td id="webdriver-result" data-pass="">?</td></tr>
+      <tr><td>chrome runtime</td><td id="chrome-result" data-pass="">?</td></tr>
+      <tr><td>cdc_ injection</td><td id="cdc-result" data-pass="">?</td></tr>
+      <tr><td>plugins length</td><td id="plugins-result" data-pass="">?</td></tr>
+    </tbody>
+  </table>
+  <p id="stealth-summary" data-passed="">Running checks...</p>
+
+  <script>
+    function render(id, pass) {
+      var cell = document.getElementById(id);
+      cell.textContent = pass ? "PASS" : "FAIL";
+      cell.setAttribute("data-pass", String(pass));
+      return pass;
+    }
+
+    // PASS means the automation marker is absent (i.e. looks like a human).
+    var checks = [
+      render("webdriver-result", navigator.webdriver !== true),
+      render("chrome-result", typeof window.chrome !== "undefined"),
+      render("cdc-result", Object.keys(window).every(function (key) {
+        return key.indexOf("cdc_") !== 0;
+      })),
+      render("plugins-result", navigator.plugins.length > 0)
+    ];
+
+    var allPassed = checks.every(function (value) { return value; });
+    var summary = document.getElementById("stealth-summary");
+    summary.textContent = allPassed ? "All checks passed." : "Automation detected.";
+    summary.setAttribute("data-passed", String(allPassed));
+  </script>
+</body>
+</html>

--- a/tests/browser/fixtures/tabs.html
+++ b/tests/browser/fixtures/tabs.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>naturo fixture: tabs</title>
+</head>
+<body>
+  <h1 id="main-heading">Tab Management</h1>
+  <p>Each button opens another fixture in a new tab/window.</p>
+
+  <!-- Exercises: tab management. window.open() with a named target creates a
+       new browsing context a driver can enumerate and switch to. -->
+  <button class="open-tab" id="open-basic"
+          onclick="window.open('basic.html', 'tab-basic')">Open basic</button>
+  <button class="open-tab" id="open-form"
+          onclick="window.open('form.html', 'tab-form')">Open form</button>
+  <button class="open-tab" id="open-api"
+          onclick="window.open('api-dashboard.html', 'tab-api')">Open API</button>
+
+  <p id="tab-status" data-opened="0">No tabs opened.</p>
+
+  <script>
+    var opened = 0;
+    var status = document.getElementById("tab-status");
+    var buttons = document.querySelectorAll(".open-tab");
+    for (var i = 0; i < buttons.length; i++) {
+      buttons[i].addEventListener("click", function () {
+        opened += 1;
+        status.textContent = "Opened " + opened + " tab(s).";
+        status.setAttribute("data-opened", String(opened));
+      });
+    }
+  </script>
+</body>
+</html>

--- a/tests/browser/test_fixtures.py
+++ b/tests/browser/test_fixtures.py
@@ -1,0 +1,130 @@
+"""Offline acceptance for the browser migration fixtures (#1062, part of #766).
+
+These deterministic static pages stand in for real-world sites so the
+before/after migration matrix (#766/#1063) can run fully offline, with no
+external sites and no flakiness. This module proves three contract properties
+for every fixture, on every OS, with no browser and no native DLL:
+
+  1. **It loads over HTTP** from a local server (the same way #1063 serves it
+     to Chrome) — a ``200`` with the right content type.
+  2. **It exercises the feature its #766 row needs** — asserted via required
+     structural markers, so a fixture cannot silently regress into an empty
+     page that "loads" but tests nothing.
+  3. **It is fully offline** — no ``http(s)://`` resource references, so the
+     matrix never depends on a network or an external site.
+
+These checks are pure-stdlib and CI-safe (Linux/macOS included): they do not
+launch Chrome or touch the native core. Driving the fixtures through a real
+browser is #1063's job.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+# fixture filename -> structural markers proving it exercises its feature.
+# Each marker is a substring that MUST appear in the served page; if a fixture
+# is gutted, the matching test fails loudly instead of silently passing.
+FIXTURE_MARKERS: dict[str, list[str]] = {
+    # Element finding + text extraction.
+    "basic.html": ['id="main-heading"', 'class="nav-link"', 'id="intro"'],
+    # Form filling, dropdown selection, file upload, submit.
+    "form.html": [
+        'id="signup-form"',
+        'method="post"',
+        'name="username"',
+        "<textarea",
+        "<select",
+        'type="file"',
+        'type="submit"',
+    ],
+    # Scraping loop + scroll: JS appends note cards as the feed scrolls.
+    "infinite-scroll.html": ['id="feed"', "note-card", 'addEventListener("scroll"'],
+    # Slider captcha: draggable handle validated against a target offset.
+    "captcha-slider.html": [
+        'id="slider-track"',
+        'id="slider-handle"',
+        'id="slider-status"',
+    ],
+    # Image captcha: click-to-verify grid with a known target cell.
+    "captcha-image.html": ['id="captcha-grid"', "captcha-cell", "data-target"],
+    # iframe switching: 2-level nested frames ending in a form.
+    "iframe-nested.html": ['id="frame-level1"', "iframe-level1.html"],
+    "iframe-level1.html": ['id="frame-level2"', "iframe-level2.html"],
+    "iframe-level2.html": ['id="deep-input"', "<form"],
+    # Network interception: page fetches JSON via XHR/fetch and renders it.
+    "api-dashboard.html": ['id="api-output"', "api-data.json", "fetch("],
+    "api-data.json": ['"orders"'],
+    # Anti-detection: reads navigator.webdriver and automation markers.
+    "stealth-check.html": [
+        "navigator.webdriver",
+        'id="webdriver-result"',
+        'id="stealth-summary"',
+    ],
+    # Hover interaction: submenu revealed on hover.
+    "hover-menu.html": ['id="menu-trigger"', 'id="menu-dropdown"', ":hover"],
+    # Tab management: links open new windows.
+    "tabs.html": ["window.open(", 'class="open-tab"'],
+    # Download management: anchor triggers a file download.
+    "download.html": ['id="download-link"', "download="],
+}
+
+ALL_FIXTURES = sorted(FIXTURE_MARKERS)
+HTML_FIXTURES = [name for name in ALL_FIXTURES if name.endswith(".html")]
+
+# The 11 top-level pages the #766 fixture table requires (excludes the nested
+# iframe children and the XHR JSON endpoint, which are supporting files).
+REQUIRED_766_FIXTURES = {
+    "basic.html",
+    "form.html",
+    "infinite-scroll.html",
+    "captcha-slider.html",
+    "captcha-image.html",
+    "iframe-nested.html",
+    "api-dashboard.html",
+    "stealth-check.html",
+    "hover-menu.html",
+    "tabs.html",
+    "download.html",
+}
+
+
+@pytest.mark.parametrize("name", ALL_FIXTURES)
+def test_fixture_loads_and_exercises_feature(name: str, fixtures_server: str) -> None:
+    """Each fixture serves a 200 with the right type and its feature markers."""
+    url = f"{fixtures_server}/{name}"
+    with urllib.request.urlopen(url, timeout=10) as response:  # noqa: S310 - loopback
+        assert response.status == 200
+        content_type = response.headers.get_content_type()
+        body = response.read().decode("utf-8")
+
+    if name.endswith(".json"):
+        assert content_type == "application/json", f"{name}: got {content_type}"
+        json.loads(body)  # must be valid, parseable JSON
+    else:
+        assert content_type == "text/html", f"{name}: got {content_type}"
+
+    for marker in FIXTURE_MARKERS[name]:
+        assert marker in body, f"{name} missing required marker: {marker!r}"
+
+
+@pytest.mark.parametrize("name", HTML_FIXTURES)
+def test_fixture_is_fully_offline(name: str, fixtures_dir: Path) -> None:
+    """No fixture may reference an external resource (#1062: 'No external sites')."""
+    text = (fixtures_dir / name).read_text(encoding="utf-8").lower()
+    for forbidden in ("http://", "https://", 'src="//', "src='//"):
+        assert forbidden not in text, (
+            f"{name} references an external resource ({forbidden!r}); fixtures "
+            "must load fully offline so the migration matrix is deterministic."
+        )
+
+
+def test_all_766_fixtures_present(fixtures_dir: Path) -> None:
+    """Every page named in the #766 fixture table exists on disk."""
+    present = {path.name for path in fixtures_dir.glob("*.html")}
+    missing = REQUIRED_766_FIXTURES - present
+    assert not missing, f"missing #766 fixtures: {sorted(missing)}"


### PR DESCRIPTION
## What
First concrete step of #766: the deterministic, fully-offline HTML fixtures the before/after migration matrix needs.

Adds all 11 pages from the #766 fixture table — `basic`, `form`, `infinite-scroll`, `captcha-slider`, `captcha-image`, `iframe-nested`, `api-dashboard`, `stealth-check`, `hover-menu`, `tabs`, `download` — plus the two nested-iframe children (`iframe-level1/level2.html`) and the XHR JSON endpoint (`api-data.json`) they depend on. Each page exercises exactly the feature its row needs (form fill/dropdown/upload, scroll scraping loop, slider/image captcha, 2-level frame switching, network interception, anti-detection vectors, hover menu, tab `window.open`, file download) and references **no** external resource.

## How tested
`tests/browser/test_fixtures.py` — pure-stdlib, CI-safe (no Chrome, no native DLL, runs on Linux/macOS). It serves the fixtures over a local HTTP server (the same model #1063 will point Chrome at) and asserts, for every fixture:
1. loads with `200` and the correct content type (`text/html` / `application/json`),
2. contains the structural markers proving its feature (so a gutted fixture fails loudly, not silently),
3. references no `http(s)://` resource (offline determinism).

`python -m pytest tests/browser/ -q` → **28 passed**. `ruff` clean, `mypy` clean on the new files, full-suite `--collect-only` → 6804 tests collected (no collection break).

## Scope
Test fixtures only — no production code touched. Unblocks the #766/#1063 before/after equivalence matrix.

fixes #1062