### PR TITLE
docs: caveat unimplemented browser cookies + JS-click in migration guide (fixes #1106)

### DIFF
--- a/docs/MIGRATION_FROM_RPA_SCRIPTS.md
+++ b/docs/MIGRATION_FROM_RPA_SCRIPTS.md
@@ -108,7 +108,7 @@ which engine found which element — just use `naturo click e42`.
 | `page.ele("xpath://...")` | `naturo browser find "xpath://..."` | `page.find("xpath://...")` |
 | `page.eles("xpath://...")` | `naturo browser find "xpath://..." --all` | `page.find_all("xpath://...")` |
 | `ele.click()` | `naturo browser click <selector>` | `element.click()` |
-| `ele.click(by_js=True)` | `naturo browser click <selector> --js` | `element.click(js=True)` |
+| `ele.click(by_js=True)` | `naturo browser click <selector> --js` 🚧 | `element.click(js=True)` 🚧 |
 | `ele.input(text)` | `naturo browser type <selector> <text>` | `element.type(text)` |
 | `ele.input(text, True)` | `naturo browser type <selector> <text> --clear-first` | `element.type(text, clear_first=True)` |
 | `ele.text` | `naturo browser text <selector>` | `element.text` |
@@ -121,6 +121,17 @@ which engine found which element — just use `naturo click e42`.
 | `page.set.window.max()` | `naturo app maximize --app chrome` | N/A (use CLI) |
 | `page.run_js_loaded(js)` | `naturo browser eval <js>` | `page.evaluate(js)` |
 | `ele.click.to_upload(path)` | `naturo browser click <sel>` + `naturo dialog type <path>` + `naturo dialog accept` | see [File Upload](#file-upload) |
+
+> **🚧 Not yet implemented:** the JS-click fallback row above (`naturo browser
+> click <selector> --js` / `element.click(js=True)`) does **not** exist in the
+> current build — `browser click` accepts only `--offset-x`/`--offset-y`/`--json`
+> and `BrowserElement.click()` takes `offset_x`/`offset_y` only. Until it ships,
+> dispatch a JS click via the (working) `eval` path —
+> `naturo browser eval "document.querySelector('#sel').click()"` /
+> `page.evaluate("document.querySelector('#sel').click()")` — or use a regular
+> `click`. Whether to add a dedicated `--js`/`click(js=True)` path or prune it
+> from this guide is tracked in
+> [#1106](https://github.com/AcePeak/naturo/issues/1106).
 
 ### Selenium to naturo
 
@@ -135,10 +146,17 @@ which engine found which element — just use `naturo click e42`.
 | `ActionChains(d).click_and_hold(e).move_by_offset(x,y).release()` | `naturo drag --from-element <sel> --offset-x <x>` | see [Slider Captcha](#slider-captcha) |
 | `driver.execute_script(js)` | `naturo browser eval <js>` | `page.evaluate(js)` |
 | `driver.execute_cdp_cmd(...)` | Built-in (stealth is default) | Built-in |
-| `driver.get_cookies()` | `naturo browser cookies save --path f.json` | `page.cookies.save(path)` |
-| `driver.add_cookie(c)` | `naturo browser cookies load --path f.json` | `page.cookies.load(path)` |
+| `driver.get_cookies()` | `naturo browser cookies save --path f.json` 🚧 | `page.cookies.save(path)` 🚧 |
+| `driver.add_cookie(c)` | `naturo browser cookies load --path f.json` 🚧 | `page.cookies.load(path)` 🚧 |
 | `driver.switch_to.frame(el)` | `naturo browser frame-find <frame> <selector>` | `page.frame(selector).find(...)` |
 | `options.set_capability('goog:loggingPrefs', ...)` | `naturo browser requests --pattern <glob>` | `page.network.capture_snapshot()` |
+
+> **🚧 Not yet implemented:** the two cookie rows above (`naturo browser cookies
+> …` / `page.cookies.…`) do **not** exist in the current build — there is no
+> `cookies` command on the `browser` group and no `BrowserPage.cookies`
+> property. Tracked in
+> [#1106](https://github.com/AcePeak/naturo/issues/1106); see the
+> [Cookie Management](#cookie-management) caveat below.
 
 ### pywinauto / uiautomation to naturo
 
@@ -399,7 +417,12 @@ page.find("xpath://button[@class='upload-video']").hover()
 page.find("xpath://button[@class='upload-video']").click(js=True)
 ```
 
-### Scroll
+> **🚧 Not yet implemented:** the `--js` / `click(js=True)` calls above are the
+> JS-click fallback, which does **not** exist in the current build. Drop `--js`
+> for a normal click after the hover, or dispatch via the working `eval` path
+> (`naturo browser eval "document.querySelector('…').click()"`). Tracked in
+> [#1106](https://github.com/AcePeak/naturo/issues/1106). See the
+> [JavaScript Execution](#javascript-execution) caveat for details.
 
 **Before** — from a Xiaohongshu infinite-scroll project (DrissionPage):
 ```python
@@ -584,6 +607,14 @@ page.cookies.load("cookies.json")
 page.cookies.delete(domain=".douyin.com")
 ```
 
+> **🚧 Not yet implemented:** the `naturo browser cookies` command family
+> (`save`/`clear`/`load`/`delete`) and the `BrowserPage.cookies` property shown
+> in the `After` block do **not** exist in the current build, so the
+> cookie-cycling pattern has no shipped `After` equivalent yet. Whether to
+> implement these surfaces or prune them from this guide is tracked in
+> [#1106](https://github.com/AcePeak/naturo/issues/1106) — do not rely on the
+> commands above until it resolves.
+
 ### JavaScript Execution
 
 **Before** — from a Douyin project (Selenium, JS click fallback):
@@ -627,6 +658,15 @@ count = page.evaluate("document.querySelectorAll('.item').length")
 page.evaluate("document.body.style.zoom='0.85'")
 page.find("#login-btn").click(js=True)
 ```
+
+> **🚧 Not yet implemented:** `naturo browser eval` / `page.evaluate(...)` (the
+> `readyState`, `querySelectorAll`, `reload`, and `zoom` lines above) work today,
+> but the JS-click fallback on the last line of each block — `naturo browser
+> click "#login-btn" --js` / `page.find("#login-btn").click(js=True)` — does
+> **not** exist yet. Until it ships, click via the working `eval` path:
+> `naturo browser eval "document.querySelector('#login-btn').click()"` /
+> `page.evaluate("document.querySelector('#login-btn').click()")`. Tracked in
+> [#1106](https://github.com/AcePeak/naturo/issues/1106).
 
 ### Tab Management
 
@@ -1350,6 +1390,13 @@ for _ in range(10):
     page.evaluate("location.reload()")
     page.wait_for_load(timeout=10000)
 ```
+
+> **🚧 Not yet implemented:** the `naturo browser cookies …` / `page.cookies.…`
+> calls in this loop do **not** exist in the current build (see
+> [Cookie Management](#cookie-management)), so this cookie-cycling `After`
+> example is not yet runnable end-to-end. The title-check, `eval`, and
+> `wait --load` steps around them are real. Tracked in
+> [#1106](https://github.com/AcePeak/naturo/issues/1106).
 
 ---
 

--- a/tests/test_migration_guide_cookies_jsclick_doc_1106.py
+++ b/tests/test_migration_guide_cookies_jsclick_doc_1106.py
@@ -1,0 +1,167 @@
+"""Never-lie guard for the migration guide's cookie + JS-click surfaces (#1106).
+
+``docs/MIGRATION_FROM_RPA_SCRIPTS.md`` documents two browser surfaces that do
+not exist in the shipped product (the same defect class as the network gap
+#1088 and the iframe gap #1082):
+
+* a ``naturo browser cookies`` command family (``save``/``clear``/``load``/
+  ``delete``) plus a ``BrowserPage.cookies`` property, and
+* a JS-click fallback -- ``naturo browser click <selector> --js`` and
+  ``BrowserElement.click(js=True)``.
+
+A user following the guide would hit ``No such command`` /
+``unexpected keyword argument``, violating the SOUL.md never-lie contract for
+our own documentation.
+
+The resolution chosen for #1106 (per the orchestrator triage) is to **caveat,
+not prune or implement**: deciding whether to ship those public APIs or delete
+the claims is Ace's call, so the guide keeps the examples but flags each one as
+"not yet implemented". This module pins that contract from both directions:
+
+* It derives the *real* surface at runtime -- the registered ``browser``
+  subcommands, ``BrowserPage``'s attributes, and the ``browser click`` /
+  ``BrowserElement.click`` signatures -- and asserts the four surfaces are still
+  absent. If anyone later *implements* them, these assertions fail, forcing the
+  caveats (and this test) to be revisited.
+* It asserts that every Markdown region mentioning one of the not-yet-shipped
+  surfaces also carries the ``#1106`` "not yet implemented" caveat, so the guide
+  can never silently advertise a surface that does not exist.
+
+The tests read only the on-disk Markdown and import pure Python metadata, so
+they need no browser/desktop and run on every CI lane.
+
+Relates to #1106. Sibling never-lie doc guard to #1082 / #1088 and the #766
+equivalence suite.
+"""
+from __future__ import annotations
+
+import inspect
+import re
+from pathlib import Path
+
+from naturo.browser import BrowserElement, BrowserPage
+from naturo.cli import main
+
+_GUIDE_PATH = (
+    Path(__file__).resolve().parents[1] / "docs" / "MIGRATION_FROM_RPA_SCRIPTS.md"
+)
+
+# naturo-specific tokens for the surfaces the guide documents but does not ship.
+# These match only the *naturo* CLI/SDK forms, never the Selenium/DrissionPage
+# "Before" snippets (e.g. ``ele.click(by_js=True)``), which legitimately
+# describe the other tool. ``--js`` is word-bounded so it does not match
+# ``--json``.
+_FICTIONAL_TOKENS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"naturo browser cookies"),
+    re.compile(r"page\.cookies"),
+    re.compile(r"\.click\(js="),
+    re.compile(r"--js\b"),
+)
+
+_CAVEAT_REFERENCE = "#1106"
+
+
+def _guide_text() -> str:
+    """Return the full migration-guide Markdown as text."""
+    return _GUIDE_PATH.read_text(encoding="utf-8")
+
+
+def _regions(text: str) -> list[str]:
+    """Split the guide into regions at Markdown section boundaries.
+
+    A boundary is a top/second-level heading (``## ``/``### ``) or a horizontal
+    rule (``---``). Each returned region is the text from one boundary up to the
+    next, so a documented surface and the caveat that immediately follows it in
+    the same section land in the same region.
+
+    Args:
+        text: The full guide Markdown.
+
+    Returns:
+        The list of region bodies in document order.
+    """
+    boundary = re.compile(r"^(?:#{2,3} |---\s*$)")
+    regions: list[str] = []
+    current: list[str] = []
+    for line in text.splitlines():
+        if boundary.match(line):
+            if current:
+                regions.append("\n".join(current))
+            current = [line]
+        else:
+            current.append(line)
+    if current:
+        regions.append("\n".join(current))
+    return regions
+
+
+def _real_browser_subcommands() -> set[str]:
+    """Return the set of registered ``naturo browser`` leaf subcommand names."""
+    browser_group = main.commands["browser"]
+    return set(browser_group.commands.keys())  # type: ignore[attr-defined]
+
+
+def _click_command_option_names() -> set[str]:
+    """Return the long-option strings on the ``naturo browser click`` command."""
+    click_command = main.commands["browser"].commands["click"]  # type: ignore[attr-defined]
+    return {
+        opt
+        for param in click_command.params
+        for opt in getattr(param, "opts", [])
+        if opt.startswith("--")
+    }
+
+
+def test_cookies_surface_is_absent_from_shipped_code() -> None:
+    """No ``browser cookies`` command and no ``BrowserPage.cookies`` exist.
+
+    Justifies the guide's "not yet implemented" caveat. If this fails because the
+    surface was implemented, drop the #1106 caveat from the guide and retire this
+    assertion.
+    """
+    assert "cookies" not in _real_browser_subcommands(), (
+        "A `browser cookies` subcommand now exists -- remove the #1106 "
+        "'not yet implemented' caveat from MIGRATION_FROM_RPA_SCRIPTS.md."
+    )
+    assert not hasattr(BrowserPage, "cookies"), (
+        "BrowserPage.cookies now exists -- remove the #1106 caveat from the "
+        "migration guide's Cookie Management section."
+    )
+
+
+def test_js_click_surface_is_absent_from_shipped_code() -> None:
+    """No ``browser click --js`` option and no ``click(js=...)`` parameter exist.
+
+    Justifies the guide's "not yet implemented" caveat. If this fails because the
+    surface was implemented, drop the #1106 caveat from the guide and retire this
+    assertion.
+    """
+    assert "--js" not in _click_command_option_names(), (
+        "`browser click --js` now exists -- remove the #1106 caveat from the "
+        "migration guide's JavaScript Execution section."
+    )
+    click_parameters = inspect.signature(BrowserElement.click).parameters
+    assert "js" not in click_parameters, (
+        "BrowserElement.click now accepts a `js` parameter -- remove the #1106 "
+        "caveat from the migration guide."
+    )
+
+
+def test_every_fictional_mention_carries_the_1106_caveat() -> None:
+    """Each guide region naming a not-yet-shipped surface references #1106.
+
+    The guide intentionally keeps the cookie/JS-click examples (pruning vs.
+    implementing is Ace's call) but must flag every one of them, so the published
+    guide never advertises a surface that does not exist without a caveat.
+    """
+    offending: list[str] = []
+    for region in _regions(_guide_text()):
+        if any(token.search(region) for token in _FICTIONAL_TOKENS):
+            if _CAVEAT_REFERENCE not in region:
+                heading = region.splitlines()[0].strip()
+                offending.append(heading)
+    assert not offending, (
+        "Migration-guide region(s) document the not-yet-shipped `browser "
+        f"cookies` / `--js` surface without a {_CAVEAT_REFERENCE} caveat: "
+        f"{offending}. Add a '🚧 Not yet implemented' note referencing #1106."
+    )


### PR DESCRIPTION
## What
`docs/MIGRATION_FROM_RPA_SCRIPTS.md` advertised two browser surfaces that do **not** exist in the shipped product:

- a `naturo browser cookies` command family (`save`/`clear`/`load`/`delete`) + `BrowserPage.cookies`, and
- a JS-click fallback — `naturo browser click <selector> --js` / `BrowserElement.click(js=True)`.

A user following the guide hits `No such command` / `unexpected keyword argument` — a never-lie / migration-credibility defect (SOUL.md), same class as #1082 / #1088.

This PR is the **Dev-actionable interim** from the orchestrator triage on #1106: **caveat the claims, do not implement the public API or prune the docs unattended** (that resolution is Ace's call). Every guide region naming one of these surfaces now carries a "🚧 Not yet implemented" note linking #1106:

- both command-mapping tables (DrissionPage + Selenium),
- the **Cookie Management** worked example,
- the **JavaScript Execution** worked example (the working `eval`/`page.evaluate(...)` rows are left intact),
- the hover-then-click example,
- the **Cookie Cycling Anti-Captcha** recipe.

Where a real alternative exists, it is offered: dispatch a JS click via the working `eval` path (`naturo browser eval "document.querySelector('#sel').click()"` / `page.evaluate(...)`).

No public API added, no documented feature deleted.

## How tested
- Confirmed at runtime that all four surfaces are genuinely absent: no `cookies` browser subcommand, `BrowserPage` has no `cookies`, `browser click` has no `--js`, `BrowserElement.click` has no `js` param.
- New hermetic guard `tests/test_migration_guide_cookies_jsclick_doc_1106.py` (no browser/desktop, runs on every CI lane): derives the real surface at runtime and asserts the four APIs are still absent **and** that every fictional-surface region carries the #1106 caveat. Bidirectional — implementing the API later trips the absence checks; removing a caveat while the API is missing trips the coverage check.
- `python -m ruff check` clean; new test + sibling doc guards (#1082/#1088) green (9 passed); `--collect-only` succeeds (cross-platform collection).

Relates to #766. Sibling never-lie doc guard to #1082 / #1088.