### PR TITLE
fix: browser screenshot emits registered, correctly-attributed error codes (fixes #1135)

### DIFF
--- a/naturo/browser/_page.py
+++ b/naturo/browser/_page.py
@@ -31,6 +31,18 @@ from naturo.browser._selectors import (
 logger = logging.getLogger(__name__)
 
 
+class BrowserElementNotFoundError(RuntimeError):
+    """A selector matched no element on the page.
+
+    Subclasses :class:`RuntimeError` so existing ``except RuntimeError`` handlers
+    (and the browser CLI's ``ELEMENT_NOT_FOUND`` mapping) keep working unchanged,
+    while callers that need to distinguish a *missing element* from a genuine
+    operation failure — e.g. ``browser screenshot``, which must attribute a
+    missing selector to ``ELEMENT_NOT_FOUND`` rather than ``SCREENSHOT_FAILED``
+    (#1135) — can catch this narrower type.
+    """
+
+
 class BrowserPage:
     """High-level browser page for CDP-based automation.
 
@@ -479,8 +491,11 @@ class BrowserPage:
 
         Raises:
             ValueError: If both *selector* and *full_page* are given.
-            RuntimeError: If *selector* matches no element, or the matched
-                element has no rendered layout box to crop to.
+            BrowserElementNotFoundError: If *selector* matches no element (a
+                :class:`RuntimeError` subclass, so the missing-element case can
+                be attributed distinctly from a capture failure).
+            RuntimeError: If the matched element has no rendered layout box to
+                crop to.
         """
         if selector is not None and full_page:
             raise ValueError(
@@ -489,7 +504,13 @@ class BrowserPage:
 
         params: Dict[str, Any] = {"format": "png"}
         if selector is not None:
-            element = self.find(selector)
+            try:
+                element = self.find(selector)
+            except RuntimeError as exc:
+                # find() reports a missing element as a bare RuntimeError; re-raise
+                # as the narrower type so the CLI attributes it to ELEMENT_NOT_FOUND
+                # (recoverable) rather than a capture failure (#1135).
+                raise BrowserElementNotFoundError(str(exc)) from exc
             box = element._bounding_box()
             if box is None:
                 raise RuntimeError(

--- a/naturo/cli/_browser/visual.py
+++ b/naturo/cli/_browser/visual.py
@@ -7,6 +7,7 @@ from typing import Optional
 
 import click
 
+from naturo.browser._page import BrowserElementNotFoundError
 from naturo.cli import browser_cmd
 from naturo.cli._browser._group import browser
 from naturo.cli.error_helpers import emit_exception_error
@@ -39,6 +40,10 @@ def screenshot_cmd(ctx: click.Context, path: str, selector: Optional[str],
             click.echo(f"Screenshot saved: {saved_path}")
     except ValueError as exc:
         emit_exception_error(exc, json_output, fallback_code="INVALID_INPUT")
+    except BrowserElementNotFoundError as exc:
+        # A missing --selector is a recoverable not-found, not a capture failure;
+        # attribute it distinctly so the agent gets the right recovery hint (#1135).
+        emit_exception_error(exc, json_output, fallback_code="ELEMENT_NOT_FOUND")
     except RuntimeError as exc:
         emit_exception_error(exc, json_output, fallback_code="SCREENSHOT_FAILED")
     finally:

--- a/naturo/cli/error_helpers.py
+++ b/naturo/cli/error_helpers.py
@@ -157,6 +157,12 @@ _RECOVERY_HINTS: dict[str, tuple[str, bool]] = {
         "Use 'naturo list windows' to verify.",
         True,
     ),
+    "SCREENSHOT_FAILED": (
+        "Browser screenshot failed. Ensure the page has finished loading and the "
+        "target element is visible (not display:none or zero-area), then retry. "
+        "Use 'naturo browser screenshot' without --selector to capture the viewport.",
+        True,
+    ),
     "TIMEOUT": (
         "Operation timed out. Try: 1) increase --timeout, 2) verify the target window "
         "is in the foreground, 3) take a screenshot to check the current UI state.",

--- a/naturo/errors.py
+++ b/naturo/errors.py
@@ -30,6 +30,7 @@ class ErrorCode:
 
     # Operation errors
     CAPTURE_FAILED = "CAPTURE_FAILED"
+    SCREENSHOT_FAILED = "SCREENSHOT_FAILED"
     INTERACTION_FAILED = "INTERACTION_FAILED"
     TIMEOUT = "TIMEOUT"
     CANCELLED = "CANCELLED"
@@ -108,6 +109,9 @@ _ERROR_CATEGORIES: dict[str, str] = {
     ErrorCode.RECORDING_NOT_FOUND: ErrorCategory.SESSION,
     ErrorCode.FILE_NOT_FOUND: ErrorCategory.IO,
     ErrorCode.CAPTURE_FAILED: ErrorCategory.AUTOMATION,
+    # A browser/CDP screenshot that failed to render or encode is an automation
+    # operation failure, alongside CAPTURE_FAILED (#1135).
+    ErrorCode.SCREENSHOT_FAILED: ErrorCategory.AUTOMATION,
     ErrorCode.INTERACTION_FAILED: ErrorCategory.AUTOMATION,
     ErrorCode.TIMEOUT: ErrorCategory.AUTOMATION,
     # Cancellation is an operation-lifecycle outcome, like ``TIMEOUT`` (#1101).

--- a/tests/test_browser_screenshot_error_codes_1135.py
+++ b/tests/test_browser_screenshot_error_codes_1135.py
@@ -1,0 +1,164 @@
+"""Regression tests for #1135: ``browser screenshot`` error-code taxonomy.
+
+``naturo browser screenshot`` errored with ``fallback_code="SCREENSHOT_FAILED"``,
+but that code was **not** a registered :class:`~naturo.errors.ErrorCode` and had
+no ``_RECOVERY_HINTS`` entry, so the envelope silently degraded to
+``category: unknown`` / ``recoverable: false`` / no hint — even for a plain
+"selector matched no element" condition. That breaks the agent self-correction
+contract (an unrecognised code looks like an internal failure rather than a
+recoverable not-found).
+
+These tests pin two things:
+
+1. **Registration** — ``SCREENSHOT_FAILED`` is a real ``ErrorCode`` with a
+   non-``unknown`` category and a recovery hint, so a genuine capture failure is
+   categorised and recoverable.
+2. **Error attribution** (dev-cycle rule) — a *missing selector* is reported as
+   ``ELEMENT_NOT_FOUND`` (recoverable, automation), distinct from a genuine
+   *capture* failure (``SCREENSHOT_FAILED``); the two no longer share one code.
+
+A family-wide sweep also guards against any *other* ``browser`` command emitting
+a bare, unregistered ``fallback_code`` string in future.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import click.testing
+import pytest
+
+from naturo.browser._page import BrowserElementNotFoundError
+from naturo.cli._browser._group import browser
+from naturo.cli.error_helpers import _RECOVERY_HINTS
+from naturo.errors import ErrorCategory, ErrorCode, category_for_code
+
+
+def _invoke(args, mock_page):
+    runner = click.testing.CliRunner()
+    with patch("naturo.cli.browser_cmd._get_page", return_value=mock_page):
+        return runner.invoke(browser, args, catch_exceptions=False)
+
+
+# ── Registration ──────────────────────────────────────────────────────────────
+
+
+class TestScreenshotFailedRegistered:
+    """``SCREENSHOT_FAILED`` must be a first-class, categorised, recoverable code."""
+
+    def test_is_a_registered_error_code(self):
+        assert getattr(ErrorCode, "SCREENSHOT_FAILED", None) == "SCREENSHOT_FAILED"
+
+    def test_category_is_not_unknown(self):
+        assert category_for_code("SCREENSHOT_FAILED") == ErrorCategory.AUTOMATION
+
+    def test_has_a_recovery_hint(self):
+        hint, recoverable = _RECOVERY_HINTS["SCREENSHOT_FAILED"]
+        assert hint
+        assert recoverable is True
+
+
+# ── Error attribution at the CLI ──────────────────────────────────────────────
+
+
+class TestScreenshotErrorAttribution:
+    """The ``-j`` error envelope must name the real culprit with a real code."""
+
+    def test_missing_selector_is_element_not_found(self):
+        """A selector that matches nothing → recoverable ELEMENT_NOT_FOUND."""
+        mock_page = MagicMock()
+        mock_page.screenshot.side_effect = BrowserElementNotFoundError(
+            "No element found for selector: #ghost"
+        )
+
+        result = _invoke(
+            ["screenshot", "--selector", "#ghost", "--json"], mock_page
+        )
+
+        assert result.exit_code != 0
+        payload = json.loads(result.output)
+        err = payload["error"]
+        assert err["code"] == "ELEMENT_NOT_FOUND"
+        assert err["category"] == ErrorCategory.AUTOMATION
+        assert err["recoverable"] is True
+        assert err["suggested_action"]
+
+    def test_capture_failure_is_screenshot_failed(self):
+        """A genuine capture failure → registered SCREENSHOT_FAILED, not 'unknown'."""
+        mock_page = MagicMock()
+        mock_page.screenshot.side_effect = RuntimeError(
+            "Cannot screenshot element '#hidden': it has no rendered layout box"
+        )
+
+        result = _invoke(
+            ["screenshot", "--selector", "#hidden", "--json"], mock_page
+        )
+
+        assert result.exit_code != 0
+        payload = json.loads(result.output)
+        err = payload["error"]
+        assert err["code"] == "SCREENSHOT_FAILED"
+        assert err["category"] == ErrorCategory.AUTOMATION
+        # No longer 'unknown'/non-recoverable — the contract the issue flagged.
+        assert err["category"] != ErrorCategory.UNKNOWN
+        assert err["recoverable"] is True
+        assert err["suggested_action"]
+
+    def test_selector_and_full_page_is_invalid_input(self):
+        """The mutually-exclusive validation error stays INVALID_INPUT."""
+        mock_page = MagicMock()
+        mock_page.screenshot.side_effect = ValueError(
+            "screenshot: 'selector' and 'full_page' are mutually exclusive"
+        )
+
+        result = _invoke(
+            ["screenshot", "--selector", "#x", "--full-page", "--json"], mock_page
+        )
+
+        assert result.exit_code != 0
+        assert json.loads(result.output)["error"]["code"] == "INVALID_INPUT"
+
+
+class TestBrowserElementNotFoundErrorType:
+    """The typed not-found error must stay a ``RuntimeError`` for back-compat."""
+
+    def test_is_a_runtime_error_subclass(self):
+        # Existing handlers / tests that ``except RuntimeError`` must keep working.
+        assert issubclass(BrowserElementNotFoundError, RuntimeError)
+
+
+# ── Family-wide sweep ─────────────────────────────────────────────────────────
+
+
+def _registered_codes() -> set[str]:
+    return {
+        getattr(ErrorCode, name)
+        for name in dir(ErrorCode)
+        if not name.startswith("_") and isinstance(getattr(ErrorCode, name), str)
+    }
+
+
+def test_no_browser_command_emits_an_unregistered_fallback_code():
+    """Every ``fallback_code=`` literal in the browser CLI must be a real code.
+
+    A bare, unregistered code degrades to ``category: unknown`` /
+    ``recoverable: false`` (the #1135 defect). This sweep keeps the whole
+    ``naturo browser`` family honest, not just ``screenshot``.
+    """
+    browser_pkg = Path(__file__).resolve().parents[1] / "naturo" / "cli" / "_browser"
+    registered = _registered_codes()
+
+    offenders: list[str] = []
+    for source in browser_pkg.rglob("*.py"):
+        text = source.read_text(encoding="utf-8")
+        for code in re.findall(r"""fallback_code\s*=\s*["']([A-Z_]+)["']""", text):
+            if code not in registered:
+                offenders.append(f"{source.name}: {code}")
+
+    assert not offenders, (
+        "Unregistered fallback_code(s) found — register them in "
+        f"ErrorCode + _ERROR_CATEGORIES + _RECOVERY_HINTS: {offenders}"
+    )


### PR DESCRIPTION
## What
`naturo browser screenshot` reported failures with `fallback_code="SCREENSHOT_FAILED"`, but that code was **not** a registered `ErrorCode` and had no `_RECOVERY_HINTS` entry — so every screenshot error silently degraded to `category: unknown` / `recoverable: false` / no hint, even a plain "selector matched no element". That breaks the agent self-correction contract (an unrecognised code looks like an internal failure, not a recoverable not-found).

This also conflated two distinct failure sources under one (wrong) code — a *missing selector* and a *genuine capture failure* — violating the error-attribution rule.

## How
- **Register `SCREENSHOT_FAILED`** in the same diff across all three required places: `ErrorCode` enum (`errors.py`), the `_ERROR_CATEGORIES` map → `automation`, and `_RECOVERY_HINTS` → recoverable with a capture-failure hint.
- **Attribute the two legs distinctly** (error-attribution rule): a missing selector now resolves to `ELEMENT_NOT_FOUND` (recoverable, automation, with the proper "inspect/retry" hint); a genuine capture failure (no rendered layout box / CDP error) stays `SCREENSHOT_FAILED`; the mutually-exclusive `--selector`+`--full-page` validation stays `INVALID_INPUT`.
- To split the legs without fragile message matching, `BrowserPage.screenshot()` re-raises the missing-element case as a new `BrowserElementNotFoundError` (a **`RuntimeError` subclass**, so every existing `except RuntimeError` handler keeps working unchanged; it lives in the private `naturo.browser._page` module and is not re-exported).
- **Family-wide sweep:** confirmed `SCREENSHOT_FAILED` was the *only* unregistered `fallback_code` in the `naturo browser` family (the rest — `APP_NOT_FOUND`/`TIMEOUT`/`INVALID_INPUT`/`ELEMENT_NOT_FOUND` — are registered). Added a self-maintaining test that scans the browser CLI package and fails if any command emits a bare, unregistered `fallback_code`.

### Before → After (live)
`naturo browser screenshot --selector '#does-not-exist' -j`
- before: `code: SCREENSHOT_FAILED, category: unknown, recoverable: false`
- after: `code: ELEMENT_NOT_FOUND, category: automation, recoverable: true` + recovery hint

## How tested
- New `tests/test_browser_screenshot_error_codes_1135.py`: registration (code/category/hint), CLI error attribution asserting **category + recoverable** (not just envelope shape) for the not-found, capture-failure, and validation legs, the `RuntimeError`-subclass back-compat guard, and the family-wide bare-`fallback_code` sweep. Hermetic (mocks `_get_page`, no `@desktop`/host deps).
- `ruff check naturo/` clean; `mypy` clean on all four changed modules.
- Focused regression run: **968 passed, 0 failed** across the error-envelope + browser + screenshot suites; existing #1123 selector tests still green; full suite collects (6994 tests, no import break).

## Note for review
This is a taxonomy/error-attribution **correctness** fix (no new CLI flag, no changed signature, no previously-inert flag made functional). Registering a new `ErrorCode` is the routine remediation the dev-cycle prescribes for this class of bug (cf. #1086/#1047/#1067). Auto-merge enabled accordingly.