### PR TITLE
fix: detect display:none/zero-area elements in browser wait_for (part of #766)

### DIFF
--- a/naturo/browser/_element.py
+++ b/naturo/browser/_element.py
@@ -339,6 +339,34 @@ class BrowserElement:
                     ))
         return elements
 
+    def _is_displayed(self) -> bool:
+        """Return whether this element is currently rendered and visible.
+
+        Visibility here means the documented :meth:`BrowserPage.wait_for`
+        contract: the node is in the document, is not ``display:none`` /
+        ``visibility:hidden`` / ``visibility:collapse``, and has a non-zero
+        layout box. This deliberately does **not** reuse
+        :meth:`_get_click_point`, whose ``getBoundingClientRect`` fallback
+        returns a valid all-zeros point ``(0, 0)`` for an unrendered element
+        (the click-path quirk tracked in #1083) and so cannot distinguish a
+        hidden node from a visible one.
+
+        Returns:
+            True if the element is connected and visibly rendered, else False.
+        """
+        result = self._call_function(
+            "function() {"
+            "  if (!this.isConnected) { return false; }"
+            "  var style = window.getComputedStyle(this);"
+            "  if (style.display === 'none'"
+            "      || style.visibility === 'hidden'"
+            "      || style.visibility === 'collapse') { return false; }"
+            "  var rect = this.getBoundingClientRect();"
+            "  return rect.width > 0 && rect.height > 0;"
+            "}"
+        )
+        return bool(result)
+
     def _get_click_point(
         self, offset_x: int = 0, offset_y: int = 0
     ) -> Optional[tuple[float, float]]:

--- a/naturo/browser/_page.py
+++ b/naturo/browser/_page.py
@@ -245,8 +245,11 @@ class BrowserPage:
             element = self._resolve_element(parsed)
             if state in ("attached", "visible") and element is not None:
                 if state == "visible":
-                    box = element._get_click_point()
-                    if box is not None:
+                    # Visibility is decided by the element's rendered box, not by
+                    # _get_click_point (whose all-zeros fallback reports an
+                    # unrendered node as a valid (0,0) point — #1083 — and would
+                    # wrongly satisfy "visible" for a display:none element).
+                    if element._is_displayed():
                         return element
                 else:
                     return element
@@ -254,11 +257,14 @@ class BrowserPage:
                 # Return a dummy element since the element is gone
                 return BrowserElement(self, "", description="<detached>")
             elif state == "hidden":
