### PR TITLE
fix: browser screenshot self-heals headless first-frame stall (fixes #1124)

### DIFF
--- a/naturo/browser/_page.py
+++ b/naturo/browser/_page.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from naturo.browser._frame import BrowserFrame
     from naturo.browser._network import NetworkMonitor
 
-from naturo.cdp import CDPClient, CDPError, CDPConnectionError
+from naturo.cdp import CDPClient, CDPError, CDPConnectionError, CDPTimeoutError
 from naturo.browser._element import BrowserElement
 from naturo.browser._selectors import (
     ParsedSelector,
@@ -502,6 +502,18 @@ class BrowserPage:
                 "screenshot: 'selector' and 'full_page' are mutually exclusive"
             )
 
+        # A freshly-launched headless Chrome may not have composited an
+        # on-screen frame yet, and a separately-connected CDP session (the
+        # canonical ``browser screenshot`` process after ``browser launch``)
+        # has not enabled the Page domain. The very first
+        # ``Page.captureScreenshot`` then blocks until the compositor yields a
+        # frame, timing out the user's first action after launch (#1124).
+        # Enabling the Page domain lets Chrome schedule that frame; the bounded
+        # retry in ``_capture_screenshot`` self-heals a residual first-frame
+        # stall. ``Page.enable`` is idempotent, so this is safe when the page
+        # was already navigated/reloaded on this connection.
+        self._cdp.send("Page.enable")
+
         params: Dict[str, Any] = {"format": "png"}
         if selector is not None:
             try:
@@ -540,7 +552,7 @@ class BrowserPage:
                 "scale": 1,
             }
 
-        result = self._cdp.send("Page.captureScreenshot", params)
+        result = self._capture_screenshot(params)
         data = result.get("data", "")
 
         import base64
@@ -548,6 +560,37 @@ class BrowserPage:
             f.write(base64.b64decode(data))
 
         return path
