### PR TITLE
feat: add `naturo click --image` template-match shortcut (fixes #1059)

### DIFF
--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -407,6 +407,8 @@ Click on a UI element, text, or coordinates.
 | `--on` | text | Target element (eN ref or text label) |
 | `--id` | text | Automation element ID |
 | `--coords` | integer | X Y coordinates |
+| `--image` | path | Locate a template image (PNG/JPG) on the target window or screen and click the center of the best match (see `naturo find --image`) |
+| `--threshold` | float | Minimum match score in [0.0, 1.0] for `--image` (higher is stricter, default `0.9`) |
 | `--double` | boolean | Double-click |
 | `--right` | boolean | Right-click |
 | `--app` | text | Target application (name or partial match) |
@@ -432,9 +434,17 @@ Click on a UI element, text, or coordinates.
 naturo click --coords 500 300
 naturo click --coords 500 300 --right
 naturo click --id "button_ok"
+naturo click --image submit.png                   # click the center of a template match
+naturo click --image icon.png --app Notepad --threshold 0.85  # match within an app
 naturo click e42 --paste
 naturo click e42 --copy
 ```
+
+`--image` reuses the `naturo find --image` matcher: it captures the target
+window (when `--app`/`--window`/`--hwnd`/`--pid` is given) or the screen, locates
+the best template match above `--threshold`, and clicks its center. When no match
+clears the threshold it returns `ELEMENT_NOT_FOUND` and clicks nothing rather than
+guessing a location.
 
 ## `naturo drag`
 

--- a/naturo/cli/core/_find.py
+++ b/naturo/cli/core/_find.py
@@ -387,6 +387,208 @@ def _monitor_origin(backend: Any, screen_index: int) -> tuple[int, int]:
     return 0, 0
 
 
+class _ImageMatchError(Exception):
+    """Internal carrier for an image-matching failure with its own error code.
+
+    Lets the shared matching core (:func:`_resolve_image_matches`) attribute each
+    distinct failure source to its own code/message (#1067/#1070) while leaving
+    each caller — ``find --image`` and ``click --image`` (#1059) — to render the
+    error in its command's house style (a plain ``_json_error_str`` code for
+    ``find`` vs. the structured ``_json_err`` envelope for ``click``).
+
+    Attributes:
+        code: The attributing error-code string (a registered ``ErrorCode``).
+        message: The human-readable error message.
+    """
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+def _resolve_image_matches(
+    template_path: str,
+    threshold: float,
+    find_all: bool,
+    *,
+    app: str | None,
+    window_title: str | None,
+    hwnd: int | None,
+    pid: int | None,
+    screenshot: str | None,
+    limit: int,
+    json_output: bool,
+) -> tuple[list[Any], int, int, int | None, int, int]:
+    """Load a template, acquire the haystack, and run NCC template matching.
+
+    Shared core behind ``naturo find --image`` and ``naturo click --image``
+    (#1059) so both commands resolve a template to coordinates identically — same
+    capture precedence, same threshold semantics, and the same per-source error
+    attribution (#1067/#1070). The caller owns rendering: matches are returned
+    rather than printed, and every failure is raised as :class:`_ImageMatchError`
+    carrying the error code instead of being emitted directly.
+
+    The haystack is, in order of precedence:
+
+    * the image at ``screenshot`` when given (offline/deterministic matching for
+      replay and headless pipelines — coordinates are relative to the
+      screenshot's top-left, origin ``(0, 0)``);
+    * a specific window when any of app/window/hwnd/pid is given;
+    * otherwise the primary screen.
+
+    Args:
+        template_path: Path to the template image (PNG/JPG).
+        threshold: Minimum match score in ``[0.0, 1.0]``.
+        find_all: When True, return every non-overlapping match; otherwise the
+            single best.
+        app: Target app name/partial match.
+        window_title: Target window title substring.
+        hwnd: Target window handle.
+        pid: Target process ID.
+        screenshot: Optional path to an existing screenshot to match against
+            instead of capturing live. Incompatible with the window-targeting
+            flags (app/window/hwnd/pid), which are rejected rather than silently
+            ignored (#1070), since the screenshot is the haystack.
+        limit: Maximum number of matches to return.
+        json_output: Forwarded to backend acquisition so a headless-session
+            error is rendered in the caller's chosen format.
+
+    Returns:
+        ``(matches, origin_x, origin_y, target_hwnd, haystack_width,
+        haystack_height)`` where ``matches`` are
+        :class:`~naturo.image_match.Match` objects in haystack coordinates and
+        ``(origin_x, origin_y)`` is the offset to add for screen-absolute
+        coordinates.
+
+    Raises:
+        _ImageMatchError: On invalid threshold, missing/undecodable template or
+            screenshot, a missing Pillow dependency, a GUI-less platform (live
+            path only), window-not-found, or a live-capture fault — each with its
+            own attributing code.
+        SystemExit: Propagated from backend acquisition when no interactive
+            desktop session exists (live path only).
+    """
+    import os
+
+    if not (0.0 <= threshold <= 1.0):
+        raise _ImageMatchError(
+            "INVALID_INPUT",
+            f"--threshold must be between 0.0 and 1.0, got {threshold}",
+        )
+
+    if not os.path.exists(template_path):
+        raise _ImageMatchError(
+            "FILE_NOT_FOUND", f"Template image not found: {template_path}",
+        )
+
+    try:
+        from PIL import Image
+    except ImportError as e:  # pragma: no cover - exercised only without Pillow
+        raise _ImageMatchError(
+            "MISSING_DEPENDENCY",
+            f"Pillow is required for --image matching: {e}. "
+            "Install it with 'pip install naturo[annotate]'.",
+        )
+
+    from naturo.image_match import match_template
+
+    # Offline mode (#1070): when --screenshot is given the screenshot IS the
+    # search haystack, so the window-targeting flags do not apply. Reject the
+    # combination explicitly rather than silently ignoring it (the convention
+    # the --ai path already follows) — silently discarding --screenshot and
+    # matching the live screen returns confidently-wrong coordinates. Offline
+    # matching needs no live capture, so it is also exempt from the GUI-platform
+    # requirement that the live-capture path enforces (it runs headless).
+    if screenshot is not None:
+        if hwnd or app or window_title or pid:
+            raise _ImageMatchError(
+                "INVALID_INPUT",
+                "--screenshot matches against the supplied image, so "
+                "--app/--window/--hwnd/--pid do not apply; drop those flags to "
+                "match the screenshot, or drop --screenshot to capture a live "
+                "window.",
+            )
+        if not os.path.exists(screenshot):
+            raise _ImageMatchError(
+                "FILE_NOT_FOUND", f"Screenshot file not found: {screenshot}",
+            )
+    elif not _common._platform_supports_gui():
+        raise _ImageMatchError(
+            "PLATFORM_ERROR", _common._platform_error_msg("Image matching"),
+        )
+
+    # Load the template once, in its own try, so a template that exists but
+    # cannot be decoded is attributed to the template — never mis-reported as a
+    # haystack capture/load failure (#1067).
+    try:
+        with Image.open(template_path) as tmpl_src:
+            template = tmpl_src.copy()
+    except Exception as e:
+        raise _ImageMatchError(
+            "INVALID_TEMPLATE",
+            f"Template image could not be loaded: {template_path} ({e})",
+        )
+
+    # Acquire the haystack: the supplied screenshot (offline) or a live capture.
+    target_hwnd = hwnd
+    if screenshot is not None:
+        try:
+            with Image.open(screenshot) as hay_src:
+                haystack = hay_src.copy()
+        except Exception as e:
+            raise _ImageMatchError(
+                "INVALID_SCREENSHOT",
+                f"Screenshot could not be loaded: {screenshot} ({e})",
+            )
+        # Matches are located within the supplied screenshot, so coordinates are
+        # relative to its top-left rather than screen-absolute.
+        origin_x, origin_y = 0, 0
+        target_hwnd = None
+    else:
+        backend = _common._get_backend(json_output)
+        targeted = bool(hwnd or app or window_title or pid)
+
+        import tempfile
+        fd, capture_path = tempfile.mkstemp(suffix=".png")
+        os.close(fd)
+        try:
+            if targeted:
+                if not target_hwnd and hasattr(backend, "_resolve_hwnd"):
+                    target_hwnd = backend._resolve_hwnd(
+                        app=app, window_title=window_title, pid=pid)
+                if not target_hwnd:
+                    target = app or window_title or (f"pid={pid}" if pid else "target")
+                    raise _ImageMatchError(
+                        "WINDOW_NOT_FOUND", f"Window not found: {target}")
+                backend.capture_window(hwnd=target_hwnd, output_path=capture_path)
+                origin_x, origin_y = _window_origin(target_hwnd)
+            else:
+                backend.capture_screen(screen_index=0, output_path=capture_path)
+                origin_x, origin_y = _monitor_origin(backend, 0)
+
+            with Image.open(capture_path) as hay_src:
+                haystack = hay_src.copy()
+        except _ImageMatchError:
+            raise
+        except Exception as e:
+            raise _ImageMatchError("CAPTURE_FAILED", f"Screen capture failed: {e}")
+        finally:
+            try:
+                os.remove(capture_path)
+            except OSError:
+                pass
+
+    try:
+        matches = match_template(
+            haystack, template, threshold=threshold, find_all=find_all, max_results=limit,
+        )
+    except ValueError as e:
+        raise _ImageMatchError("INVALID_INPUT", str(e))
+
+    return matches, origin_x, origin_y, target_hwnd, haystack.width, haystack.height
+
+
 def _find_with_image(
     template_path: str,
     threshold: float,
@@ -443,35 +645,6 @@ def _find_with_image(
     """
     import os
 
-    if not (0.0 <= threshold <= 1.0):
-        msg = f"--threshold must be between 0.0 and 1.0, got {threshold}"
-        if json_output:
-            click.echo(_common._json_error_str("INVALID_INPUT", msg))
-        else:
-            click.echo(f"Error: {msg}", err=True)
-        raise SystemExit(1)
-
-    if not os.path.exists(template_path):
-        msg = f"Template image not found: {template_path}"
-        if json_output:
-            click.echo(_common._json_error_str("FILE_NOT_FOUND", msg))
-        else:
-            click.echo(f"Error: {msg}", err=True)
-        raise SystemExit(1)
-
-    try:
-        from PIL import Image
-    except ImportError as e:  # pragma: no cover - exercised only without Pillow
-        msg = (f"Pillow is required for --image matching: {e}. "
-               "Install it with 'pip install naturo[annotate]'.")
-        if json_output:
-            click.echo(_common._json_error_str("MISSING_DEPENDENCY", msg))
-        else:
-            click.echo(f"Error: {msg}", err=True)
-        raise SystemExit(1)
-
-    from naturo.image_match import match_template
-
     def _emit(code: str, message: str) -> NoReturn:
         if json_output:
             click.echo(_common._json_error_str(code, message))
@@ -479,93 +652,16 @@ def _find_with_image(
             click.echo(f"Error: {message}", err=True)
         raise SystemExit(1)
 
-    # Offline mode (#1070): when --screenshot is given the screenshot IS the
-    # search haystack, so the window-targeting flags do not apply.  Reject the
-    # combination explicitly rather than silently ignoring it (the convention
-    # the --ai path already follows) — silently discarding --screenshot and
-    # matching the live screen returns confidently-wrong coordinates.  Offline
-    # matching needs no live capture, so it is also exempt from the GUI-platform
-    # requirement that the live-capture path enforces (it runs headless).
-    if screenshot is not None:
-        if hwnd or app or window_title or pid:
-            _emit(
-                "INVALID_INPUT",
-                "--screenshot matches against the supplied image, so "
-                "--app/--window/--hwnd/--pid do not apply; drop those flags to "
-                "match the screenshot, or drop --screenshot to capture a live "
-                "window.",
+    try:
+        matches, origin_x, origin_y, target_hwnd, haystack_width, haystack_height = (
+            _resolve_image_matches(
+                template_path, threshold, find_all,
+                app=app, window_title=window_title, hwnd=hwnd, pid=pid,
+                screenshot=screenshot, limit=limit, json_output=json_output,
             )
-        if not os.path.exists(screenshot):
-            _emit("FILE_NOT_FOUND", f"Screenshot file not found: {screenshot}")
-    elif not _common._platform_supports_gui():
-        _emit("PLATFORM_ERROR", _common._platform_error_msg("Image matching"))
-
-    # Load the template once, in its own try, so a template that exists but
-    # cannot be decoded is attributed to the template — never mis-reported as a
-    # haystack capture/load failure (#1067).
-    try:
-        with Image.open(template_path) as tmpl_src:
-            template = tmpl_src.copy()
-    except Exception as e:
-        _emit("INVALID_TEMPLATE",
-              f"Template image could not be loaded: {template_path} ({e})")
-
-    # Acquire the haystack: the supplied screenshot (offline) or a live capture.
-    target_hwnd = hwnd
-    if screenshot is not None:
-        try:
-            with Image.open(screenshot) as hay_src:
-                haystack = hay_src.copy()
-        except Exception as e:
-            _emit("INVALID_SCREENSHOT",
-                  f"Screenshot could not be loaded: {screenshot} ({e})")
-        # Matches are located within the supplied screenshot, so coordinates are
-        # relative to its top-left rather than screen-absolute.
-        origin_x, origin_y = 0, 0
-        target_hwnd = None
-    else:
-        backend = _common._get_backend(json_output)
-        targeted = bool(hwnd or app or window_title or pid)
-
-        import tempfile
-        fd, capture_path = tempfile.mkstemp(suffix=".png")
-        os.close(fd)
-        try:
-            if targeted:
-                if not target_hwnd and hasattr(backend, "_resolve_hwnd"):
-                    target_hwnd = backend._resolve_hwnd(
-                        app=app, window_title=window_title, pid=pid)
-                if not target_hwnd:
-                    target = app or window_title or (f"pid={pid}" if pid else "target")
-                    _emit("WINDOW_NOT_FOUND", f"Window not found: {target}")
-                backend.capture_window(hwnd=target_hwnd, output_path=capture_path)
-                origin_x, origin_y = _window_origin(target_hwnd)
-            else:
-                backend.capture_screen(screen_index=0, output_path=capture_path)
-                origin_x, origin_y = _monitor_origin(backend, 0)
-
-            with Image.open(capture_path) as hay_src:
-                haystack = hay_src.copy()
-        except SystemExit:
-            raise
-        except Exception as e:
-            _emit("CAPTURE_FAILED", f"Screen capture failed: {e}")
-        finally:
-            try:
-                os.remove(capture_path)
-            except OSError:
-                pass
-
-    try:
-        matches = match_template(
-            haystack, template, threshold=threshold, find_all=find_all, max_results=limit,
         )
-    except ValueError as e:
-        if json_output:
-            click.echo(_common._json_error_str("INVALID_INPUT", str(e)))
-        else:
-            click.echo(f"Error: {e}", err=True)
-        raise SystemExit(1)
+    except _ImageMatchError as exc:
+        _emit(exc.code, exc.message)
 
     # Register matches as snapshot elements so `naturo click eN` works, mirroring
     # the ref bookkeeping the text-search path uses.
@@ -597,8 +693,8 @@ def _find_with_image(
         value=None,
         x=origin_x,
         y=origin_y,
-        width=haystack.width,
-        height=haystack.height,
+        width=haystack_width,
+        height=haystack_height,
         children=children,
         hwnd=target_hwnd or 0,
     )

--- a/naturo/cli/error_helpers.py
+++ b/naturo/cli/error_helpers.py
@@ -85,6 +85,16 @@ _RECOVERY_HINTS: dict[str, tuple[str, bool]] = {
         "the screen resolution and verify the target position.",
         False,
     ),
+    "INVALID_TEMPLATE": (
+        "The --image template file exists but could not be decoded. Check that it "
+        "is a valid PNG/JPG image smaller than the target window/screen.",
+        False,
+    ),
+    "INVALID_SCREENSHOT": (
+        "The --screenshot file exists but could not be decoded. Check that it is a "
+        "valid PNG/JPG screenshot to match against.",
+        False,
+    ),
     "APP_NOT_FOUND": (
         "The application is not running. Use 'naturo app list' to see running apps, "
         "or 'naturo app launch <name>' to start it.",

--- a/naturo/cli/interaction/_click.py
+++ b/naturo/cli/interaction/_click.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from typing import Any
 
 import click
@@ -39,6 +40,12 @@ def _get_screen_bound() -> int:
 @click.option("--ref", "ref_alias", hidden=True, help="Deprecated alias for --on")
 @click.option("--id", "element_id", help="Automation element ID")
 @click.option("--coords", nargs=2, type=int, metavar="X Y", help="X Y coordinates")
+@click.option("--image", "image_template", type=click.Path(), default=None,
+              help="Locate a template image (PNG/JPG) on the target window or "
+                   "screen and click the center of the best match "
+                   "(see 'naturo find --image').")
+@click.option("--threshold", type=float, default=0.9, show_default=True,
+              help="Minimum match score in [0.0, 1.0] for --image (higher is stricter)")
 @click.option("--double", is_flag=True, help="Double-click")
 @click.option("--right", is_flag=True, help="Right-click")
 @click.option("--app", help="Target application (name or partial match)")
@@ -66,7 +73,8 @@ def _get_screen_bound() -> int:
 @click.option("--process-name", "app", default=None, hidden=True, help="")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 def click_cmd(query: str | None, on_text: str | None, ref_alias: str | None,
-              element_id: str | None, coords: tuple[int, int] | None, double: bool,
+              element_id: str | None, coords: tuple[int, int] | None,
+              image_template: str | None, threshold: float, double: bool,
               right: bool, app: str | None, pid: int | None,
               window_title: str | None, hwnd: int | None, wait_for: float | None,
               input_mode: str, method: str, selector: str | None, app_id: str | None,
@@ -93,6 +101,8 @@ def click_cmd(query: str | None, on_text: str | None, ref_alias: str | None,
       naturo click --coords 500 300
       naturo click --coords 500 300 --right
       naturo click --id "button_ok"
+      naturo click --image submit.png
+      naturo click --image icon.png --app Notepad --threshold 0.85
       naturo click e42 --paste
       naturo click e42 --copy
     """
@@ -108,6 +118,56 @@ def click_cmd(query: str | None, on_text: str | None, ref_alias: str | None,
     backend = _common._get_backend(json_output)
 
     button = "right" if right else "left"
+
+    # Image-match targeting (#1059): locate a template on the window/screen and
+    # click the center of the best match. --image is its own targeting strategy,
+    # so it is mutually exclusive with the text/coords/ref/selector targets; the
+    # window-scoping flags (--app/--window/--hwnd/--pid) still apply — they choose
+    # the capture source, exactly as in `naturo find --image`. Matching is pure
+    # computation (no input injection): it resolves coordinates that then flow
+    # through the standard coordinate-click path below.
+    _image_match_info: dict[str, Any] | None = None
+    if image_template is not None:
+        from naturo.cli.core._find import _ImageMatchError, _resolve_image_matches
+        _conflict = (
+            "--coords" if coords else
+            "--id" if element_id else
+            "--selector" if selector else
+            "--on/QUERY" if (on_text or query) else
+            None
+        )
+        if _conflict is not None:
+            _common._json_err(
+                f"{_conflict} cannot be combined with --image; --image is its own "
+                "targeting strategy (it clicks the matched template's center).",
+                json_output, code="INVALID_INPUT",
+            )
+            return
+        try:
+            _matches, _ox, _oy, _thwnd, _hw, _hh = _resolve_image_matches(
+                image_template, threshold, False,
+                app=app, window_title=window_title, hwnd=hwnd, pid=pid,
+                screenshot=None, limit=1, json_output=json_output,
+            )
+        except _ImageMatchError as exc:
+            _common._json_err(exc.message, json_output, code=exc.code)
+            return
+        if not _matches:
+            _common._json_err(
+                f"No match for template '{os.path.basename(image_template)}' "
+                f"(threshold {threshold}). Lower --threshold or verify the template "
+                "is visible on the target.",
+                json_output, code="ELEMENT_NOT_FOUND",
+            )
+            return
+        _m = _matches[0]
+        # Center the click on the match, translating haystack coordinates to
+        # screen-absolute via the captured window/monitor origin.
+        coords = (_ox + _m.x + _m.width // 2, _oy + _m.y + _m.height // 2)
+        _image_match_info = {
+            "template": os.path.basename(image_template),
+            "score": round(_m.score, 4),
+        }
 
     # Resolve target coordinates or element_id
     # Priority: --selector (semantic) > --coords > --id > --on/query (#103)
@@ -399,6 +459,8 @@ def click_cmd(query: str | None, on_text: str | None, ref_alias: str | None,
     else:
         loc = f"({x}, {y})" if coords else (target_id or "element")
     result_data: dict[str, Any] = {"action": action, "target": str(loc), "button": button}
+    if _image_match_info is not None:
+        result_data["image_match"] = _image_match_info
     if _clipboard_action:
         result_data["clipboard_action"] = _clipboard_action
     # (#248) Indicate UIA click was used for UWP apps

--- a/naturo/errors.py
+++ b/naturo/errors.py
@@ -38,6 +38,12 @@ class ErrorCode:
     INVALID_INPUT = "INVALID_INPUT"
     INVALID_COORDINATES = "INVALID_COORDINATES"
 
+    # Image-matching errors (naturo find/click --image, #1059)
+    INVALID_TEMPLATE = "INVALID_TEMPLATE"
+    INVALID_SCREENSHOT = "INVALID_SCREENSHOT"
+    MISSING_DEPENDENCY = "MISSING_DEPENDENCY"
+    PLATFORM_ERROR = "PLATFORM_ERROR"
+
     # Dialog errors
     DIALOG_NOT_FOUND = "DIALOG_NOT_FOUND"
 
@@ -101,6 +107,13 @@ _ERROR_CATEGORIES: dict[str, str] = {
     ErrorCode.TIMEOUT: ErrorCategory.AUTOMATION,
     ErrorCode.INVALID_INPUT: ErrorCategory.VALIDATION,
     ErrorCode.INVALID_COORDINATES: ErrorCategory.VALIDATION,
+    # Image-matching codes (#1059): a template/screenshot the user supplied that
+    # cannot be decoded is a validation fault; a missing optional matcher
+    # dependency is configuration; a GUI-less platform is environment.
+    ErrorCode.INVALID_TEMPLATE: ErrorCategory.VALIDATION,
+    ErrorCode.INVALID_SCREENSHOT: ErrorCategory.VALIDATION,
+    ErrorCode.MISSING_DEPENDENCY: ErrorCategory.CONFIGURATION,
+    ErrorCode.PLATFORM_ERROR: ErrorCategory.ENVIRONMENT,
     ErrorCode.DIALOG_NOT_FOUND: ErrorCategory.AUTOMATION,
     ErrorCode.DEPENDENCY_MISSING: ErrorCategory.CONFIGURATION,
     ErrorCode.NO_DESKTOP_SESSION: ErrorCategory.ENVIRONMENT,

--- a/tests/test_click_image_1059.py
+++ b/tests/test_click_image_1059.py
@@ -1,0 +1,245 @@
+"""Tests for ``naturo click --image`` template-match targeting (#1059).
+
+``click --image template.png`` locates the template on the target window/screen
+(reusing the ``find --image`` matching core) and clicks the center of the best
+match — the ``naturo click --image`` shortcut from the unified-find-engine scope
+(#809).
+
+Image matching is pure computation, so these tests resolve the click coordinates
+deterministically against in-memory fixtures with the capture backend mocked, and
+assert the resolved coordinates by mocking the click backend's ``click`` call —
+no real input injection and no desktop session, so they run on every CI platform.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+# Pillow backs the matcher; skip the whole module where it is unavailable.
+pytest.importorskip("PIL")
+
+from click.testing import CliRunner  # noqa: E402
+from PIL import Image  # noqa: E402
+from unittest.mock import MagicMock, patch  # noqa: E402
+
+from naturo.cli.interaction._click import click_cmd  # noqa: E402
+
+
+def _distinctive_patch(width: int = 24, height: int = 18) -> Image.Image:
+    """A patch with strong internal contrast so NCC is well conditioned."""
+    patch_img = Image.new("L", (width, height), 0)
+    px = patch_img.load()
+    for y in range(height):
+        for x in range(width):
+            px[x, y] = 255 if (x // 4 + y // 4) % 2 == 0 else 0
+    return patch_img
+
+
+def _haystack_with_patch(
+    size: tuple[int, int], patch_img: Image.Image, at: tuple[int, int], background: int = 128,
+) -> Image.Image:
+    """Build a haystack with ``patch_img`` pasted at ``at`` over a lightly textured
+    background (so the background carries no spurious high-contrast match)."""
+    width, height = size
+    base = Image.new("L", size, background)
+    px = base.load()
+    for y in range(height):
+        for x in range(width):
+            px[x, y] = (background + (x + y) % 7) % 256
+    base.paste(patch_img, at)
+    return base
+
+
+def _backend(capture_image: Image.Image) -> MagicMock:
+    """A backend whose live capture writes ``capture_image`` and whose ``click``
+    records the resolved coordinates."""
+    backend = MagicMock()
+
+    def _capture_screen(screen_index: int = 0, output_path: str = "capture.png"):
+        capture_image.save(output_path)
+        return MagicMock(path=output_path)
+
+    def _capture_window(hwnd: int, output_path: str = "capture.png"):
+        capture_image.save(output_path)
+        return MagicMock(path=output_path)
+
+    backend.capture_screen.side_effect = _capture_screen
+    backend.capture_window.side_effect = _capture_window
+    backend.list_monitors.return_value = [MagicMock(x=0, y=0)]
+    backend.click.return_value = None
+    backend.focus_window.return_value = None
+    backend._resolve_hwnd.return_value = 4242
+    backend._resolve_hwnds.return_value = [4242]
+    backend._is_afh_window.return_value = False
+    backend._is_winui_window.return_value = False
+    return backend
+
+
+def _patches(backend: MagicMock):
+    """Patch every host-dependent call on the click --image path so the result
+    reflects the code, not the runner's desktop state."""
+    return [
+        patch("naturo.cli.core._common._platform_supports_gui", return_value=True),
+        patch("naturo.cli.core._common._get_backend", return_value=backend),
+        patch("naturo.cli.interaction._common._get_backend", return_value=backend),
+        patch("naturo.cli.interaction._common._resolve_app_id",
+              return_value=(None, None, None)),
+        patch("naturo.cli.interaction._common._auto_route", return_value={}),
+    ]
+
+
+def _invoke(runner: CliRunner, backend: MagicMock, args: list[str]):
+    ctx = _patches(backend)
+    with ctx[0], ctx[1], ctx[2], ctx[3], ctx[4]:
+        return runner.invoke(click_cmd, args, catch_exceptions=False)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+class TestClickImageHappyPath:
+    """--image resolves to the match center and clicks it (live capture)."""
+
+    def test_clicks_center_of_match(self, runner, tmp_path) -> None:
+        patch_img = _distinctive_patch()  # 24x18
+        screen = _haystack_with_patch((320, 240), patch_img, at=(60, 90))
+        template_file = tmp_path / "tmpl.png"
+        patch_img.save(template_file)
+        backend = _backend(screen)
+
+        result = _invoke(runner, backend, ["--image", str(template_file)])
+
+        assert result.exit_code == 0, result.output
+        backend.click.assert_called_once()
+        kwargs = backend.click.call_args.kwargs
+        # Center of the match: top-left (60,90) + half of (24,18) = (72,99).
+        assert abs(kwargs["x"] - 72) <= 2
+        assert abs(kwargs["y"] - 99) <= 2
+        assert kwargs["button"] == "left"
+        assert kwargs["double"] is False
+
+    def test_json_reports_template_and_score(self, runner, tmp_path) -> None:
+        patch_img = _distinctive_patch()
+        screen = _haystack_with_patch((320, 240), patch_img, at=(40, 50))
+        template_file = tmp_path / "tmpl.png"
+        patch_img.save(template_file)
+        backend = _backend(screen)
+
+        result = _invoke(runner, backend, ["--image", str(template_file), "--json"])
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["success"] is True
+        match = payload["data"]["image_match"]
+        assert match["template"] == "tmpl.png"
+        assert match["score"] >= 0.9
+
+    def test_double_and_right_flags_flow_through(self, runner, tmp_path) -> None:
+        patch_img = _distinctive_patch()
+        screen = _haystack_with_patch((320, 240), patch_img, at=(60, 90))
+        template_file = tmp_path / "tmpl.png"
+        patch_img.save(template_file)
+        backend = _backend(screen)
+
+        result = _invoke(
+            runner, backend,
+            ["--image", str(template_file), "--double", "--right"],
+        )
+
+        assert result.exit_code == 0, result.output
+        kwargs = backend.click.call_args.kwargs
+        assert kwargs["double"] is True
+        assert kwargs["button"] == "right"
+
+
+class TestClickImageErrors:
+    """Failures are attributed to their own registered error codes, and no click
+    is dispatched (prefer a false negative over clicking the wrong place)."""
+
+    def test_no_match_is_element_not_found(self, runner, tmp_path) -> None:
+        patch_img = _distinctive_patch()
+        # The screen is uniform black: the template cannot be present.
+        black = Image.new("L", (320, 240), 0)
+        template_file = tmp_path / "tmpl.png"
+        patch_img.save(template_file)
+        backend = _backend(black)
+
+        result = _invoke(
+            runner, backend,
+            ["--image", str(template_file), "--threshold", "0.95", "--json"],
+        )
+
+        assert result.exit_code == 1, result.output
+        error = json.loads(result.output)["error"]
+        assert error["code"] == "ELEMENT_NOT_FOUND"
+        assert error["category"] == "automation"
+        backend.click.assert_not_called()
+
+    def test_missing_template_file_is_file_not_found(self, runner, tmp_path) -> None:
+        backend = _backend(Image.new("L", (100, 100), 128))
+
+        result = _invoke(
+            runner, backend,
+            ["--image", str(tmp_path / "nope.png"), "--json"],
+        )
+
+        assert result.exit_code == 1, result.output
+        assert json.loads(result.output)["error"]["code"] == "FILE_NOT_FOUND"
+        backend.click.assert_not_called()
+
+    def test_undecodable_template_is_invalid_template(self, runner, tmp_path) -> None:
+        """A bad template carries the registered INVALID_TEMPLATE code with its
+        proper (non-degraded) category — locks the #1059 error-code registration."""
+        bad_template = tmp_path / "bad.png"
+        bad_template.write_text("not an image", encoding="utf-8")
+        backend = _backend(_haystack_with_patch((100, 100), _distinctive_patch(), at=(10, 10)))
+
+        result = _invoke(runner, backend, ["--image", str(bad_template), "--json"])
+
+        assert result.exit_code == 1, result.output
+        error = json.loads(result.output)["error"]
+        assert error["code"] == "INVALID_TEMPLATE"
+        assert error["category"] == "validation"
+        backend.click.assert_not_called()
+
+    def test_bad_threshold_is_invalid_input(self, runner, tmp_path) -> None:
+        template_file = tmp_path / "tmpl.png"
+        _distinctive_patch().save(template_file)
+        backend = _backend(Image.new("L", (100, 100), 128))
+
+        result = _invoke(
+            runner, backend,
+            ["--image", str(template_file), "--threshold", "1.5", "--json"],
+        )
+
+        assert result.exit_code == 1, result.output
+        assert json.loads(result.output)["error"]["code"] == "INVALID_INPUT"
+        backend.click.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "extra",
+        [
+            ["--coords", "10", "20"],
+            ["--id", "button_ok"],
+            ["--on", "Save"],
+            ["some text query"],
+        ],
+    )
+    def test_image_is_mutually_exclusive_with_other_targets(
+        self, runner, tmp_path, extra,
+    ) -> None:
+        template_file = tmp_path / "tmpl.png"
+        _distinctive_patch().save(template_file)
+        backend = _backend(Image.new("L", (100, 100), 128))
+
+        result = _invoke(
+            runner, backend,
+            ["--image", str(template_file), "--json", *extra],
+        )
+
+        assert result.exit_code == 1, result.output
+        assert json.loads(result.output)["error"]["code"] == "INVALID_INPUT"
+        backend.click.assert_not_called()


### PR DESCRIPTION
## What

Completes the unified find engine's image strategy (#809) by adding the `naturo click --image template.png` shortcut from #1059's acceptance criteria. It locates the template on the target window/screen (reusing the `find --image` matcher) and clicks the **center of the best match**.

```bash
naturo click --image submit.png                      # click a template match on the screen
naturo click --image icon.png --app Notepad --threshold 0.85
```

## How

- **Shared matching core.** Extracted `_resolve_image_matches` in `core/_find.py` so `find --image` and `click --image` resolve a template to coordinates *identically* — same capture precedence (screenshot → window → screen), same threshold semantics, and the same per-source error attribution (#1067/#1070, via a new `_ImageMatchError` carrier). `find --image` now consumes the core; its behavior is byte-identical (all existing find-image tests pass).
- **Live-capture only.** `click --image` deliberately omits `--screenshot`: screenshot-relative coordinates are not meaningfully clickable on a live screen (a product-direction nuance left out of this slice). Matching is pure computation — it resolves coordinates that flow through the **existing** coordinate-click path, so no new input-injection code is added (relevant under the active input freeze, #863/#975).
- **Tight targeting semantics.** `--image` is its own strategy: mutually exclusive with `--coords`/`--id`/`--on`/`QUERY`/`--selector` (→ `INVALID_INPUT`); window-scoping flags (`--app`/`--window`/`--hwnd`/`--pid`) still apply and choose the capture source, exactly as in `find --image`. A no-match returns `ELEMENT_NOT_FOUND` and **clicks nothing** rather than guessing a location (prefer a false negative — SOUL "never lie").
- **Error-code registration.** Registered the image-matching error family (`INVALID_TEMPLATE`, `INVALID_SCREENSHOT`, `MISSING_DEPENDENCY`, `PLATFORM_ERROR`) in the `ErrorCode` enum + category map + recovery hints, so **both** `find` and `click` now emit non-degraded envelopes (correct `category`) instead of `category=unknown`.

## How tested

- New hermetic `tests/test_click_image_1059.py` (11 tests): center-of-match resolution, JSON `image_match` info, `--double`/`--right` flow-through, no-match → `ELEMENT_NOT_FOUND`, missing/undecodable template, bad threshold, and parametrized mutual-exclusivity. Capture **and** click backends are mocked — no desktop session, no input injection, runs on every CI platform (`@pytest.mark.desktop`-free; `--collect-only` clean).
- `ruff check naturo/` clean; `mypy` clean on changed files.
- Full non-desktop suite: 6482 passed; the only new failure I introduced (a recovery-hint wording rule) was fixed. Remaining suite failures are pre-existing/environmental (GBK-locale YAML decode, Linux/non-Windows platform guards, gitignored-DLL version, #1084 process-name leak) — none touch this diff.

Fixes #1059.