### PR TITLE
docs: fix migration guide dropdown scroll_to_element(element) → element.scroll_into_view() (part of #766)

### DIFF
--- a/docs/MIGRATION_FROM_RPA_SCRIPTS.md
+++ b/docs/MIGRATION_FROM_RPA_SCRIPTS.md
@@ -114,7 +114,7 @@ which engine found which element — just use `naturo click e42`.
 | `ele.text` | `naturo browser text <selector>` | `element.text` |
 | `ele.attr("href")` | `naturo browser attr <selector> href` | `element.attr("href")` |
 | `ele.hover().click()` | `naturo browser hover <sel> && naturo browser click <sel>` | `element.hover(); element.click()` |
-| `ele.scroll.to_see()` | `naturo browser scroll --to-element <sel>` | `page.scroll_to_element(sel)` |
+| `ele.scroll.to_see()` | `naturo browser scroll --to-element <sel>` | `page.scroll_to_element(sel)` or `element.scroll_into_view()` |
 | `page.scroll.down(1000)` | `naturo browser scroll --by 1000` | `page.scroll_by(1000)` |
 | `page.wait.doc_loaded()` | `naturo browser navigate <url> --wait-until load` | `page.wait_for_load()` |
 | `page.get_screenshot(path)` | `naturo browser screenshot --path file.png` | `page.screenshot("file.png")` |
@@ -1682,7 +1682,7 @@ page.find("xpath://div[@class='playlist-select']").click()
 
 target_playlists = ["My Playlist 1", "My Playlist 2"]
 for item in page.find_all("xpath://div[@class='playlist-item']"):
-    page.scroll_to_element(item)
+    item.scroll_into_view()
     if item.text in target_playlists:
         item.click()
 

--- a/tests/browser/fixtures/playlist-select.html
+++ b/tests/browser/fixtures/playlist-select.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>naturo fixture: playlist-select</title>
+  <style>
+    body { margin: 0; font-family: sans-serif; }
+    .playlist-select { padding: 12px; cursor: pointer; background: #eee; }
+    /* The dropdown list is hidden until the select control is opened, mirroring
+       the YouTube-publishing "open dropdown, then pick playlists" flow. */
+    #playlist-list { display: none; }
+    #playlist-list.open { display: block; }
+    /* Tall items so the lower ones start well below any default headless
+       viewport, making the per-item scroll-into-view genuinely necessary
+       (not a no-op) to reach and click them. */
+    .playlist-item {
+      height: 400px;
+      box-sizing: border-box;
+      padding: 12px;
+      border-bottom: 1px solid #ccc;
+      cursor: pointer;
+    }
+    .playlist-item[data-selected="true"] { background: #cfe8cf; }
+  </style>
+</head>
+<body>
+  <h1 id="main-heading">Playlist Selection</h1>
+
+  <!-- Exercises the migration guide's "Dropdown / Playlist Selection" section:
+       open a dropdown, then iterate the items and click only those whose text
+       matches a target set (multi-select-by-text), then confirm with Done. The
+       selectors match the guide verbatim (div.playlist-select / div.playlist-item
+       / button.done). -->
+  <div class="playlist-select" id="playlist-select">Choose playlists &#9662;</div>
+  <div id="playlist-list">
+    <div class="playlist-item" data-selected="false">My Playlist 1</div>
+    <div class="playlist-item" data-selected="false">My Playlist 2</div>
+    <div class="playlist-item" data-selected="false">My Playlist 3</div>
+    <div class="playlist-item" data-selected="false">Travel Vlogs</div>
+    <div class="playlist-item" data-selected="false">Cooking Channel</div>
+  </div>
+
+  <button class="done" id="done">Done</button>
+
+  <!-- The authoritative record of what the Done click finalized: a
+       comma-separated, document-order list of the selected playlist names.
+       The test reads this back rather than trusting the click sequence. -->
+  <p id="result" data-result="">Nothing confirmed.</p>
+
+  <script>
+    document.getElementById("playlist-select").addEventListener("click", function () {
+      document.getElementById("playlist-list").classList.add("open");
+    });
+
+    document.getElementById("playlist-list").addEventListener("click", function (event) {
+      var item = event.target.closest(".playlist-item");
+      if (!item) { return; }
+      // Toggle selection so a multi-select loop accumulates each matched item.
+      var selected = item.getAttribute("data-selected") === "true";
+      item.setAttribute("data-selected", selected ? "false" : "true");
+    });
+
+    document.getElementById("done").addEventListener("click", function () {
+      var names = Array.from(document.querySelectorAll('.playlist-item[data-selected="true"]'))
+        .map(function (el) { return el.textContent.trim(); });
+      var result = document.getElementById("result");
+      result.setAttribute("data-result", names.join(","));
+      result.textContent = names.length
+        ? "Confirmed: " + names.join(", ")
+        : "Nothing confirmed.";
+    });
+  </script>
+</body>
+</html>

--- a/tests/browser/test_migration_equivalence.py
+++ b/tests/browser/test_migration_equivalence.py
@@ -1034,3 +1034,116 @@ def test_anti_detection_equivalence(
         )
         == "true"
     )
+
+
+def test_dropdown_playlist_selection_equivalence(
+    browser_page: BrowserPage, fixtures_server: str
+) -> None:
+    """Reproduce the DrissionPage dropdown multi-select-by-text flow via naturo.
+
+    Mirrors the migration guide's "Dropdown / Playlist Selection" section -- the
+    YouTube-publishing pattern where a dropdown is opened, then the script
+    iterates the items and clicks only those whose text matches a target set,
+    scrolling each into view first, and finally clicks Done. The *Before*
+    DrissionPage code is::
+
+        element = self.page.ele(self.elements['播放选择'])
+        element.scroll.to_center(); element.hover().click()
+        for element in self.page.eles(self.elements['播放列表']):
+            element.scroll.to_see()
+            if element.text in target_playlists:
+                element.click()
+        self.page.ele(self.elements['完成']).click()
+
+    The *After* surface is :meth:`BrowserPage.scroll_to_element` (selector form)
+    to reach the trigger, :meth:`BrowserElement.hover` + :meth:`BrowserElement.click`
+    to open it, then per item :meth:`BrowserElement.scroll_into_view` +
+    ``element.text`` + :meth:`BrowserElement.click`, then a final ``find().click()``.
+
+    Driven against ``playlist-select.html`` -- a closed dropdown whose five tall
+    items run well below the viewport fold -- this row proves the distinct part of
+    the pattern not covered by the hover/Tab rows: a **multi-select-by-text loop**
+    over off-screen items. Per naturo's never-lie contract (SOUL.md) the outcome is
+    read back from the page's authoritative ``Done``-finalized record rather than
+    trusting the click sequence, and three legs are checked:
+
+    * **Exactness:** only the items whose ``text`` is in the target set end up
+      selected -- in document order -- and non-matching items stay unselected (the
+      negative leg: a loop that clicked indiscriminately, or matched on the wrong
+      field, would select the wrong set).
+    * **Scroll is real, not a no-op:** the lowest target sits far below the fold,
+      so the per-item ``scroll_into_view`` must actually move the viewport
+      (``window.scrollY`` advances from 0) for the item to be reached.
+    * **Doc-fix guard:** :meth:`BrowserPage.scroll_to_element` takes a *selector
+      string*, not an element. The guide previously showed
+      ``page.scroll_to_element(item)`` (passing the in-hand element), which raises;
+      the element's own :meth:`~BrowserElement.scroll_into_view` is the correct
+      API and is what this row -- and the corrected guide -- uses.
+    """
+    target_playlists = ["My Playlist 1", "Cooking Channel"]
+    browser_page.navigate(f"{fixtures_server}/playlist-select.html")
+
+    # never-lie precondition: the dropdown starts closed (its list is hidden), so
+    # the open step below is genuinely required to reach the items.
+    assert (
+        browser_page.evaluate(
+            "getComputedStyle(document.getElementById('playlist-list')).display"
+        )
+        == "none"
+    )
+
+    # Before: element.scroll.to_center(); element.hover().click()  ->  After:
+    # scroll_to_element(selector) reaches the trigger, then hover()+click() open it.
+    browser_page.scroll_to_element("xpath://div[@class='playlist-select']")
+    browser_page.find("xpath://div[@class='playlist-select']").hover()
+    browser_page.find("xpath://div[@class='playlist-select']").click()
+    browser_page.wait_for_function(
+        "getComputedStyle(document.getElementById('playlist-list')).display === 'block'",
+        timeout=3.0,
+    )
+
+    # The dropdown items are all enumerable and carry their playlist names in
+    # document order (the `self.page.eles(...)` the Before loop walks).
+    items = browser_page.find_all("xpath://div[@class='playlist-item']")
+    assert [item.text for item in items] == [
+        "My Playlist 1",
+        "My Playlist 2",
+        "My Playlist 3",
+        "Travel Vlogs",
+        "Cooking Channel",
+    ]
+
+    # Doc-fix guard: scroll_to_element wants a selector string. Passing the in-hand
+    # element (the guide's old `page.scroll_to_element(item)`) raises; the element's
+    # own scroll_into_view() is the correct API the loop below uses.
+    with pytest.raises((AttributeError, TypeError)):
+        browser_page.scroll_to_element(items[0])  # type: ignore[arg-type]
+
+    # The page is still scrolled to the top before the select loop runs.
+    assert int(browser_page.evaluate("window.scrollY")) == 0
+
+    # Before: for element in eles(...): element.scroll.to_see(); if text in targets:
+    # element.click()  ->  After: per item scroll_into_view() + text match + click().
+    for item in items:
+        item.scroll_into_view()
+        if item.text in target_playlists:
+            item.click()
+
+    # Scroll is real, not a no-op: the lowest target ("Cooking Channel") sits far
+    # below the fold, so scroll_into_view must have moved the viewport to reach it.
+    assert int(browser_page.evaluate("window.scrollY")) > 0
+
+    # Before: self.page.ele('完成').click()  ->  After: find("button.done").click().
+    browser_page.find("xpath://button[@class='done']").click()
+
+    # never-lie: read the authoritative selection the Done handler finalized rather
+    # than trusting the clicks. Exactly the target set, in document order, is
+    # selected -- and nothing else.
+    assert (
+        browser_page.find("#result").attr("data-result")
+        == "My Playlist 1,Cooking Channel"
+    )
+    # Negative leg: every non-target item is still unselected.
+    for item in items:
+        expected = "true" if item.text in target_playlists else "false"
+        assert item.attr("data-selected") == expected


### PR DESCRIPTION
## What
The migration guide's **Dropdown / Playlist Selection** SDK example showed:

```python
for item in page.find_all("xpath://div[@class='playlist-item']"):
    page.scroll_to_element(item)   # <- passes an element
```

But `BrowserPage.scroll_to_element` takes a **selector string** (it calls `self.find(selector)` → `parse_selector(selector).strip()`), so passing an in-hand element raises `AttributeError`. A user copying the guide gets a crash — a never-lie / doc-credibility defect (SOUL.md), same class as the prior migration-guide doc corrections (#1082 / #1088 / #1098).

The element's own `scroll_into_view()` is the correct API. This PR:
- corrects the example to `item.scroll_into_view()`;
- clarifies the API-mapping row (`ele.scroll.to_see()` → `page.scroll_to_element(sel)` **or** `element.scroll_into_view()`) so the element form is documented and the bug isn't reintroduced;
- pins the dropdown **multi-select-by-text** flow (the part not covered by the existing hover / tab rows) with a new equivalence row + offline fixture.

No public API added or changed — `scroll_into_view()` is already a shipped `BrowserElement` method; this only fixes docs + adds a test.

## How tested
- `tests/browser/fixtures/playlist-select.html` — a closed dropdown whose five tall items run below the viewport fold.
- New `test_dropdown_playlist_selection_equivalence` (real headless Chrome, `@pytest.mark.desktop`) proves three legs:
  - **exactness** — only items whose `text` is in the target set are selected, in document order; non-matching items stay unselected (read back from the authoritative `Done`-finalized record, not the click sequence);
  - **scroll is real** — the lowest target sits far below the fold, so `scroll_into_view` must advance `window.scrollY` from 0 to reach it;
  - **doc-fix guard** — `page.scroll_to_element(element)` raises while `element.scroll_into_view()` works, so the broken form can't silently return to the guide.
- Gate: `ruff check` PASS; `mypy naturo/` n/a (no `naturo/` source delta — test + fixture + docs only); `pytest tests/browser/test_migration_equivalence.py` → **16 passed** (15 prior + new, real headless Chrome); `--collect-only -m "not desktop"` clean (CI parity).