### PR TITLE
fix: app window-state --app resolves by process name, not title (fixes #1065)

### DIFF
--- a/naturo/cli/_app/_common.py
+++ b/naturo/cli/_app/_common.py
@@ -92,32 +92,45 @@ def _resolve_window_target(backend, name, window_title=None, hwnd=None, pid=None
     Accepts the unified window-targeting flag set: positional NAME / ``--app``
     (*name*), ``--window`` (*window_title*), ``--hwnd``, and ``--pid``.
 
-    When ``--pid`` is supplied without an explicit ``--hwnd``, the PID is
-    resolved to a concrete window handle through the backend's canonical
-    ``_resolve_hwnd`` resolver — the same path ``see``/``capture``/``click``
-    use — so PID targeting works without a backend method-signature change
-    (#871).  *name*/*window_title* further narrow the PID match when supplied
-    alongside it.  An explicit ``--hwnd`` always wins (most specific target).
+    Resolution dimensions (#1065 — consistent with the gold-standard
+    ``see``/``capture``/``click`` and ``list windows``):
+
+    * An explicit ``--hwnd`` always wins (most specific target).
+    * Positional NAME / ``--app`` (*name*) and/or ``--pid`` are resolved to a
+      concrete window handle through the backend's canonical ``_resolve_hwnd``
+      resolver, which matches the **process name** first (title as a fallback)
+      — the same path the gold-standard commands use.  This makes ``--app``
+      mean "application/process name" everywhere, so it works for localized
+      apps whose window title differs from the exe name (e.g. Calculator →
+      ``计算器``).  *window_title* narrows the match when supplied alongside.
+    * ``--window`` alone (*window_title* with no *name*/*pid*) keeps
+      title-substring semantics — the backend window method resolves the title.
 
     Args:
         backend: Active backend instance (provides ``_resolve_hwnd``).
         name: Application/process name (positional NAME or ``--app``).
         window_title: Optional title substring to pick a specific window.
-        hwnd: Optional direct window handle (takes priority over *pid*).
+        hwnd: Optional direct window handle (takes priority over *name*/*pid*).
         pid: Optional process ID to target.
 
     Returns:
         Dict with ``title`` and/or ``hwnd`` keys for backend calls.
 
     Raises:
-        WindowNotFoundError: When *pid* matches no resolvable window
+        WindowNotFoundError: When *name*/*pid* match no resolvable window
             (propagated from ``_resolve_hwnd``).
     """
-    if pid is not None and hwnd is None and hasattr(backend, "_resolve_hwnd"):
-        hwnd = backend._resolve_hwnd(app=name, window_title=window_title, pid=pid)
-        return {"title": None, "hwnd": hwnd}
-    effective_title = window_title or name
-    return {"title": effective_title, "hwnd": hwnd}
+    # Explicit --hwnd is the most specific target and short-circuits resolution.
+    if hwnd is not None:
+        return {"title": window_title or name, "hwnd": hwnd}
+    # NAME/--app and/or --pid → canonical process-aware resolver (#1065): the
+    # same path see/capture/click use, so --app means process name, not title.
+    if (name is not None or pid is not None) and hasattr(backend, "_resolve_hwnd"):
+        resolved_hwnd = backend._resolve_hwnd(app=name, window_title=window_title, pid=pid)
+        return {"title": None, "hwnd": resolved_hwnd}
+    # --window only (or a backend without _resolve_hwnd): title-substring match,
+    # resolved by the backend method itself.
+    return {"title": window_title or name, "hwnd": hwnd}
 
 
 def _require_target(name, window_title, hwnd, pid, json_output):

--- a/tests/test_app_targeting_parity_1065.py
+++ b/tests/test_app_targeting_parity_1065.py
@@ -1,0 +1,191 @@
+"""#1065: ``app`` window-state ``--app``/NAME must mean *process name*, not title.
+
+The #871 harmonization (#1056) added ``--app``/positional-NAME to the ``app``
+window-state subgroup (``focus``/``close``/``minimize``/``maximize``/``restore``/
+``move``) but resolved the value as a **window-title** substring only — it never
+consulted the process name.  That contradicts the gold-standard commands
+(``see``/``capture``/``click``) and ``list windows --app``, whose ``--app``
+matches the **process name** via ``backend._resolve_hwnd(app=...)``.  The result
+was that ``naturo app focus --app Calculator`` failed for any localized app whose
+window title differs from its process name (e.g. Calculator → ``计算器``).
+
+These tests pin the corrected contract: ``--app``/NAME routes through the same
+process-aware resolver as the gold-standard commands, while ``--window`` stays a
+title-substring selector.  They are hermetic (no real desktop) — the parity bug
+lives entirely in the CLI routing helper ``_resolve_window_target``.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from naturo.cli._app._common import _resolve_window_target
+from naturo.cli.app_cmd import (
+    app_close,
+    app_focus,
+    app_maximize,
+    app_minimize,
+    app_move,
+    app_restore,
+)
+
+runner = CliRunner()
+
+# The window-state commands and the backend method each delegates to.  ``move``
+# is exercised separately because it needs geometry flags.
+_STATE_COMMANDS = [
+    (app_focus, "focus_window"),
+    (app_close, "close_window"),
+    (app_minimize, "minimize_window"),
+    (app_maximize, "maximize_window"),
+    (app_restore, "restore_window"),
+]
+
+
+@pytest.fixture
+def mock_backend():
+    backend = MagicMock()
+    # The canonical resolver returns a concrete handle, exactly as the real
+    # WindowsBackend._resolve_hwnd does.
+    backend._resolve_hwnd.return_value = 4242
+    return backend
+
+
+@pytest.mark.parametrize("cmd,backend_method", _STATE_COMMANDS)
+def test_app_flag_routes_through_process_aware_resolver(cmd, backend_method, mock_backend):
+    """``--app NAME`` must resolve via ``_resolve_hwnd(app=NAME, ...)`` (process
+    name), not be dropped into the backend's ``title=`` kwarg (#1065)."""
+    with patch("naturo.backends.base.get_backend", return_value=mock_backend):
+        result = runner.invoke(cmd, ["--app", "Calculator"])
+    assert result.exit_code == 0, result.output
+    mock_backend._resolve_hwnd.assert_called_once_with(
+        app="Calculator", window_title=None, pid=None
+    )
+    call_kwargs = getattr(mock_backend, backend_method).call_args.kwargs
+    assert call_kwargs["title"] is None
+    assert call_kwargs["hwnd"] == 4242
+
+
+@pytest.mark.parametrize("cmd,backend_method", _STATE_COMMANDS)
+def test_positional_name_routes_through_process_aware_resolver(cmd, backend_method, mock_backend):
+    """The positional NAME form resolves identically to ``--app`` (#1065)."""
+    with patch("naturo.backends.base.get_backend", return_value=mock_backend):
+        result = runner.invoke(cmd, ["Calculator"])
+    assert result.exit_code == 0, result.output
+    mock_backend._resolve_hwnd.assert_called_once_with(
+        app="Calculator", window_title=None, pid=None
+    )
+
+
+@pytest.mark.parametrize("cmd,backend_method", _STATE_COMMANDS)
+def test_window_flag_stays_title_substring(cmd, backend_method, mock_backend):
+    """``--window`` alone keeps title-substring semantics — the backend method
+    resolves the title itself, so no CLI-layer ``_resolve_hwnd`` call."""
+    with patch("naturo.backends.base.get_backend", return_value=mock_backend):
+        result = runner.invoke(cmd, ["--window", "Untitled"])
+    assert result.exit_code == 0, result.output
+    mock_backend._resolve_hwnd.assert_not_called()
+    call_kwargs = getattr(mock_backend, backend_method).call_args.kwargs
+    assert call_kwargs["title"] == "Untitled"
+    assert call_kwargs["hwnd"] is None
+
+
+@pytest.mark.parametrize("cmd,backend_method", _STATE_COMMANDS)
+def test_app_not_found_surfaces_window_not_found(cmd, backend_method, mock_backend):
+    """An unresolvable ``--app`` surfaces ``WindowNotFoundError`` (exit 1) rather
+    than silently substring-matching a wrong window's title."""
+    from naturo.errors import WindowNotFoundError
+
+    mock_backend._resolve_hwnd.side_effect = WindowNotFoundError("Calculator")
+    with patch("naturo.backends.base.get_backend", return_value=mock_backend):
+        result = runner.invoke(cmd, ["--app", "Calculator"])
+    assert result.exit_code != 0
+    getattr(mock_backend, backend_method).assert_not_called()
+
+
+def test_move_app_flag_routes_through_process_aware_resolver(mock_backend):
+    """``app move --app NAME`` resolves by process name like the others (#1065)."""
+    with patch("naturo.backends.base.get_backend", return_value=mock_backend):
+        result = runner.invoke(app_move, ["--app", "Calculator", "--x", "10", "--y", "20"])
+    assert result.exit_code == 0, result.output
+    mock_backend._resolve_hwnd.assert_called_once_with(
+        app="Calculator", window_title=None, pid=None
+    )
+    mock_backend.move_window.assert_called_once_with(x=10, y=20, title=None, hwnd=4242)
+
+
+def test_process_name_match_wins_over_localized_title():
+    """End-to-end parity: ``--app`` matches the *process name* even when the
+    window TITLE differs (the localized-Calculator trap from #1065).
+
+    Drives a fake ``_resolve_hwnd`` that mimics the real process-name-first
+    matching over a window list whose title (``计算器``) shares no substring with
+    the app name (``Calculator``).  A title-only resolver (the old bug) would
+    raise ``WindowNotFoundError``; the corrected routing finds it by exe name.
+    """
+    from naturo.errors import WindowNotFoundError
+
+    windows = [
+        SimpleNamespace(handle=777, title="计算器", process_name="CalculatorApp.exe", pid=10),
+        SimpleNamespace(handle=888, title="Untitled - Notepad", process_name="notepad.exe", pid=20),
+    ]
+
+    def fake_resolve_hwnd(app=None, window_title=None, pid=None):
+        term = (app or window_title or "").lower()
+        for w in windows:
+            if app and term in w.process_name.lower():
+                return w.handle
+        for w in windows:
+            if term and term in w.title.lower():
+                return w.handle
+        raise WindowNotFoundError(term)
+
+    backend = MagicMock()
+    backend._resolve_hwnd.side_effect = fake_resolve_hwnd
+
+    with patch("naturo.backends.base.get_backend", return_value=backend):
+        result = runner.invoke(app_focus, ["--app", "Calculator", "-j"])
+    assert result.exit_code == 0, result.output
+    backend.focus_window.assert_called_once_with(title=None, hwnd=777)
+
+
+# ---------------------------------------------------------------------------
+# Direct unit tests for the routing helper.
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_target_name_uses_app_dimension():
+    backend = MagicMock()
+    backend._resolve_hwnd.return_value = 4242
+    kwargs = _resolve_window_target(backend, "Calculator")
+    backend._resolve_hwnd.assert_called_once_with(
+        app="Calculator", window_title=None, pid=None
+    )
+    assert kwargs == {"title": None, "hwnd": 4242}
+
+
+def test_resolve_target_window_only_stays_title():
+    backend = MagicMock()
+    kwargs = _resolve_window_target(backend, None, window_title="Chat")
+    backend._resolve_hwnd.assert_not_called()
+    assert kwargs == {"title": "Chat", "hwnd": None}
+
+
+def test_resolve_target_explicit_hwnd_wins():
+    backend = MagicMock()
+    kwargs = _resolve_window_target(backend, "Calculator", hwnd=555)
+    backend._resolve_hwnd.assert_not_called()
+    assert kwargs["hwnd"] == 555
+
+
+def test_resolve_target_app_and_window_combine():
+    backend = MagicMock()
+    backend._resolve_hwnd.return_value = 4242
+    kwargs = _resolve_window_target(backend, "Calculator", window_title="Chat")
+    backend._resolve_hwnd.assert_called_once_with(
+        app="Calculator", window_title="Chat", pid=None
+    )
+    assert kwargs == {"title": None, "hwnd": 4242}

--- a/tests/test_app_window_targeting_871.py
+++ b/tests/test_app_window_targeting_871.py
@@ -96,15 +96,18 @@ def test_pid_resolves_to_hwnd(cmd, backend_method, mock_backend):
 
 
 @pytest.mark.parametrize("cmd,backend_method", _STATE_COMMANDS)
-def test_app_flag_targets_by_name(cmd, backend_method, mock_backend):
-    """--app is accepted on every window-state command and targets by title."""
+def test_app_flag_targets_by_process_name(cmd, backend_method, mock_backend):
+    """--app resolves by process name via the canonical resolver, not by title
+    (#1065 — parity with see/capture/click and list windows)."""
     with patch("naturo.backends.base.get_backend", return_value=mock_backend):
         result = runner.invoke(cmd, ["--app", "Notepad"])
     assert result.exit_code == 0, result.output
-    mock_backend._resolve_hwnd.assert_not_called()
+    mock_backend._resolve_hwnd.assert_called_once_with(
+        app="Notepad", window_title=None, pid=None
+    )
     call_kwargs = getattr(mock_backend, backend_method).call_args.kwargs
-    assert call_kwargs["title"] == "Notepad"
-    assert call_kwargs["hwnd"] is None
+    assert call_kwargs["title"] is None
+    assert call_kwargs["hwnd"] == 999
 
 
 @pytest.mark.parametrize("cmd,backend_method", _STATE_COMMANDS)
@@ -132,12 +135,16 @@ def test_move_accepts_app_and_pid(mock_backend):
     mock_backend.move_window.assert_called_once_with(x=10, y=20, title=None, hwnd=999)
 
 
-def test_move_app_flag_targets_by_name(mock_backend):
-    """app move --app targets by title (parity with the other state commands)."""
+def test_move_app_flag_targets_by_process_name(mock_backend):
+    """app move --app resolves by process name (parity with the other state
+    commands and the gold standard — #1065)."""
     with patch("naturo.backends.base.get_backend", return_value=mock_backend):
         result = runner.invoke(app_move, ["--app", "Notepad", "--x", "10", "--y", "20"])
     assert result.exit_code == 0, result.output
-    mock_backend.move_window.assert_called_once_with(x=10, y=20, title="Notepad", hwnd=None)
+    mock_backend._resolve_hwnd.assert_called_once_with(
+        app="Notepad", window_title=None, pid=None
+    )
+    mock_backend.move_window.assert_called_once_with(x=10, y=20, title=None, hwnd=999)
 
 
 def test_pid_combined_with_window_filter(mock_backend):


### PR DESCRIPTION
## What

`naturo app focus/close/minimize/maximize/restore/move` gained `--app`/positional-NAME in the #871 harmonization (#1056, 503128a), but the value was resolved as a **window-title substring only** — it never consulted the process name. That contradicted:

1. The flag's own help text — `--app  Application name` (vs `--window  Window title pattern`).
2. The gold-standard commands (`see`/`capture`/`click`), whose `--app` matches the **process name** via `backend._resolve_hwnd(app=...)`.
3. `list windows --app`, which also matches the process name.

So the same `--app <value>` resolved with contradictory semantics across the matrix #871 set out to unify, and `app focus --app <name>` silently failed (`WINDOW_NOT_FOUND`) for any **localized** app whose title differs from its exe name (e.g. Calculator → `计算器`) — exactly the real-desktop condition naturo targets.

## How

In `naturo/cli/_app/_common.py::_resolve_window_target`, route positional NAME / `--app` through the **same canonical process-aware resolver** (`backend._resolve_hwnd(app=name, window_title=..., pid=...)`) already used by the `--pid` branch and the gold-standard commands, returning a concrete `hwnd`. `--window` keeps title-substring semantics; an explicit `--hwnd` still wins. No backend method-signature change, **no new public surface** — this aligns the code to the already-documented `--app` = application-name contract.

## How tested

- New `tests/test_app_targeting_parity_1065.py` (26 tests): `--app`/NAME routes through the process-aware resolver across all six commands; an end-to-end fake-resolver test proving a **process-name match wins when the window title differs** (the localized-Calculator trap); `--window` stays title-only; not-found surfaces `WindowNotFoundError` (exit 1); helper unit tests for each routing branch.
- Updated the two #871 tests that encoded the old title-only behavior to assert the corrected parity contract.
- Gate: `ruff` clean; `mypy` clean on the changed file (`--follow-imports=skip --python-version=3.12`: Success; the only env-level mypy error is the pre-existing `mcp` 3.10-match-stmt issue, identical with this change stashed); 427 passed in the broad app/window/CLI suites; new+updated files `--collect-only` clean (cross-platform).

## Relation

Part of the #871 window-targeting harmonization umbrella; sibling to #1058 (the over-broad direction). Fixes the over-narrow / wrong-dimension direction.