### PR TITLE
test: prove Scroll (scroll_by / scroll_to_element) equivalence row (part of #766)

### DIFF
--- a/tests/browser/fixtures/scroll.html
+++ b/tests/browser/fixtures/scroll.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>naturo fixture: scroll</title>
+  <style>
+    body { margin: 0; }
+    #top-marker { height: 40px; background: #cfe; }
+    .spacer { height: 2000px; background: #eee; }
+    #target { height: 60px; background: #fc9; }
+  </style>
+</head>
+<body>
+  <!-- Exercises: page scrolling. The page is far taller than any viewport, so a
+       "scroll into view" must perform a real scroll to reveal the target. -->
+  <div id="top-marker">top</div>
+
+  <!-- A spacer taller than any viewport parks #target ~2040px down, well below
+       the fold, so it is off-screen until the viewport actually moves. -->
+  <div class="spacer" id="spacer-top"></div>
+  <div id="target">target row</div>
+
+  <!-- Trailing space so block:'center' can fully center #target (it is not near
+       the document bottom), distinguishing a centered into-view scroll from a
+       top-aligned one. -->
+  <div class="spacer" id="spacer-bottom"></div>
+</body>
+</html>

--- a/tests/browser/test_migration_equivalence.py
+++ b/tests/browser/test_migration_equivalence.py
@@ -700,6 +700,71 @@ def test_xpath_scoped_card_scrape_equivalence(
     assert cards[2].find(".note-author").text == "@mina"
 
 
+def test_scroll_equivalence(
+    browser_page: BrowserPage, fixtures_server: str
+) -> None:
+    """Reproduce the DrissionPage scroll-by-pixels / scroll-into-view pattern via naturo.
+
+    Mirrors the migration guide's "Scroll" section / DrissionPage API mapping:
+    the *Before* code calls ``page.scroll.down(1000)`` to advance a feed (the
+    Xiaohongshu/Dianping scroll loops that motivate #763) and
+    ``ele.scroll.to_see()`` to bring an off-screen control into view before
+    acting on it. The *After* surface is :meth:`BrowserPage.scroll_by` and
+    :meth:`BrowserPage.scroll_to_element`.
+
+    Driven against ``scroll.html`` -- a page far taller than the viewport with a
+    ``#target`` row parked ~2000px below the fold -- naturo must genuinely move
+    the viewport. Per naturo's never-lie contract (SOUL.md) the movement is
+    proven on the page's own scroll state, both ways: the page opens at the top
+    (``scrollY`` 0, target below the fold), ``scroll_by`` advances ``scrollY`` by
+    the requested pixels, and ``scroll_to_element`` brings the previously
+    off-screen target into the viewport and centres it. A "scroll" that silently
+    left the viewport in place would fail every assertion -- ``scrollY`` and the
+    target's viewport-relative rect are the live, authoritative scroll position,
+    so they cannot report movement that did not happen.
+    """
+    browser_page.navigate(f"{fixtures_server}/scroll.html")
+
+    def scroll_y() -> int:
+        return int(browser_page.evaluate("Math.round(window.scrollY)"))
+
+    def target_top() -> float:
+        # The target's top edge, in viewport-relative CSS pixels (negative ->
+        # scrolled past it, >= innerHeight -> still below the fold).
+        return float(
+            browser_page.evaluate(
+                "document.getElementById('target').getBoundingClientRect().top"
+            )
+        )
+
+    viewport_height = int(browser_page.evaluate("window.innerHeight"))
+
+    # never-lie (precondition): the page opens at the top and the target is parked
+    # below the fold, so any later "in view" assertion can only come from a real
+    # scroll this test performed.
+    assert scroll_y() == 0
+    assert browser_page.find("#top-marker").text == "top"
+    assert target_top() > viewport_height  # target is below the visible viewport
+
+    # Before: page.scroll.down(1000)  ->  After: page.scroll_by(1000).
+    # never-lie: the viewport genuinely advanced by the requested pixels; a silent
+    # no-op would leave scrollY at 0.
+    browser_page.scroll_by(1000)
+    assert abs(scroll_y() - 1000) <= 2
+
+    # Before: ele.scroll.to_see()  ->  After: page.scroll_to_element("#target").
+    # never-lie: the previously off-screen target is now within the viewport and
+    # centred (scroll_into_view uses block:'center'), proving the scroll landed on
+    # the element rather than a top-aligned nudge or no-op.
+    browser_page.scroll_to_element("#target")
+    top_after = target_top()
+    assert 0 <= top_after < viewport_height  # target is now visible
+    # Centred, not merely top-aligned: block:'center' leaves clear space above the
+    # target (a block:'start' scroll would put its top at ~0). The fixture's
+    # trailing spacer guarantees there is room to centre.
+    assert top_after >= viewport_height * 0.2
+
+
 def test_javascript_execution_equivalence(
     browser_page: BrowserPage, fixtures_server: str
 ) -> None:


### PR DESCRIPTION
## What
Adds an end-to-end migration-equivalence acceptance test for the migration guide's **Scroll** section / DrissionPage API-mapping rows that were documented but not yet proven end-to-end:

- `page.scroll.down(1000)` → `BrowserPage.scroll_by(1000)`
- `ele.scroll.to_see()` → `BrowserPage.scroll_to_element(selector)`

These are the scroll primitives the real Xiaohongshu/Dianping scrape loops (the #763 targets) depend on. The only previously-covered scroll surface was `scroll_to_bottom` (via the infinite-scroll test); `scroll_by` and `scroll_to_element` had no end-to-end equivalence proof.

New offline fixture `tests/browser/fixtures/scroll.html`: a page far taller than any viewport with a `#target` row parked ~2000px below the fold (plus a trailing spacer so `block:'center'` can fully centre it).

## How tested
`python -m pytest tests/browser/test_migration_equivalence.py` → **13 passed** on real headless Chrome (incl. the new `test_scroll_equivalence`). `--collect-only` succeeds without Chrome (CI-safe; the suite is `@pytest.mark.desktop`). `ruff check` clean.

never-lie (SOUL.md), proven both ways on the live, authoritative scroll state:
- precondition: page opens at the top (`scrollY == 0`) with the target below the fold (`getBoundingClientRect().top > innerHeight`), so any later "in view" assertion can only come from a real scroll;
- `scroll_by(1000)` advances `scrollY` to ~1000 (a silent no-op would leave it at 0);
- `scroll_to_element` brings the previously off-screen target into the viewport and centres it (clear space above → `block:'center'`, not a top-aligned nudge).

No public API or `naturo/` code changed — test + fixture only.

Part of #766 (migration-guide Before/After acceptance matrix); does not close the umbrella.