### PR TITLE
fix: raise instead of clicking (0,0) on zero-area browser elements (fixes #1083)

### DIFF
--- a/naturo/browser/_element.py
+++ b/naturo/browser/_element.py
@@ -381,17 +381,19 @@ class BrowserElement:
         spot in the top document (#1080).
 
         Falls back to ``getBoundingClientRect`` only when the node exposes no
-        content quad (e.g. an unrendered or zero-area box) — that path is
-        already correct for top-level elements and is the best available
-        estimate when no layout box exists.
+        content quad — that path is already correct for a genuinely top-level
+        element that still has a non-zero box. When the fallback rect is itself
+        zero-area (an unrendered ``display:none`` / detached node, which reports
+        an all-zeros rect), this returns ``None`` rather than the misleading
+        viewport origin ``(0, 0)`` so callers fail loudly (never-lie, #1083).
 
         Args:
             offset_x: X offset from top-left (0 = center).
             offset_y: Y offset from top-left (0 = center).
 
         Returns:
-            (x, y) top-document coordinates, or None if no box model is
-            available at all.
+            (x, y) top-document coordinates, or None when no usable box model is
+            available (no content quad and no non-zero bounding box).
         """
         self.scroll_into_view()
 
@@ -416,6 +418,18 @@ class BrowserElement:
             "}"
         )
         if not box or not isinstance(box, dict):
+            return None
+
+        # A node with no content quad AND a zero-area bounding box is not
+        # rendered (display:none, detached, visibility:collapse). For such a
+        # node getBoundingClientRect reports an all-zeros rect, so computing a
+        # point here would dispatch the click at the top-document origin (0, 0)
+        # and silently hit whatever sits in the viewport's top-left corner while
+        # reporting success — a never-lie violation (#1083). Treat it as "no box
+        # model": return None so click()/hover() raise loudly instead. A
+        # genuinely top-level element with a non-zero box but no quad still
+        # falls through to a real point below.
+        if box["width"] == 0 and box["height"] == 0:
             return None
 
         if offset_x == 0 and offset_y == 0:

--- a/tests/test_browser_element.py
+++ b/tests/test_browser_element.py
@@ -205,6 +205,26 @@ class TestBrowserElementClick:
         with pytest.raises(RuntimeError, match="Cannot determine element position"):
             el.click()
 
+    def test_click_raises_on_zero_area_box_never_dispatches(self):
+        # display:none / detached / zero-area element: no content quad, and
+        # getBoundingClientRect reports an all-zeros rect. click() must raise
+        # rather than silently dispatch at the (0, 0) viewport origin (#1083).
+        el, page, cdp = _make_element()
+        cdp.send.side_effect = [
+            {"result": {"value": None}},  # scrollIntoView
+            {"quads": []},  # getContentQuads: no quad
+            {"result": {"value": {"x": 0, "y": 0, "width": 0, "height": 0}}},
+        ]
+
+        with pytest.raises(RuntimeError, match="Cannot determine element position"):
+            el.click()
+
+        mouse_calls = [
+            c for c in cdp.send.call_args_list
+            if c[0][0] == "Input.dispatchMouseEvent"
+        ]
+        assert mouse_calls == []  # never dispatched at (0, 0)
+
 
 # ═════════════════════════════════════════════════════════════════════════════
 # Hover
@@ -245,6 +265,25 @@ class TestBrowserElementHover:
 
         with pytest.raises(RuntimeError, match="Cannot determine element position"):
             el.hover()
+
+    def test_hover_raises_on_zero_area_box_never_dispatches(self):
+        # Mirror of the click guard (#1083): a zero-area / unrendered element
+        # must make hover() raise rather than move the mouse to (0, 0).
+        el, page, cdp = _make_element()
+        cdp.send.side_effect = [
+            {"result": {"value": None}},  # scrollIntoView
+            {"quads": []},  # getContentQuads: no quad
+            {"result": {"value": {"x": 0, "y": 0, "width": 0, "height": 0}}},
+        ]
+
+        with pytest.raises(RuntimeError, match="Cannot determine element position"):
+            el.hover()
+
+        mouse_calls = [
+            c for c in cdp.send.call_args_list
+            if c[0][0] == "Input.dispatchMouseEvent"
+        ]
+        assert mouse_calls == []
 
 
 # ═════════════════════════════════════════════════════════════════════════════
@@ -443,6 +482,18 @@ class TestGetClickPoint:
             {"result": {"value": None}},  # scrollIntoView
             {"quads": []},  # no quad
             {"result": {"value": "not-a-dict"}},
+        ]
+        assert el._get_click_point() is None
+
+    def test_returns_none_on_zero_area_box(self):
+        # #1083: an unrendered element yields no quad and an all-zeros rect.
+        # _get_click_point must return None (not the origin (0, 0)) so the
+        # click/hover guards raise instead of dispatching at the wrong spot.
+        el, page, cdp = _make_element()
+        cdp.send.side_effect = [
+            {"result": {"value": None}},  # scrollIntoView
+            {"quads": []},  # no quad
+            {"result": {"value": {"x": 0, "y": 0, "width": 0, "height": 0}}},
         ]
         assert el._get_click_point() is None
 


### PR DESCRIPTION
## What
`BrowserElement.click()` / `hover()` resolve a click point via `_get_click_point()`. For an element with no content quad (`display:none`, detached, zero-area), the `getBoundingClientRect` fallback returns an all-zeros rect, so the method computed `(0, 0)` and silently dispatched `Input.dispatchMouseEvent` at the top-document origin — hitting whatever sits in the viewport's top-left corner and **reporting success**. This is a never-lie violation (SOUL.md) on the headline browser-click surface: a script targeting a hidden element gets a confidently-wrong success and debugs the wrong subsystem.

## How
In the `getBoundingClientRect` fallback (`naturo/browser/_element.py`), treat a zero-area box (`width == 0 and height == 0`) as 'no box model' and return `None`, so the existing `click()`/`hover()` `is None` guards raise loudly (`RuntimeError: Cannot determine element position`). A genuinely top-level element with a **non-zero** box but no quad still resolves to a real point — no regression to the #1080 iframe-coordinate fix. Updated the `_get_click_point` docstring to match.

## How tested
Hermetic, CDP-mocked unit tests (no Chrome needed, CI-collectable):
- `test_click_raises_on_zero_area_box_never_dispatches` — `click()` raises and **never** dispatches a mouse event for an all-zeros rect.
- `test_hover_raises_on_zero_area_box_never_dispatches` — same guard for `hover()`.
- `test_returns_none_on_zero_area_box` — `_get_click_point()` returns `None`.

Verified all three **fail** on pre-fix code (return `(0.0, 0.0)`) and pass after. `tests/test_browser_element.py`: 36 passed. `ruff` clean; broader browser unit suite green (pre-existing, environment-only `tmp_path` PermissionErrors in screenshot tests are unrelated — they fail identically on pristine develop).