### PR TITLE
fix: eN stale-ref errors use registered STALE_SNAPSHOT_CACHE, not bare REF_NOT_FOUND (fixes #1086)

### DIFF
--- a/naturo/cli/core/_capture.py
+++ b/naturo/cli/core/_capture.py
@@ -150,7 +150,8 @@ def capture(app: str | None, pid: int | None, window_title: str | None, hwnd: in
                     "Run 'naturo see' first to create a snapshot."
                 )
                 if json_output:
-                    click.echo(_common._json_error_str("REF_NOT_FOUND", msg))
+                    click.echo(_common._json_error_str(
+                        "STALE_SNAPSHOT_CACHE", msg, context={"ref": element_ref}))
                 else:
                     click.echo(f"Error: {msg}", err=True)
                 raise SystemExit(1)

--- a/naturo/cli/interaction/_click.py
+++ b/naturo/cli/interaction/_click.py
@@ -267,7 +267,8 @@ def click_cmd(query: str | None, on_text: str | None, ref_alias: str | None,
                     f"Element ref '{target_id}' not found. Run 'naturo see' first to "
                     f"capture a fresh snapshot, then use the eN ref within 10 minutes.",
                     json_output,
-                    code="REF_NOT_FOUND",
+                    code="STALE_SNAPSHOT_CACHE",
+                    context={"ref": target_id},
                 )
                 return
 

--- a/naturo/cli/interaction/_common.py
+++ b/naturo/cli/interaction/_common.py
@@ -627,10 +627,10 @@ def _resolve_text_or_ref_target(
     ``see`` snapshot; any other string is looked up by name/automation-id through
     the backend's element search and reduced to the matched element's centre.
 
-    On failure this emits the canonical error envelope — ``REF_NOT_FOUND`` for a
-    stale ``eN`` ref, ``ELEMENT_NOT_FOUND`` for a missing text/id target — and
-    terminates the process (via :func:`_json_err`), so callers treat a ``None``
-    return as "stop".
+    On failure this emits the canonical error envelope — ``STALE_SNAPSHOT_CACHE``
+    for a stale ``eN`` ref (matching ``get``/``set``), ``ELEMENT_NOT_FOUND`` for a
+    missing text/id target — and terminates the process (via :func:`_json_err`),
+    so callers treat a ``None`` return as "stop".
 
     Args:
         target_id: The element token — an ``eN`` snapshot ref, visible text, or
@@ -654,7 +654,8 @@ def _resolve_text_or_ref_target(
             f"Element ref '{target_id}' not found. Run 'naturo see' first to "
             f"capture a fresh snapshot, then use the eN ref within 10 minutes.",
             json_output,
-            code="REF_NOT_FOUND",
+            code="STALE_SNAPSHOT_CACHE",
+            context={"ref": target_id},
         )
         return None
 
@@ -877,7 +878,8 @@ def _json_ok(data: dict, json_output: bool) -> None:
 
 def _json_err(msg: str, json_output: bool, exit_code: int = 1,
               code: str = "ACTION_ERROR", *,
-              exc: Optional[BaseException] = None) -> NoReturn:
+              exc: Optional[BaseException] = None,
+              context: Optional[dict] = None) -> NoReturn:
     """Emit error result as JSON or plain text, then exit.
 
     Includes agent-friendly recovery hints from the error_helpers registry.
@@ -902,6 +904,9 @@ def _json_err(msg: str, json_output: bool, exit_code: int = 1,
         code: Error code for the JSON envelope and the non-semantic fallback.
         exc: The original exception, when available, so a ``NaturoError``'s
             structured identity can be preserved.
+        context: Structured detail merged into the JSON envelope's ``context``
+            field (e.g. ``{"ref": "e7"}`` for a stale snapshot ref). Ignored on
+            the ``exc`` and plain-text paths.
     """
     from naturo.errors import NaturoError
     if isinstance(exc, NaturoError):
@@ -910,7 +915,7 @@ def _json_err(msg: str, json_output: bool, exit_code: int = 1,
                              exit_code=exit_code)
     if json_output:
         from naturo.cli.error_helpers import json_error
-        click.echo(json_error(code, msg))
+        click.echo(json_error(code, msg, context=context))
     else:
         click.echo(f"Error: {msg}", err=True)
     sys.exit(exit_code)

--- a/naturo/cli/interaction/_mouse.py
+++ b/naturo/cli/interaction/_mouse.py
@@ -266,7 +266,8 @@ def drag(from_text, from_coords, from_selector, from_element,
                 f"Source element ref '{from_text}' not found or has zero-size bounds. "
                 f"Run 'naturo see' first to capture a fresh snapshot.",
                 json_output,
-                code="REF_NOT_FOUND",
+                code="STALE_SNAPSHOT_CACHE",
+                context={"ref": from_text},
             )
             return
     else:
@@ -315,7 +316,8 @@ def drag(from_text, from_coords, from_selector, from_element,
                 f"Destination element ref '{to_text}' not found or has zero-size bounds. "
                 f"Run 'naturo see' first to capture a fresh snapshot.",
                 json_output,
-                code="REF_NOT_FOUND",
+                code="STALE_SNAPSHOT_CACHE",
+                context={"ref": to_text},
             )
             return
     else:

--- a/naturo/cli/interaction/_press.py
+++ b/naturo/cli/interaction/_press.py
@@ -207,7 +207,8 @@ def press(keys: tuple[str, ...], count: int, delay: float, hold_duration: float 
                     f"Element ref '{on_element}' not found. Run 'naturo see' first to "
                     f"capture a fresh snapshot, then use the eN ref within 10 minutes.",
                     json_output,
-                    code="REF_NOT_FOUND",
+                    code="STALE_SNAPSHOT_CACHE",
+                    context={"ref": on_element},
                 )
                 return
         else:

--- a/naturo/cli/interaction/_type.py
+++ b/naturo/cli/interaction/_type.py
@@ -243,7 +243,8 @@ def type_cmd(text, delay, profile, wpm, press_return, tab_count, escape,
                     f"Element ref '{on_element}' not found. Run 'naturo see' first to "
                     f"capture a fresh snapshot, then use the eN ref within 10 minutes.",
                     json_output,
-                    code="REF_NOT_FOUND",
+                    code="STALE_SNAPSHOT_CACHE",
+                    context={"ref": on_element},
                 )
                 return
         else:

--- a/tests/test_capture_crop.py
+++ b/tests/test_capture_crop.py
@@ -222,7 +222,7 @@ class TestElementRefCrop:
         result = self._run_with_element("e99", png_200x100, element=None)
         data = json.loads(result.output)
         assert data["success"] is False
-        assert "REF_NOT_FOUND" in data["error"]["code"]
+        assert data["error"]["code"] == "STALE_SNAPSHOT_CACHE"
 
     def test_element_ref_crops_image(self, png_200x100):
         el = UIElement(

--- a/tests/test_capture_ux.py
+++ b/tests/test_capture_ux.py
@@ -28,7 +28,7 @@ def test_capture_ref_alias():
     # This will fail with "Element ref 'e999' not found" which proves --ref is accepted
     result = runner.invoke(main, ["capture", "--ref", "e999", "--json"])
     assert "--ref" not in result.output or "No such option" not in result.output
-    # Should get REF_NOT_FOUND or similar, not "No such option: --ref"
+    # Should get STALE_SNAPSHOT_CACHE or similar, not "No such option: --ref"
     if result.exit_code != 0:
         assert "No such option" not in result.output
 

--- a/tests/test_cli_capture.py
+++ b/tests/test_cli_capture.py
@@ -219,7 +219,7 @@ class TestElementCrop:
                 "-p", "/tmp/out.png", "--element", "e999", "--json", "--no-snapshot",
             ], catch_exceptions=False)
         assert result.exit_code != 0
