### PR TITLE
fix: land browser click/hover on elements inside iframes (fixes #1080)

### DIFF
--- a/naturo/browser/_element.py
+++ b/naturo/browser/_element.py
@@ -342,19 +342,45 @@ class BrowserElement:
     def _get_click_point(
         self, offset_x: int = 0, offset_y: int = 0
     ) -> Optional[tuple[float, float]]:
-        """Get the click coordinates for this element.
+        """Get the click coordinates for this element, in top-document space.
 
-        Scrolls into view and uses getBoundingClientRect to determine position.
+        Scrolls the element into view, then resolves its position with CDP
+        ``DOM.getContentQuads``, whose vertices are in **top-level viewport** CSS
+        pixels at any iframe depth — the same coordinate space
+        ``Input.dispatchMouseEvent`` uses. This is what lets a click/hover land
+        on an element nested inside one or more iframes; a JS
+        ``getBoundingClientRect`` is frame-relative and would point at the wrong
+        spot in the top document (#1080).
+
+        Falls back to ``getBoundingClientRect`` only when the node exposes no
+        content quad (e.g. an unrendered or zero-area box) — that path is
+        already correct for top-level elements and is the best available
+        estimate when no layout box exists.
 
         Args:
             offset_x: X offset from top-left (0 = center).
             offset_y: Y offset from top-left (0 = center).
 
         Returns:
-            (x, y) screen coordinates, or None if box model unavailable.
+            (x, y) top-document coordinates, or None if no box model is
+            available at all.
         """
         self.scroll_into_view()
 
+        quad = self._content_quad()
+        if quad is not None:
+            xs = quad[0::2]
+            ys = quad[1::2]
+            if offset_x == 0 and offset_y == 0:
+                return (sum(xs) / 4.0, sum(ys) / 4.0)
+            # Offsets are measured from the element's top-left corner, which is
+            # the first quad vertex (top-left, top-right, bottom-right,
+            # bottom-left order per the CDP spec).
+            return (xs[0] + offset_x, ys[0] + offset_y)
+
+        # Fallback: no content quad (unrendered/zero-area). getBoundingClientRect
+        # is frame-relative, but for a top-level element it coincides with the
+        # dispatch coordinate space, and it is the only estimate left here.
         box = self._call_function(
             "function() {"
             "  var r = this.getBoundingClientRect();"
@@ -372,6 +398,32 @@ class BrowserElement:
             y = box["y"] + offset_y
 
         return (x, y)
+
+    def _content_quad(self) -> Optional[List[float]]:
+        """Return this element's first content quad in top-document CSS pixels.
+
+        Uses CDP ``DOM.getContentQuads``, which reports quad vertices relative
+        to the top-level viewport regardless of how deeply the node is nested in
+        iframes — so the result is directly usable as
+        ``Input.dispatchMouseEvent`` coordinates.
+
+        Returns:
+            The first quad as ``[x1, y1, x2, y2, x3, y3, x4, y4]``, or ``None``
+            when the node has no layout box (CDP raises) or returns no quads.
+        """
+        try:
+            result = self._page._cdp.send(
+                "DOM.getContentQuads", {"objectId": self._object_id}
+            )
+        except Exception as exc:
+            # No layout box (display:none, detached, zero-area) — CDP raises
+            # "could not compute content quads". Caller falls back gracefully.
+            logger.debug("getContentQuads failed for %r: %s", self, exc)
+            return None
+        quads = result.get("quads") or []
+        if not quads:
+            return None
+        return [float(v) for v in quads[0]]
 
     def __repr__(self) -> str:
         desc = self._description or self._object_id[:20]

--- a/tests/browser/test_migration_equivalence.py
+++ b/tests/browser/test_migration_equivalence.py
@@ -134,3 +134,45 @@ def test_form_interaction_equivalence(
     status = browser_page.find("#form-status")
     assert status.text == "Submitted: alice"
     assert status.attr("data-submitted") == "true"
+
+
+def test_iframe_switching_equivalence(
+    browser_page: BrowserPage, fixtures_server: str
+) -> None:
+    """Reproduce the Selenium ``switch_to.frame`` captcha/login flow via naturo.
+
+    Mirrors the migration guide's "iframe Handling" section: the *Before* code
+    chains ``driver.switch_to.frame(...)`` to reach an element nested two iframe
+    levels deep, then fills and submits a form inside it. The *After* surface is
+    the scoped :meth:`BrowserPage.frame` / :meth:`BrowserFrame.frame` objects.
+
+    Driven against ``iframe-nested.html`` (top -> ``frame-level1`` ->
+    ``frame-level2`` -> ``#deep-form``), this proves both that frame scoping
+    resolves the deeply-nested element *and* — per naturo's never-lie contract
+    (SOUL.md) — that a frame-scoped ``click`` actually lands on its target and
+    fires the form submit, rather than silently missing because the element's
+    frame-relative coordinates were dispatched in the top document (#1080).
+    """
+    browser_page.navigate(f"{fixtures_server}/iframe-nested.html")
+
+    # Before: driver.switch_to.frame(level1); driver.switch_to.frame(level2)
+    #  ->  After: page.frame(name=...).frame(name=...)
+    level2 = browser_page.frame(name="frame-level1").frame(name="frame-level2")
+
+    # The nested frame's own content is reachable through the scoped object.
+    assert level2.find("#level2-heading").text == "Level 2 frame"
+
+    # Before: ele.input(...)  ->  After: frame.find(...).type(...)
+    level2.find("#deep-input").type("nested-ok", clear_first=True)
+    assert level2.find("#deep-input").value == "nested-ok"
+
+    # Before: ele.click() inside the switched frame
+    #  ->  After: frame.find(...).click(). This is the #1080 regression guard:
+    # the click point must be resolved in top-document coordinates so the event
+    # lands inside the (doubly-nested) iframe instead of the top-level page.
+    level2.find("#deep-submit").click()
+
+    # never-lie: the in-frame submit handler must have actually run.
+    deep_status = level2.find("#deep-status")
+    assert deep_status.text == "Submitted: nested-ok"
+    assert deep_status.attr("data-submitted") == "true"

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -247,12 +247,12 @@ class TestBrowserElement:
 
     def test_click_dispatches_mouse_events(self):
         el = self._make_element()
-        # Mock getBoundingClientRect
+        # Mock DOM.getContentQuads (top-document coords, #1080)
         el._page._cdp.send.side_effect = [
             # scroll_into_view (callFunctionOn)
             {"result": {"value": None}},
-            # getBoundingClientRect (callFunctionOn)
-            {"result": {"value": {"x": 100, "y": 200, "width": 80, "height": 30}}},
+            # getContentQuads -> one quad: TL,TR,BR,BL
+            {"quads": [[100, 200, 180, 200, 180, 230, 100, 230]]},
             # mousePressed
             {},
             # mouseReleased
@@ -260,7 +260,7 @@ class TestBrowserElement:
         ]
         el.click()
         calls = el._page._cdp.send.call_args_list
-        # Should have 4 calls: scrollIntoView, getBoundingClientRect, mousePressed, mouseReleased
+        # Should have 4 calls: scrollIntoView, getContentQuads, mousePressed, mouseReleased
         assert len(calls) == 4
         # Params are passed as dict in second positional arg
         assert calls[2][0][1]["type"] == "mousePressed"

--- a/tests/test_browser_element.py
+++ b/tests/test_browser_element.py
@@ -116,10 +116,11 @@ class TestBrowserElementClick:
 
     def test_click_dispatches_mouse_events(self):
         el, page, cdp = _make_element()
-        # First call: scrollIntoView, second: getBoundingClientRect
+        # scrollIntoView, then DOM.getContentQuads (top-document coords, #1080).
+        # Quad vertices: TL(100,200) TR(150,200) BR(150,230) BL(100,230).
         cdp.send.side_effect = [
             {"result": {"value": None}},  # scrollIntoView
-            {"result": {"value": {"x": 100, "y": 200, "width": 50, "height": 30}}},
+            {"quads": [[100, 200, 150, 200, 150, 230, 100, 230]]},
             {},  # mousePressed
             {},  # mouseReleased
         ]
@@ -136,7 +137,7 @@ class TestBrowserElementClick:
         assert mouse_calls[0][0][1]["type"] == "mousePressed"
         assert mouse_calls[1][0][1]["type"] == "mouseReleased"
 
-        # Click should be at center: 100 + 25, 200 + 15
+        # Click should be at the quad centroid: (100+150)/2, (200+230)/2
         assert mouse_calls[0][0][1]["x"] == 125.0
         assert mouse_calls[0][0][1]["y"] == 215.0
 
@@ -144,7 +145,7 @@ class TestBrowserElementClick:
         el, page, cdp = _make_element()
         cdp.send.side_effect = [
             {"result": {"value": None}},  # scrollIntoView
-            {"result": {"value": {"x": 100, "y": 200, "width": 50, "height": 30}}},
+            {"quads": [[100, 200, 150, 200, 150, 230, 100, 230]]},
             {},  # mousePressed
             {},  # mouseReleased
         ]
@@ -155,14 +156,49 @@ class TestBrowserElementClick:
             c for c in cdp.send.call_args_list
             if c[0][0] == "Input.dispatchMouseEvent"
         ]
-        # With offset: x + offset_x, y + offset_y
+        # Offsets are from the top-left quad vertex: 100 + 10, 200 + 5
         assert mouse_calls[0][0][1]["x"] == 110
         assert mouse_calls[0][0][1]["y"] == 205
+
+    def test_click_falls_back_to_bounding_rect_without_quad(self):
+        el, page, cdp = _make_element()
+        # No content quad (unrendered/zero-area) -> getBoundingClientRect path.
+        cdp.send.side_effect = [
+            {"result": {"value": None}},  # scrollIntoView
+            {"quads": []},  # getContentQuads: no quad
+            {"result": {"value": {"x": 100, "y": 200, "width": 50, "height": 30}}},
+            {},  # mousePressed
+            {},  # mouseReleased
+        ]
+
+        el.click()
+
+        mouse_calls = [
+            c for c in cdp.send.call_args_list
+            if c[0][0] == "Input.dispatchMouseEvent"
+        ]
+        assert mouse_calls[0][0][1]["x"] == 125.0  # 100 + 25
+        assert mouse_calls[0][0][1]["y"] == 215.0  # 200 + 15
 
     def test_click_raises_when_no_position(self):
         el, page, cdp = _make_element()
         cdp.send.side_effect = [
             {"result": {"value": None}},  # scrollIntoView
+            {"quads": []},  # getContentQuads: no quad
+            {"result": {"value": None}},  # getBoundingClientRect returns None
+        ]
+
+        with pytest.raises(RuntimeError, match="Cannot determine element position"):
+            el.click()
+
+    def test_click_raises_when_quad_computation_errors(self):
+        el, page, cdp = _make_element()
+        # getContentQuads can raise (CDP "could not compute content quads"); the
+        # fallback then also finds no box -> click must raise, never silently
+        # no-op (never-lie, #1080).
+        cdp.send.side_effect = [
+            {"result": {"value": None}},  # scrollIntoView
+            RuntimeError("could not compute content quads"),
             {"result": {"value": None}},  # getBoundingClientRect returns None
         ]
 
@@ -180,9 +216,10 @@ class TestBrowserElementHover:
 
     def test_hover_dispatches_mouse_moved(self):
         el, page, cdp = _make_element()
+        # Quad TL(50,60) TR(70,60) BR(70,70) BL(50,70) -> centroid (60,65).
         cdp.send.side_effect = [
             {"result": {"value": None}},  # scrollIntoView
-            {"result": {"value": {"x": 50, "y": 60, "width": 20, "height": 10}}},
+            {"quads": [[50, 60, 70, 60, 70, 70, 50, 70]]},
             {},  # mouseMoved
         ]
 
@@ -195,13 +232,14 @@ class TestBrowserElementHover:
         ]
         assert len(mouse_calls) == 1
         assert mouse_calls[0][0][1]["type"] == "mouseMoved"
-        assert mouse_calls[0][0][1]["x"] == 60.0  # 50 + 10
-        assert mouse_calls[0][0][1]["y"] == 65.0  # 60 + 5
+        assert mouse_calls[0][0][1]["x"] == 60.0  # quad centroid x
+        assert mouse_calls[0][0][1]["y"] == 65.0  # quad centroid y
 
     def test_hover_raises_when_no_position(self):
         el, page, cdp = _make_element()
         cdp.send.side_effect = [
             {"result": {"value": None}},  # scrollIntoView
+            {"quads": []},  # getContentQuads: no quad
             {"result": {"value": None}},  # no bounding rect
         ]
 
@@ -357,30 +395,44 @@ class TestBrowserElementFind:
 
 
 class TestGetClickPoint:
-    """Bounding rect and coordinate calculation tests."""
+    """Content-quad and coordinate calculation tests (#1080)."""
 
-    def test_center_point(self):
+    def test_center_point_from_quad(self):
+        el, page, cdp = _make_element()
+        # Quad TL(10,20) TR(110,20) BR(110,70) BL(10,70) -> centroid (60,45).
+        cdp.send.side_effect = [
+            {"result": {"value": None}},  # scrollIntoView
+            {"quads": [[10, 20, 110, 20, 110, 70, 10, 70]]},
+        ]
+        point = el._get_click_point()
+        assert point == (60.0, 45.0)
+
+    def test_offset_point_from_quad(self):
         el, page, cdp = _make_element()
         cdp.send.side_effect = [
             {"result": {"value": None}},  # scrollIntoView
+            {"quads": [[10, 20, 110, 20, 110, 70, 10, 70]]},
+        ]
+        # Offset measured from the top-left quad vertex (10,20).
+        point = el._get_click_point(offset_x=5, offset_y=10)
+        assert point == (15, 30)
+
+    def test_falls_back_to_bounding_rect_without_quad(self):
+        el, page, cdp = _make_element()
+        # getContentQuads returns no quad -> getBoundingClientRect fallback.
+        cdp.send.side_effect = [
+            {"result": {"value": None}},  # scrollIntoView
+            {"quads": []},  # no quad
             {"result": {"value": {"x": 10, "y": 20, "width": 100, "height": 50}}},
         ]
         point = el._get_click_point()
         assert point == (60.0, 45.0)  # 10+50, 20+25
 
-    def test_offset_point(self):
-        el, page, cdp = _make_element()
-        cdp.send.side_effect = [
-            {"result": {"value": None}},  # scrollIntoView
-            {"result": {"value": {"x": 10, "y": 20, "width": 100, "height": 50}}},
-        ]
-        point = el._get_click_point(offset_x=5, offset_y=10)
-        assert point == (15, 30)  # 10+5, 20+10
-
     def test_returns_none_when_no_box(self):
         el, page, cdp = _make_element()
         cdp.send.side_effect = [
             {"result": {"value": None}},  # scrollIntoView
+            {"quads": []},  # no quad
             {"result": {"value": None}},  # no rect
         ]
         assert el._get_click_point() is None
@@ -389,6 +441,7 @@ class TestGetClickPoint:
         el, page, cdp = _make_element()
         cdp.send.side_effect = [
             {"result": {"value": None}},  # scrollIntoView
+            {"quads": []},  # no quad
             {"result": {"value": "not-a-dict"}},
         ]
         assert el._get_click_point() is None


### PR DESCRIPTION
## What

`naturo`'s browser `click()`/`hover()` **silently missed** any element inside an `<iframe>` — they returned success but had zero effect on the page, a never-lie violation (SOUL.md / #226). Root cause: `BrowserElement._get_click_point()` read the target via JS `getBoundingClientRect()` (frame-relative) but dispatched `Input.dispatchMouseEvent` in the **top-level** document; for nested frames the coordinate systems differ by the accumulated iframe offsets, so the click landed on the top page. `type()` was unaffected (DOM-level focus + key events).

This is a moat fix for the documented browser-migration story (DrissionPage/Selenium `switch_to.frame` → `page.frame(...)`, `docs/MIGRATION_FROM_RPA_SCRIPTS.md` "iframe Handling"; part of #766/#763).

## How

- Resolve the click point with CDP `DOM.getContentQuads`, whose vertices are in **top-level viewport** CSS pixels at any iframe depth (the Puppeteer/Playwright approach), so the dispatched coordinates match. Falls back to `getBoundingClientRect` only when a node has no layout box.
- Top-level (non-iframe) clicks are unchanged — there the two coordinate spaces coincide; the existing top-level form-submit equivalence test still passes.

## How tested

- New `@pytest.mark.desktop` test `test_iframe_switching_equivalence` (part of #766) on the fully-offline doubly-nested fixture `iframe-nested.html`: switch `frame -> frame`, type into `#deep-input`, click `#deep-submit`, and assert the in-frame submit actually fired — `#deep-status` becomes `"Submitted: nested-ok"`, `data-submitted="true"` (never-lie).
- Verified the defect first: pre-fix the same flow left `#deep-status` = `"Not submitted."` / `false`; the frame-relative point `(290.9, 78.9)` vs the true top-level `(310.9, 286.6)` confirmed the offset.
- `tests/browser/` 31 passed (incl. all 3 migration tests); non-desktop browser subset 28 passed; `--collect-only` succeeds with no browser (CI-safe, `@desktop` skipped on the Linux/macOS matrix).
- Gate: `ruff` clean; `mypy naturo/browser/_element.py` clean (`mypy naturo/` only trips on the pre-existing site-packages `mcp` match-stmt artifact, not this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)