### PR TITLE
docs: correct migration guide wait surface to shipped API (fixes #1112)

### DIFF
--- a/docs/MIGRATION_FROM_RPA_SCRIPTS.md
+++ b/docs/MIGRATION_FROM_RPA_SCRIPTS.md
@@ -116,7 +116,7 @@ which engine found which element — just use `naturo click e42`.
 | `ele.hover().click()` | `naturo browser hover <sel> && naturo browser click <sel>` | `element.hover(); element.click()` |
 | `ele.scroll.to_see()` | `naturo browser scroll --to-element <sel>` | `page.scroll_to_element(sel)` |
 | `page.scroll.down(1000)` | `naturo browser scroll --by 1000` | `page.scroll_by(1000)` |
-| `page.wait.doc_loaded()` | `naturo browser wait --load` | `page.wait_for_load()` |
+| `page.wait.doc_loaded()` | `naturo browser navigate <url> --wait-until load` | `page.wait_for_load()` |
 | `page.get_screenshot(path)` | `naturo browser screenshot --path file.png` | `page.screenshot("file.png")` |
 | `page.set.window.max()` | `naturo app maximize --app chrome` | N/A (use CLI) |
 | `page.run_js_loaded(js)` | `naturo browser eval <js>` | `page.evaluate(js)` |
@@ -138,7 +138,7 @@ which engine found which element — just use `naturo click e42`.
 | Selenium | naturo CLI | naturo Python SDK |
 |----------|-----------|-------------------|
 | `webdriver.Chrome(options=opts)` | `naturo browser launch` | `BrowserPage()` |
-| `WebDriverWait(d,t).until(EC.presence(...))` | `naturo browser wait <selector> --timeout <ms>` | `page.wait_for(selector, timeout=ms)` |
+| `WebDriverWait(d,t).until(EC.presence(...))` | `naturo browser wait <selector> --timeout <seconds>` | `page.wait_for(selector, timeout=seconds)` |
 | `driver.find_element(By.XPATH, '...')` | `naturo browser find "xpath://..."` | `page.find("xpath://...")` |
 | `driver.find_elements(By.XPATH, '...')` | `naturo browser find "xpath://..." --all` | `page.find_all("xpath://...")` |
 | `element.send_keys(text)` | `naturo browser type <sel> <text>` | `element.type(text)` |
@@ -263,12 +263,12 @@ if not page.ele(self.ele_dict["发布时间和发布地点"]):
 **After**:
 ```bash
 naturo browser navigate "https://ecom.example.com/dashboard/evaluation/poi"
-naturo browser wait --load --timeout 10000
+naturo browser wait-network-idle    # navigate already waits for load; settle dynamic content
 ```
 
 ```python
 page.navigate("https://ecom.example.com/dashboard/evaluation/poi")
-page.wait_for_load(timeout=10000)
+page.wait_for_network_idle()  # navigate already waits for load; settle dynamic content
 ```
 
 ### Element Finding
@@ -502,11 +502,11 @@ time.sleep(random.uniform(0.5, 1.5))  # scattered throughout every script
 
 **After** — event-driven waits, no guessing:
 ```bash
-# Page lifecycle
-naturo browser wait --load                          # Page fully loaded
-naturo browser wait --dom-ready                     # DOM content loaded
-naturo browser wait --network-idle                  # No network activity for 500ms
-naturo browser wait --network-idle --time 1000      # Custom idle threshold
+# Page lifecycle (load-waiting is built into `navigate --wait-until`)
+naturo browser navigate <url> --wait-until load             # Wait for the load event (default)
+naturo browser navigate <url> --wait-until domcontentloaded # Wait for DOMContentLoaded
+naturo browser wait-network-idle                            # No network activity for 0.5s
+naturo browser wait-network-idle --idle-time 1.0            # Custom idle threshold (seconds)
 
 # Element state
 naturo browser wait ".results" --timeout 10000               # Element exists in DOM
@@ -515,19 +515,20 @@ naturo browser wait ".spinner" --state hidden --timeout 30000   # Spinner gone
 naturo browser wait ".old-item" --state detached              # Element removed from DOM
 
 # Navigation
-naturo browser wait --navigate --url-contains "success"
+naturo browser wait-url "success"                            # Wait until the URL contains a substring
+naturo browser wait-navigation                              # Wait for the next navigation to complete
 
 # JS condition
-naturo browser wait --eval "window.dataLoaded === true" --timeout 5000
+naturo browser wait-function "window.dataLoaded === true" --timeout 5
 ```
 
 ```python
 page.wait_for_load()
-page.wait_for_network_idle(time=500)
+page.wait_for_network_idle(idle_time=0.5)
 page.wait_for(".results", state="visible", timeout=10000)
 page.wait_for(".spinner", state="hidden", timeout=30000)
-page.wait_for_navigation(url_contains="success")
-page.wait_for_eval("window.dataLoaded === true")
+page.wait_for_url("success")
+page.wait_for_function("window.dataLoaded === true")
 ```
 
 ### Screenshots
@@ -1067,7 +1068,7 @@ send_keys('{ENTER}')
 # === Part 1: Scrape Dianping (browser) ===
 naturo browser launch --profile dianping
 naturo browser navigate "https://ecom.example.com/dashboard/evaluation/poi"
-naturo browser wait --load
+naturo browser wait-network-idle
 
 naturo browser click "xpath://div[@class='tab-review']"
 naturo browser type "xpath://input[@class='store-search']" "My Store Name" --clear-first
@@ -1374,7 +1375,7 @@ for i in $(seq 1 10); do
   sleep 5
   naturo browser cookies load --path /tmp/cookies.json
   naturo browser eval "location.reload()"
-  naturo browser wait --load --timeout 10000
+  naturo browser wait-network-idle
 done
 ```
 
@@ -1388,14 +1389,14 @@ for _ in range(10):
     time.sleep(5)
     page.cookies.load("/tmp/cookies.json")
     page.evaluate("location.reload()")
-    page.wait_for_load(timeout=10000)
+    page.wait_for_network_idle()
 ```
 
 > **🚧 Not yet implemented:** the `naturo browser cookies …` / `page.cookies.…`
 > calls in this loop do **not** exist in the current build (see
 > [Cookie Management](#cookie-management)), so this cookie-cycling `After`
 > example is not yet runnable end-to-end. The title-check, `eval`, and
-> `wait --load` steps around them are real. Tracked in
+> `wait-network-idle` steps around them are real. Tracked in
 > [#1106](https://github.com/AcePeak/naturo/issues/1106).
 
 ---
@@ -1581,7 +1582,7 @@ for _ in range(80):
 # Or pure CLI for simpler extraction
 naturo browser launch --profile xhs-main
 naturo browser navigate "https://www.xiaohongshu.com/explore"
-naturo browser wait --load
+naturo browser wait-network-idle
 
 for i in $(seq 1 80); do
   naturo browser find "xpath://div[@class='note-item']//a[@class='note-link']" --all --json \

--- a/tests/test_migration_guide_wait_surface_doc_1112.py
+++ b/tests/test_migration_guide_wait_surface_doc_1112.py
@@ -1,0 +1,175 @@
+"""Never-lie guard for the migration guide's browser *wait* surface (#1112).
+
+``docs/MIGRATION_FROM_RPA_SCRIPTS.md`` documented a waiting surface that does
+not exist in the shipped product (the same defect class as the cookie/JS-click
+gap #1106, the network gap #1088, and the iframe gap #1082). A user copying the
+guide's ``Waiting`` examples would hit ``AttributeError`` / ``TypeError`` /
+``No such option``:
+
+* Python SDK -- ``page.wait_for_eval(...)`` (the method is
+  ``wait_for_function``), ``page.wait_for_navigation(url_contains=...)`` (URL
+  matching is ``wait_for_url(pattern)``; ``wait_for_navigation`` takes no
+  ``url_contains``), and ``page.wait_for_network_idle(time=...)`` (the kwarg is
+  ``idle_time`` and the unit is *seconds*).
+* CLI -- ``naturo browser wait --load`` / ``--dom-ready`` / ``--network-idle``
+  / ``--navigate`` / ``--eval`` / ``--url-contains``. The shipped ``wait``
+  command has none of those flags; load-waiting lives on
+  ``navigate --wait-until``, and the other waits are *separate* subcommands
+  (``wait-navigation`` / ``wait-url`` / ``wait-function`` /
+  ``wait-network-idle``).
+
+Unlike #1106 (caveat-not-prune, because shipping those APIs is Ace's call),
+this is a pure doc error: correcting the names adds and removes no public
+surface, so the resolution is to *fix the guide to match shipped reality*. This
+module pins that contract from both directions:
+
+* It derives the *real* wait surface at runtime -- ``BrowserPage``'s wait
+  methods and their signatures, plus the registered ``browser`` subcommands and
+  the ``browser wait`` options -- and asserts the shipped shape is what the
+  corrected guide now claims. If the surface ever drifts (a method renamed, a
+  flag added), these assertions fire so the guide is revisited.
+* It asserts the guide no longer contains any of the fictional wait tokens, so
+  the published guide can never re-advertise a wait API that does not exist.
+
+The tests read only the on-disk Markdown and import pure Python metadata, so
+they need no browser/desktop and run on every CI lane.
+
+Relates to #1112. Sibling never-lie doc guard to #1082 / #1088 / #1106 and the
+#766 equivalence suite (``test_wait_state_equivalence``).
+"""
+from __future__ import annotations
+
+import inspect
+import re
+from pathlib import Path
+
+from naturo.browser import BrowserPage
+from naturo.cli import main
+
+_GUIDE_PATH = (
+    Path(__file__).resolve().parents[1] / "docs" / "MIGRATION_FROM_RPA_SCRIPTS.md"
+)
+
+# naturo-specific tokens for the wait surfaces the guide documented but does not
+# ship. Each matches only the *naturo* CLI/SDK form, never the Selenium /
+# DrissionPage "Before" snippets (e.g. ``page.wait.doc_loaded()``), which
+# legitimately describe the other tool. The ``--network-idle`` / ``--navigate``
+# forms use a literal ``wait <space>--`` so they match the fictional flag form
+# but never the real ``wait-network-idle`` / ``wait-navigation`` subcommands
+# (which use a hyphen, not a space).
+_FICTIONAL_TOKENS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"wait_for_eval"),
+    re.compile(r"wait_for_navigation\([^)]*url_contains"),
+    re.compile(r"wait_for_network_idle\([^)]*\btime="),
+    re.compile(r"naturo browser wait --load"),
+    re.compile(r"naturo browser wait --dom-ready"),
+    re.compile(r"naturo browser wait --network-idle"),
+    re.compile(r"naturo browser wait --navigate"),
+    re.compile(r"naturo browser wait --eval"),
+    re.compile(r"--url-contains"),
+)
+
+
+def _guide_text() -> str:
+    """Return the full migration-guide Markdown as text."""
+    return _GUIDE_PATH.read_text(encoding="utf-8")
+
+
+def _real_browser_subcommands() -> set[str]:
+    """Return the set of registered ``naturo browser`` leaf subcommand names."""
+    browser_group = main.commands["browser"]
+    return set(browser_group.commands.keys())  # type: ignore[attr-defined]
+
+
+def _wait_command_option_names() -> set[str]:
+    """Return the long-option strings on the ``naturo browser wait`` command."""
+    wait_command = main.commands["browser"].commands["wait"]  # type: ignore[attr-defined]
+    return {
+        opt
+        for param in wait_command.params
+        for opt in getattr(param, "opts", [])
+        if opt.startswith("--")
+    }
+
+
+def test_real_python_wait_surface_matches_corrected_guide() -> None:
+    """The shipped ``BrowserPage`` wait methods are what the corrected guide claims.
+
+    Pins the names/signatures the guide was corrected to: ``wait_for_function``,
+    ``wait_for_url(pattern)``, and ``wait_for_network_idle(idle_time=...)`` — and
+    the absence of the fictional ``wait_for_eval`` / ``wait_for_navigation(
+    url_contains=...)`` / ``wait_for_network_idle(time=...)`` forms. If this
+    drifts, revisit the guide's Waiting section and the two API-mapping rows.
+    """
+    assert hasattr(BrowserPage, "wait_for_function"), (
+        "BrowserPage.wait_for_function vanished — the migration guide's "
+        "Waiting section now claims it."
+    )
+    assert hasattr(BrowserPage, "wait_for_url"), (
+        "BrowserPage.wait_for_url vanished — the guide maps URL waits to it."
+    )
+    assert not hasattr(BrowserPage, "wait_for_eval"), (
+        "BrowserPage.wait_for_eval now exists — it used to be fictional; "
+        "update the migration guide and this guard."
+    )
+
+    navigation_params = inspect.signature(BrowserPage.wait_for_navigation).parameters
+    assert "url_contains" not in navigation_params, (
+        "wait_for_navigation now accepts url_contains — the guide was corrected "
+        "to use wait_for_url(pattern); revisit the Waiting section."
+    )
+
+    idle_params = inspect.signature(BrowserPage.wait_for_network_idle).parameters
+    assert "idle_time" in idle_params, (
+        "wait_for_network_idle no longer takes idle_time — the guide claims it."
+    )
+    assert "time" not in idle_params, (
+        "wait_for_network_idle now takes a `time` kwarg — the guide was "
+        "corrected away from it; revisit the Waiting section."
+    )
+
+
+def test_real_cli_wait_surface_matches_corrected_guide() -> None:
+    """The shipped ``browser`` wait subcommands/flags match the corrected guide.
+
+    The guide was corrected to the real separate subcommands
+    (``wait-navigation`` / ``wait-url`` / ``wait-function`` /
+    ``wait-network-idle``) and to ``navigate --wait-until`` for load waiting; the
+    single ``wait`` command exposes none of the fictional lifecycle flags.
+    """
+    subcommands = _real_browser_subcommands()
+    for required in ("wait", "wait-navigation", "wait-url", "wait-function",
+                     "wait-network-idle"):
+        assert required in subcommands, (
+            f"`browser {required}` subcommand is missing — the migration guide "
+            "documents it as the shipped wait surface."
+        )
+
+    wait_options = _wait_command_option_names()
+    for fictional in ("--load", "--dom-ready", "--network-idle", "--navigate",
+                      "--eval", "--url-contains"):
+        assert fictional not in wait_options, (
+            f"`browser wait {fictional}` now exists — it used to be fictional; "
+            "update the migration guide's Waiting section and this guard."
+        )
+
+
+def test_guide_has_no_fictional_wait_tokens() -> None:
+    """The migration guide no longer advertises any non-existent wait API.
+
+    Every faithful row is proven end-to-end by
+    ``tests/browser/test_migration_equivalence.py``; this guard ensures the
+    guide's prose can never reintroduce a wait method/flag that the shipped
+    product does not provide.
+    """
+    text = _guide_text()
+    offending = sorted(
+        token.pattern for token in _FICTIONAL_TOKENS if token.search(text)
+    )
+    assert not offending, (
+        "MIGRATION_FROM_RPA_SCRIPTS.md still documents non-existent wait "
+        f"surface(s): {offending}. Correct them to the shipped names "
+        "(wait_for_function / wait_for_url / wait_for_network_idle(idle_time=) "
+        "and the wait-navigation / wait-url / wait-function / wait-network-idle "
+        "subcommands; load-waiting via `navigate --wait-until`)."
+    )


### PR DESCRIPTION
## What
Corrects `docs/MIGRATION_FROM_RPA_SCRIPTS.md` so its **Waiting** section and the two wait API-mapping rows match the shipped surface. The guide documented wait APIs that do not exist — a never-lie doc gap (SOUL.md): a user copying the examples would hit `AttributeError` / `TypeError` / `No such option`.

Corrections (adds and removes **no** public surface — pure doc fix):

| Guide said (fictional) | Shipped (corrected to) |
|---|---|
| `page.wait_for_eval(expr)` | `page.wait_for_function(expr)` |
| `page.wait_for_navigation(url_contains=\"x\")` | `page.wait_for_url(\"x\")` |
| `page.wait_for_network_idle(time=500)` | `page.wait_for_network_idle(idle_time=0.5)` (kwarg `idle_time`, seconds) |
| `naturo browser wait --load / --dom-ready` | `naturo browser navigate <url> --wait-until load\|domcontentloaded` |
| `naturo browser wait --network-idle [--time 1000]` | `naturo browser wait-network-idle [--idle-time 1.0]` |
| `naturo browser wait --navigate --url-contains \"x\"` | `naturo browser wait-url \"x\"` / `wait-navigation` |
| `naturo browser wait --eval \"...\"` | `naturo browser wait-function \"...\"` |

Inline post-navigate/reload `wait --load` calls now use the real standalone `wait-network-idle`.

## How tested
- New hermetic guard `tests/test_migration_guide_wait_surface_doc_1112.py` (3 tests, sibling to the #1082/#1088/#1106 never-lie guards): derives the real wait surface at runtime (`BrowserPage` methods/signatures + registered `browser` subcommands + `browser wait` options) and asserts the guide carries **no** fictional wait tokens. Written test-first (failed red on the old doc, green after the fix).
- All 4 migration-guide doc guards pass (`1082`/`1088`/`1106`/`1112`): 12 passed.
- `ruff check` clean; `--collect-only` succeeds with no browser/desktop/optional deps (runs on every CI lane). No `naturo/` source changed.

## Scope note
The doc-wide `--timeout`/`timeout=` **millisecond-vs-seconds** mismatch (e.g. `--timeout 10000` = 10000s) is a distinct defect, filed separately as #1115 to keep this PR atomic.