### PR TITLE
docs: fix migration guide browser timeouts from milliseconds to seconds (fixes #1115)

### DIFF
--- a/docs/MIGRATION_FROM_RPA_SCRIPTS.md
+++ b/docs/MIGRATION_FROM_RPA_SCRIPTS.md
@@ -369,9 +369,9 @@ if page.ele(self.ele_dict["输入查询结果"]):
 naturo browser click "xpath://div[@class='tab-review']"
 naturo browser click "xpath://div[@class='store-selector']"
 naturo browser type "xpath://input[@class='store-search']" "My Store Name" --clear-first
-naturo browser wait "xpath://div[@class='search-result']" --state visible --timeout 5000
+naturo browser wait "xpath://div[@class='search-result']" --state visible --timeout 5
 naturo browser click "xpath://div[@class='search-result']"
-naturo browser wait "xpath://div[@class='loading-spinner']" --state hidden --timeout 30000
+naturo browser wait "xpath://div[@class='loading-spinner']" --state hidden --timeout 30
 naturo browser click "xpath://button[@class='confirm-match']"
 naturo browser text "xpath://span[@class='store-score']"
 ```
@@ -380,9 +380,9 @@ naturo browser text "xpath://span[@class='store-score']"
 page.find("xpath://div[@class='tab-review']").click()
 page.find("xpath://div[@class='store-selector']").click()
 page.find("xpath://input[@class='store-search']").type("My Store Name", clear_first=True)
-page.wait_for("xpath://div[@class='search-result']", state="visible", timeout=5000)
+page.wait_for("xpath://div[@class='search-result']", state="visible", timeout=5)
 page.find("xpath://div[@class='search-result']").click()
-page.wait_for("xpath://div[@class='loading-spinner']", state="hidden", timeout=30000)
+page.wait_for("xpath://div[@class='loading-spinner']", state="hidden", timeout=30)
 page.find("xpath://button[@class='confirm-match']").click()
 score = page.find("xpath://span[@class='store-score']").text
 ```
@@ -509,9 +509,9 @@ naturo browser wait-network-idle                            # No network activit
 naturo browser wait-network-idle --idle-time 1.0            # Custom idle threshold (seconds)
 
 # Element state
-naturo browser wait ".results" --timeout 10000               # Element exists in DOM
-naturo browser wait ".results" --state visible --timeout 10000  # Element is visible
-naturo browser wait ".spinner" --state hidden --timeout 30000   # Spinner gone
+naturo browser wait ".results" --timeout 10               # Element exists in DOM
+naturo browser wait ".results" --state visible --timeout 10  # Element is visible
+naturo browser wait ".spinner" --state hidden --timeout 30   # Spinner gone
 naturo browser wait ".old-item" --state detached              # Element removed from DOM
 
 # Navigation
@@ -525,8 +525,8 @@ naturo browser wait-function "window.dataLoaded === true" --timeout 5
 ```python
 page.wait_for_load()
 page.wait_for_network_idle(idle_time=0.5)
-page.wait_for(".results", state="visible", timeout=10000)
-page.wait_for(".spinner", state="hidden", timeout=30000)
+page.wait_for(".results", state="visible", timeout=10)
+page.wait_for(".spinner", state="hidden", timeout=30)
 page.wait_for_url("success")
 page.wait_for_function("window.dataLoaded === true")
 ```
@@ -717,7 +717,7 @@ naturo browser click "xpath://input[@class='file-select']"
 naturo dialog type "/path/to/video.mp4"
 naturo dialog accept
 # Wait for upload to complete
-naturo browser wait ".upload-progress-done" --state visible --timeout 60000
+naturo browser wait ".upload-progress-done" --state visible --timeout 60
 
 # Thumbnail upload — scroll to element first
 naturo browser scroll --to-element "xpath://div[@class='thumbnail-upload']"
@@ -1072,9 +1072,9 @@ naturo browser wait-network-idle
 
 naturo browser click "xpath://div[@class='tab-review']"
 naturo browser type "xpath://input[@class='store-search']" "My Store Name" --clear-first
-naturo browser wait "xpath://div[@class='search-result']" --state visible --timeout 5000
+naturo browser wait "xpath://div[@class='search-result']" --state visible --timeout 5
 naturo browser click "xpath://div[@class='search-result']"
-naturo browser wait "xpath://div[@class='loading-spinner']" --state hidden --timeout 30000
+naturo browser wait "xpath://div[@class='loading-spinner']" --state hidden --timeout 30
 SCORE=$(naturo browser text "xpath://span[@class='store-score']")
 
 # === Part 2: Post to WeChat Video Channel (desktop) ===
@@ -1264,7 +1264,7 @@ naturo drag \
   --release-delay 80
 
 # Step 4: Verify success
-naturo browser wait ".captcha-success" --timeout 3000
+naturo browser wait ".captcha-success" --timeout 3
 ```
 
 What `--trajectory bezier --jitter 2 --overshoot 12` does internally:
@@ -1860,7 +1860,7 @@ for _ in range(80):
 results = []
 for note in notes:
     page.navigate(note["link"])
-    page.wait_for(selectors["publish_date"], timeout=10000)
+    page.wait_for(selectors["publish_date"], timeout=10)
     info = {"type": note["type"]}
     info["author"] = page.find(selectors["author"]).text
     info["user_id"] = page.find(selectors["user_id"]).text.split("：")[-1]
@@ -1945,7 +1945,7 @@ for try_i in range(300):
 **After**:
 ```bash
 # Wait for element with proper timeout (no polling loop needed)
-naturo browser wait "#my-element" --timeout 10000
+naturo browser wait "#my-element" --timeout 10
 
 # Check if element is in an iframe
 naturo browser frames

--- a/tests/test_migration_guide_timeout_units_doc_1115.py
+++ b/tests/test_migration_guide_timeout_units_doc_1115.py
@@ -1,0 +1,148 @@
+"""Never-lie guard for the migration guide's browser *timeout unit* (#1115).
+
+``docs/MIGRATION_FROM_RPA_SCRIPTS.md`` passed naturo browser timeouts in
+**milliseconds** (e.g. ``--timeout 10000``, ``timeout=30000``), but every
+shipped naturo browser timeout is in **seconds**:
+
+* CLI -- ``naturo browser wait`` / ``wait-navigation`` / ``wait-url`` /
+  ``wait-function`` / ``wait-network-idle`` all declare ``--timeout`` as
+  ``type=float, default=30.0, help="Timeout in seconds"``
+  (``naturo/cli/_browser/waits.py``).
+* SDK -- ``BrowserPage.wait_for`` / ``wait_for_url`` / ``wait_for_function`` /
+  ``wait_for_network_idle`` / ``wait_for_download`` all document ``timeout`` as
+  "Max wait time in **seconds**" (``naturo/browser/_page.py``).
+
+So a user copying ``naturo browser wait ".results" --timeout 10000`` would wait
+**10000 seconds (~2.8h)**, not 10s -- the example does not do what it appears to
+(SOUL.md "Never Lie"). Same never-lie doc class as the wait-surface gap #1112,
+the cookie/JS-click gap #1106, the network gap #1088, and the iframe gap #1082.
+
+Unlike #1106 (caveat-not-prune, because shipping those APIs is Ace's call), this
+is a pure doc error: the unit is already *seconds* in shipped code, so the
+resolution is to *fix the guide to match shipped reality* (ms -> s). This module
+pins that contract from both directions:
+
+* It derives the *real* unit at runtime -- the ``browser wait`` ``--timeout``
+  help string and the ``BrowserPage`` wait-method docstrings -- and asserts the
+  shipped surface declares *seconds*. If the unit ever drifts to milliseconds,
+  these assertions fire so the guide is revisited.
+* It scans the guide and asserts no naturo ``--timeout``/``timeout=`` literal is
+  an implausibly large value (>= 1000). Every legitimate naturo example waits a
+  handful of seconds (<= 60); the only ">= 1000" values were the ms bug. The
+  Selenium / DrissionPage "Before" snippets legitimately use ``timeout=`` too,
+  but always with small values (``timeout=0.5`` / ``10`` / ``30``), so the
+  >= 1000 threshold matches only the naturo ms regressions and never the
+  "Before" tool's own seconds-based calls.
+
+The tests read only the on-disk Markdown and import pure Python metadata, so
+they need no browser/desktop and run on every CI lane.
+
+Relates to #1115. Sibling never-lie doc guard to #1082 / #1088 / #1106 / #1112
+and the #766 equivalence suite (``test_wait_state_equivalence``).
+"""
+from __future__ import annotations
+
+import inspect
+import re
+from pathlib import Path
+
+from naturo.browser import BrowserPage
+from naturo.cli import main
+
+_GUIDE_PATH = (
+    Path(__file__).resolve().parents[1] / "docs" / "MIGRATION_FROM_RPA_SCRIPTS.md"
+)
+
+# Any naturo timeout literal >= this value (in the guide's nominal "seconds"
+# unit) is an implausible wait (~17 min .. hours) and is therefore a leftover
+# millisecond value. Every faithful naturo example waits <= 60 s; the "Before"
+# tool snippets use <= 30 s. So this threshold separates the ms bug from every
+# legitimate timeout without touching the "Before" snippets.
+_IMPLAUSIBLE_TIMEOUT_SECONDS = 1000
+
+# CLI form ``--timeout <N>`` (naturo only -- the "Before" snippets are Python,
+# never CLI) and SDK keyword form ``timeout=<N>`` (both tools), each capturing
+# the leading integer part of the numeric literal.
+_TIMEOUT_LITERALS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"--timeout\s+(\d+)"),
+    re.compile(r"\btimeout=(\d+)"),
+)
+
+
+def _guide_text() -> str:
+    """Return the full migration-guide Markdown as text."""
+    return _GUIDE_PATH.read_text(encoding="utf-8")
+
+
+def _wait_timeout_help() -> str:
+    """Return the ``--timeout`` help string on ``naturo browser wait``."""
+    wait_command = main.commands["browser"].commands["wait"]  # type: ignore[attr-defined]
+    for param in wait_command.params:
+        if "--timeout" in getattr(param, "opts", []):
+            return param.help or ""
+    raise AssertionError(
+        "`naturo browser wait` no longer exposes a --timeout option — the "
+        "migration guide documents it."
+    )
+
+
+def test_real_timeout_unit_is_seconds_cli() -> None:
+    """The shipped ``browser wait --timeout`` declares *seconds*, as the guide claims.
+
+    If the CLI ever re-defined ``--timeout`` in milliseconds, this fires so the
+    guide's timeout values are revisited rather than silently lying again.
+    """
+    help_text = _wait_timeout_help().lower()
+    assert "second" in help_text, (
+        "`naturo browser wait --timeout` help no longer says 'seconds' "
+        f"(got: {help_text!r}) — the migration guide passes its timeouts in "
+        "seconds; revisit the guide if the unit changed."
+    )
+    assert "millisecond" not in help_text and " ms" not in help_text, (
+        "`naturo browser wait --timeout` now documents milliseconds — the "
+        "migration guide uses seconds; revisit the guide and this guard."
+    )
+
+
+def test_real_timeout_unit_is_seconds_sdk() -> None:
+    """The shipped ``BrowserPage`` wait methods document ``timeout`` in *seconds*."""
+    for method_name in (
+        "wait_for",
+        "wait_for_url",
+        "wait_for_function",
+        "wait_for_network_idle",
+    ):
+        method = getattr(BrowserPage, method_name, None)
+        assert method is not None, (
+            f"BrowserPage.{method_name} vanished — the migration guide documents it."
+        )
+        doc = (inspect.getdoc(method) or "").lower()
+        assert "second" in doc, (
+            f"BrowserPage.{method_name} docstring no longer documents its timeout "
+            "in seconds — the migration guide assumes seconds; revisit both."
+        )
+
+
+def test_guide_has_no_millisecond_timeout_literals() -> None:
+    """The migration guide never passes a naturo timeout as a millisecond value.
+
+    Every faithful row is proven end-to-end by
+    ``tests/browser/test_migration_equivalence.py``; this guard ensures the
+    guide's prose can never reintroduce a millisecond timeout that the shipped
+    seconds-based API would silently misinterpret as a multi-hour wait.
+    """
+    text = _guide_text()
+    offending = sorted(
+        {
+            int(match)
+            for pattern in _TIMEOUT_LITERALS
+            for match in pattern.findall(text)
+            if int(match) >= _IMPLAUSIBLE_TIMEOUT_SECONDS
+        }
+    )
+    assert not offending, (
+        "MIGRATION_FROM_RPA_SCRIPTS.md passes naturo timeout(s) as millisecond "
+        f"values {offending} — every shipped naturo browser timeout is in "
+        "seconds, so these would wait thousands of seconds. Convert them to "
+        "seconds (10000 -> 10, 30000 -> 30, 60000 -> 60, etc.)."
+    )


