### PR TITLE
fix: capture `type` actions in recordings (fixes #1111)

### DIFF
--- a/naturo/cli/interaction/_type.py
+++ b/naturo/cli/interaction/_type.py
@@ -393,6 +393,26 @@ def type_cmd(text, delay, profile, wpm, press_return, tab_count, escape,
         _common._json_err(str(exc), json_output, exc=exc)
         return
 
+    # (#1111) Capture this action as a recording step so `record play`
+    # reproduces the typing — `_type.py` previously never recorded, so a
+    # `type` performed during an active recording was silently dropped even
+    # though recording.py already replays a "type" step. Mirrors the
+    # `_record_action` calls in _click.py / _mouse.py / _press.py.
+    #
+    # Pasted text (text not None) replays as typed text: the same content
+    # ends up in the target, which preserves the recording's intent. A bare
+    # clipboard paste (text is None) carries no capturable content, so it is
+    # not recorded. Follow-up navigation keys are captured as `press` steps
+    # so a login flow (type → tab → type → return) replays faithfully.
+    if text is not None:
+        _common._record_action("type", {"text": text, "wpm": wpm})
+    if press_return:
+        _common._record_action("press", {"key": "enter", "count": 1})
+    if tab_count:
+        _common._record_action("press", {"key": "tab", "count": tab_count})
+    if escape:
+        _common._record_action("press", {"key": "escape", "count": 1})
+
     action = "pasted" if paste_mode else "typed"
     display_text = text if text is not None else "(clipboard)"
     display_len = len(text) if text is not None else 0

--- a/tests/test_type_recording_1111.py
+++ b/tests/test_type_recording_1111.py
@@ -1,0 +1,114 @@
+"""Regression tests for #1111: `naturo type` must be captured by `record`.
+
+Before the fix, ``naturo/cli/interaction/_type.py`` never called
+``_common._record_action`` on its success path, so a ``type`` performed while
+a recording was active was silently dropped (``step_count`` stayed 0) even
+though ``recording.py`` already replays a ``"type"`` step. A recorded login
+flow's username/password typing was therefore lost on replay.
+
+These tests drive the real recording pipeline (temp recordings dir + an
+active recording) with a mocked backend, then assert the ``type`` step — and
+its follow-up navigation keys — are captured. They are intentionally not
+Windows-only: the typing path is exercised entirely through a mocked backend,
+so the recording-capture contract is verified on every CI platform.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from naturo import recording as rec_mod
+from naturo.recording import Recording, get_active_recording, set_active_recording
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def active_recording(tmp_path):
+    """Point recordings at a temp dir with one active (empty) recording."""
+    with patch.object(rec_mod, "RECORDINGS_DIR", tmp_path):
+        rec = Recording(
+            name="login flow",
+            recording_id="rec_20260401_120000",
+            created_at="2026-04-01T12:00:00",
+        )
+        set_active_recording(rec)
+        yield
+
+
+def _invoke_type(runner, args):
+    """Invoke the type command with a mocked backend and routing."""
+    from naturo.cli.interaction import type_cmd
+
+    mock_backend = MagicMock()
+    mock_backend.clipboard_get.return_value = ""
+    with patch(
+        "naturo.cli.interaction._common._get_backend", return_value=mock_backend
+    ), patch("naturo.cli.interaction._common._auto_route", return_value={}):
+        return runner.invoke(type_cmd, args)
+
+
+def test_type_is_recorded(runner, active_recording):
+    """A `type` during an active recording yields a `type` step (text + wpm)."""
+    result = _invoke_type(runner, ["QA_PROBE", "--wpm", "90", "--json", "--no-verify"])
+    assert result.exit_code == 0, result.output
+
+    rec = get_active_recording()
+    assert rec is not None
+    type_steps = [s for s in rec.steps if s.command == "type"]
+    assert len(type_steps) == 1, f"expected one type step, got {rec.to_dict()}"
+    assert type_steps[0].args["text"] == "QA_PROBE"
+    assert type_steps[0].args["wpm"] == 90
+
+
+def test_pasted_text_is_recorded_as_type(runner, active_recording):
+    """`type "x" --paste` records a replayable `type` step with the text."""
+    result = _invoke_type(runner, ["hello", "--paste", "--json", "--no-verify"])
+    assert result.exit_code == 0, result.output
+
+    rec = get_active_recording()
+    type_steps = [s for s in rec.steps if s.command == "type"]
+    assert len(type_steps) == 1
+    assert type_steps[0].args["text"] == "hello"
+
+
+def test_bare_clipboard_paste_is_not_recorded(runner, active_recording):
+    """`type --paste` with no text has no capturable content → no step."""
+    result = _invoke_type(runner, ["--paste", "--json"])
+    assert result.exit_code == 0, result.output
+
+    rec = get_active_recording()
+    assert rec.steps == []
+
+
+def test_followup_keys_are_recorded(runner, active_recording):
+    """--return/--tab/--escape are captured as press steps after the type."""
+    result = _invoke_type(
+        runner,
+        ["user", "--return", "--tab", "2", "--escape", "--json", "--no-verify"],
+    )
+    assert result.exit_code == 0, result.output
+
+    rec = get_active_recording()
+    captured = [(s.command, s.args) for s in rec.steps]
+    assert captured == [
+        ("type", {"text": "user", "wpm": 120}),
+        ("press", {"key": "enter", "count": 1}),
+        ("press", {"key": "tab", "count": 2}),
+        ("press", {"key": "escape", "count": 1}),
+    ]
+
+
+def test_no_recording_active_is_a_noop(runner, tmp_path):
+    """With no active recording, typing must not error (record is optional)."""
+    with patch.object(rec_mod, "RECORDINGS_DIR", tmp_path):
+        set_active_recording(None)  # ensure clean state
+        result = _invoke_type(runner, ["hello", "--json", "--no-verify"])
+    assert result.exit_code == 0, result.output
+    with patch.object(rec_mod, "RECORDINGS_DIR", tmp_path):
+        assert get_active_recording() is None


### PR DESCRIPTION
## What
`naturo type` actions were **silently dropped** from recordings. While a recording was active, `click`/`move`/`scroll`/`drag`/`press`/`hotkey` were captured but `type` was not — even though `record play` already replays a `type` step. A recorded login flow's username/password typing was lost on replay (the advertised `record start "Login flow"` use case).

**Root cause:** `naturo/cli/interaction/_type.py` never called `_common._record_action(...)` on its success path (unlike its sibling interaction commands).

**Fix:** on the success path, record a `type` step (`text` + `wpm` for timing fidelity), mirroring `_click.py`/`_mouse.py`/`_press.py`. Pasted text replays as typed text; a bare clipboard paste (no text) carries no capturable content so it is not recorded. The `--return`/`--tab`/`--escape` follow-up keys are captured as `press` steps (matching their execution order) so `type -> tab -> type -> return` replays faithfully. These step shapes exactly match `recording.py`'s existing replay handlers (`type`: text+wpm; `press`: key+count).

## How tested
- New `tests/test_type_recording_1111.py` (5 tests) drives the **real** recording pipeline (temp recordings dir + active recording) with a mocked backend — hermetic and cross-platform (not `@desktop`): asserts the `type` step is captured with text+wpm, pasted text records as a replayable `type` step, a bare clipboard paste records nothing, follow-up keys capture as ordered `press` steps, and no-active-recording is a no-op.
- Gate: `ruff` clean; `mypy` clean for the changed file (pre-existing unrelated dep/module errors only); `pytest` 5/5 new + 331 related recording/type tests pass; `--collect-only` clean (CI-style).