### PR TITLE
fix: clipboard get reports non-text content truthfully instead of empty/text (fixes #1079)

### DIFF
--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -1491,6 +1491,13 @@ naturo clipboard clear                  # Clear clipboard
 
 Read current clipboard content.
 
+When the clipboard holds non-text data (an image or a file-drop list) there is
+no text to return: the plain output reports `(clipboard contains non-text data:
+image|files)` rather than falsely claiming the clipboard is empty, and the JSON
+`format` field reflects the real content type (`image`/`files`/`empty`/`text`)
+with `has_text` indicating whether text is present — consistent with `clipboard
+info`.
+
 **Options:**
 
 | Flag | Type | Description |

--- a/naturo/cli/system/_clipboard.py
+++ b/naturo/cli/system/_clipboard.py
@@ -13,12 +13,15 @@ Examples:
 from __future__ import annotations
 
 from naturo.cli._jsonio import json_dumps
+import logging
 import sys
 
 import click
 
 from naturo.cli.error_helpers import emit_error, emit_exception_error
 from naturo.cli.fuzzy_group import FuzzyGroup
+
+logger = logging.getLogger(__name__)
 
 
 def _get_backend(json_output: bool = False):
@@ -114,8 +117,13 @@ def clipboard() -> None:
 def get(fmt: str, json_output: bool) -> None:
     """Read current clipboard content.
 
-    Returns the text content of the system clipboard. If the clipboard is
-    empty or contains non-text data, returns an empty string.
+    Returns the text content of the system clipboard. When the clipboard holds
+    non-text data (an image or a file-drop list) there is no text to return, so
+    the reported ``format`` reflects the real content (``image``/``files``)
+    rather than ``text``, and the plain output says the clipboard holds non-text
+    data instead of falsely claiming it is empty (#1079). A genuinely empty
+    clipboard reports ``format: empty``. ``clipboard info`` is the source of
+    truth that ``get`` consults for this distinction.
 
     \b
     Examples:
@@ -129,17 +137,44 @@ def get(fmt: str, json_output: bool) -> None:
         emit_exception_error(exc, json_output, fallback_code="CLIPBOARD_ERROR")
         return
 
+    # Determine the real clipboard format so non-text content is never
+    # misreported as empty text (#1079). When text is present the format is
+    # unambiguously "text", so skip the extra clipboard probe; only consult
+    # ``clipboard info`` when there is no text to tell a genuinely empty
+    # clipboard apart from one holding an image or files. The ``--format``
+    # choice (text-only) selects the read strategy, not the reported content
+    # type, so it no longer dictates the ``format`` field.
+    if text:
+        clip_format = "text"
+        has_text = True
+    else:
+        clip_format = "empty"
+        has_text = False
+        try:
+            clip_info = backend.clipboard_info()
+        except Exception as exc:
+            # A failed info probe must not turn a successful (empty) read into
+            # an error; fall back to reporting an empty clipboard.
+            logger.debug("clipboard_info probe failed during get: %s", exc)
+            clip_info = {}
+        if isinstance(clip_info, dict):
+            clip_format = clip_info.get("format") or "empty"
+            has_text = bool(clip_info.get("has_text", False))
+
     if json_output:
         click.echo(json_dumps({
             "success": True,
             "action": "clipboard_get",
-            "format": fmt,
+            "format": clip_format,
             "text": text,
             "length": len(text),
+            "has_text": has_text,
         }))
     else:
         if text:
             click.echo(text)
+        elif clip_format in ("image", "files"):
+            click.echo(f"(clipboard contains non-text data: {clip_format})", err=True)
         else:
             click.echo("(clipboard is empty)", err=True)
 

--- a/tests/test_clipboard_cmd.py
+++ b/tests/test_clipboard_cmd.py
@@ -82,6 +82,104 @@ class TestClipboardGet:
         assert "line1" in result.output
         assert "line2" in result.output
 
+    # --- #1079: non-text content must not be misreported as empty/text ------
+
+    def test_get_image_plain_reports_non_text(self, runner, mock_backend):
+        """An image on the clipboard must not be reported as '(clipboard is empty)'."""
+        mock_backend.clipboard_get.return_value = ""
+        mock_backend.clipboard_info.return_value = {
+            "format": "image", "size": 4096,
+            "has_text": False, "has_image": True, "has_files": False,
+        }
+        with patch("naturo.backends.base.get_backend", return_value=mock_backend):
+            result = runner.invoke(clipboard, ["get"])
+        assert result.exit_code == 0
+        assert "non-text" in result.output.lower()
+        assert "image" in result.output.lower()
+        assert "is empty" not in result.output
+
+    def test_get_files_plain_reports_non_text(self, runner, mock_backend):
+        """A file-drop list must not be reported as '(clipboard is empty)'."""
+        mock_backend.clipboard_get.return_value = ""
+        mock_backend.clipboard_info.return_value = {
+            "format": "files", "size": 128,
+            "has_text": False, "has_image": False, "has_files": True,
+        }
+        with patch("naturo.backends.base.get_backend", return_value=mock_backend):
+            result = runner.invoke(clipboard, ["get"])
+        assert result.exit_code == 0
+        assert "non-text" in result.output.lower()
+        assert "files" in result.output.lower()
+        assert "is empty" not in result.output
+
+    def test_get_image_json_reflects_real_format(self, runner, mock_backend):
+        """get -j must report the true format (not a hardcoded 'text') for an image."""
+        mock_backend.clipboard_get.return_value = ""
+        mock_backend.clipboard_info.return_value = {
+            "format": "image", "size": 4096,
+            "has_text": False, "has_image": True, "has_files": False,
+        }
+        with patch("naturo.backends.base.get_backend", return_value=mock_backend):
+            result = runner.invoke(clipboard, ["get", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["success"] is True
+        assert data["text"] == ""
+        assert data["length"] == 0
+        assert data["format"] == "image"
+        assert data["has_text"] is False
+
+    def test_get_files_json_reflects_real_format(self, runner, mock_backend):
+        """get -j must report 'files' (not 'text') for a file-drop list."""
+        mock_backend.clipboard_get.return_value = ""
+        mock_backend.clipboard_info.return_value = {
+            "format": "files", "size": 128,
+            "has_text": False, "has_image": False, "has_files": True,
+        }
+        with patch("naturo.backends.base.get_backend", return_value=mock_backend):
+            result = runner.invoke(clipboard, ["get", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["format"] == "files"
+        assert data["has_text"] is False
+
+    def test_get_truly_empty_json_reports_empty_format(self, runner, mock_backend):
+        """A genuinely empty clipboard reports format 'empty', not 'text'."""
+        mock_backend.clipboard_get.return_value = ""
+        mock_backend.clipboard_info.return_value = {
+            "format": "empty", "size": 0,
+            "has_text": False, "has_image": False, "has_files": False,
+        }
+        with patch("naturo.backends.base.get_backend", return_value=mock_backend):
+            result = runner.invoke(clipboard, ["get", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["format"] == "empty"
+        assert data["has_text"] is False
+
+    def test_get_text_json_does_not_probe_info(self, runner, mock_backend):
+        """When text is present the format is unambiguously 'text' and info is not consulted."""
+        mock_backend.clipboard_get.return_value = "hello"
+        with patch("naturo.backends.base.get_backend", return_value=mock_backend):
+            result = runner.invoke(clipboard, ["get", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["format"] == "text"
+        assert data["has_text"] is True
+        mock_backend.clipboard_info.assert_not_called()
+
+    def test_get_info_probe_failure_falls_back_to_empty(self, runner, mock_backend):
+        """If info probing fails on an empty text read, get still succeeds (reports empty)."""
+        from naturo.errors import NaturoError
+        mock_backend.clipboard_get.return_value = ""
+        mock_backend.clipboard_info.side_effect = NaturoError("CLIPBOARD_ERROR", "locked")
+        with patch("naturo.backends.base.get_backend", return_value=mock_backend):
+            result = runner.invoke(clipboard, ["get", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["success"] is True
+        assert data["format"] == "empty"
+
 
 # ---------------------------------------------------------------------------
 # clipboard set


### PR DESCRIPTION
## What
`naturo clipboard get` misreported **non-text** clipboard content (an image or a file-drop list) as `(clipboard is empty)` (plain) and `format: "text"` (JSON) — directly contradicting `clipboard info` for the identical clipboard state. An agent that copied a screenshot or files and then ran `clipboard get` was told the clipboard was empty and would conclude the copy silently failed. This is a never-lie / contract bug (SOUL.md, #1079).

## How
- `get` now consults `clipboard_info()` (the same source of truth as `clipboard info`) **only when `clipboard_get()` returns no text**, so a genuinely empty clipboard is told apart from one holding non-text data.
- Plain output: non-text content prints `(clipboard contains non-text data: image|files)`; a truly empty clipboard still prints `(clipboard is empty)`.
- JSON output: `format` now reflects the real content type (`image`/`files`/`empty`/`text`) instead of a hardcoded `"text"`, plus a truthful additive `has_text` field.
- When text is present the format is unambiguously `text`, so the extra probe is skipped; a failed info probe degrades gracefully to reporting empty (a successful empty read never becomes an error).
- No CLI flag / parameter / signature change — purely corrects the value of existing output and adds one truthful field.

## How tested
- New hermetic unit tests in `tests/test_clipboard_cmd.py` covering: image & files → plain non-text message and JSON real format + `has_text:false`; truly-empty → `format:empty`; text-present skips the info probe (`assert_not_called`); info-probe failure degrades to empty.
- `tests/test_clipboard_cmd.py`: 31 passed. `ruff check naturo/`: clean. `mypy naturo/`: clean (no naturo errors).
- Full suite `python -m pytest tests/ -m "not desktop" --timeout=120 --basetemp=<clean>`: **6647 passed**, 8 failed + 11 errors — all pre-existing desktop-hermeticity/env failures unrelated to this change (test_verify #1100, test_win32_hybrid #1133, test_app_ids/test_version_consistency/test_agent timing & DLL-version, test_cost_guardrails config-read), proven identical with this change stashed.
- End-to-end on a real Windows desktop: placed an image on the clipboard (PowerShell `SetImage`, reversible, no SendInput) → `clipboard get` prints `(clipboard contains non-text data: image)` and `get -j` returns `{"format":"image","text":"","length":0,"has_text":false}`, matching `clipboard info`.