-        assert "REF_NOT_FOUND" in result.output
+        assert "STALE_SNAPSHOT_CACHE" in result.output
 
     def test_element_zero_size_error(self, runner, mock_backend):
         mock_elem = MagicMock()

--- a/tests/test_cli_click.py
+++ b/tests/test_cli_click.py
@@ -138,7 +138,7 @@ class TestRefClick:
              patch("naturo.snapshot.get_snapshot_manager", return_value=mock_mgr):
             result = runner.invoke(click_cmd, ["e999", "--json"], catch_exceptions=False)
         assert result.exit_code != 0
-        assert "REF_NOT_FOUND" in result.output
+        assert "STALE_SNAPSHOT_CACHE" in result.output
 
     def test_click_ref_zero_bounds_invokes_uia(self, runner, mock_backend):
         mock_elem = MagicMock()

--- a/tests/test_cli_press.py
+++ b/tests/test_cli_press.py
@@ -536,7 +536,7 @@ class TestPressOnElement:
                 catch_exceptions=False,
             )
             assert result.exit_code != 0
-            assert "REF_NOT_FOUND" in result.output or "not found" in result.output.lower()
+            assert "STALE_SNAPSHOT_CACHE" in result.output or "not found" in result.output.lower()
 
     @patch("naturo.cli.interaction._common._auto_route", return_value=None)
     @patch("naturo.cli.interaction._common._get_backend")

