### PR TITLE
feat: add File Download migration equivalence row + honor documented download page API (part of #766)

### DIFF
--- a/docs/MIGRATION_FROM_RPA_SCRIPTS.md
+++ b/docs/MIGRATION_FROM_RPA_SCRIPTS.md
@@ -714,15 +714,16 @@ naturo browser download --dir /path/to/downloads
 # Click download link
 naturo browser click "#export-btn"
 
-# Wait for download to complete — returns filename and path
-naturo browser download --wait --timeout 30000
+# Wait for download to complete — returns filename and path (timeout in seconds)
+naturo browser download --wait --timeout 30
 ```
 
 ```python
 page.set_download_dir("/path/to/downloads")
 page.find("#export-btn").click()
-download = page.wait_for_download(timeout=30000)
+download = page.wait_for_download(timeout=30)  # timeout in seconds
 print(download.path)  # /path/to/downloads/report.xlsx
+print(download.name)  # report.xlsx
 ```
 
 ### iframe Handling

--- a/naturo/browser/__init__.py
+++ b/naturo/browser/__init__.py
@@ -45,11 +45,13 @@ from naturo.browser._launcher import (
     list_profiles,
 )
 from naturo.browser._frame import BrowserFrame
+from naturo.browser._download import DownloadResult
 
 __all__ = [
     "BrowserPage",
     "BrowserElement",
     "BrowserFrame",
+    "DownloadResult",
     "SelectorType",
     "ParsedSelector",
     "parse_selector",

--- a/naturo/browser/_download.py
+++ b/naturo/browser/_download.py
@@ -25,10 +25,34 @@ from __future__ import annotations
 import logging
 import os
 import time
+from dataclasses import dataclass
+
 logger = logging.getLogger(__name__)
 
 # Chrome uses these extensions for partial downloads
 _PARTIAL_EXTENSIONS = frozenset({".crdownload", ".tmp", ".download", ".part"})
+
+
+@dataclass(frozen=True)
+class DownloadResult:
+    """A completed browser download.
+
+    Returned by :meth:`naturo.browser.BrowserPage.wait_for_download`. The
+    ``path`` attribute is the documented surface (see the migration guide's
+    *File Download* section); ``name`` and ``size`` are convenience accessors.
+    """
+
+    path: str
+
+    @property
+    def name(self) -> str:
+        """The downloaded file's basename, e.g. ``report.txt``."""
+        return os.path.basename(self.path)
+
+    @property
+    def size(self) -> int:
+        """The downloaded file's size in bytes."""
+        return os.path.getsize(self.path)
 
 
 def set_download_dir(page, directory: str) -> None:

--- a/naturo/browser/_page.py
+++ b/naturo/browser/_page.py
@@ -7,11 +7,13 @@ browser automation: navigate, find elements, click, type, wait, etc.
 from __future__ import annotations
 
 import logging
+import os
 import re
 import time
 from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from naturo.browser._download import DownloadResult
     from naturo.browser._frame import BrowserFrame
     from naturo.browser._network import NetworkMonitor
 
@@ -624,6 +626,66 @@ class BrowserPage:
         """
         el = self.find(selector)
         el.scroll_into_view()
+
+    # ── Downloads ─────────────────────────────────────────────────────────
+
+    def set_download_dir(self, directory: str) -> None:
+        """Route browser downloads to *directory* without a save dialog.
+
+        The naturo equivalent of DrissionPage's
+        ``co.set_pref("download.default_directory", ...)`` plus
+        ``download.prompt_for_download = False`` (see the migration guide's
+        *File Download* section): issues the CDP ``Browser.setDownloadBehavior``
+        command so files are saved to *directory* automatically, and remembers
+        the path so :meth:`wait_for_download` knows where to poll.
+
+        Args:
+            directory: Path to an existing directory to save downloads in.
+
+        Raises:
+            ValueError: If *directory* does not exist.
+        """
+        from naturo.browser._download import set_download_dir
+
+        set_download_dir(self, directory)
+        self._download_dir = os.path.abspath(directory)
+
+    def wait_for_download(
+        self,
+        timeout: float = 60.0,
+        poll_interval: float = 0.5,
+    ) -> "DownloadResult":
+        """Block until a download started on this page finishes.
+
+        The naturo equivalent of the DrissionPage/Selenium "click the link,
+        then poll the filesystem for the file" pattern: after a click triggers
+        a download, this waits until the file in the configured download
+        directory has fully landed (no Chrome ``.crdownload`` partial remains)
+        and returns it. :meth:`set_download_dir` must be called first.
+
+        Args:
+            timeout: Maximum seconds to wait for the download to complete.
+            poll_interval: Seconds between directory polls.
+
+        Returns:
+            A :class:`~naturo.browser._download.DownloadResult` whose ``path``
+            is the absolute path to the completed file.
+
+        Raises:
+            RuntimeError: If :meth:`set_download_dir` was not called first.
+            TimeoutError: If no download completes within *timeout*.
+        """
+        from naturo.browser._download import DownloadResult, wait_for_download
+
+        download_dir = getattr(self, "_download_dir", None)
+        if download_dir is None:
+            raise RuntimeError(
+                "set_download_dir() must be called before wait_for_download()"
+            )
+        path = wait_for_download(
+            download_dir, timeout=timeout, poll_interval=poll_interval
+        )
+        return DownloadResult(path=path)
 
     # ── Lifecycle ─────────────────────────────────────────────────────────
 

--- a/tests/browser/test_migration_equivalence.py
+++ b/tests/browser/test_migration_equivalence.py
@@ -21,12 +21,14 @@ so concurrent desktop runs (e.g. Dev + QA) never share a Chrome profile.
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import socket
 import subprocess
 import tempfile
 import time
 from contextlib import contextmanager
+from pathlib import Path
 from typing import Iterator
 
 import pytest
@@ -571,3 +573,67 @@ def test_tab_management_equivalence(
     page.switch_tab(form_tab_id)
     page.find("#username").type("carol", clear_first=True)
     assert page.find("#username").value == "carol"
+
+
+def test_file_download_equivalence(
+    isolated_browser_page: BrowserPage,
+    fixtures_server: str,
+    fixtures_dir: Path,
+) -> None:
+    """Reproduce the DrissionPage download-prefs + filesystem-poll pattern via naturo.
+
+    Mirrors the migration guide's "File Download" section: the *Before* code
+    sets ``co.set_pref("download.default_directory", dir)`` (plus
+    ``download.prompt_for_download = False``), clicks the export link, then
+    spins ``while not os.path.exists(expected_file): time.sleep(1)`` until the
+    file lands. The *After* surface is :meth:`BrowserPage.set_download_dir`
+    followed by :meth:`BrowserPage.wait_for_download`, exactly as the guide
+    documents (``download.path`` / ``download.name``).
+
+    Driven against ``download.html`` -- whose ``#download-link`` anchor carries
+    ``download="report.txt"`` and points at the deterministic 42-byte
+    ``download-payload.txt`` -- naturo must route the download to the configured
+    directory and block until it completes. Per naturo's never-lie contract
+    (SOUL.md) the equivalence is proven on the *bytes that landed on disk*: the
+    downloaded file's content must be byte-for-byte the served payload (the same
+    content/size check the Before code performs after polling), proving a real,
+    completed download rather than a partial ``.crdownload`` or a placeholder.
+
+    This test uses :func:`isolated_browser_page` because
+    ``Browser.setDownloadBehavior`` installs connection-wide download state that
+    must not leak into the module-shared read-only browser.
+    """
+    page = isolated_browser_page
+    # A throwaway download directory (matching this module's tempfile.mkdtemp
+    # style for browser temp dirs, so concurrent desktop runs never collide).
+    download_dir = tempfile.mkdtemp(prefix="naturo_download_")
+    try:
+        # Before: co.set_pref("download.default_directory", dir) + prompt suppression
+        #  ->  After: page.set_download_dir(dir).
+        page.set_download_dir(download_dir)
+
+        page.navigate(f"{fixtures_server}/download.html")
+
+        # never-lie (precondition): nothing has been saved yet, so a passing
+        # assertion below can only come from a download this test triggered.
+        assert os.listdir(download_dir) == []
+
+        # Before: click the export link, then `while not os.path.exists(f): sleep(1)`
+        #  ->  After: click() + wait_for_download() polling until no partial remains.
+        page.find("#download-link").click()
+        result = page.wait_for_download(timeout=20.0)
+
+        # The anchor's download="report.txt" attribute names the saved file.
+        assert result.name == "report.txt"
+        assert os.path.basename(result.path) == "report.txt"
+        assert os.path.isfile(result.path)
+
+        # never-lie: the bytes on disk are exactly the served payload -- the same
+        # content/size equivalence the Before code verifies after its poll loop,
+        # proving the download completed rather than leaving a partial file.
+        served = (fixtures_dir / "download-payload.txt").read_bytes()
+        downloaded = Path(result.path).read_bytes()
+        assert downloaded == served
+        assert result.size == len(served) == 42
+    finally:
+        shutil.rmtree(download_dir, ignore_errors=True)


### PR DESCRIPTION
## What
Lands the **File Download** Before/After equivalence row for the v0.3.2 migration acceptance suite (#766), and fixes a **never-lie doc-vs-code gap** it surfaced.

The migration guide's *File Download* section (`docs/MIGRATION_FROM_RPA_SCRIPTS.md`) documents the *After* surface as fluent page methods — `page.set_download_dir(...)` and `page.wait_for_download(...)` returning an object with `.path` — matching every other browser row. But `BrowserPage` had **no such methods**; only module-level functions existed in `_download.py` (not even exported). The published guide was promising an API that did not exist.

### Changes
- **`BrowserPage.set_download_dir()` + `BrowserPage.wait_for_download()`** — delegate to the existing `_download.py` helpers; `wait_for_download` returns a new frozen `DownloadResult` dataclass exposing `.path`/`.name`/`.size` (the `.path` surface the guide documents). Both exported from `naturo.browser`.
- **Guide fix**: timeout examples `30000` → `30`. The CLI `--timeout` and module functions are **seconds**-based (default 60), so `30000` was wrong.
- **`test_file_download_equivalence`**: drives the documented *After* API against the offline `download.html` fixture.

> ⚠️ **Review flag (public API):** this adds two public `BrowserPage` methods + exports `DownloadResult`. These were already specified in the committed migration guide, so this closes a doc-vs-code gap rather than making a new product-direction call — but flagging for explicit reviewer sign-off per the public-API guardrail.

## How tested
- `test_file_download_equivalence` asserts the bytes on disk are **byte-for-byte** the served 42-byte payload (never-lie: a real completed download, not a placeholder/partial). Browser-CDP only (no OS input) → safe under the input freeze.
- Full migration module: **10 passed** (was 9) on real headless Chrome.
- Pre-existing `tests/test_browser_download.py`: **23 passed** with my changes (fresh basetemp; the local `pytest-of-Naturobot` temp base is environmentally locked — #935).
- Broader: 552 browser/page/download tests pass; full suite collects 6899 with no import breakage.
- `ruff` clean; `mypy` clean on changed files (the only mypy error is the pre-existing third-party `mcp` py3.9 match-stmt block).

## Scope
Umbrella **#766 stays open**: the only remaining row (slider-captcha) needs a new CDP drag surface (human-gated, product-direction).