### PR TITLE
test: infinite-scroll scrape equivalence + fix dead scroll fixture (part of #766)

### DIFF
--- a/tests/browser/fixtures/infinite-scroll.html
+++ b/tests/browser/fixtures/infinite-scroll.html
@@ -23,7 +23,12 @@
     var BATCH = 6;
     var loaded = 0;
     var feed = document.getElementById("feed");
-    var status = document.getElementById("status");
+    // NB: must not be named `status` -- a bare global `status` aliases the
+    // legacy `window.status` accessor, which coerces any assignment to a
+    // string. That would make `statusEl.setAttribute(...)` throw mid-batch and
+    // abort the script before the scroll listener below is ever attached, so
+    // the feed would silently never grow past the first batch.
+    var statusEl = document.getElementById("status");
 
     function appendBatch() {
       var remaining = Math.min(BATCH, TOTAL - loaded);
@@ -37,8 +42,8 @@
         feed.appendChild(card);
       }
       loaded += remaining;
-      status.textContent = "Loaded " + loaded + " of " + TOTAL + " cards.";
-      status.setAttribute("data-loaded", String(loaded));
+      statusEl.textContent = "Loaded " + loaded + " of " + TOTAL + " cards.";
+      statusEl.setAttribute("data-loaded", String(loaded));
     }
 
     // First batch on load, then more each time the user nears the bottom.

--- a/tests/browser/test_migration_equivalence.py
+++ b/tests/browser/test_migration_equivalence.py
@@ -176,3 +176,67 @@ def test_iframe_switching_equivalence(
     deep_status = level2.find("#deep-status")
     assert deep_status.text == "Submitted: nested-ok"
     assert deep_status.attr("data-submitted") == "true"
+
+
+def test_infinite_scroll_scraping_equivalence(
+    browser_page: BrowserPage, fixtures_server: str
+) -> None:
+    """Reproduce the Xiaohongshu infinite-scroll scrape loop via naturo.
+
+    Mirrors the migration guide's "Data Scraping with Infinite Scroll" pattern
+    (the real DrissionPage Xiaohongshu brand-keyword project): the *Before*
+    code loops ``page.eles(note)``, dedups each card by a stable id, and calls
+    ``page.scroll.down(1000)`` until the feed stops growing. The *After*
+    surface is :meth:`BrowserPage.find_all` + :meth:`BrowserPage.scroll_to_bottom`
+    with ``attr``-keyed dedup.
+
+    Driven against ``infinite-scroll.html`` -- a feed that lazily appends six
+    cards each time a scroll nears the bottom, up to a fixed total of 30 -- the
+    scrape loop must collect every card exactly once, in document order, and
+    terminate on its own when the feed is exhausted (rather than over- or
+    under-counting). Per naturo's never-lie contract (SOUL.md) the scrape's own
+    tally is cross-checked against the page's authoritative ``data-loaded``
+    counter.
+    """
+    browser_page.navigate(f"{fixtures_server}/infinite-scroll.html")
+
+    # Lazy feed: only the first batch exists before any scroll happens.
+    assert len(browser_page.find_all(".note-card")) == 6
+    assert browser_page.find("#status").attr("data-loaded") == "6"
+
+    # Before: for _ in range(80): eles = page.eles(note); dedup; scroll.down(1000)
+    #  ->  After: find_all + attr-keyed dedup + scroll, terminating when a
+    # scroll loads no new cards instead of relying on a fixed iteration cap.
+    # scroll_to_bottom (vs a fixed scroll_by step) deterministically crosses the
+    # feed's lazy-load threshold on every call, so each scroll appends exactly
+    # one batch -- the page grows the document as it loads, which a fixed-pixel
+    # step can undershoot.
+    seen_indices: list[str] = []
+    seen: set[str] = set()
+    for _ in range(40):  # generous safety cap; real exit is "no new cards".
+        for card in browser_page.find_all(".note-card"):
+            index = card.attr("data-index")
+            assert index is not None  # every fixture card carries a stable id
+            if index not in seen:
+                seen.add(index)
+                seen_indices.append(index)
+        if len(seen) >= 30:
+            break
+        # The scroll event handler appends the next batch asynchronously, so
+        # wait for the feed to actually grow before re-scraping. A timeout here
+        # means the feed is exhausted -> the scrape loop is done.
+        before = len(seen)
+        browser_page.scroll_to_bottom()
+        try:
+            browser_page.wait_for_function(
+                f"document.querySelectorAll('.note-card').length > {before}",
+                timeout=3.0,
+            )
+        except TimeoutError:
+            break
+
+    # Equivalence: every one of the 30 cards scraped exactly once, in document
+    # order -- the same deduplicated set the DrissionPage scroll loop yields.
+    assert seen_indices == [str(i) for i in range(30)]
+    # never-lie: the scrape's tally agrees with the page's own load counter.
+    assert browser_page.find("#status").attr("data-loaded") == "30"


### PR DESCRIPTION
## What
Adds the **infinite-scroll Before/After equivalence** slice of the migration acceptance matrix (#766) and fixes a real bug in the `#1073` fixture it drives.

- **New test** `test_infinite_scroll_scraping_equivalence` reproduces the migration guide's flagship *"Data Scraping with Infinite Scroll"* pattern (the real DrissionPage Xiaohongshu brand-keyword project): scrape `find_all(".note-card")`, dedup by a stable `data-index`, `scroll_to_bottom()` to trigger the lazy-load, repeat until the feed is exhausted. Asserts all 30 cards are collected exactly once in document order, and — per naturo's never-lie contract — cross-checks the scrape's tally against the page's own `data-loaded` counter.
- **Fixture fix** `infinite-scroll.html`: the script declared `var status = document.getElementById("status")`. A bare global `status` aliases the legacy `window.status` accessor, which coerces assignment to a **string**, so `status.setAttribute(...)` threw mid-batch and aborted the script **before `window.addEventListener("scroll", ...)` was ever attached**. The "infinite-scroll" fixture therefore silently never grew past its first 6 cards. Renamed to `statusEl`.

## Why this matters
Without the fixture fix, any infinite-scroll test would be testing a feed that doesn't scroll — false confidence. The fixture now genuinely lazy-loads to 30 cards as documented.

## How tested
- `tests/browser/test_migration_equivalence.py` — **4 passed** on a real desktop (headless Chrome via CDP), incl. the new test (feed grows 6→12→18→24→30, all scraped once).
- `tests/browser/test_fixtures.py` — **28 passed** (fixture structure invariants intact).
- `--collect-only` succeeds with no browser (CI-safe; the new test is `@pytest.mark.desktop`).
- `ruff check` clean.

Part of #766 — remaining fixtures: captcha-slider, captcha-image, tabs, download, hover-menu, api-dashboard, stealth-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)