--- a/tests/test_cli_type.py
+++ b/tests/test_cli_type.py
@@ -272,7 +272,7 @@ class TestOnElement:
              patch("naturo.snapshot.get_snapshot_manager", return_value=mock_mgr):
             result = runner.invoke(type_cmd, ["hello", "--on", "e999", "--json"], catch_exceptions=False)
         assert result.exit_code != 0
-        assert "REF_NOT_FOUND" in result.output
+        assert "STALE_SNAPSHOT_CACHE" in result.output
 
     def test_on_text_finds_element(self, runner, mock_backend):
         mock_elem = MagicMock()

--- a/tests/test_click_ref_skip_routing.py
+++ b/tests/test_click_ref_skip_routing.py
@@ -183,7 +183,7 @@ class TestClickRefSkipsRouting:
         # e999 doesn't exist in the snapshot
         result = runner.invoke(click_cmd, ["e999", "--no-verify"])
 
-        # Should have errored with REF_NOT_FOUND, not called auto_route
+        # Should have errored with STALE_SNAPSHOT_CACHE, not called auto_route
         mock_auto_route.assert_not_called()
 
     @patch("naturo.cli.interaction._common._auto_route")

--- a/tests/test_input_mouse.py
+++ b/tests/test_input_mouse.py
@@ -503,8 +503,8 @@ class TestMoveTargetResolution:
         assert args[0] == 333
         assert args[1] == 444
 
-    def test_move_stale_eN_ref_yields_ref_not_found(self, runner):
-        """A stale ``move --to eN`` ref yields REF_NOT_FOUND, not a move."""
+    def test_move_stale_eN_ref_yields_stale_snapshot_cache(self, runner):
+        """A stale ``move --to eN`` ref yields STALE_SNAPSHOT_CACHE, not a move."""
         from unittest.mock import patch, MagicMock
 
         mock_backend = MagicMock()
@@ -514,7 +514,7 @@ class TestMoveTargetResolution:
              patch("naturo.snapshot.get_snapshot_manager", return_value=mock_mgr):
             result = runner.invoke(main, ["move", "--to", "e99", "-j"])
         assert result.exit_code != 0
-        assert json.loads(result.output)["error"]["code"] == "REF_NOT_FOUND"
+        assert json.loads(result.output)["error"]["code"] == "STALE_SNAPSHOT_CACHE"
         mock_backend.move_mouse.assert_not_called()
 
     def test_move_no_target_still_reports_invalid_input(self, runner):

--- a/tests/test_stale_ref_envelope_1086.py
+++ b/tests/test_stale_ref_envelope_1086.py
@@ -31,9 +31,10 @@ from click.testing import CliRunner
 
 from naturo.cli import main
 