+
+    def _capture_screenshot(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Send ``Page.captureScreenshot`` with one bounded retry on timeout.
+
+        A freshly-launched headless Chrome may not have produced an on-screen
+        frame yet, so the first ``Page.captureScreenshot`` can block until the
+        compositor yields a frame. The attempt itself forces that frame, so a
+        single retry returns immediately rather than failing the user's first
+        capture after launch (#1124). The retry is bounded (exactly one) so a
+        genuinely dead connection still surfaces a ``CDPTimeoutError`` instead
+        of looping.
+
+        Args:
+            params: Parameters for the ``Page.captureScreenshot`` command.
+
+        Returns:
+            The ``result`` field of the CDP response (carries the base64
+            ``data``).
+
+        Raises:
+            CDPTimeoutError: If both the initial capture and the single retry
+                time out.
+        """
+        try:
+            return self._cdp.send("Page.captureScreenshot", params)
+        except CDPTimeoutError:
+            logger.warning(
+                "First Page.captureScreenshot stalled (headless first-frame); "
+                "retrying once (#1124)."
+            )
+            return self._cdp.send("Page.captureScreenshot", params)
 
     def evaluate(self, expression: str) -> Any:
         """Evaluate a JavaScript expression in the page context.

--- a/tests/browser/test_screenshot_first_frame_1124.py
+++ b/tests/browser/test_screenshot_first_frame_1124.py
@@ -1,0 +1,183 @@
+"""First-frame screenshot robustness tests (#1124).
+
+The canonical first action an AI agent takes after ``browser launch`` is a
+``browser screenshot`` — and against a freshly-launched **headless** Chrome the
+first ``Page.captureScreenshot`` can stall until the compositor has produced an
+on-screen frame, timing out the full CDP budget and writing no file. naturo's
+verification model is "only trust screenshot evidence", so a 100%-on-first-try
+failure there is release-blocking.
+
+The fix (:meth:`naturo.browser._page.BrowserPage.screenshot`) enables the Page
+domain before the first capture and retries the capture once on timeout, so a
+transient first-frame stall self-heals instead of failing.
+
+The unit tests below are hermetic — they drive a fake CDP transport, so they run
+on the headless Linux/macOS CI matrix and deterministically prove the retry and
+the Page-domain enable without needing a real first-frame race. The
+``@pytest.mark.desktop`` test at the end is the integration guard: it launches a
+real headless Chrome and asserts the very first capture writes a valid PNG.
+"""
+from __future__ import annotations
+
+import base64
+import socket
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from naturo.browser._page import BrowserPage
+from naturo.cdp import CDPTimeoutError
+
+# A minimal but structurally valid 1x1 PNG — what a real ``captureScreenshot``
+# response carries (base64), so the success path writes a genuine PNG to disk.
+_ONE_PX_PNG_B64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA"
+    "60e6kgAAAABJRU5ErkJggg=="
+)
+
+
+class _FakeCDP:
+    """Minimal stand-in for :class:`naturo.cdp.CDPClient`.
+
+    Records every method sent and lets a test choose how many of the leading
+    ``Page.captureScreenshot`` calls raise :class:`CDPTimeoutError` (simulating
+    the headless first-frame stall) before one returns image data.
+    """
+
+    def __init__(self, capture_timeouts: int = 0) -> None:
+        self.calls: List[str] = []
+        self._remaining_timeouts = capture_timeouts
+        self.capture_count = 0
+
+    def send(self, method: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        self.calls.append(method)
+        if method == "Page.captureScreenshot":
+            self.capture_count += 1
+            if self._remaining_timeouts > 0:
+                self._remaining_timeouts -= 1
+                raise CDPTimeoutError("simulated headless first-frame stall")
+            return {"data": _ONE_PX_PNG_B64}
+        return {}
+
+
+def _page_with_fake_cdp(fake: _FakeCDP) -> BrowserPage:
+    """Build a BrowserPage wired to *fake* without touching real Chrome.
+
+    Bypasses ``__init__`` (which would connect over CDP) so the screenshot logic
+    can be exercised against the fake transport in isolation.
+    """
+    page = BrowserPage.__new__(BrowserPage)
+    page._cdp = fake  # type: ignore[attr-defined]
+    return page
+
+
+def test_screenshot_enables_page_domain_before_capture(tmp_path: Path) -> None:
+    """The cold screenshot path enables the Page domain before capturing.
+
+    A separately-connected ``screenshot`` process never navigates, so without an
+    explicit ``Page.enable`` the compositor may never schedule the first frame
+    (#1124).
+    """
+    fake = _FakeCDP(capture_timeouts=0)
+    page = _page_with_fake_cdp(fake)
+
+    out = page.screenshot(str(tmp_path / "shot.png"))
+
+    assert "Page.enable" in fake.calls
+    assert fake.calls.index("Page.enable") < fake.calls.index("Page.captureScreenshot")
+    assert Path(out).read_bytes()[:8] == b"\x89PNG\r\n\x1a\n"
+
+
+def test_screenshot_retries_once_on_first_frame_timeout(tmp_path: Path) -> None:
+    """A first-capture timeout self-heals via exactly one retry (#1124)."""
+    fake = _FakeCDP(capture_timeouts=1)
+    page = _page_with_fake_cdp(fake)
+
+    out = page.screenshot(str(tmp_path / "shot.png"))
+
+    assert fake.capture_count == 2, "expected exactly one retry after the stall"
+    assert Path(out).read_bytes()[:8] == b"\x89PNG\r\n\x1a\n"
+
+
+def test_screenshot_no_retry_when_first_capture_succeeds(tmp_path: Path) -> None:
+    """The happy path (modern headless) captures once — the retry is a net."""
+    fake = _FakeCDP(capture_timeouts=0)
+    page = _page_with_fake_cdp(fake)
+
+    page.screenshot(str(tmp_path / "shot.png"))
+
+    assert fake.capture_count == 1
+
+
+def test_screenshot_retry_is_bounded(tmp_path: Path) -> None:
+    """A persistently dead capture surfaces the timeout, not an infinite loop."""
+    fake = _FakeCDP(capture_timeouts=99)
+    page = _page_with_fake_cdp(fake)
+
+    with pytest.raises(CDPTimeoutError):
+        page.screenshot(str(tmp_path / "shot.png"))
+
+    assert fake.capture_count == 2, "retry must be bounded to a single re-attempt"
+
+
+# ── Integration guard (real headless Chrome) ─────────────────────────────────
+
+
+def _free_tcp_port() -> int:
+    """Return a currently-free loopback TCP port for the CDP endpoint."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+@pytest.mark.desktop
+def test_first_screenshot_after_headless_launch_writes_png(tmp_path: Path) -> None:
+    """The very first capture against a fresh headless Chrome writes a PNG.
+
+    Faithful to the #1124 repro: ``browser launch --url`` loads content in one
+    connection, then a *separate* cold connection (the ``browser screenshot``
+    process) takes the first capture against the Chrome instance. That first
+    capture must write a valid PNG and not raise — no warm-up screenshot
+    required.
+    """
+    import shutil
+
+    from naturo.browser import launch_chrome
+
+    fixture = (Path(__file__).parent / "fixtures" / "basic.html").resolve().as_uri()
+    user_data_dir = tempfile.mkdtemp(prefix="naturo_first_frame_")
+    port = _free_tcp_port()
+    chrome = launch_chrome(
+        port=port,
+        headless=True,
+        user_data_dir=user_data_dir,
+        timeout=30.0,
+    )
+    try:
+        # Load content the way ``browser launch --url`` does, then drop the
+        # connection — navigating does not warm the compositor (only a capture
+        # does), so the next connection's first capture is the cold path.
+        loader = BrowserPage(port=port)
+        loader.navigate(fixture)
+        loader.close()
+
+        # A fresh cold connection: this first capture is the #1124 scenario.
+        page = BrowserPage(port=port)
+        try:
+            out = page.screenshot(str(tmp_path / "first.png"))
+        finally:
+            page.close()
+
+        data = Path(out).read_bytes()
+        assert data[:8] == b"\x89PNG\r\n\x1a\n", "first capture wrote a non-PNG"
+        assert data[12:16] == b"IHDR", "first capture wrote a truncated PNG"
+    finally:
+        chrome.terminate()
+        try:
+            chrome.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            chrome.kill()
+        shutil.rmtree(user_data_dir, ignore_errors=True)

--- a/tests/test_browser_page.py
+++ b/tests/test_browser_page.py
@@ -355,6 +355,7 @@ class TestBrowserPageScreenshot:
         fake_png = base64.b64encode(b"full").decode()
         page, cdp = _make_page()
         cdp.send.side_effect = [
+            {},  # Page.enable (headless first-frame guard, #1124)
             {"contentSize": {"width": 1920, "height": 5000}},  # getLayoutMetrics
             {"data": fake_png},  # captureScreenshot
         ]
@@ -362,7 +363,7 @@ class TestBrowserPageScreenshot:
         path = str(tmp_path / "full.png")
         page.screenshot(path, full_page=True)
 
-        # First call is getLayoutMetrics
+        # Layout metrics are queried for the full-page clip.
         cdp.send.assert_any_call("Page.getLayoutMetrics")
 
     def test_screenshot_passes_params_positionally_1119(self, tmp_path):

--- a/tests/test_browser_screenshot_selector_1123.py
+++ b/tests/test_browser_screenshot_selector_1123.py
@@ -57,7 +57,10 @@ class TestScreenshotSelectorSDK:
 
         assert result == out
         page.find.assert_called_once_with("#intro")
-        cdp.send.assert_called_once_with(
+        # The Page domain is enabled before the capture (headless first-frame
+        # guard, #1124), then exactly one capture carries the element clip.
+        cdp.send.assert_any_call("Page.enable")
+        cdp.send.assert_any_call(
             "Page.captureScreenshot",
             {
                 "format": "png",
@@ -71,6 +74,12 @@ class TestScreenshotSelectorSDK:
                 "captureBeyondViewport": True,
             },
         )
+        capture_calls = [
+            call
+            for call in cdp.send.call_args_list
+            if call.args[0] == "Page.captureScreenshot"
+        ]
+        assert len(capture_calls) == 1
         with open(out, "rb") as fh:
             assert fh.read() == b"cropped"
 
@@ -118,9 +127,16 @@ class TestScreenshotSelectorSDK:
 
         page.screenshot(str(tmp_path / "v.png"))
 
-        cdp.send.assert_called_once_with(
-            "Page.captureScreenshot", {"format": "png"}
-        )
+        # The Page domain is enabled before the capture (headless first-frame
+        # guard, #1124); the capture itself stays a single plain viewport grab.
+        cdp.send.assert_any_call("Page.enable")
+        cdp.send.assert_any_call("Page.captureScreenshot", {"format": "png"})
+        capture_calls = [
+            call
+            for call in cdp.send.call_args_list
+            if call.args[0] == "Page.captureScreenshot"
+        ]
+        assert len(capture_calls) == 1
 
 
 # ── BrowserElement._bounding_box ──────────────────────────────────────────────


### PR DESCRIPTION
## What
Fixes #1124 — the **first** \`browser screenshot\` against a freshly-launched **headless** Chrome could time out the full CDP budget and write no file (exit 1), failing naturo's canonical first action after \`launch\` for an agent whose verification model is "only trust screenshot evidence".

## Root cause
In headless mode Chrome does not composite an on-screen frame until something forces it. The separately-connected \`screenshot\` process (the canonical CLI flow: \`browser launch\` then a separate \`browser screenshot\`) never enabled the Page domain and jumped straight to \`Page.captureScreenshot\`, which blocks until a frame exists — so the first capture stalls the entire 30 s timeout and fails, while every later capture succeeds (the timed-out attempt warmed the compositor).

## How
- Send \`Page.enable\` before the first capture so Chrome schedules the first frame (matches \`navigate\`/\`reload\`/\`wait\`; idempotent).
- Wrap the capture in a **single bounded retry** (\`_capture_screenshot\`): the stalled attempt forces the frame, so the retry returns immediately and writes a valid PNG instead of failing. Bounded to one re-attempt so a genuinely dead connection still surfaces \`CDPTimeoutError\` rather than looping.

No CLI flag, signature, or public-API change — pure robustness fix.

## How tested
- **Hermetic unit tests** (run on the headless CI matrix) drive a fake CDP transport to prove: Page-domain enable precedes capture; a first-frame timeout self-heals via exactly one retry; the happy path captures once; the retry is bounded (re-raises on a persistently dead capture).
- **\`@pytest.mark.desktop\` integration test**: launches real headless Chrome, loads content on one connection, then takes the very first cold-connection capture and asserts a valid PNG — faithful to the #1124 repro.
- **Manual e2e on a real desktop** reproduced the genuine stall: the CLI logged \`First Page.captureScreenshot stalled (headless first-frame); retrying once (#1124)\` and the retry wrote a valid 11560-byte PNG with **exit 0** (was: exit 1, no file).
- \`ruff\` clean, \`mypy\` clean, full \`tests/browser/\` + \`tests/test_cdp.py\` (non-desktop) green.

## Note for reviewers
In the rare case the stall still occurs, the first attempt consumes the ~30 s CDP timeout before the retry succeeds — the same wait users already experienced, but it now **succeeds** instead of failing. Bounding that first-attempt latency (a shorter capture timeout) is a possible follow-up, kept out of scope to keep this fix atomic.