### PR TITLE
fix: round-trip full-path process_name back into --app (fixes #1084)

### DIFF
--- a/naturo/backends/windows/_element/_app_discovery.py
+++ b/naturo/backends/windows/_element/_app_discovery.py
@@ -183,6 +183,18 @@ class AppDiscoveryMixin:
             return 0  # foreground window
 
         search_lower = search.lower() if search else ""
+        # (#1084) An agent may feed the full-path `process_name` that
+        # `list windows`/`list apps`/`app list` emit (e.g.
+        # "C:\\...\\WindowsTerminal.exe") straight back into --app. Normalize the
+        # --app query to a basename without the .exe suffix so it compares the
+        # same way `proc_stem` is derived below, keeping the discover→act
+        # round-trip working across the whole --app family. A plain name
+        # ("notepad") normalizes to itself, so existing matching is unchanged;
+        # basenaming also preserves the #789 guard against a shared directory
+        # component (e.g. "WindowsApps") over-matching unrelated windows.
+        app_query = (ntpath.basename(search_lower) or search_lower) if app else search_lower
+        if app and app_query.endswith(".exe"):
+            app_query = app_query[:-4]
         windows = self.list_windows()
 
         # (#471) Filter by PID when provided — only consider windows owned
@@ -238,10 +250,12 @@ class AppDiscoveryMixin:
                 # All PID-filtered windows are valid candidates
                 score = 1
             elif match_process:
-                # Process-name matching (priority)
-                if search_lower == proc_stem:
+                # Process-name matching (priority). Uses the normalized
+                # `app_query` (basename, no .exe) so a full-path --app value
+                # round-trips (#1084).
+                if app_query == proc_stem:
                     score = 4  # exact process name
-                elif search_lower in proc_stem:
+                elif app_query in proc_stem:
                     score = 3  # substring in process name
                 # (#465) Title-only fallback removed from --app matching.
                 # When --app is used, we only match by process name or alias.
@@ -251,7 +265,7 @@ class AppDiscoveryMixin:
                 #
                 # Alias matching: cross-locale app name resolution
                 if score == 0:
-                    aliases = self._APP_ALIASES.get(search_lower, set())
+                    aliases = self._APP_ALIASES.get(app_query, set())
                     for alias in aliases:
                         if alias == proc_stem:
                             score = 4  # alias → exact process name
@@ -491,6 +505,12 @@ class AppDiscoveryMixin:
             return []
 
         search_lower = search.lower()
+        # (#1084) Normalize a full-path --app query to a basename without .exe
+        # so the value emitted by the list family round-trips here too; mirrors
+        # _resolve_hwnd. See that method for the full rationale.
+        app_query = (ntpath.basename(search_lower) or search_lower) if app else search_lower
+        if app and app_query.endswith(".exe"):
+            app_query = app_query[:-4]
         windows = self.list_windows()
         console_session = _get_console_session_id()
         match_process = app is not None
@@ -507,15 +527,15 @@ class AppDiscoveryMixin:
             title_lower = w.title.lower()
 
             if match_process:
-                # Process-name matching
-                if search_lower == proc_stem:
+                # Process-name matching (normalized query, #1084)
+                if app_query == proc_stem:
                     score = 4
-                elif search_lower in proc_stem:
+                elif app_query in proc_stem:
                     score = 3
                 # (#465) No title fallback for --app (see _resolve_hwnd)
                 # Alias matching
                 if score == 0:
-                    aliases = self._APP_ALIASES.get(search_lower, set())
+                    aliases = self._APP_ALIASES.get(app_query, set())
                     for alias in aliases:
                         if alias == proc_stem:
                             score = 4

--- a/naturo/cli/core/_list.py
+++ b/naturo/cli/core/_list.py
@@ -92,9 +92,18 @@ def windows(app, window_title, hwnd, app_id, pid, json_output) -> None:
         # Apply filters (all combine with AND).
         if app:
             app_lower = app.lower()
+            # An agent may feed the full-path `process_name` this command emits
+            # (e.g. "C:\\...\\WindowsTerminal.exe") straight back into --app, so
+            # basename the query before the process-name comparison to keep the
+            # discover→act round-trip working (#1084). This mirrors the
+            # gold-standard `_resolve_hwnd`, which compares against
+            # basename(process_name) and deliberately avoids full-path matching
+            # to prevent over-matching shared directories (#789). A non-path
+            # query basenames to itself, so name/substring matching is unchanged.
+            app_query = ntpath.basename(app_lower) or app_lower
             win_list = [w for w in win_list
                         if app_lower in w.title.lower()
-                        or app_lower in ntpath.basename(w.process_name).lower()]
+                        or app_query in ntpath.basename(w.process_name).lower()]
         if window_title:
             title_lower = window_title.lower()
             win_list = [w for w in win_list if title_lower in w.title.lower()]