-#: ``(command-id, argv)`` for every command that resolves an ``eN`` ref. The ref
-#: ``e999`` is never in the (mocked-empty) snapshot cache, so each invocation
-#: takes the stale-ref leg.
+#: ``(command-id, argv)`` for every *interaction* command that resolves an
+#: ``eN`` ref before doing any platform-gated work. The ref ``e999`` is never in
+#: the (mocked-empty) snapshot cache, so each invocation takes the stale-ref leg
+#: on any OS — these are platform-invariant.
 STALE_REF_INVOCATIONS = [
     ("click", ["click", "--id", "e999", "-j"]),
     ("type", ["type", "hello", "--on", "e999", "-j"]),
@@ -41,7 +42,6 @@ STALE_REF_INVOCATIONS = [
     ("move", ["move", "--to", "e999", "-j"]),
     ("drag", ["drag", "--from", "e999", "--to", "e1", "-j"]),
     ("scroll", ["scroll", "down", "--on", "e999", "-j"]),
-    ("capture", ["capture", "--element", "e999", "-j"]),
 ]
 
 
@@ -50,36 +50,15 @@ def runner() -> CliRunner:
     return CliRunner()
 
 
-def _invoke_with_empty_snapshot(runner: CliRunner, argv: list[str]):
-    """Run ``argv`` with a snapshot manager that resolves every ref to ``None``.
+def _assert_stale_envelope(command: str, result) -> None:
+    """Assert ``result`` carries the canonical ``STALE_SNAPSHOT_CACHE`` envelope.
 
-    Neutralises the snapshot cache and the live backend / auto-router so the
-    forced path reflects the code, not the host's desktop state (hermetic on
-    headless CI and a real desktop alike).
+    Pins the agent-self-correction contract — a non-``unknown`` category, a
+    recovery hint, ``recoverable:true`` and a ``{"ref": ...}`` context, matching
+    ``get``/``set`` — rather than just the envelope shape (which is why the
+    shape-only #1001 contract test passed while these values were wrong).
     """
-    mock_mgr = MagicMock()
-    mock_mgr.resolve_ref.return_value = None
-    mock_mgr.resolve_ref_element.return_value = None
-    with patch("naturo.snapshot.get_snapshot_manager", return_value=mock_mgr), \
-         patch("naturo.cli.interaction._common._get_backend",
-               return_value=MagicMock()), \
-         patch("naturo.cli.interaction._common._auto_route", return_value={}):
-        return runner.invoke(main, argv)
-
-
-@pytest.mark.parametrize(
-    "command,argv", STALE_REF_INVOCATIONS, ids=[c for c, _ in STALE_REF_INVOCATIONS]
-)
-def test_stale_ref_emits_recoverable_session_envelope(runner, command, argv):
-    """An unknown ``eN`` ref yields the registered ``STALE_SNAPSHOT_CACHE`` envelope.
-
-    Pins the agent-self-correction contract: a non-``unknown`` category, a
-    recovery hint, ``recoverable:true`` and a ``{"ref": ...}`` context — matching
-    ``get``/``set`` — for every command that accepts an ``eN`` ref.
-    """
-    result = _invoke_with_empty_snapshot(runner, argv)
     assert result.exit_code != 0, f"{command}: expected a non-zero exit, got 0"
-
     error = json.loads(result.output)["error"]
     assert error["code"] == "STALE_SNAPSHOT_CACHE", (
         f"{command}: code {error['code']!r} is not the registered ErrorCode"
@@ -96,3 +75,49 @@ def test_stale_ref_emits_recoverable_session_envelope(runner, command, argv):
     assert error["context"] == {"ref": "e999"}, (
         f"{command}: context {error['context']!r} should carry the offending ref"
     )
+
+
+@pytest.mark.parametrize(
+    "command,argv", STALE_REF_INVOCATIONS, ids=[c for c, _ in STALE_REF_INVOCATIONS]
+)
+def test_stale_ref_emits_recoverable_session_envelope(runner, command, argv):
+    """An unknown ``eN`` ref yields the registered ``STALE_SNAPSHOT_CACHE`` envelope.
+
+    Covers every interaction command that accepts an ``eN`` ref. The snapshot
+    cache, live backend and auto-router are neutralised so the forced path
+    reflects the code, not the host's desktop state (hermetic on headless CI and
+    a real desktop alike).
+    """
+    mock_mgr = MagicMock()
+    mock_mgr.resolve_ref.return_value = None
+    mock_mgr.resolve_ref_element.return_value = None
+    with patch("naturo.snapshot.get_snapshot_manager", return_value=mock_mgr), \
+         patch("naturo.cli.interaction._common._get_backend",
+               return_value=MagicMock()), \
+         patch("naturo.cli.interaction._common._auto_route", return_value={}):
+        result = runner.invoke(main, argv)
+    _assert_stale_envelope(command, result)
+
+
+def test_capture_element_stale_ref_emits_recoverable_session_envelope(runner):
+    """``capture --element eN`` with a stale ref uses ``STALE_SNAPSHOT_CACHE`` too.
+
+    ``capture`` crops the *captured* screen to the element, so its ``eN``-ref
+    check necessarily runs after the GUI-platform gate (on a headless host the
+    gate correctly short-circuits to ``PLATFORM_ERROR``). The gate and backend
+    are mocked here so the stale-ref leg is reached deterministically on any OS,
+    proving its envelope matches the interaction commands and ``get``/``set``.
+    """
+    mock_mgr = MagicMock()
+    mock_mgr.resolve_ref.return_value = None
+    mock_mgr.resolve_ref_element.return_value = None
+    with patch("naturo.snapshot.get_snapshot_manager", return_value=mock_mgr), \
+         patch("naturo.cli.core._common._platform_supports_gui", return_value=True), \
+         patch("naturo.cli.core._common._get_backend", return_value=MagicMock()), \
+         patch("naturo.cli.core._common._ensure_output_dir"):
+        # Route through --app so capture takes the window branch and skips the
+        # screen-index validation, reaching the element-ref crop where the stale
+        # ref surfaces.
+        result = runner.invoke(
+            main, ["capture", "--app", "Dummy", "--element", "e999", "-j"])
+    _assert_stale_envelope("capture", result)

--- a/tests/test_stale_ref_envelope_1086.py
+++ b/tests/test_stale_ref_envelope_1086.py
@@ -1,0 +1,98 @@
+"""Contract test for the stale ``eN`` snapshot-ref error envelope (#1086).
+
+Every command that accepts an ``eN`` element ref resolves it against the most
+recent ``see`` snapshot *before* doing any work. When that ref is missing or
+stale the failure is **recoverable** — the agent just needs to run ``naturo
+see`` and retry — and it is the semantically identical condition that ``get`` /
+``set`` already surface as the registered :class:`~naturo.errors.ErrorCode`
+``STALE_SNAPSHOT_CACHE`` (``category:"session"``, ``recoverable:true``, with a
+recovery hint and ``context={"ref": ...}``).
+
+Before #1086 the interaction commands (``click``/``type``/``press``/``move``/
+``drag``/``scroll``) and ``capture --element`` instead emitted a *bare string*
+``code:"REF_NOT_FOUND"`` — absent from the ``ErrorCode`` enum and the recovery
+registry — which silently degraded to ``category:"unknown"``,
+``recoverable:false`` and ``suggested_action:null``. An AI agent dispatching on
+those fields to self-correct hit a dead end on the single most-used command
+(``click``).
+
+This test pins the corrected contract — *category and recoverable*, not just the
+envelope shape — across every command that accepts an ``eN`` ref, so the
+semantic leg cannot drift again (the shape-only contract test in #1001 passed
+while these values were wrong).
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from naturo.cli import main
+
+#: ``(command-id, argv)`` for every command that resolves an ``eN`` ref. The ref
+#: ``e999`` is never in the (mocked-empty) snapshot cache, so each invocation
+#: takes the stale-ref leg.
+STALE_REF_INVOCATIONS = [
+    ("click", ["click", "--id", "e999", "-j"]),
+    ("type", ["type", "hello", "--on", "e999", "-j"]),
+    ("press", ["press", "enter", "--on", "e999", "-j"]),
+    ("move", ["move", "--to", "e999", "-j"]),
+    ("drag", ["drag", "--from", "e999", "--to", "e1", "-j"]),
+    ("scroll", ["scroll", "down", "--on", "e999", "-j"]),
+    ("capture", ["capture", "--element", "e999", "-j"]),
+]
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _invoke_with_empty_snapshot(runner: CliRunner, argv: list[str]):
+    """Run ``argv`` with a snapshot manager that resolves every ref to ``None``.
+
+    Neutralises the snapshot cache and the live backend / auto-router so the
+    forced path reflects the code, not the host's desktop state (hermetic on
+    headless CI and a real desktop alike).
+    """
+    mock_mgr = MagicMock()
+    mock_mgr.resolve_ref.return_value = None
+    mock_mgr.resolve_ref_element.return_value = None
+    with patch("naturo.snapshot.get_snapshot_manager", return_value=mock_mgr), \
+         patch("naturo.cli.interaction._common._get_backend",
+               return_value=MagicMock()), \
+         patch("naturo.cli.interaction._common._auto_route", return_value={}):
+        return runner.invoke(main, argv)
+
+
+@pytest.mark.parametrize(
+    "command,argv", STALE_REF_INVOCATIONS, ids=[c for c, _ in STALE_REF_INVOCATIONS]
+)
+def test_stale_ref_emits_recoverable_session_envelope(runner, command, argv):
+    """An unknown ``eN`` ref yields the registered ``STALE_SNAPSHOT_CACHE`` envelope.
+
+    Pins the agent-self-correction contract: a non-``unknown`` category, a
+    recovery hint, ``recoverable:true`` and a ``{"ref": ...}`` context — matching
+    ``get``/``set`` — for every command that accepts an ``eN`` ref.
+    """
+    result = _invoke_with_empty_snapshot(runner, argv)
+    assert result.exit_code != 0, f"{command}: expected a non-zero exit, got 0"
+
+    error = json.loads(result.output)["error"]
+    assert error["code"] == "STALE_SNAPSHOT_CACHE", (
+        f"{command}: code {error['code']!r} is not the registered ErrorCode"
+    )
+    assert error["category"] == "session", (
+        f"{command}: category {error['category']!r} degraded (expected 'session')"
+    )
+    assert error["recoverable"] is True, (
+        f"{command}: a stale ref is recoverable by running 'naturo see'"
+    )
+    assert error["suggested_action"], (
+        f"{command}: missing the recovery hint that lets an agent self-correct"
+    )
+    assert error["context"] == {"ref": "e999"}, (
+        f"{command}: context {error['context']!r} should carry the offending ref"
+    )

