### PR TITLE
fix: attach standard error block to wait predicate-timeout -j output (fixes #1089)

### DIFF
--- a/naturo/cli/error_helpers.py
+++ b/naturo/cli/error_helpers.py
@@ -304,6 +304,70 @@ _RECOVERY_HINTS: dict[str, tuple[str, bool]] = {
 }
 
 
+def build_error_object(
+    code: str,
+    message: str,
+    *,
+    category: Optional[str] = None,
+    context: Optional[dict[str, Any]] = None,
+    suggested_action: Optional[str] = None,
+    recoverable: Optional[bool] = None,
+    extra: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
+    """Build the canonical six-key ``error`` object (without the envelope wrapper).
+
+    This is the single source of truth for the *shape* of the ``error`` member —
+    ``code``, ``message``, ``category``, ``context``, ``suggested_action`` and
+    ``recoverable``, in that order, identical to
+    :meth:`naturo.errors.NaturoError.to_dict` (#884). :func:`json_error` wraps the
+    result in the ``{"success": False, "error": ...}`` envelope, but a command that
+    has *already* built a partial result dict and needs to merge in a standard
+    error block — without raising through ``json_error`` — calls this directly. For
+    example ``wait`` reports a predicate **timeout** as ``success:false`` without
+    raising, so it attaches the block to its existing ``mode``/``wait_time`` payload
+    rather than discarding those keys (issue #1089).
+
+    If ``category``, ``suggested_action`` or ``recoverable`` are not provided, they
+    are resolved from the error code: the category from
+    :func:`naturo.errors.category_for_code`, and the recovery hint/recoverability
+    from the local registry.
+
+    Args:
+        code: Error code string (e.g., 'INVALID_INPUT', 'TIMEOUT').
+        message: Human-readable error message.
+        category: Error class (environment/validation/automation/...). Resolved
+            from the code when None, defaulting to 'unknown'.
+        context: Structured detail for the error. Defaults to an empty dict.
+        suggested_action: Recovery hint for AI agents (auto-populated if None;
+            may remain ``null`` when the code has no registered hint).
+        recoverable: Whether retrying might help (auto-populated if None).
+        extra: Additional key-value pairs to merge into the error object on top of
+            the canonical keys.
+
+    Returns:
+        The ``error`` object as a dict, ready to embed in a JSON response.
+    """
+    # Look up defaults from registry
+    hint_action, hint_recoverable = _RECOVERY_HINTS.get(code, (None, False))
+
+    action = suggested_action if suggested_action is not None else hint_action
+    is_recoverable = recoverable if recoverable is not None else hint_recoverable
+
+    error: dict[str, Any] = {
+        "code": code,
+        "message": message,
+        "category": category if category is not None else category_for_code(code),
+        "context": context if context is not None else {},
+        "suggested_action": action,
+        "recoverable": bool(is_recoverable),
+    }
+
+    if extra:
+        error.update(extra)
+
+    return error
+
+
 def json_error(
     code: str,
     message: str,
@@ -345,24 +409,15 @@ def json_error(
     Returns:
         JSON string ready for click.echo().
     """
-    # Look up defaults from registry
-    hint_action, hint_recoverable = _RECOVERY_HINTS.get(code, (None, False))
-
-    action = suggested_action if suggested_action is not None else hint_action
-    is_recoverable = recoverable if recoverable is not None else hint_recoverable
-
-    error: dict[str, Any] = {
-        "code": code,
-        "message": message,
-        "category": category if category is not None else category_for_code(code),
-        "context": context if context is not None else {},
-        "suggested_action": action,
-        "recoverable": bool(is_recoverable),
-    }
-
-    if extra:
-        error.update(extra)
-
+    error = build_error_object(
+        code,
+        message,
+        category=category,
+        context=context,
+        suggested_action=suggested_action,
+        recoverable=recoverable,
+        extra=extra,
+    )
     return json_dumps({"success": False, "error": error})
 
 

--- a/naturo/cli/wait_cmd.py
+++ b/naturo/cli/wait_cmd.py
@@ -2,7 +2,7 @@
 from naturo.cli._jsonio import json_dumps
 import time
 
-from naturo.cli.error_helpers import json_error as _json_error_str
+from naturo.cli.error_helpers import build_error_object, json_error as _json_error_str
 from naturo.cli.options import app_id_option, resolve_app_id_to_hwnd
 import sys
 import click
@@ -189,6 +189,21 @@ def wait(ctx, duration, element, window_title, gone, timeout, interval,
                 "width": result.element.width,
                 "height": result.element.height,
             }
+        if not result.found:
+            # (#1089) A predicate timeout reports success:false *without* raising,
+            # so it never reaches the ``_json_error_str`` path every other failure
+            # uses. Attach the standard error block here — alongside, not in place
+            # of, the #895 canonical success-shape keys — so a ``-j`` agent gets
+            # the same code/category/message/recovery contract on the most common
+            # ``wait`` failure (target never appears) as on validation failures.
+            # ``TIMEOUT`` (category automation, recoverable) is the operation-level
+            # outcome for every appear/disappear mode; the message mirrors the
+            # human path's ``Error: Timeout after ...`` text.
+            target = element or gone or window_title
+            output["error"] = build_error_object(
+                "TIMEOUT",
+                f"Timeout after {result.wait_time:.1f}s waiting for '{target}'",
+            )
         click.echo(json_dumps(output, indent=2))
         if not result.found:
             sys.exit(1)

--- a/tests/test_error_envelope_contract_1001.py
+++ b/tests/test_error_envelope_contract_1001.py
@@ -280,6 +280,50 @@ def test_interaction_action_error_keeps_semantic_identity(argv, action_method, m
     assert error["suggested_action"], f"{' '.join(argv)} dropped the recovery hint"
 
 
+@pytest.mark.parametrize(
+    "argv,wait_fn",
+    [
+        (["wait", "--element", "Button:ZZZabsent", "--app", "Notepad", "--timeout", "1"],
+         "wait_for_element"),
+        (["wait", "--window", "ZZZabsentWindow", "--timeout", "1"], "wait_for_window"),
+        (["wait", "--gone", "Dialog:ZZZpresent", "--timeout", "1"], "wait_until_gone"),
+    ],
+    ids=["element", "window", "gone"],
+)
+def test_wait_timeout_success_false_is_canonical(argv, wait_fn, monkeypatch) -> None:
+    """A ``wait`` predicate *timeout* surfaces the canonical error envelope (#1089).
+
+    ``wait`` returns ``success:false`` on timeout **without raising**, so the
+    failure slips past the fast-fail ``json_error`` path that layers 1–2 above
+    enumerate (#895 fixed the success shape; this leg pins the failure shape).
+    The wait backend and the desktop pre-flight gate are stubbed so the timeout
+    is driven deterministically with no desktop and no DLL — the timeout path is
+    asserted to attach the same six canonical keys every other failure carries,
+    keeping the #895 ``mode``/``wait_time``/``found``/``warnings`` keys intact.
+    """
+    timeout_result = MagicMock(found=False, wait_time=1.0, warnings=[], element=None)
+    monkeypatch.setattr(f"naturo.wait.{wait_fn}", lambda *a, **k: timeout_result)
+    monkeypatch.setattr(
+        "naturo.cli.core._common._enforce_desktop_session", lambda *a, **k: None
+    )
+
+    result = CliRunner().invoke(main, [*argv, "-j"], catch_exceptions=True)
+
+    assert result.exit_code == 1, result.output
+    payload = json.loads(result.output)
+    # #895 success-shape keys must coexist with the #1089 error block.
+    assert {"success", "mode", "wait_time", "found", "warnings"} <= set(payload)
+    error = _single_error_object(result.output)
+    assert list(error.keys())[:6] == _CANONICAL_KEYS, (
+        f"{' '.join(argv)} -j timeout error drifted from the canonical schema: "
+        f"{list(error.keys())}"
+    )
+    assert error["code"] == "TIMEOUT"
+    assert error["category"] == "automation"
+    assert error["recoverable"] is True
+    assert error["suggested_action"]
+
+
 def test_json_err_preserves_naturoerror_but_falls_back_for_plain_exception(capsys) -> None:
     """``_common._json_err`` is the funnel #1004 fixed — pin both of its branches.
 

--- a/tests/test_wait_cmd.py
+++ b/tests/test_wait_cmd.py
@@ -350,6 +350,118 @@ class TestWaitEnvelopeConsistency:
 
 
 # ---------------------------------------------------------------------------
+# Timeout-failure error envelope (#1089)
+# ---------------------------------------------------------------------------
+
+# The six canonical keys, in order, that every ``-j`` error object must carry —
+# identical to naturo.errors.NaturoError.to_dict() and json_error's object (#884).
+_CANONICAL_ERROR_KEYS = [
+    "code", "message", "category", "context", "suggested_action", "recoverable",
+]
+
+
+class TestWaitTimeoutErrorEnvelope:
+    """Predicate-mode timeout (-j) carries the standard ``error`` block (#1089).
+
+    A ``wait`` predicate timeout sets ``success:false`` and exits 1 *without
+    raising*, so it never reaches the ``json_error`` path the rest of the CLI
+    uses. Before #1089 the ``-j`` timeout envelope therefore omitted the ``error``
+    object entirely — every other failing command, and ``wait``'s own validation
+    failures, emit ``{code, message, category, recoverable, ...}``. These tests
+    pin that the timeout path now attaches the canonical block while keeping the
+    #895 success-shape keys intact.
+
+    The desktop pre-flight gate is mocked out so the forced timeout path reflects
+    the *code*, not the runner's desktop state (hermeticity, cf. #1068).
+    """
+
+    @staticmethod
+    def _timeout_result(wait_time: float = 1.0):
+        result = MagicMock()
+        result.found = False
+        result.wait_time = wait_time
+        result.warnings = []
+        result.element = None
+        return result
+
+    @patch("naturo.cli.core._common._enforce_desktop_session", lambda *a, **k: None)
+    @patch("naturo.wait.wait_for_element")
+    def test_element_timeout_attaches_canonical_error(self, mock_wfe, runner):
+        mock_wfe.return_value = self._timeout_result(1.0)
+        result = runner.invoke(
+            wait, ["--element", "Button:ZZZNoExist", "--app", "Notepad",
+                   "--timeout", "1", "--json"],
+        )
+        assert result.exit_code == 1
+        data = json.loads(result.output)
+        # #895 success-shape keys stay intact.
+        assert set(data) >= CANONICAL_WAIT_KEYS
+        assert data["success"] is False
+        assert data["found"] is False
+        assert data["mode"] == "element"
+        # #1089 error block: canonical six keys, in order, with resolved taxonomy.
+        error = data["error"]
+        assert list(error.keys()) == _CANONICAL_ERROR_KEYS
+        assert error["code"] == "TIMEOUT"
+        assert error["category"] == "automation"
+        assert error["recoverable"] is True
+        assert error["suggested_action"]
+        assert "Button:ZZZNoExist" in error["message"]
+        assert "1.0s" in error["message"]
+
+    @patch("naturo.cli.core._common._enforce_desktop_session", lambda *a, **k: None)
+    @patch("naturo.wait.wait_for_window")
+    def test_window_timeout_attaches_canonical_error(self, mock_wfw, runner):
+        mock_wfw.return_value = self._timeout_result(2.0)
+        result = runner.invoke(wait, ["--window", "ZZZNoWindow", "--timeout", "2", "--json"])
+        assert result.exit_code == 1
+        data = json.loads(result.output)
+        assert data["mode"] == "window"
+        error = data["error"]
+        assert list(error.keys()) == _CANONICAL_ERROR_KEYS
+        assert error["code"] == "TIMEOUT"
+        assert error["category"] == "automation"
+        assert "ZZZNoWindow" in error["message"]
+
+    @patch("naturo.cli.core._common._enforce_desktop_session", lambda *a, **k: None)
+    @patch("naturo.wait.wait_until_gone")
+    def test_gone_timeout_attaches_canonical_error(self, mock_wug, runner):
+        mock_wug.return_value = self._timeout_result(1.0)
+        result = runner.invoke(wait, ["--gone", "Dialog:Loading", "--timeout", "1", "--json"])
+        assert result.exit_code == 1
+        data = json.loads(result.output)
+        assert data["mode"] == "gone"
+        error = data["error"]
+        assert list(error.keys()) == _CANONICAL_ERROR_KEYS
+        assert error["code"] == "TIMEOUT"
+        assert "Dialog:Loading" in error["message"]
+
+    @patch("naturo.cli.core._common._enforce_desktop_session", lambda *a, **k: None)
+    @patch("naturo.wait.wait_for_element")
+    def test_found_success_has_no_error_block(self, mock_wfe, runner, mock_wait_result):
+        """The error block is attached only on failure — success stays clean."""
+        mock_wfe.return_value = mock_wait_result
+        result = runner.invoke(wait, ["--element", "Button:Save", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["success"] is True
+        assert "error" not in data
+
+    @patch("naturo.cli.core._common._enforce_desktop_session", lambda *a, **k: None)
+    @patch("naturo.wait.wait_for_element")
+    def test_human_path_timeout_message_matches_error_message(self, mock_wfe, runner):
+        """The -j error message mirrors the human-path ``Error: Timeout ...`` text."""
+        mock_wfe.return_value = self._timeout_result(1.0)
+        human = runner.invoke(wait, ["--element", "Button:ZZZNoExist", "--timeout", "1"])
+        mock_wfe.return_value = self._timeout_result(1.0)
+        js = runner.invoke(wait, ["--element", "Button:ZZZNoExist", "--timeout", "1", "--json"])
+        # Human path: "Error: Timeout after 1.0s waiting for 'Button:ZZZNoExist'"
+        assert "Timeout after 1.0s waiting for 'Button:ZZZNoExist'" in human.output
+        assert json.loads(js.output)["error"]["message"] == \
+            "Timeout after 1.0s waiting for 'Button:ZZZNoExist'"
+
+
+# ---------------------------------------------------------------------------
 # Help
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What
`naturo wait` predicate appear/disappear modes (`--element` / `--window` / `--gone`) set `success:false` and exit 1 on **timeout** but their `-j` envelope omitted the standard `error` block — no `code`, `category`, `message`, or `recovery` hint. The timeout path returns `success:false` *without raising*, so it slipped past the `json_error` fast-fail path that every other failure (and `wait`'s own validation failures) funnel through. On the most common `wait` failure (the target never appears), an agent parsing `-j` got nothing to self-correct on. This is the still-open leg of the error-envelope-consistency family (#884 / #895 / #1001).

## How
- `wait_cmd.py`: on the predicate `not result.found` branch, attach the canonical error block to the existing `-j` output **alongside** the #895 success-shape keys (`mode`/`wait_time`/`found`/`warnings`). Code `TIMEOUT` (registered → category `automation`, `recoverable:true`); message mirrors the human path's `Timeout after Xs waiting for '<target>'`.
- `error_helpers.py`: factor the six-key error-object construction out of `json_error` into a reusable `build_error_object()` so the embedded block is the same single-source-of-truth shape; `json_error` now wraps it (behavior unchanged, pinned by the existing #884/#1001 source-of-truth tests).

## How tested
- New `TestWaitTimeoutErrorEnvelope` (element/window/gone): assert the canonical six keys in order, `code=TIMEOUT`, `category=automation`, `recoverable=true`, message parity with the human path, and that success output stays clean (no `error` key).
- Extended the **#1001 contract test** to drive a wait timeout across all three predicate modes so the success-false path can no longer silently drop the envelope.
- Hermetic: both the wait backend and the desktop pre-flight gate are mocked, so the path reflects code not host (cf. #1068). Desktop-free → runs on every CI lane.
- Gate: `ruff` clean, `mypy` clean, targeted + all `json_error`/envelope/wait suites green (904 passed in isolation). `--collect-only` clean (no Windows/optional-dep import at collection).

Public surface: none — `build_error_object` is an internal CLI helper; no new/changed CLI flag or command. This makes `wait` *conform* to the already-committed universal error contract.