### PR DESCRIPTION
## What
Fix `docs/MIGRATION_FROM_RPA_SCRIPTS.md`, which passed naturo browser timeouts in **milliseconds** (`--timeout 10000`/`5000`/`30000`/`60000`, `timeout=10000`) while every shipped naturo browser timeout is in **seconds**. A user copying `naturo browser wait ".results" --timeout 10000` would wait ~2.8 hours, not 10 s — a never-lie doc gap (SOUL.md), same class as #1082 / #1088 / #1106 / #1112.

Verified the real unit in code:
- CLI `naturo/cli/_browser/waits.py`: every `--timeout` is `type=float, default=30.0, help="Timeout in seconds"`.
- SDK `naturo/browser/_page.py`: wait methods document `timeout` as "Max wait time in seconds" and compute `deadline = time.monotonic() + timeout`.

## Change (docs + test only — no public API/CLI change)
- Sweep every naturo CLI/SDK timeout literal ms → s (10000→10, 5000→5, 30000→30, 60000→60). Selenium/DrissionPage **Before** snippets left untouched.
- Add `tests/test_migration_guide_timeout_units_doc_1115.py`, a guard that:
  1. Derives the real unit at runtime from the `browser wait --timeout` help and `BrowserPage` wait-method docstrings, asserting **seconds** (so a future drift to ms reopens the guide).
  2. Scans the guide for implausibly large (≥ 1000) naturo `--timeout`/`timeout=` literals, so the ms bug cannot recur. The ≥ 1000 threshold matches only the ms regressions, never the small-valued Before snippets.

## How tested
- `ruff check naturo/` and the test file → All checks passed.
- `mypy` on the new test → Success, no issues.
- `pytest tests/test_migration_guide_timeout_units_doc_1115.py` → 3 passed.
- `--collect-only` clean (CI-safe; reads on-disk Markdown + pure Python metadata, no browser/desktop).
- Verified no remaining `timeout >= 1000` literals anywhere in the guide.

Fixes #1115.