--- a/tests/test_type_paste_and_on.py
+++ b/tests/test_type_paste_and_on.py
@@ -131,7 +131,7 @@ class TestTypeOnElement:
 
         data = json.loads(result.output)
         assert data["success"] is False
-        assert data["error"]["code"] == "REF_NOT_FOUND"
+        assert data["error"]["code"] == "STALE_SNAPSHOT_CACHE"
 
     @_win_only
     def test_type_on_with_paste_clicks_then_pastes(self, runner):


### PR DESCRIPTION
## What
The `eN` snapshot-ref-not-found leg of every command that accepts `--id eN` — `click`, `type`, `press`, `move`, `drag`, `scroll`, and `capture --element` — emitted a **bare string** `code:"REF_NOT_FOUND"`. That literal is not an `ErrorCode` enum member and has no `_RECOVERY_HINTS` entry, so the `-j` envelope silently degraded to `category:"unknown"`, `recoverable:false`, `suggested_action:null` — while the **semantically identical** condition on `get`/`set` correctly surfaces the registered `STALE_SNAPSHOT_CACHE` (`category:"session"`, `recoverable:true`, with a hint and `context:{"ref": ...}`).

An AI agent dispatching on `error.category` / `error.recoverable` / `error.suggested_action` to self-correct therefore hit a dead end on the single most-used command (`click`), even though the failure is trivially recoverable by running `naturo see`. This is the still-open leg of the #877 → #884 → #1004 envelope contract (shape was fixed by #884; `get`/`set` semantics by #877; the interaction backend `ElementNotFoundError` path by #1004 — but **not** the pre-backend `eN`-resolve path).

