### PR TITLE
fix: scope element-level find/find_all to the parent's subtree (fixes #1063)

### DIFF
--- a/naturo/browser/_page.py
+++ b/naturo/browser/_page.py
@@ -24,6 +24,8 @@ from naturo.browser._selectors import (
     parse_selector,
     to_cdp_expression,
     to_cdp_expression_all,
+    to_scoped_function,
+    to_scoped_function_all,
 )
 
 logger = logging.getLogger(__name__)
@@ -759,34 +761,43 @@ class BrowserPage:
     def _find_within(
         self, parent: BrowserElement, parsed: ParsedSelector
     ) -> Optional[BrowserElement]:
-        """Find an element within a parent's subtree.
+        """Find the first element within a parent's subtree.
 
-        Used for XPath/text selectors that need scoped evaluation.
+        Used for XPath/text selectors that need scoped evaluation. The search is
+        dispatched with ``this`` bound to *parent* (CDP ``Runtime.callFunctionOn``)
+        so the match is confined to that element's subtree — an XPath context
+        node, a TreeWalker rooted at the parent — rather than resolved against
+        the whole document. This is what makes ``element.find("xpath:.//span")``
+        return the parent's own descendant instead of the document's first global
+        match (the DrissionPage ``item.ele("xpath:.//span")`` scrape pattern,
+        #1063).
 
         Args:
             parent: The parent element to search within.
             parsed: Parsed selector.
 
         Returns:
-            BrowserElement or None.
+            BrowserElement for the first scoped match, or None.
         """
-        # For simplicity, evaluate in page context with DOM constraint
-        # A more complete implementation would scope the XPath/text search
-        return self._resolve_element(parsed)
+        return parent._call_function_returning_element(to_scoped_function(parsed))
 
     def _find_all_within(
         self, parent: BrowserElement, parsed: ParsedSelector
     ) -> List[BrowserElement]:
         """Find all elements within a parent's subtree.
 
+        The array counterpart of :meth:`_find_within`: evaluates the selector
+        with ``this`` bound to *parent* so every match is scoped to that
+        element's subtree, in document order.
+
         Args:
             parent: The parent element.
             parsed: Parsed selector.
 
         Returns:
-            List of BrowserElement instances.
+            List of scoped BrowserElement instances (possibly empty).
         """
-        return self._resolve_elements(parsed)
+        return parent._call_function_returning_elements(to_scoped_function_all(parsed))
 
     def _wait_for_event(
         self, event_name: str, timeout: Optional[float] = None

--- a/naturo/browser/_selectors.py
+++ b/naturo/browser/_selectors.py
@@ -126,6 +126,11 @@ _HTML_TAGS = frozenset({
 })
 
 
+def _escape_js_string(value: str) -> str:
+    """Escape a string for embedding inside a single-quoted JS literal."""
+    return value.replace("\\", "\\\\").replace("'", "\\'")
+
+
 def to_cdp_expression(parsed: ParsedSelector) -> str:
     """Convert a parsed selector to a JavaScript expression for CDP evaluation.
 
@@ -139,18 +144,18 @@ def to_cdp_expression(parsed: ParsedSelector) -> str:
         JavaScript expression string.
     """
     if parsed.type == SelectorType.CSS:
-        escaped = parsed.expression.replace("\\", "\\\\").replace("'", "\\'")
+        escaped = _escape_js_string(parsed.expression)
         return f"document.querySelector('{escaped}')"
 
     if parsed.type == SelectorType.XPATH:
-        escaped = parsed.expression.replace("\\", "\\\\").replace("'", "\\'")
+        escaped = _escape_js_string(parsed.expression)
         return (
             f"document.evaluate('{escaped}', document, null, "
             f"XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue"
         )
 
     # Text search via TreeWalker
-    escaped = parsed.expression.replace("\\", "\\\\").replace("'", "\\'")
+    escaped = _escape_js_string(parsed.expression)
     return (
         f"(function() {{"
         f"  var tw = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);"
@@ -174,11 +179,11 @@ def to_cdp_expression_all(parsed: ParsedSelector) -> str:
         JavaScript expression string returning an Array of elements.
     """
     if parsed.type == SelectorType.CSS:
-        escaped = parsed.expression.replace("\\", "\\\\").replace("'", "\\'")
+        escaped = _escape_js_string(parsed.expression)
         return f"Array.from(document.querySelectorAll('{escaped}'))"
 
     if parsed.type == SelectorType.XPATH:
-        escaped = parsed.expression.replace("\\", "\\\\").replace("'", "\\'")
+        escaped = _escape_js_string(parsed.expression)
         return (
             f"(function() {{"
             f"  var r = document.evaluate('{escaped}', document, null, "
@@ -189,7 +194,7 @@ def to_cdp_expression_all(parsed: ParsedSelector) -> str:
         )
 
     # Text search — return all matches
-    escaped = parsed.expression.replace("\\", "\\\\").replace("'", "\\'")
+    escaped = _escape_js_string(parsed.expression)
     return (
         f"(function() {{"
         f"  var tw = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);"
@@ -202,4 +207,99 @@ def to_cdp_expression_all(parsed: ParsedSelector) -> str:
         f"  }}"
         f"  return results;"
         f"}})()"
+    )
+
+
+def to_scoped_function(parsed: ParsedSelector) -> str:
+    """Build a JS function that finds the first match *within* a context element.
+
+    The returned source is a function declaration suitable for CDP
+    ``Runtime.callFunctionOn`` with ``this`` bound to the parent DOM node, so the
+    search is scoped to that node's subtree rather than the whole document. This
+    is what makes ``element.find(...)`` honour the parent (e.g. the DrissionPage
+    ``item.ele("xpath:.//span")`` per-card scrape pattern), instead of silently
+    returning the document's first global match.
+
+    XPath is evaluated with the parent as the context node, so a relative
+    expression (``.//span``) resolves against the parent. Text search walks only
+    the parent's text nodes. CSS uses the parent's ``querySelector``.
+
+    Args:
+        parsed: A parsed selector.
+
+    Returns:
+        JavaScript function-declaration source returning the first matching
+        element, or ``null``.
+    """
+    escaped = _escape_js_string(parsed.expression)
+
+    if parsed.type == SelectorType.CSS:
+        return f"function() {{ return this.querySelector('{escaped}'); }}"
+
+    if parsed.type == SelectorType.XPATH:
+        return (
+            f"function() {{"
+            f"  return document.evaluate('{escaped}', this, null, "
+            f"XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;"
+            f"}}"
+        )
+
+    # Text search via a TreeWalker rooted at the context element.
+    return (
+        f"function() {{"
+        f"  var tw = document.createTreeWalker(this, NodeFilter.SHOW_TEXT);"
+        f"  while (tw.nextNode()) {{"
+        f"    if (tw.currentNode.textContent.includes('{escaped}')) {{"
+        f"      return tw.currentNode.parentElement;"
+        f"    }}"
+        f"  }}"
+        f"  return null;"
+        f"}}"
+    )
+
+
+def to_scoped_function_all(parsed: ParsedSelector) -> str:
+    """Build a JS function that finds all matches *within* a context element.
+
+    The array counterpart of :func:`to_scoped_function`: a function declaration
+    for CDP ``Runtime.callFunctionOn`` (``this`` = parent node) returning every
+    descendant match in document order, scoped to the parent's subtree.
+
+    Args:
+        parsed: A parsed selector.
+
+    Returns:
+        JavaScript function-declaration source returning an ``Array`` of
+        matching elements.
+    """
+    escaped = _escape_js_string(parsed.expression)
+
+    if parsed.type == SelectorType.CSS:
+        return (
+            f"function() {{ return Array.from(this.querySelectorAll('{escaped}')); }}"
+        )
+
+    if parsed.type == SelectorType.XPATH:
+        return (
+            f"function() {{"
+            f"  var r = document.evaluate('{escaped}', this, null, "
+            f"XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null);"
+            f"  var a = []; for (var i = 0; i < r.snapshotLength; i++) a.push(r.snapshotItem(i));"
+            f"  return a;"
+            f"}}"
+        )
+
+    # Text search via a TreeWalker rooted at the context element.
+    return (
+        f"function() {{"
+        f"  var tw = document.createTreeWalker(this, NodeFilter.SHOW_TEXT);"
+        f"  var results = [];"
+        f"  while (tw.nextNode()) {{"
+        f"    if (tw.currentNode.textContent.includes('{escaped}')) {{"
+        f"      var el = tw.currentNode.parentElement;"
+        f"      if (el && results.indexOf(el) === -1) results.push(el);"
+        f"    }}"
+        f"  }}"
+        f"  return results;"
+        f"}}"
     )

--- a/tests/browser/fixtures/xhs-feed.html
+++ b/tests/browser/fixtures/xhs-feed.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>naturo fixture: xhs-feed</title>
+  <style>
+    #explore-feed { margin: 0; padding: 0; list-style: none; }
+    .note-item { border-bottom: 1px solid #ccc; padding: 8px; }
+    .note-title { font-weight: 600; }
+    .note-author { color: #888; }
+  </style>
+</head>
+<body>
+  <!--
+    Static feed mirroring the rpa-client-lingkehudong (Xiaohongshu / 小红书)
+    explore-page scrape (#1063 / #763): the DrissionPage *Before* code does
+
+        items = page.eles("xpath://div[contains(@class,'note-item')]")
+        for item in items:
+            title = item.ele("xpath:.//span").text
+
+    i.e. it finds every note card, then reads each card's OWN title span with a
+    relative xpath scoped to that card. Each card here carries a distinct title
+    and author so a per-card scoped read must return that card's own text — if
+    the scoping is broken and the xpath resolves against the whole document,
+    every card collapses to the first card's title, which the equivalence test
+    explicitly guards against.
+  -->
+  <h1 id="page-heading">Explore</h1>
+  <div id="explore-feed">
+    <div class="note-item" data-note-id="n0">
+      <span class="note-title">城市夜景手机摄影技巧</span>
+      <span class="note-author">@aurora</span>
+    </div>
+    <div class="note-item" data-note-id="n1">
+      <span class="note-title">十分钟快手早餐合集</span>
+      <span class="note-author">@chef-lin</span>
+    </div>
+    <div class="note-item" data-note-id="n2">
+      <span class="note-title">通勤穿搭分享</span>
+      <span class="note-author">@mina</span>
+    </div>
+    <div class="note-item" data-note-id="n3">
+      <span class="note-title">阳台多肉养护笔记</span>
+      <span class="note-author">@green-thumb</span>
+    </div>
+  </div>
+</body>
+</html>

--- a/tests/browser/test_migration_equivalence.py
+++ b/tests/browser/test_migration_equivalence.py
@@ -639,6 +639,67 @@ def test_file_download_equivalence(
         shutil.rmtree(download_dir, ignore_errors=True)
 
 
+def test_xpath_scoped_card_scrape_equivalence(
+    browser_page: BrowserPage, fixtures_server: str
+) -> None:
+    """Reproduce the rpa-client-lingkehudong (小红书) per-card xpath scrape via naturo.
+
+    Mirrors the migration guide / #763 Phase-1 target: the DrissionPage *Before*
+    code enumerates feed cards and reads each card's OWN field with a relative
+    xpath scoped to that card::
+
+        items = page.eles("xpath://div[contains(@class,'note-item')]")
+        for item in items:
+            title = item.ele("xpath:.//span").text
+
+    The *After* surface is :meth:`BrowserPage.find_all` for the card list and the
+    element-scoped :meth:`BrowserElement.find` / :meth:`BrowserElement.find_all`
+    for each card's children. Driven against ``xhs-feed.html`` (four
+    ``.note-item`` cards, each with a distinct title + author span), naturo must
+    reproduce the scrape exactly: the same card count and, per card, that card's
+    own title text.
+
+    never-lie (SOUL.md): the scoping is proven, not assumed. A relative
+    ``xpath:.//span`` resolved against the whole document (the pre-#1063 bug)
+    would return the *first* card's title for *every* card, so the scrape would
+    confidently report four identical titles. The assertion therefore pins the
+    four distinct, per-card titles in document order — which only holds if
+    ``item.find(...)`` genuinely confines the search to that card's subtree.
+    """
+    browser_page.navigate(f"{fixtures_server}/xhs-feed.html")
+
+    # Before: page.eles("xpath://div[contains(@class,'note-item')]")
+    #  ->  After: page.find_all("xpath://div[contains(@class,'note-item')]").
+    cards = browser_page.find_all("xpath://div[contains(@class,'note-item')]")
+    assert len(cards) == 4
+
+    # Before: for item in items: title = item.ele("xpath:.//span").text
+    #  ->  After: card.find("xpath:.//span").text, scoped to each card. The first
+    # span in each card is its title, so the relative xpath must return that
+    # card's own title -- distinct per card, in document order.
+    titles = [card.find("xpath:.//span").text for card in cards]
+    assert titles == [
+        "城市夜景手机摄影技巧",
+        "十分钟快手早餐合集",
+        "通勤穿搭分享",
+        "阳台多肉养护笔记",
+    ]
+    # never-lie: every scraped title is distinct -- a document-scoped (unscoped)
+    # xpath would collapse all four to the first card's title.
+    assert len(set(titles)) == 4
+
+    # Scoped find_all: each card exposes exactly its own two spans (title,
+    # author), not the feed's eight, proving the array form is scoped too.
+    first_card_spans = cards[0].find_all("xpath:.//span")
+    assert [span.text for span in first_card_spans] == [
+        "城市夜景手机摄影技巧",
+        "@aurora",
+    ]
+
+    # A scoped CSS read resolves against the same card subtree as the xpath read.
+    assert cards[2].find(".note-author").text == "@mina"
+
+
 def test_javascript_execution_equivalence(
     browser_page: BrowserPage, fixtures_server: str
 ) -> None:

--- a/tests/test_browser_selectors.py
+++ b/tests/test_browser_selectors.py
@@ -10,6 +10,8 @@ from naturo.browser._selectors import (
     parse_selector,
     to_cdp_expression,
     to_cdp_expression_all,
+    to_scoped_function,
+    to_scoped_function_all,
 )
 
 
@@ -236,3 +238,84 @@ class TestToCdpExpressionAll:
         parsed = ParsedSelector(SelectorType.TEXT, "it's")
         js = to_cdp_expression_all(parsed)
         assert "\\'" in js
+
+
+# ---------------------------------------------------------------------------
+# to_scoped_function — element-scoped single-match search (#1063)
+# ---------------------------------------------------------------------------
+
+
+class TestToScopedFunction:
+    """to_scoped_function returns a function scoped to the context element."""
+
+    def test_is_a_function_declaration(self) -> None:
+        # Must be a function declaration for Runtime.callFunctionOn, not a bare
+        # expression (the latter would be evaluated in global/document scope).
+        parsed = ParsedSelector(SelectorType.CSS, "span")
+        assert to_scoped_function(parsed).startswith("function()")
+
+    def test_css_uses_this_queryselector(self) -> None:
+        parsed = ParsedSelector(SelectorType.CSS, ".note-title")
+        js = to_scoped_function(parsed)
+        assert "this.querySelector(" in js
+        assert "document.querySelector(" not in js
+
+    def test_xpath_context_node_is_this_not_document(self) -> None:
+        # The #1063 fix: a relative xpath must resolve against the parent element
+        # (context node ``this``), not the whole document.
+        parsed = ParsedSelector(SelectorType.XPATH, ".//span")
+        js = to_scoped_function(parsed)
+        assert "document.evaluate('.//span', this, null" in js
+        assert "FIRST_ORDERED_NODE_TYPE" in js
+
+    def test_text_treewalker_rooted_at_this(self) -> None:
+        parsed = ParsedSelector(SelectorType.TEXT, "hello")
+        js = to_scoped_function(parsed)
+        assert "createTreeWalker(this," in js
+        assert "createTreeWalker(document.body" not in js
+
+    def test_xpath_escapes_quotes(self) -> None:
+        parsed = ParsedSelector(SelectorType.XPATH, ".//a[@href='x']")
+        assert "\\'" in to_scoped_function(parsed)
+
+
+# ---------------------------------------------------------------------------
+# to_scoped_function_all — element-scoped multi-match search (#1063)
+# ---------------------------------------------------------------------------
+
+
+class TestToScopedFunctionAll:
+    """to_scoped_function_all returns a scoped function yielding an array."""
+
+    def test_is_a_function_declaration(self) -> None:
+        parsed = ParsedSelector(SelectorType.CSS, "span")
+        assert to_scoped_function_all(parsed).startswith("function()")
+
+    def test_css_uses_this_queryselectorall(self) -> None:
+        parsed = ParsedSelector(SelectorType.CSS, "li.item")
+        js = to_scoped_function_all(parsed)
+        assert "this.querySelectorAll(" in js
+        assert "Array.from(" in js
+        assert "document.querySelectorAll(" not in js
+
+    def test_xpath_context_node_is_this_not_document(self) -> None:
+        parsed = ParsedSelector(SelectorType.XPATH, ".//span")
+        js = to_scoped_function_all(parsed)
+        assert "document.evaluate('.//span', this, null" in js
+        assert "ORDERED_NODE_SNAPSHOT_TYPE" in js
+        assert "snapshotLength" in js
+
+    def test_text_treewalker_rooted_at_this(self) -> None:
+        parsed = ParsedSelector(SelectorType.TEXT, "Item")
+        js = to_scoped_function_all(parsed)
+        assert "createTreeWalker(this," in js
+        assert "createTreeWalker(document.body" not in js
+
+    def test_text_deduplicates_parents(self) -> None:
+        parsed = ParsedSelector(SelectorType.TEXT, "dup")
+        js = to_scoped_function_all(parsed)
+        assert "indexOf(el) === -1" in js
+
+    def test_xpath_escapes_quotes(self) -> None:
+        parsed = ParsedSelector(SelectorType.XPATH, ".//a[@href='x']")
+        assert "\\'" in to_scoped_function_all(parsed)


### PR DESCRIPTION
## What
`BrowserElement.find` / `find_all` are documented to return a **child** element, but for XPath/text selectors `BrowserPage._find_within` / `_find_all_within` resolved the selector against the **whole document**, ignoring the parent. The per-card scrape pattern from the #1063 Phase-1 target (`rpa-client-lingkehudong`, 小红书):

```python
items = page.eles("xpath://div[contains(@class,'note-item')]")
for item in items:
    title = item.ele("xpath:.//span").text   # naturo: item.find("xpath:.//span").text
```

returned the **first** card's title for **every** card — a confidently-wrong result that breaks naturo's never-lie contract (SOUL.md).

## How
- Evaluate scoped XPath/text/CSS searches with `this` bound to the parent node via CDP `Runtime.callFunctionOn` — an XPath **context node** and a `TreeWalker` rooted at the parent — so a relative `xpath:.//span` resolves against that element's subtree.
- New `to_scoped_function` / `to_scoped_function_all` builders centralise the scoped JS; `_escape_js_string` deduplicates selector escaping (also applied to the existing builders).
- `_find_within` / `_find_all_within` keep their delegation contract (existing unit tests in `test_browser_element.py` unchanged) but now pass the parent's objectId.

No public API/CLI change — this fixes existing documented behaviour; the new builders live in the private `_selectors` module.

## How tested
- **New desktop equivalence test** `test_xpath_scoped_card_scrape_equivalence` (real headless Chrome, offline `xhs-feed.html` fixture) reproduces the Xiaohongshu per-card xpath scrape and asserts four **distinct** per-card titles in document order. Proven both ways: temporarily restoring the document-scoped behaviour collapses all four to the first card's title and the test **fails** — confirming it's a real guard.
- **Hermetic unit tests** (`test_browser_selectors.py`, run on CI without a browser) assert the scoped builders use `this`, not `document` (XPath context node, TreeWalker root, `this.querySelector(All)`).
- `python -m ruff check naturo/` clean; `tests/browser/test_migration_equivalence.py` + `tests/test_browser_selectors.py` + `tests/test_browser_element.py` → 96 passed; `--collect-only` succeeds without a browser.

Part of #766 / #763 migration acceptance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)