-                if element is None:
-                    return BrowserElement(self, "", description="<hidden>")
-                box = element._get_click_point()
-                if box is None:
-                    return element
+                # Hidden = gone from the DOM, or present but not rendered. Using
+                # _is_displayed (not _get_click_point) lets a display:none /
+                # zero-area element — e.g. a spinner toggled off — satisfy the
+                # state, which the click-point check never could (#1083).
+                if element is None or not element._is_displayed():
+                    return element if element is not None else BrowserElement(
+                        self, "", description="<hidden>"
+                    )
 
             if time.monotonic() > deadline:
                 raise TimeoutError(

--- a/tests/browser/fixtures/waits.html
+++ b/tests/browser/fixtures/waits.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>naturo fixture: waits</title>
+  <style>
+    body { margin: 0; font-family: sans-serif; }
+    .hidden { display: none; }
+    #loading-spinner { height: 40px; background: #fc9; }
+    #search-result { height: 40px; background: #cfe; }
+    #old-item { height: 40px; background: #ddd; }
+  </style>
+</head>
+<body>
+  <!-- Exercises: event-driven element-state waits (the migration guide's
+       "Waiting" section). The page starts in a fixed initial state and only
+       transitions when startTransitions(ms) is invoked, so the wait under test
+       genuinely has to block for the state change rather than win a race at
+       load time:
+         - #loading-spinner: visible now, display:none after the delay
+           (the Dianping "正在加载" poll loop -> wait --state hidden)
+         - #search-result: absent now, injected + visible after the delay
+           (Selenium WebDriverWait presence/visible -> wait --state visible)
+         - #old-item: in the DOM now, removed after the delay
+           (wait --state detached) -->
+  <div id="loading-spinner">loading…</div>
+  <div id="old-item">old item</div>
+
+  <script>
+    // Schedule the state transitions `delay_ms` from now. Kept off the load
+    // path on purpose: the test asserts the initial state first (so a no-op
+    // wait cannot pass), then calls this, then waits for each target state.
+    function startTransitions(delay_ms) {
+      window.setTimeout(function () {
+        document.getElementById('loading-spinner').classList.add('hidden');
+
+        var result = document.createElement('div');
+        result.id = 'search-result';
+        result.textContent = 'result ready';
+        document.body.appendChild(result);
+
+        var old = document.getElementById('old-item');
+        if (old) {
+          old.remove();
+        }
+      }, delay_ms);
+      return true;
+    }
+  </script>
+</body>
+</html>

--- a/tests/browser/test_migration_equivalence.py
+++ b/tests/browser/test_migration_equivalence.py
@@ -823,3 +823,92 @@ def test_javascript_execution_equivalence(
     )
     assert browser_page.evaluate("document.readyState") == "complete"
     assert browser_page.evaluate("document.querySelectorAll('.nav-link').length") == 3
+
+
+def test_wait_state_equivalence(
+    browser_page: BrowserPage, fixtures_server: str
+) -> None:
+    """Reproduce the DrissionPage/Selenium event-driven element waits via naturo.
+
+    Mirrors the migration guide's "Waiting" section -- the core "no more
+    ``time.sleep(random.uniform(...))``" pitch. The *Before* code hand-rolls
+    polling: the Dianping ``for try_i in range(300): … if not page.ele("正在加载")``
+    loop waits for a spinner to disappear, and Selenium's
+    ``WebDriverWait(…).until(EC.presence_of_element_located(...))`` waits for a
+    result to appear. The *After* surface is :meth:`BrowserPage.wait_for` with
+    its documented states ``visible`` / ``hidden`` / ``detached`` (the same
+    ``naturo browser wait <selector> --state …`` the guide shows).
+
+    Driven against ``waits.html``, each state is proven independently on a fresh
+    load. Per naturo's never-lie contract (SOUL.md) the fixture starts in a fixed
+    state and only transitions when ``startTransitions(ms)`` is invoked *after*
+    the precondition is asserted, so the wait genuinely has to block for the
+    change: the test confirms the element is in the opposite state first, then
+    measures that ``wait_for`` did not return until the scheduled transition
+    landed (a no-op wait would return immediately and miss the lower bound), and
+    finally reads the page's own DOM state to confirm the target state holds.
+
+    Scope note (never-lie): the same guide section also documents
+    ``page.wait_for_eval(...)``, ``wait_for_navigation(url_contains=…)`` and
+    ``wait_for_network_idle(time=…)`` plus ``naturo browser wait --load/--eval/
+    --navigate`` flags, none of which match the shipped API
+    (``wait_for_function`` / ``wait_for_url`` / ``idle_time=`` and the separate
+    ``wait-navigation`` / ``wait-url`` / ``wait-function`` / ``wait-network-idle``
+    subcommands). That doc-vs-code drift is tracked separately in #1112 rather
+    than asserted here; this row proves only the faithfully-implemented
+    element-state waits.
+    """
+    # The scheduled delay before the page transitions, and a lower bound well
+    # below it: a wait that genuinely blocked for the transition must take at
+    # least this long, while a no-op wait would return near-instantly.
+    transition_delay_s = 0.5
+    min_blocked_s = 0.25
+
+    def _time_wait_for(selector: str, state: str) -> float:
+        """Schedule the transitions, then time ``wait_for`` reaching *state*.
+
+        Returns the wall-clock seconds ``wait_for`` blocked, so the caller can
+        assert it actually waited for the scheduled change rather than returning
+        immediately.
+        """
+        browser_page.evaluate(f"startTransitions({int(transition_delay_s * 1000)})")
+        start = time.monotonic()
+        browser_page.wait_for(selector, state=state, timeout=10.0)
+        return time.monotonic() - start
+
+    # ── state="visible": Selenium WebDriverWait(presence/visible) ─────────────
+    browser_page.navigate(f"{fixtures_server}/waits.html")
+    # never-lie precondition: the result does not exist yet, so a later "visible"
+    # can only come from the injection this test triggers.
+    assert browser_page.evaluate("document.getElementById('search-result') === null")
+    elapsed = _time_wait_for("#search-result", state="visible")
+    assert elapsed >= min_blocked_s  # the wait blocked for the injection
+    assert browser_page.find("#search-result").text == "result ready"
+    assert browser_page.evaluate(
+        "getComputedStyle(document.getElementById('search-result')).display"
+        " !== 'none'"
+    )
+
+    # ── state="hidden": the Dianping 300-iteration spinner poll loop ──────────
+    browser_page.navigate(f"{fixtures_server}/waits.html")
+    # never-lie precondition: the spinner is visible at load, so "hidden" must be
+    # the result of the transition, not the starting state.
+    assert browser_page.evaluate(
+        "getComputedStyle(document.getElementById('loading-spinner')).display"
+        " !== 'none'"
+    )
+    elapsed = _time_wait_for("#loading-spinner", state="hidden")
+    assert elapsed >= min_blocked_s  # the wait blocked until the spinner hid
+    assert browser_page.evaluate(
+        "getComputedStyle(document.getElementById('loading-spinner')).display"
+        " === 'none'"
+    )
+
+    # ── state="detached": wait for an element to leave the DOM ────────────────
+    browser_page.navigate(f"{fixtures_server}/waits.html")
+    # never-lie precondition: the element is in the DOM at load, so "detached"
+    # proves the removal happened rather than it never having existed.
+    assert browser_page.evaluate("!!document.getElementById('old-item')")
+    elapsed = _time_wait_for("#old-item", state="detached")
+    assert elapsed >= min_blocked_s  # the wait blocked until the node was removed
+    assert browser_page.evaluate("document.getElementById('old-item') === null")

--- a/tests/test_browser_page.py
+++ b/tests/test_browser_page.py
@@ -284,19 +284,34 @@ class TestBrowserPageWaitFor:
                 with pytest.raises(TimeoutError, match="Timeout waiting"):
                     page.wait_for("#never", timeout=1.0)
 
-    def test_wait_for_visible_checks_click_point(self):
+    def test_wait_for_visible_checks_displayed(self):
         page, cdp = _make_page()
         # _resolve_element returns element
         cdp.send.return_value = {
             "result": {"objectId": "obj-v", "description": "div"}
         }
-        # Patch BrowserElement._get_click_point to return coords
+        # Visibility is decided by _is_displayed (the element's rendered box),
+        # not _get_click_point — a display:none node yields a valid (0,0) point
+        # there and would wrongly satisfy "visible" (#1083).
         with patch(
-            "naturo.browser._element.BrowserElement._get_click_point",
-            return_value=(100, 200),
+            "naturo.browser._element.BrowserElement._is_displayed",
+            return_value=True,
         ):
             el = page.wait_for("#visible", timeout=1.0, state="visible")
             assert el.object_id == "obj-v"
+
+    def test_wait_for_hidden_returns_when_present_but_not_displayed(self):
+        page, cdp = _make_page()
+        # _resolve_element finds the element, but it is not rendered.
+        cdp.send.return_value = {
+            "result": {"objectId": "obj-h", "description": "div"}
+        }
+        with patch(
+            "naturo.browser._element.BrowserElement._is_displayed",
+            return_value=False,
+        ):
+            el = page.wait_for("#spinner", timeout=1.0, state="hidden")
+            assert el.object_id == "obj-h"
 
 
 # ═════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## What

Proves the migration guide's **Waiting** equivalence row (part of #766) and, in doing so, fixes a real bug it exposed in `BrowserPage.wait_for`.

**Bug:** `wait_for(state="visible"|"hidden")` decided visibility via `BrowserElement._get_click_point()`, whose `getBoundingClientRect` fallback returns a valid all-zeros point `(0, 0)` for an unrendered node (the click-path quirk tracked in #1083). Consequences:
- `--state hidden` **never fired** for a `display:none` / zero-area element (e.g. a spinner toggled off) — the exact Dianping "正在加载" spinner-gone pattern the guide documents.
- `--state visible` would wrongly pass for a `display:none` element.

This breaks the guide's headline "no more `time.sleep` polling" value proposition.

**Fix:** add `BrowserElement._is_displayed()` (connected **and** not `display:none`/`visibility:hidden|collapse` **and** non-zero layout box) and have `wait_for` use it for the visible/hidden states. The **click path is untouched**, so this does not preempt #1083.

## How tested

- New `tests/browser/test_migration_equivalence.py::test_wait_state_equivalence` drives real headless Chrome (CDP) against a new offline fixture `tests/browser/fixtures/waits.html`. Each of `visible` / `hidden` / `detached` is proven on a fresh load with:
  - a **never-lie precondition** (the element is asserted to be in the *opposite* state first, via the page's own DOM, so a no-op wait cannot pass),
  - a **blocked-duration** check (the transition is scheduled *after* the precondition; `wait_for` must block ≥0.25 s for the scheduled change rather than return immediately),
  - a post-state assertion read from the live DOM.
- Updated the affected unit tests in `tests/test_browser_page.py` to mock `_is_displayed` (the now-authoritative visibility check) and added a present-but-not-displayed `hidden` case.
- Gate: `ruff` clean; `mypy` clean on the changed files (`_element.py`/`_page.py`); full `test_migration_equivalence` module **14 passed** on a real desktop; browser wait/page/element units **91 passed** (the only failures locally are a `tmp_path` `PermissionError` from the shared Windows temp dir under concurrent runs, #935 — env-only, not in this diff); `pytest --collect-only` clean across 6918 tests (no cross-platform import break).

## Scope notes

- No new public symbol, CLI flag, or contract — `_is_displayed` is private and this makes `wait_for` match its **already-documented** states (`visible` = "in DOM and has non-zero size", `hidden` = "not visible").
- The same guide section also documents `page.wait_for_eval(...)`, `wait_for_navigation(url_contains=…)`, `wait_for_network_idle(time=…)` and `naturo browser wait --load/--eval/--navigate` flags that don't match the shipped API — filed as never-lie doc gap **#1112**, not papered over here.
- Part of #766; does not close the umbrella.