--- a/tests/test_app_path_roundtrip_1084.py
+++ b/tests/test_app_path_roundtrip_1084.py
@@ -1,0 +1,126 @@
+"""Tests for #1084: the full-path ``process_name`` the list family emits must
+round-trip back into ``--app`` everywhere.
+
+``list windows``/``list apps``/``app list`` expose each window's executable as
+``process_name`` set to a full absolute path (e.g.
+``C:\\Program Files\\WindowsApps\\...\\WindowsTerminal.exe``). An agent that
+discovers a window and feeds that exact value back into ``--app`` must select
+the same window — both via ``list windows --app`` (covered in
+``test_cli_list.py``) and via the shared resolver used by
+``see``/``capture``/``click``/``find``/``highlight``/``menu`` (covered here).
+
+The resolver previously normalized only the *stored* ``process_name`` to a
+basename (#789) while comparing it against the *raw* query, so a full-path or
+``.exe``-suffixed query matched nothing — the discover→act round-trip was broken
+and ``list windows --app`` would have diverged from the action commands.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from naturo.backends.base import WindowInfo
+
+_ELEMENT_MOD = "naturo.backends.windows._element._app_discovery"
+
+# A realistic full-path process_name as emitted by `list windows -j` for a
+# packaged (MSIX) app — the exact value from the #1084 repro.
+_TERMINAL_PATH = (
+    r"C:\Program Files\WindowsApps"
+    r"\Microsoft.WindowsTerminal_1.24.11321.0_x64__8wekyb3d8bbwe"
+    r"\WindowsTerminal.exe"
+)
+
+
+def _backend_class():
+    try:
+        from naturo.backends.windows import WindowsBackend
+        return WindowsBackend
+    except Exception:
+        pytest.skip("WindowsBackend not available on this platform")
+
+
+def _windows():
+    """Two windows whose process_name fields contain full executable paths."""
+    return [
+        WindowInfo(
+            handle=2001, title="claude",
+            process_name=_TERMINAL_PATH, pid=300,
+            x=0, y=0, width=1200, height=800,
+            is_visible=True, is_minimized=False,
+        ),
+        WindowInfo(
+            handle=2002, title="Untitled - Notepad",
+            process_name=r"C:\Windows\System32\notepad.exe", pid=100,
+            x=0, y=0, width=800, height=600,
+            is_visible=True, is_minimized=False,
+        ),
+    ]
+
+
+def _resolve_hwnd(app):
+    BackendClass = _backend_class()
+    backend = MagicMock(spec=BackendClass)
+    backend.list_windows = MagicMock(return_value=_windows())
+    backend._resolve_hwnd = BackendClass._resolve_hwnd.__get__(backend)
+    backend._APP_ALIASES = BackendClass._APP_ALIASES
+    backend._DESKTOP_SHELL_CLASSES = BackendClass._DESKTOP_SHELL_CLASSES
+    backend._get_window_class_name = MagicMock(return_value="")
+    backend._get_foreground_hwnd = MagicMock(return_value=0)
+    backend._uwp_afh_fallback = MagicMock(return_value=None)
+    with patch(f"{_ELEMENT_MOD}._get_console_session_id", return_value=-1), \
+         patch(f"{_ELEMENT_MOD}._get_process_session_id", return_value=1):
+        return backend._resolve_hwnd(app=app)
+
+
+def _resolve_hwnds(app):
+    BackendClass = _backend_class()
+    backend = MagicMock(spec=BackendClass)
+    backend.list_windows = MagicMock(return_value=_windows())
+    backend._resolve_hwnds = BackendClass._resolve_hwnds.__get__(backend)
+    backend._APP_ALIASES = BackendClass._APP_ALIASES
+    backend._uwp_afh_fallback = MagicMock(return_value=None)
+    with patch(f"{_ELEMENT_MOD}._get_console_session_id", return_value=-1), \
+         patch(f"{_ELEMENT_MOD}._get_process_session_id", return_value=1):
+        return backend._resolve_hwnds(app=app)
+
+
+class TestResolveHwndPathRoundTrip:
+    """_resolve_hwnd must accept the full-path value list output emits."""
+
+    def test_full_path_round_trips(self):
+        # The exact emitted process_name selects the same window.
+        assert _resolve_hwnd(_TERMINAL_PATH) == 2001
+
+    def test_basename_with_exe_round_trips(self):
+        assert _resolve_hwnd("WindowsTerminal.exe") == 2001
+
+    def test_plain_basename_still_matches(self):
+        assert _resolve_hwnd("WindowsTerminal") == 2001
+
+    def test_partial_name_still_matches(self):
+        assert _resolve_hwnd("terminal") == 2001
+
+    def test_shared_directory_does_not_overmatch(self):
+        # Basenaming the query must NOT broaden to full-path substring matching:
+        # a shared directory component must not pull in unrelated windows (#789).
+        from naturo.errors import WindowNotFoundError
+        with pytest.raises(WindowNotFoundError):
+            _resolve_hwnd(r"C:\Program Files\WindowsApps")
+
+
+class TestResolveHwndsPathRoundTrip:
+    """_resolve_hwnds must round-trip the full path the same way (#304 see --app)."""
+
+    def test_full_path_round_trips(self):
+        assert 2001 in _resolve_hwnds(_TERMINAL_PATH)
+
+    def test_basename_with_exe_round_trips(self):
+        assert 2001 in _resolve_hwnds("WindowsTerminal.exe")
+
+    def test_plain_basename_still_matches(self):
+        assert 2001 in _resolve_hwnds("WindowsTerminal")
+
+    def test_shared_directory_does_not_overmatch(self):
+        assert _resolve_hwnds(r"C:\Program Files\WindowsApps") == []

--- a/tests/test_cli_list.py
+++ b/tests/test_cli_list.py
@@ -144,6 +144,72 @@ class TestListWindows:
         assert "PLATFORM_ERROR" in result.output
 
 
+# ── list windows: --app round-trips its own full-path output (#1084) ──
+
+
+class TestListWindowsAppRoundTrip:
+    """The full-path ``process_name`` emitted by ``list windows -j`` must feed
+    straight back into ``--app`` and select the same window (#1084).
+
+    Previously ``--app`` matched the query against ``basename(process_name)``
+    only, while the JSON output leaked the full absolute path — so an agent
+    that discovered a window and fed its reported ``process_name`` back into
+    ``--app`` got zero matches (discover→act round-trip broken).
+    """
+
+    FULL_PATH = (
+        r"C:\Program Files\WindowsApps"
+        r"\Microsoft.WindowsTerminal_1.24.11321.0_x64__8wekyb3d8bbwe"
+        r"\WindowsTerminal.exe"
+    )
+
+    @pytest.fixture
+    def path_backend(self):
+        backend = MagicMock()
+        backend.list_windows.return_value = [
+            _make_window(handle=2001, title="claude", process_name=self.FULL_PATH, pid=300),
+            _make_window(handle=2002, title="Calculator", process_name="calc.exe", pid=200),
+        ]
+        return backend
+
+    def _run(self, runner, backend, app_value):
+        with _patch_platform(), _patch_backend(backend), \
+             patch("os.getpid", return_value=99999), patch("os.getppid", return_value=99998):
+            return runner.invoke(
+                list_cmd, ["windows", "--app", app_value, "--json"], catch_exceptions=False
+            )
+
+    def test_full_path_process_name_round_trips(self, runner, path_backend):
+        # The exact value emitted in the JSON must select the same window.
+        result = self._run(runner, path_backend, self.FULL_PATH)
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["count"] == 1
+        assert data["windows"][0]["handle"] == 2001
+        # And the round-tripped value is exactly what the command emitted.
+        assert data["windows"][0]["process_name"] == self.FULL_PATH
+
+    def test_basename_still_matches(self, runner, path_backend):
+        result = self._run(runner, path_backend, "WindowsTerminal.exe")
+        data = json.loads(result.output)
+        assert data["count"] == 1
+        assert data["windows"][0]["handle"] == 2001
+
+    def test_partial_name_still_matches(self, runner, path_backend):
+        result = self._run(runner, path_backend, "terminal")
+        data = json.loads(result.output)
+        assert data["count"] == 1
+        assert data["windows"][0]["handle"] == 2001
+
+    def test_path_query_does_not_overmatch_siblings(self, runner, path_backend):
+        # Basenaming the query must NOT broaden to full-path substring matching:
+        # a shared directory component (e.g. "WindowsApps") must not pull in
+        # unrelated windows the way matching the whole path would (#789).
+        result = self._run(runner, path_backend, r"C:\Program Files\WindowsApps")
+        data = json.loads(result.output)
+        assert data["count"] == 0
+
+
 # ── list screens ─────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## What
`list windows`/`list apps`/`app list` emit each window's `process_name` as a full absolute path (e.g. `C:\Program Files\WindowsApps\…\WindowsTerminal.exe`), but `--app` matching compared the query against the **basename** of the stored process_name only (#789) while leaving the **query** un-normalized. An agent that discovered a window with `list … -j` and fed the reported `process_name` straight back into `--app` got **zero matches** — the discover→act round-trip was broken.

This normalizes the `--app` query itself to a basename without the `.exe` suffix at **every** matching chokepoint, so the value the list family emits selects the same window everywhere it can be used — keeping the whole `--app` family resolving the same way (cross-command parity) rather than fixing one command and diverging from the rest.

## How
- `list windows --app` inline filter — `naturo/cli/core/_list.py`
- shared resolver `_resolve_hwnd`/`_resolve_hwnds` (used by `see`/`capture`/`click`/`find`/`highlight`/`menu`) — `naturo/backends/windows/_element/_app_discovery.py`

A plain name (`notepad`) normalizes to itself, so existing matching is unchanged. Basenaming the query preserves the **#789 guard**: a shared directory component (e.g. `WindowsApps`) must not over-match unrelated windows.

## How tested
- `ruff check naturo/` → All checks passed; `mypy` on changed files → no issues.
- New round-trip/parity tests, all green on a real Windows desktop:
  - `tests/test_cli_list.py::TestListWindowsAppRoundTrip` — full-path round-trips, basename + partial still match, path query does not over-match siblings.
  - `tests/test_app_path_roundtrip_1084.py` — same assertions at the resolver level (`_resolve_hwnd` + `_resolve_hwnds`), incl. `.exe`-suffixed and full-path queries.
- Full non-desktop suite (`pytest tests/ -m "not desktop"`): **6048 passed**; my 13 new tests pass. Verified against a clean-baseline run (6036 passed) — no regressions: the only non-baseline delta is a pre-existing flaky timing test (`test_agent::test_total_time_recorded`, fails in isolation too, unrelated to these modules). Remaining failures/errors are pre-existing Windows-desktop/platform env issues identical in both runs.

Fixes #1084