### PR TITLE
fix: browser screenshot --selector now crops to the element (fixes #1123)

### DIFF
--- a/naturo/browser/_element.py
+++ b/naturo/browser/_element.py
@@ -8,7 +8,7 @@ All DOM operations are performed via CDP commands on the associated page.
 from __future__ import annotations
 
 import logging
-from typing import Any, List, Optional, TYPE_CHECKING
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from naturo.browser._page import BrowserPage
@@ -466,6 +466,55 @@ class BrowserElement:
         if not quads:
             return None
         return [float(v) for v in quads[0]]
+
+    def _bounding_box(self) -> Optional[Dict[str, float]]:
+        """Return this element's bounding box in top-document CSS pixels.
+
+        Scrolls the element into view, then resolves its rectangle the same way
+        :meth:`_get_click_point` does — preferring CDP ``DOM.getContentQuads``
+        (top-level viewport coordinates at any iframe depth) and falling back to
+        ``getBoundingClientRect`` only when the node exposes no content quad.
+        The result is directly usable as the ``clip`` for
+        ``Page.captureScreenshot`` (with ``captureBeyondViewport``).
+
+        Returns:
+            A dict with ``x``, ``y``, ``width``, ``height`` keys, or ``None``
+            when the node has no rendered layout box (``display:none``,
+            detached, or zero-area) so callers can fail loudly rather than
+            capture the wrong region (never-lie, #1083).
+        """
+        self.scroll_into_view()
+
+        quad = self._content_quad()
+        if quad is not None:
+            xs = quad[0::2]
+            ys = quad[1::2]
+            x = min(xs)
+            y = min(ys)
+            return {"x": x, "y": y, "width": max(xs) - x, "height": max(ys) - y}
+
+        # Fallback: no content quad. getBoundingClientRect is frame-relative but
+        # coincides with the top-document space for a genuinely top-level node.
+        box = self._call_function(
+            "function() {"
+            "  var r = this.getBoundingClientRect();"
+            "  return {x: r.x, y: r.y, width: r.width, height: r.height};"
+            "}"
+        )
+        if not box or not isinstance(box, dict):
+            return None
+
+        # A zero-area box means the node is not rendered (display:none, detached,
+        # visibility:collapse); there is nothing to crop to, so report no box.
+        if box["width"] == 0 and box["height"] == 0:
+            return None
+
+        return {
+            "x": box["x"],
+            "y": box["y"],
+            "width": box["width"],
+            "height": box["height"],
+        }
 
     def __repr__(self) -> str:
         desc = self._description or self._object_id[:20]

--- a/naturo/browser/_page.py
+++ b/naturo/browser/_page.py
@@ -459,18 +459,55 @@ class BrowserPage:
 
     # ── Page operations ───────────────────────────────────────────────────
 
-    def screenshot(self, path: str, full_page: bool = False) -> str:
+    def screenshot(
+        self,
+        path: str,
+        full_page: bool = False,
+        selector: Optional[str] = None,
+    ) -> str:
         """Take a screenshot of the page.
 
         Args:
             path: File path to save the screenshot (PNG).
             full_page: If True, capture the full scrollable page.
+            selector: When given, capture only the element matching this
+                CSS/XPath/text selector (cropped to its bounding box) instead
+                of the visible viewport. Cannot be combined with *full_page*.
 
         Returns:
             The path where the screenshot was saved.
+
+        Raises:
+            ValueError: If both *selector* and *full_page* are given.
+            RuntimeError: If *selector* matches no element, or the matched
+                element has no rendered layout box to crop to.
         """
+        if selector is not None and full_page:
+            raise ValueError(
+                "screenshot: 'selector' and 'full_page' are mutually exclusive"
+            )
+
         params: Dict[str, Any] = {"format": "png"}
-        if full_page:
+        if selector is not None:
+            element = self.find(selector)
+            box = element._bounding_box()
+            if box is None:
+                raise RuntimeError(
+                    f"Cannot screenshot element {selector!r}: it has no "
+                    f"rendered layout box (display:none, detached, or zero-area)"
+                )
+            params["clip"] = {
+                "x": box["x"],
+                "y": box["y"],
+                "width": box["width"],
+                "height": box["height"],
+                "scale": 1,
+            }
+            # The element may sit outside the current viewport even after
+            # scroll-into-view (e.g. taller than the window); capture beyond the
+            # viewport so the clip region is composited rather than clamped.
+            params["captureBeyondViewport"] = True
+        elif full_page:
             # Get full page dimensions
             metrics = self._cdp.send("Page.getLayoutMetrics")
             content_size = metrics.get("contentSize", {})

--- a/naturo/cli/_browser/visual.py
+++ b/naturo/cli/_browser/visual.py
@@ -26,14 +26,19 @@ def screenshot_cmd(ctx: click.Context, path: str, selector: Optional[str],
     Examples:
         naturo browser screenshot --path page.png
         naturo browser screenshot --full-page --path full.png
+        naturo browser screenshot --selector "#intro" --path intro.png
     """
     page = browser_cmd._get_page(ctx, json_output=json_output)
     try:
-        saved_path = page.screenshot(path, full_page=full_page)
+        saved_path = page.screenshot(
+            path, full_page=full_page, selector=selector
+        )
         if json_output:
             click.echo(json_dumps({"path": saved_path, "status": "ok"}))
         else:
             click.echo(f"Screenshot saved: {saved_path}")
+    except ValueError as exc:
+        emit_exception_error(exc, json_output, fallback_code="INVALID_INPUT")
     except RuntimeError as exc:
         emit_exception_error(exc, json_output, fallback_code="SCREENSHOT_FAILED")
     finally:

--- a/tests/test_browser_cmd.py
+++ b/tests/test_browser_cmd.py
@@ -303,7 +303,7 @@ class TestScreenshot:
         assert result.exit_code == 0
         assert "screenshot.png" in result.output
         mock_page.screenshot.assert_called_once_with(
-            "screenshot.png", full_page=False,
+            "screenshot.png", full_page=False, selector=None,
         )
 
     def test_screenshot_custom_path(self, runner: click.testing.CliRunner,
@@ -318,7 +318,9 @@ class TestScreenshot:
         result = _invoke(
             runner, ["screenshot", "--full-page", "--path", "full.png"], mock_page,
         )
-        mock_page.screenshot.assert_called_once_with("full.png", full_page=True)
+        mock_page.screenshot.assert_called_once_with(
+            "full.png", full_page=True, selector=None,
+        )
 
     def test_screenshot_json(self, runner: click.testing.CliRunner,
                              mock_page: MagicMock) -> None:

--- a/tests/test_browser_screenshot_selector_1123.py
+++ b/tests/test_browser_screenshot_selector_1123.py
@@ -1,0 +1,207 @@
+"""Regression tests for #1123: ``browser screenshot --selector`` must crop.
+
+``naturo browser screenshot`` advertises ``--selector <css>`` ("Capture only
+this element"), but the option was parsed and then silently dropped — the
+command captured the whole page regardless, a never-lie / confidently-wrong
+defect (the user gets a full-page PNG while believing they cropped to an
+element). These tests pin that the selector path now resolves the element's
+bounding box and passes it as the ``clip`` to ``Page.captureScreenshot`` (the
+non-default option path, per the dev-cycle 'option coverage' rule), and that a
+missing / unrenderable element fails loudly instead of capturing the full page.
+"""
+
+from __future__ import annotations
+
+import base64
+from unittest.mock import MagicMock, patch
+
+import click.testing
+import pytest
+
+from naturo.cli._browser._group import browser
+
+
+def _make_page(send_return=None):
+    """Build a BrowserPage with a fully mocked CDPClient."""
+    tabs = [{"id": "tab-1", "title": "Example", "url": "https://example.com"}]
+    mock_cdp = MagicMock()
+    mock_cdp.list_tabs.return_value = tabs
+    mock_cdp.evaluate.return_value = ""
+    mock_cdp.send.return_value = send_return or {}
+
+    with patch("naturo.browser._page.CDPClient", return_value=mock_cdp):
+        from naturo.browser._page import BrowserPage
+        page = BrowserPage(port=9222)
+
+    return page, mock_cdp
+
+
+# ── BrowserPage.screenshot(selector=...) ──────────────────────────────────────
+
+
+class TestScreenshotSelectorSDK:
+    """SDK-level behaviour of the new ``selector`` capture path."""
+
+    def test_selector_passes_element_clip(self, tmp_path):
+        """The element's bounding box becomes the captureScreenshot clip."""
+        png = base64.b64encode(b"cropped").decode()
+        page, cdp = _make_page(send_return={"data": png})
+
+        box = {"x": 8.0, "y": 88.0, "width": 748.0, "height": 24.0}
+        element = MagicMock()
+        element._bounding_box.return_value = box
+        page.find = MagicMock(return_value=element)
+
+        out = str(tmp_path / "intro.png")
+        result = page.screenshot(out, selector="#intro")
+
+        assert result == out
+        page.find.assert_called_once_with("#intro")
+        cdp.send.assert_called_once_with(
+            "Page.captureScreenshot",
+            {
+                "format": "png",
+                "clip": {
+                    "x": 8.0,
+                    "y": 88.0,
+                    "width": 748.0,
+                    "height": 24.0,
+                    "scale": 1,
+                },
+                "captureBeyondViewport": True,
+            },
+        )
+        with open(out, "rb") as fh:
+            assert fh.read() == b"cropped"
+
+    def test_selector_not_found_raises_and_does_not_capture(self, tmp_path):
+        """A missing element fails loudly — never a silent full-page capture."""
+        page, cdp = _make_page()
+        page.find = MagicMock(
+            side_effect=RuntimeError("No element found for selector: #ghost")
+        )
+
+        with pytest.raises(RuntimeError, match="No element found"):
+            page.screenshot(str(tmp_path / "x.png"), selector="#ghost")
+
+        # The whole point of #1123: do NOT fall through to a full-page capture.
+        for call in cdp.send.call_args_list:
+            assert call.args[0] != "Page.captureScreenshot"
+
+    def test_selector_without_layout_box_raises(self, tmp_path):
+        """An element with no rendered box fails loudly rather than mis-cropping."""
+        page, cdp = _make_page()
+        element = MagicMock()
+        element._bounding_box.return_value = None
+        page.find = MagicMock(return_value=element)
+
+        with pytest.raises(RuntimeError, match="no .*rendered layout box"):
+            page.screenshot(str(tmp_path / "x.png"), selector="#hidden")
+
+        for call in cdp.send.call_args_list:
+            assert call.args[0] != "Page.captureScreenshot"
+
+    def test_selector_and_full_page_conflict(self, tmp_path):
+        """``selector`` and ``full_page`` are mutually exclusive."""
+        page, _ = _make_page()
+        page.find = MagicMock()
+
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            page.screenshot(
+                str(tmp_path / "x.png"), selector="#intro", full_page=True
+            )
+
+    def test_no_selector_is_plain_viewport_capture(self, tmp_path):
+        """Without a selector the command stays a plain viewport capture."""
+        png = base64.b64encode(b"viewport").decode()
+        page, cdp = _make_page(send_return={"data": png})
+
+        page.screenshot(str(tmp_path / "v.png"))
+
+        cdp.send.assert_called_once_with(
+            "Page.captureScreenshot", {"format": "png"}
+        )
+
+
+# ── BrowserElement._bounding_box ──────────────────────────────────────────────
+
+
+class TestElementBoundingBox:
+    """The bounding-box resolver used to build the clip."""
+
+    def _element(self, quad=None, rect=None):
+        from naturo.browser._element import BrowserElement
+
+        page = MagicMock()
+        element = BrowserElement(page, "obj-1", description="el")
+        element.scroll_into_view = MagicMock()
+        if quad is not None:
+            page._cdp.send.return_value = {"quads": [quad]}
+        else:
+            page._cdp.send.return_value = {"quads": []}
+            element._call_function = MagicMock(return_value=rect)
+        return element
+
+    def test_uses_content_quad(self):
+        # quad order: top-left, top-right, bottom-right, bottom-left
+        quad = [10.0, 20.0, 110.0, 20.0, 110.0, 70.0, 10.0, 70.0]
+        element = self._element(quad=quad)
+
+        box = element._bounding_box()
+
+        assert box == {"x": 10.0, "y": 20.0, "width": 100.0, "height": 50.0}
+        element.scroll_into_view.assert_called_once()
+
+    def test_falls_back_to_bounding_client_rect(self):
+        rect = {"x": 5.0, "y": 6.0, "width": 30.0, "height": 40.0}
+        element = self._element(quad=None, rect=rect)
+
+        assert element._bounding_box() == rect
+
+    def test_zero_area_box_returns_none(self):
+        rect = {"x": 0.0, "y": 0.0, "width": 0.0, "height": 0.0}
+        element = self._element(quad=None, rect=rect)
+
+        assert element._bounding_box() is None
+
+
+# ── CLI wiring ────────────────────────────────────────────────────────────────
+
+
+class TestScreenshotSelectorCLI:
+    """The ``--selector`` flag must reach ``BrowserPage.screenshot``."""
+
+    def _invoke(self, args, mock_page):
+        runner = click.testing.CliRunner()
+        with patch(
+            "naturo.cli.browser_cmd._get_page", return_value=mock_page
+        ):
+            return runner.invoke(browser, args, catch_exceptions=False)
+
+    def test_selector_forwarded(self):
+        mock_page = MagicMock()
+        mock_page.screenshot.return_value = "intro.png"
+
+        result = self._invoke(
+            ["screenshot", "--selector", "#intro", "--path", "intro.png"],
+            mock_page,
+        )
+
+        assert result.exit_code == 0
+        mock_page.screenshot.assert_called_once_with(
+            "intro.png", full_page=False, selector="#intro"
+        )
+
+    def test_selector_and_full_page_rejected(self):
+        mock_page = MagicMock()
+        mock_page.screenshot.side_effect = ValueError(
+            "screenshot: 'selector' and 'full_page' are mutually exclusive"
+        )
+
+        result = self._invoke(
+            ["screenshot", "--selector", "#x", "--full-page", "--json"],
+            mock_page,
+        )
+
+        assert result.exit_code != 0
+        assert "INVALID_INPUT" in result.output


### PR DESCRIPTION
## What
`naturo browser screenshot --selector <css>` was advertised (and documented in `MIGRATION_FROM_RPA_SCRIPTS.md`, both the CLI flag and the `page.screenshot(..., selector=...)` SDK form) but the option was parsed then **silently dropped** — every capture was full-viewport regardless. A documented option that is parsed and ignored is a never-lie / confidently-wrong defect (the user gets a full-page PNG while believing they cropped to an element).

## How
- `BrowserPage.screenshot` gains the already-documented `selector` parameter: it resolves the element, takes its bounding box via the existing `DOM.getContentQuads` path (with a `getBoundingClientRect` fallback), and passes it as the `clip` to `Page.captureScreenshot` with `captureBeyondViewport`.
- New private `BrowserElement._bounding_box()` reuses the same coordinate resolution as `_get_click_point` (top-document CSS pixels), returning `None` for an unrendered node so callers fail loudly (never-lie, #1083).
- **Option coverage / fail-loud** (dev-cycle rule): a missing element, an element with no layout box, or `--selector` + `--full-page` together now exit 1 with no file written (`INVALID_INPUT` for the conflict) — never a silent full-page fallback.
- This implements the already-committed documented contract; no doc change needed.

## How tested
- New `tests/test_browser_screenshot_selector_1123.py` (10 hermetic tests): clip-building on the **non-default** option path, not-found / no-box loud-fail (asserts `captureScreenshot` is **not** called), conflict rejection, and `_bounding_box` quad/rect/zero-area resolution. RED before fix (9 fail), GREEN after.
- Updated two #871-style call-signature assertions in `test_browser_cmd.py`.
- Gate: ruff clean, mypy clean (changed files), 156 passed across browser suites, new tests `--collect-only` clean (no Windows/desktop deps).
- **End-to-end on real headless Chrome**: `--selector "#intro"` → 748x24 element-cropped PNG vs 764x485 viewport; non-existent selector → exit 1, no file; conflict → `INVALID_INPUT`.