### PR TITLE
test: image-captcha click-offset migration equivalence + fix dead captcha fixture (part of #766)

### DIFF
--- a/tests/browser/fixtures/captcha-image.html
+++ b/tests/browser/fixtures/captcha-image.html
@@ -36,8 +36,13 @@
   <p id="captcha-status" data-passed="false">Select the target cell.</p>
 
   <script>
+    // Note: this status element must NOT be held in a global `var status`.
+    // A global `var status = ...` aliases the special `window.status` string
+    // property, which coerces the assigned element to "[object ...]"; every
+    // later `.setAttribute`/`.textContent` then throws or no-ops, freezing
+    // data-passed and turning this never-lie oracle into a dead fixture.
     var grid = document.getElementById("captcha-grid");
-    var status = document.getElementById("captcha-status");
+    var captchaStatus = document.getElementById("captcha-status");
     var target = grid.getAttribute("data-target");
 
     grid.addEventListener("click", function (event) {
@@ -49,8 +54,8 @@
       }
       cell.classList.add("selected");
       var passed = cell.getAttribute("data-index") === target;
-      status.setAttribute("data-passed", String(passed));
-      status.textContent = passed ? "Captcha passed." : "Wrong cell.";
+      captchaStatus.setAttribute("data-passed", String(passed));
+      captchaStatus.textContent = passed ? "Captcha passed." : "Wrong cell.";
     });
   </script>
 </body>

--- a/tests/browser/test_migration_equivalence.py
+++ b/tests/browser/test_migration_equivalence.py
@@ -356,6 +356,67 @@ def test_network_mock_response_equivalence(
     assert page.find("#api-status").text == "Loaded 1 orders."
 
 
+def test_image_captcha_click_offset_equivalence(
+    browser_page: BrowserPage, fixtures_server: str
+) -> None:
+    """Reproduce the Chaojiying coordinate-click captcha solve via naturo.
+
+    Mirrors the migration guide's "Image Recognition Captcha" section: the
+    *Before* code screenshots the captcha image, submits it to a solver
+    (Chaojiying / ddddocr) which returns pixel coordinates *relative to the
+    captcha image element*, then drives
+    ``ActionChains.move_to_element_with_offset(img, x, y).click()`` for each
+    returned point. The *After* surface is
+    :meth:`BrowserElement.click` with ``offset_x`` / ``offset_y``.
+
+    Driven against ``captcha-image.html`` -- a deterministic 3x3 grid of 80px
+    cells (4px gap) whose target is the centre cell (index 4) -- a solver
+    coordinate must land on the exact cell, proving the click honours the
+    element-relative offset rather than silently defaulting to the element
+    centre. Per naturo's never-lie contract (SOUL.md) precision is proven
+    *both ways*: a deliberately wrong offset selects the wrong cell and does
+    NOT pass, and only the correct offset flips the page's own ``data-passed``
+    flag to ``true``.
+
+    Because the target *is* the grid centre, the negative leg is essential: an
+    offset-ignoring click would hit the centre cell and spuriously pass, so the
+    wrong-offset click landing on cell 0 (the grid's top-left) is what actually
+    proves the offset is respected.
+    """
+    browser_page.navigate(f"{fixtures_server}/captcha-image.html")
+    grid = browser_page.find("#captcha-grid")
+
+    # Cell geometry: 80px cells separated by a 4px gap, so each column/row
+    # advances by 84px. Cell N's centre, measured from the grid's top-left
+    # corner (the origin _get_click_point uses for offsets), is
+    # (col * 84 + 40, row * 84 + 40) with col = N % 3, row = N // 3.
+    def cell_center(index: int) -> tuple[int, int]:
+        col, row = index % 3, index // 3
+        return (col * 84 + 40, row * 84 + 40)
+
+    # never-lie (precision, negative leg): a wrong solver coordinate must land on
+    # the wrong cell. If the click ignored the offset it would hit the grid
+    # centre -- which happens to be the target cell -- and spuriously pass.
+    # Cell 0's centre (the grid's top-left) proves the offset is honoured.
+    wrong_x, wrong_y = cell_center(0)
+    grid.click(offset_x=wrong_x, offset_y=wrong_y)
+    assert browser_page.find(".captcha-cell.selected").attr("data-index") == "0"
+    assert browser_page.find("#captcha-status").attr("data-passed") == "false"
+
+    # Before: ActionChains.move_to_element_with_offset(img, x, y).click()
+    #  ->  After: find(captcha).click(offset_x=x, offset_y=y) at the solver coord.
+    target = int(grid.attr("data-target") or "")
+    target_x, target_y = cell_center(target)
+    grid.click(offset_x=target_x, offset_y=target_y)
+
+    # never-lie: the page's own pass flag flips only because the precise target
+    # cell was hit -- the same authoritative signal the Before code checks after
+    # clicking the solver-returned coordinate.
+    assert browser_page.find(".captcha-cell.selected").attr("data-index") == str(target)
+    assert browser_page.find("#captcha-status").attr("data-passed") == "true"
+    assert browser_page.find("#captcha-status").text == "Captcha passed."
+
+
 def _wait_for_tab(page: BrowserPage, url_substring: str, timeout: float = 8.0) -> str:
     """Poll ``page.tabs()`` until a tab whose URL contains *url_substring* appears.
 


### PR DESCRIPTION
## What
Adds the **Image Recognition Captcha** row of the #766 migration-acceptance matrix and fixes the dead fixture it runs against.

- **New test** `test_image_captcha_click_offset_equivalence` — reproduces the Chaojiying coordinate-click captcha solve (`ActionChains.move_to_element_with_offset(img, x, y).click()`) via naturo's `BrowserElement.click(offset_x, offset_y)`. Drives `captcha-image.html` (a deterministic 3×3 grid of 80px cells); a solver coordinate must land on the exact target cell.
- **Dead-fixture fix** — `captcha-image.html` held its status node in a global `var status = document.getElementById(...)`, which **aliases the special `window.status` string property**: the element ref was coerced to `"[object HTMLParagraphElement]"`, so `status.setAttribute`/`.textContent` no-opped and `data-passed` was **frozen at `false` forever** — a never-lie oracle that could never report success. Renamed to `captchaStatus`. Same class as the prior `tabs.html` (#1090) and `infinite-scroll.html` (#1085) dead-fixture fixes.

## How tested
Proven empirically on real headless Chrome (CDP) **before** asserting — instrumented the grid/cell geometry and confirmed `typeof status === 'string'` / `status === window.status` was the freeze cause.

- never-lie, **both legs**: a deliberately wrong offset (cell 0, the grid top-left) selects the wrong cell and does **not** pass; only the correct offset (cell 4, the target) flips the page's own `data-passed` to `true`. Because the target *is* the grid centre, the negative leg is what actually proves the offset is honoured (an offset-ignoring click would hit centre and spuriously pass).
- `python -m pytest tests/browser/ -q` → **36 passed** (was 35) on real headless Chrome.
- `ruff check` clean; `--collect-only -m "not desktop"` deselects cleanly (CI-safe; all migration tests are `@pytest.mark.desktop`). No `naturo/` source touched.

Part of #766 (umbrella stays open). All browser CDP — no OS-level input.