### PR TITLE
docs: correct migration guide network section to shipped API (fixes #1088)

### DIFF
--- a/docs/MIGRATION_FROM_RPA_SCRIPTS.md
+++ b/docs/MIGRATION_FROM_RPA_SCRIPTS.md
@@ -138,7 +138,7 @@ which engine found which element — just use `naturo click e42`.
 | `driver.get_cookies()` | `naturo browser cookies save --path f.json` | `page.cookies.save(path)` |
 | `driver.add_cookie(c)` | `naturo browser cookies load --path f.json` | `page.cookies.load(path)` |
 | `driver.switch_to.frame(el)` | `naturo browser frame <selector>` | `page.frame(selector)` |
-| `options.set_capability('goog:loggingPrefs', ...)` | `naturo browser listen <pattern>` | `page.listen(pattern)` |
+| `options.set_capability('goog:loggingPrefs', ...)` | `naturo browser requests --pattern <glob>` | `page.network.capture_snapshot()` |
 
 ### pywinauto / uiautomation to naturo
 
@@ -793,42 +793,48 @@ for log in logs:
             data = json.loads(body["body"])
 ```
 
-**After** — first-class network listening:
+**After** — observe request metadata and intercept (block / mock) requests:
 ```bash
-# Listen for API responses matching a pattern
-naturo browser listen "*/api/v1/live/data*" --count 1 --timeout 10000
-
-# Navigate to trigger the request
+# Navigate to trigger the requests
 naturo browser navigate "https://dashboard.example.com/live"
 
-# Capture responses to a file
-naturo browser listen "*/api/v1/*" --output responses.jsonl --count 5
+# List the requests the page made (URL, type, size, duration)
+naturo browser requests
+naturo browser requests --pattern "*/api/v1/*" --json
 
 # Block unwanted requests (ads, analytics)
-naturo browser intercept --block "*.doubleclick.net/*"
-naturo browser intercept --block "*/analytics/*"
+naturo browser intercept "*.doubleclick.net/*" --action abort
+naturo browser intercept "*/analytics/*" --action abort
+
+# Mock a response for matching requests
+naturo browser intercept "*/api/v1/config*" --action fulfill \
+    --body '{"debug": true}' --status 200
 ```
 
 ```python
-# Wait for a specific API response
+# Observe the requests the page has made (metadata via the Performance API)
 page.navigate("https://dashboard.example.com/live")
-response = page.wait_for_response("*/api/v1/live/data*", timeout=10000)
-data = response.json()  # parsed response body
+requests = page.network.capture_snapshot()
+api_requests = page.network.find_requests("*/api/v1/*")
 
-# Collect multiple responses
-responses = page.collect_responses("*/api/v1/*", count=5, timeout=30000)
+# Block unwanted requests
+page.network.abort_pattern("*.doubleclick.net/*")
 
-# Listen with callback
-def on_data(resp):
-    save_to_db(resp.json())
-
-page.listen("*/api/v1/live/data*", callback=on_data)
-page.navigate("https://dashboard.example.com/live")
+# Mock a response for matching requests
+page.network.mock_response("*/api/v1/config*", body='{"debug": true}', status_code=200)
 ```
 
-This replaces 15+ lines of performance log parsing with one line. The old Selenium
-approach requires parsing raw CDP events from a log buffer; naturo handles the CDP
-subscription and response body fetching internally.
+This replaces the boilerplate of enabling performance logging and parsing raw CDP
+events from a log buffer: naturo manages the CDP subscription and exposes request
+metadata and interception directly.
+
+> **Not yet supported:** reading a captured response **body** (the Selenium
+> `Network.getResponseBody` step shown above). `naturo browser requests` reports
+> request *metadata* only (URL, type, size, timing); use `intercept --action
+> fulfill` to supply a *mock* body. Capturing a real response body (await a
+> response and parse its JSON, or stream responses via a callback) is tracked as
+> a future enhancement — see
+> [#1088](https://github.com/AcePeak/naturo/issues/1088).
 
 ---
 

--- a/tests/test_migration_guide_network_doc_1088.py
+++ b/tests/test_migration_guide_network_doc_1088.py
@@ -1,0 +1,128 @@
+"""Never-lie guard for the migration guide's network section (#1088).
+
+``docs/MIGRATION_FROM_RPA_SCRIPTS.md`` previously documented a *Network Request
+Interception* API that does not exist in the shipped surface -- a ``naturo
+browser listen`` command plus ``page.listen`` / ``page.wait_for_response`` /
+``page.collect_responses`` Python methods (the same defect class as the iframe
+gap #1082). A user following the guide would invoke commands and call methods
+that simply are not there, violating the SOUL.md never-lie contract for our own
+documentation.
+
+This module pins the fix and prevents regression. Rather than hard-coding the
+allowed strings, it derives the *real* surface at runtime -- the registered
+``browser`` subcommands from the Click tree and the public
+:class:`~naturo.browser._network.NetworkMonitor` methods -- and asserts the
+guide's network section references **only** that real surface, and that the
+known-fictional symbols appear nowhere in the guide. If someone re-documents an
+unimplemented capability (or renames a real command without updating the guide),
+these tests fail.
+
+The tests read only the on-disk Markdown and import pure Python metadata, so
+they need no browser/desktop and run on every CI lane.
+
+Relates to #1088. Sibling never-lie doc guard to the #766 equivalence suite.
+"""
+from __future__ import annotations
+
+import inspect
+import re
+from pathlib import Path
+
+from naturo.browser._network import NetworkMonitor
+from naturo.cli import main
+
+_GUIDE_PATH = (
+    Path(__file__).resolve().parents[1] / "docs" / "MIGRATION_FROM_RPA_SCRIPTS.md"
+)
+
+# Symbols the guide used to promise that the shipped surface never exposed.
+# The implemented network surface observes request *metadata* and intercepts
+# (abort / mock); it has no response-*body* streaming API. Re-introducing any of
+# these names means the guide is lying again.
+_FICTIONAL_SYMBOLS = (
+    "browser listen",
+    "page.listen",
+    "wait_for_response",
+    "collect_responses",
+)
+
+
+def _guide_text() -> str:
+    """Return the full migration-guide Markdown as text."""
+    return _GUIDE_PATH.read_text(encoding="utf-8")
+
+
+def _network_section() -> str:
+    """Return the body of the guide's *Network Request Interception* section.
+
+    Slices from the ``### Network Request Interception`` heading up to the next
+    Markdown section boundary (``### `` / ``## `` / a horizontal rule), so the
+    assertions are scoped to the section under test rather than the whole guide.
+
+    Returns:
+        The section body, or the empty string if the heading is absent.
+    """
+    text = _guide_text()
+    start = text.find("### Network Request Interception")
+    assert start != -1, "Network Request Interception section not found in guide"
+    rest = text[start + len("### Network Request Interception"):]
+    boundary = re.search(r"^(?:### |## |---)", rest, re.MULTILINE)
+    return rest[: boundary.start()] if boundary else rest
+
+
+def _real_browser_subcommands() -> set[str]:
+    """Return the set of registered ``naturo browser`` leaf subcommand names."""
+    browser_group = main.commands["browser"]
+    return set(browser_group.commands.keys())  # type: ignore[attr-defined]
+
+
+def _real_network_methods() -> set[str]:
+    """Return the public method names of :class:`NetworkMonitor`."""
+    return {
+        name
+        for name, _ in inspect.getmembers(NetworkMonitor, predicate=inspect.isfunction)
+        if not name.startswith("_")
+    }
+
+
+def test_guide_does_not_document_fictional_network_symbols() -> None:
+    """No known-fictional network symbol appears anywhere in the guide."""
+    text = _guide_text()
+    leaked = [symbol for symbol in _FICTIONAL_SYMBOLS if symbol in text]
+    assert not leaked, (
+        f"Migration guide documents network API that does not exist: {leaked}. "
+        "The shipped surface is `browser requests` / `browser intercept` and "
+        "`page.network.*` (no response-body streaming) -- see #1088."
+    )
+
+
+def test_network_section_uses_only_real_browser_commands() -> None:
+    """Every ``naturo browser <sub>`` in the section is a registered command."""
+    section = _network_section()
+    real = _real_browser_subcommands()
+    documented = set(re.findall(r"naturo browser (\w[\w-]*)", section))
+    unknown = documented - real
+    assert not unknown, (
+        f"Network section documents non-existent browser subcommand(s): "
+        f"{sorted(unknown)}. Registered subcommands: {sorted(real)}."
+    )
+    # Guard against a vacuous pass if the examples are ever dropped entirely.
+    assert {"requests", "intercept"} <= documented, (
+        "Network section should demonstrate the real `browser requests` / "
+        "`browser intercept` surface."
+    )
+
+
+def test_network_section_uses_only_real_page_network_methods() -> None:
+    """Every ``page.network.<method>(`` in the section exists on NetworkMonitor."""
+    section = _network_section()
+    real = _real_network_methods()
+    documented = set(re.findall(r"page\.network\.(\w+)\s*\(", section))
+    unknown = documented - real
+    assert not unknown, (
+        f"Network section documents non-existent NetworkMonitor method(s): "
+        f"{sorted(unknown)}. Public methods: {sorted(real)}."
+    )
+    assert documented, (
+        "Network section should show the real `page.network.*` Python API."
+    )


### PR DESCRIPTION
## What
The migration guide's **Network Request Interception** section documented an API that does not exist in the shipped surface — a `naturo browser listen` command plus `page.listen` / `page.wait_for_response` / `page.collect_responses` Python methods (same defect class as #1082's iframe gap). A user following the guide would invoke commands and call methods that simply are not there, violating the SOUL.md **never-lie** contract for our own docs.

This is the conservative **doc-down** resolution (option 1 in #1088): rewrite the *After* examples to the real, shipped surface and explicitly flag the missing capability. Implementing a richer response-body capture feature (option 2) remains a separate product call for Ace and is **not** done here — the doc now points at #1088 as the tracking issue for it.

### Changes
- Rewrite the *After* examples to the real surface:
  - `naturo browser requests [--pattern] [--json]` → request metadata (URL/type/size/timing)
  - `naturo browser intercept <pattern> --action abort|fulfill [--body] [--status]` → block / mock
  - `page.network.capture_snapshot()` / `find_requests(pattern)` / `abort_pattern(pattern)` / `mock_response(pattern, body=, status_code=)`
- Add an explicit **"Not yet supported"** note: reading a real response *body* is a tracked future enhancement, so the guide no longer over-promises.
- Fix the comparison-table row that named the same fictional `browser listen` / `page.listen` API.

### Never-lie accuracy
All documented CLI flags and Python signatures were verified against the live code (`naturo/cli/_browser/network.py`, `NetworkMonitor` in `naturo/browser/_network.py`) — including the keyword-only `body=` / `status_code=` params.

## How tested
- New `tests/test_migration_guide_network_doc_1088.py` — a **CI-runnable, code-grounded** never-lie guard (no browser/desktop): it derives the real `browser` subcommands from the Click tree and the public `NetworkMonitor` methods at runtime, then asserts the guide's network section references **only** that surface and that the known-fictional symbols appear **nowhere** in the guide. Written failing-first (3 failed → 3 passed after the doc-down).
- `python -m ruff check naturo/ tests/test_migration_guide_network_doc_1088.py` → clean.
- `python -m pytest tests/test_migration_guide_network_doc_1088.py` → 3 passed; `--collect-only` clean (no Windows/desktop deps), so it runs on every CI lane.
- Full `pytest -m "not desktop"`: the new test passes; the only failures are pre-existing platform/env noise (Linux-behavior tests on a Windows desktop, DLL version skew) unrelated to this docs/test change.