## How
- Swap the six callsites (`_click.py`, `_common.py` (scroll/move via `_resolve_text_or_ref_target`), `_mouse.py` ×2 (drag from/to), `_press.py`, `_type.py`) and `capture --element` (`core/_capture.py`) from `code="REF_NOT_FOUND"` to the registered `code="STALE_SNAPSHOT_CACHE"` with `context={"ref": <ref>}`. Category, recoverability and the recovery hint are then derived from the existing registry — zero new taxonomy.
- Extend `_json_err` with an optional `context` kwarg to carry the offending ref into the envelope (used only on the raw-code JSON path).
- The per-command human messages are unchanged.

Result: byte-for-byte parity with `get`/`set` (code/category/context/suggested_action/recoverable).

## How tested
- New `tests/test_stale_ref_envelope_1086.py` — a parametrized **contract** test asserting `category` + `recoverable` + `suggested_action` + `context` (not just envelope shape, which is why #1001 passed while the values were wrong) for an unknown `eN` ref across **all** `--id eN` commands. RED before the fix (7/7), GREEN after.
- Updated the existing tests that pinned the old `REF_NOT_FOUND` code.
- Gate: `ruff check` clean; `mypy --follow-imports=skip` clean on changed files (the lone repo-wide mypy error is the pre-existing 3rd-party `mcp` py3.10-syntax noise, absent on CI's py3.9 lane); `pytest -m "not desktop"` = **2438 passed** (the 2 `test_verify.py` `NonWindows` failures are pre-existing host-state hermeticity issues, unrelated — they fail identically on `origin/develop`).
- Verified end-to-end on the real CLI: `naturo -j click --id e99999` now returns `code:STALE_SNAPSHOT_CACHE`, `category:session`, `context:{"ref":"e99999"}`, `recoverable:true` — identical to `naturo -j get --id e99999`.