### PR TITLE
test: make JAB auto-fallback test desktop-deterministic (fixes #1069)

### DIFF
--- a/tests/test_jab.py
+++ b/tests/test_jab.py
@@ -72,8 +72,21 @@ class TestJABBackend:
     @patch("naturo.backends.windows.WindowsBackend._ensure_core")
     @patch("naturo.backends.windows.WindowsBackend._resolve_hwnd", return_value=0)
     @patch("naturo.bridge.enumerate_child_windows", return_value=None)
-    def test_auto_fallback_includes_jab(self, mock_enum, mock_resolve, mock_core_fn):
-        """auto mode tries UIA → IA2 → JAB → MSAA."""
+    @patch("naturo.bridge.enumerate_hybrid_tree", return_value=None)
+    def test_auto_fallback_includes_jab(
+        self, mock_hybrid, mock_enum, mock_resolve, mock_core_fn
+    ):
+        """auto mode tries UIA → IA2 → JAB → MSAA.
+
+        ``enumerate_hybrid_tree`` is mocked to ``None`` so the auto path
+        deterministically reaches the IA2→JAB→MSAA fallback regardless of the
+        host desktop. The ``auto`` path runs a Win32+UIA hybrid enumeration on a
+        shallow UIA tree *before* that fallback; on an interactive desktop with
+        windows open ``enumerate_hybrid_tree(hwnd=0)`` returns real top-level
+        windows, the tree is no longer empty, and the JAB fallback is skipped —
+        so without this mock the test is green on headless CI but red on a real
+        desktop (#1069), a false-confidence gate on the JAB cascade (#932).
+        """
         from naturo.backends.windows import WindowsBackend
         from naturo.bridge import ElementInfo
 


### PR DESCRIPTION
## What
Fixes #1069 — `tests/test_jab.py::TestJABBackend::test_auto_fallback_includes_jab` is a green-on-CI / red-on-desktop false-confidence gate on the #932 JAB recognition moat.

The test mocked `_ensure_core`, `_resolve_hwnd` (→0) and `naturo.bridge.enumerate_child_windows`, but **not** `naturo.bridge.enumerate_hybrid_tree`. In `_tree.py`'s `auto` path an empty UIA tree is detected as shallow and triggers a real `enumerate_hybrid_tree(hwnd=0)` Win32 enumeration *before* the IA2→JAB→MSAA fallback:
- **Headless CI:** `enumerate_hybrid_tree(hwnd=0)` returns nothing → tree stays empty → fallback runs → JAB called → **passes**.
- **Interactive desktop (windows open):** it returns real top-level windows → tree no longer empty → JAB fallback skipped → **fails** (`jab_get_element_tree ... Called 0 times`).

This masks regressions and reddens local `@desktop`-capable Dev/QA runs, impeding v0.3.2 ship-gate verification.

## How
Mock `naturo.bridge.enumerate_hybrid_tree` → `None` in this test so the `auto` path deterministically reaches the IA2→JAB→MSAA fallback regardless of host desktop state. Test-only change; the production `auto` fallback itself is correct and unchanged. Docstring documents the rationale so the mock is not removed later.

Sibling-test audit: `test_get_element_tree_jab_backend` uses `backend="jab"` (direct path, never touches `enumerate_hybrid_tree`); no other test in the module exercises `auto`. No further changes needed.

## How tested
- Reproduced the failure on this interactive desktop (pristine: `jab_get_element_tree ... Called 0 times`); after the fix it passes.
- `python -m pytest tests/test_jab.py` → **13 passed, 1 skipped**.
- `python -m pytest tests/test_jab.py --collect-only` → 14 collected (CI-collection safe).
- `ruff check tests/test_jab.py` → clean.