### PR TITLE
feat: auto-detect find strategy from bare image-path/selector queries (fixes #1144)

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,8 +158,11 @@ naturo type "Hello" --input-mode hardware
 # Press key combo
 naturo press ctrl+s
 
-# Find element
-naturo find "Edit:filename"
+# Find element — the universal locator auto-detects the strategy from the query
+naturo find "Edit:filename"                # UIA tree search (name / role:name)
+naturo find button.png                     # image template match (.png/.jpg/…)
+naturo find 'app://notepad.exe/Edit'       # resolve a selector path
+naturo find @save-btn                      # resolve a saved @named selector
 
 # App management
 naturo app launch "notepad"

--- a/naturo/cli/core/_find.py
+++ b/naturo/cli/core/_find.py
@@ -8,6 +8,44 @@ import click
 
 import naturo.cli.core._common as _common
 
+# (#1144 / #809 §4) File extensions that mark a bare query as an image-template
+# path for strategy auto-detection. Lower-cased; compared case-insensitively.
+_IMAGE_QUERY_EXTENSIONS = frozenset(
+    {".png", ".jpg", ".jpeg", ".bmp", ".gif", ".tif", ".tiff", ".webp"}
+)
+
+
+def _detect_query_strategy(query: str) -> str | None:
+    """Infer the find strategy from a bare query's shape (#1144, #809 §4).
+
+    The unified find engine is a *universal locator*: a positional (or
+    ``-q/--query``) value should reach the right strategy without the caller
+    spelling out ``--image``/``--selector``. This classifies only the
+    *unambiguous* shapes from the #809 table; everything else falls through to
+    the default UIA tree search so a normal name query is never hijacked.
+
+    Args:
+        query: The raw query string (positional arg or ``--query`` value).
+
+    Returns:
+        ``"selector"`` for a unified-selector path (an ``app://…`` URI or an
+        ``@name`` saved-selector ref), ``"image"`` for a template-image file
+        path (extension in :data:`_IMAGE_QUERY_EXTENSIONS`), or ``None`` for an
+        ordinary text/role query.
+    """
+    import os
+
+    q = query.strip()
+    # Only ``app://`` URIs and ``@name`` refs auto-route to the selector engine
+    # (per the #809 table). The ``//`` shorthand is deliberately excluded: it is
+    # far likelier to be a literal text fragment than the ``app://``/``@`` forms,
+    # so it stays a text query unless passed via the explicit --selector flag.
+    if q.startswith("app://") or q.startswith("@"):
+        return "selector"
+    if os.path.splitext(q)[1].lower() in _IMAGE_QUERY_EXTENSIONS:
+        return "image"
+    return None
+
 
 @click.command("find")
 @click.argument("query", required=False, default=None)
@@ -72,6 +110,14 @@ def find_cmd(query: str | None, query_opt: str | None, find_all: bool, role: str
     Use --backend ia2 for IA2-enabled apps (Firefox, Thunderbird, LibreOffice).
 
     \b
+    Strategy auto-detection: a bare query routes itself by shape, so you can skip
+    the explicit flag —
+        app://… or @name        -> selector resolution (same as --selector)
+        path ending .png/.jpg/… -> image template match (same as --image)
+        anything else           -> UIA tree search
+    Explicit --image/--selector/--ai always take precedence.
+
+    \b
     Examples:
         naturo find "Save"                      # fuzzy name search
         naturo find "Button:Save"               # role + name
@@ -82,10 +128,11 @@ def find_cmd(query: str | None, query_opt: str | None, find_all: bool, role: str
         naturo find "Save" --app "Notepad"              # search in specific app
         naturo find "search field" --ai --app "Chrome"  # AI + specific app
         naturo find "OK" --backend msaa          # MSAA for legacy apps
-        naturo find --image submit.png           # template match on screen
+        naturo find submit.png                   # auto-detected image template match
         naturo find --image icon.png --app Notepad --all  # all matches in app
+        naturo find 'app://notepad.exe/Edit'     # auto-detected selector resolution
+        naturo find @save-btn                    # auto-detected saved selector
         naturo find --selector '//Button[@name="Save"]'   # resolve a selector path
-        naturo find --selector 'app://notepad.exe/Edit[@automationid="15"]'
     """
     # (#752) Auto-detect app ID pattern (a1, a2, ...) in --app flag
     from naturo.cli.options import maybe_promote_app_to_app_id
@@ -105,6 +152,25 @@ def find_cmd(query: str | None, query_opt: str | None, find_all: bool, role: str
                 click.echo(f"Error: {msg}", err=True)
             raise SystemExit(1)
         hwnd = entry.handle
+
+    # (#1144 / #809 §4) Strategy auto-detection — when the caller gives a bare
+    # query and no explicit strategy flag, infer the locator strategy from the
+    # query's shape so `naturo find button.png` and `naturo find app://…` reach
+    # the image and selector engines without --image/--selector. Explicit
+    # --image/--selector/--ai always win (we only run when none is set), and an
+    # ordinary text/role query stays on the default tree-search path. The
+    # detected query is moved into the matching strategy flag so the existing
+    # dispatch (and its conflict checks) handle it unchanged.
+    _auto_query = query if query is not None else query_opt
+    if (selector is None and image_template is None and not ai
+            and not find_all and _auto_query is not None):
+        detected = _detect_query_strategy(_auto_query)
+        if detected == "selector":
+            selector = _auto_query
+            query = query_opt = None
+        elif detected == "image":
+            image_template = _auto_query
+            query = query_opt = None
 
     # Selector resolution mode — resolve a saved/inline selector path to an
     # element (the third unified-find strategy, #1061 / #809).  Dispatched

--- a/tests/test_find_autodetect_1144.py
+++ b/tests/test_find_autodetect_1144.py
@@ -1,0 +1,204 @@
+"""Tests for ``naturo find`` strategy auto-detection (feature #1144, part of #809).
+
+The unified find engine is meant to be a *universal locator*: a bare positional
+(or ``-q/--query``) value should route to the right strategy from its shape,
+without the caller having to spell out ``--image``/``--selector`` (#809 section 4):
+
+| Input shape                       | Strategy            |
+|-----------------------------------|---------------------|
+| starts with ``app://`` or ``@``   | selector resolution |
+| file path ending ``.png``/``.jpg``| image matching      |
+| everything else                   | UIA tree search     |
+
+These tests assert the *routing* decision by stubbing the per-strategy helpers
+(``_find_with_selector`` / ``_find_with_image``) — so they neither touch the
+native core nor a desktop session and run on every CI platform. A couple of
+end-to-end cases reuse the selector resolver against an in-memory tree to prove
+the auto-detected path produces the same envelope as the explicit flag.
+
+Key invariants pinned here:
+
+* explicit ``--image``/``--selector``/``--ai`` always win over auto-detection;
+* an ordinary text/role query (``Save``, ``Button:Save``, ``role:Edit``) is
+  never hijacked into the selector/image engines;
+* ``-q/--query`` auto-detects identically to the positional argument.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+
+import pytest
+from click.testing import CliRunner
+from unittest.mock import MagicMock, patch
+
+from naturo.cli.core import find_cmd
+from naturo.cli.core._find import _detect_query_strategy
+
+
+class TestDetectQueryStrategy:
+    """Unit-level coverage of the pure shape classifier."""
+
+    @pytest.mark.parametrize("query", [
+        "app://notepad.exe/Button[@name=\"Save\"]",
+        "app://chrome.exe/Edit",
+        "@save-btn",
+        "@notepad/edit-area",
+    ])
+    def test_selector_shapes(self, query) -> None:
+        assert _detect_query_strategy(query) == "selector"
+
+    @pytest.mark.parametrize("query", [
+        "button.png",
+        "submit.PNG",
+        "icon.jpg",
+        "shot.jpeg",
+        r"C:\images\save.bmp",
+        "/tmp/widget.gif",
+        "frame.webp",
+        "scan.tiff",
+    ])
+    def test_image_shapes(self, query) -> None:
+        assert _detect_query_strategy(query) == "image"
+
+    @pytest.mark.parametrize("query", [
+        "Save",
+        "Button:Save",
+        "role:Edit",
+        "the save button",
+        "*",
+        # A ``//`` shorthand is intentionally NOT auto-detected (only ``app://``
+        # and ``@`` are, per the #809 table) — it stays a text query unless the
+        # caller passes it via the explicit --selector flag.
+        "//Button[@name=\"Save\"]",
+        # A name that merely contains a dot but no image extension.
+        "v1.2.release",
+    ])
+    def test_text_shapes_fall_through(self, query) -> None:
+        assert _detect_query_strategy(query) is None
+
+
+@dataclass
+class _FakeElement:
+    """Minimal backend ``ElementInfo`` stand-in for the selector resolver."""
+
+    role: str
+    name: str = ""
+    id: str = ""
+    value: str = ""
+    x: int = 0
+    y: int = 0
+    width: int = 0
+    height: int = 0
+    children: list = field(default_factory=list)
+    properties: dict = field(default_factory=dict)
+
+
+def _sample_tree() -> _FakeElement:
+    return _FakeElement(
+        role="Window", name="Untitled - Notepad", x=0, y=0, width=800, height=600,
+        children=[
+            _FakeElement(role="Edit", name="Text Editor", id="15",
+                         x=10, y=40, width=780, height=520),
+            _FakeElement(role="Button", name="Save", x=700, y=8, width=60, height=24),
+        ],
+    )
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+class TestFindAutoDetectRouting:
+    """Bare queries dispatch to the inferred strategy helper."""
+
+    def test_image_path_routes_to_image(self, runner) -> None:
+        with patch("naturo.cli.core._find._find_with_image") as image, \
+             patch("naturo.cli.core._find._find_with_selector") as selector:
+            result = runner.invoke(find_cmd, ["button.png", "--json"])
+        assert result.exit_code == 0, result.output
+        image.assert_called_once()
+        # The detected path becomes the image template; no text query leaks in.
+        assert image.call_args.args[0] == "button.png"
+        selector.assert_not_called()
+
+    def test_app_uri_routes_to_selector(self, runner) -> None:
+        with patch("naturo.cli.core._find._find_with_selector") as selector, \
+             patch("naturo.cli.core._find._find_with_image") as image:
+            result = runner.invoke(
+                find_cmd, ["app://notepad.exe/Button[@name=\"Save\"]", "--json"])
+        assert result.exit_code == 0, result.output
+        selector.assert_called_once()
+        assert selector.call_args.args[0] == "app://notepad.exe/Button[@name=\"Save\"]"
+        image.assert_not_called()
+
+    def test_saved_ref_routes_to_selector(self, runner) -> None:
+        with patch("naturo.cli.core._find._find_with_selector") as selector:
+            result = runner.invoke(find_cmd, ["@save-btn", "--json"])
+        assert result.exit_code == 0, result.output
+        selector.assert_called_once()
+        assert selector.call_args.args[0] == "@save-btn"
+
+    def test_query_option_also_auto_detects(self, runner) -> None:
+        with patch("naturo.cli.core._find._find_with_image") as image:
+            result = runner.invoke(find_cmd, ["-q", "icon.png", "--json"])
+        assert result.exit_code == 0, result.output
+        image.assert_called_once()
+        assert image.call_args.args[0] == "icon.png"
+
+    def test_text_query_not_hijacked(self, runner) -> None:
+        """An ordinary name query must reach the tree-search path, untouched."""
+        backend = MagicMock()
+        backend.get_element_tree.return_value = None  # short-circuit after routing
+        with patch("naturo.cli.core._find._find_with_image") as image, \
+             patch("naturo.cli.core._find._find_with_selector") as selector, \
+             patch("naturo.cli.core._common._platform_supports_gui", return_value=True), \
+             patch("naturo.cli.core._common._get_backend", return_value=backend):
+            result = runner.invoke(find_cmd, ["Save", "--json"])
+        image.assert_not_called()
+        selector.assert_not_called()
+        # Reached tree search (which returned None → WINDOW_NOT_FOUND).
+        assert json.loads(result.output)["error"]["code"] == "WINDOW_NOT_FOUND"
+
+
+class TestExplicitFlagsWinOverAutoDetect:
+    def test_explicit_selector_with_image_like_value_unaffected(self, runner) -> None:
+        """``--selector foo.png`` must still go to the selector engine."""
+        with patch("naturo.cli.core._find._find_with_selector") as selector, \
+             patch("naturo.cli.core._find._find_with_image") as image:
+            result = runner.invoke(find_cmd, ["--selector", "@thing.png", "--json"])
+        assert result.exit_code == 0, result.output
+        selector.assert_called_once()
+        image.assert_not_called()
+
+    def test_ai_flag_suppresses_auto_detect(self, runner) -> None:
+        """With --ai, an image-like positional is the AI query, not a template."""
+        with patch("naturo.cli.core._find._find_with_ai") as ai_find, \
+             patch("naturo.cli.core._find._find_with_image") as image:
+            result = runner.invoke(find_cmd, ["button.png", "--ai", "--json"])
+        assert result.exit_code == 0, result.output
+        ai_find.assert_called_once()
+        image.assert_not_called()
+
+
+class TestAutoDetectEndToEndParity:
+    """Auto-detected selector path yields the same envelope as the explicit flag."""
+
+    def test_autodetect_selector_matches_explicit(self, runner) -> None:
+        tree = _sample_tree()
+
+        def run(args):
+            backend = MagicMock()
+            backend.get_element_tree.return_value = tree
+            with patch("naturo.cli.core._common._platform_supports_gui", return_value=True), \
+                 patch("naturo.cli.core._common._get_backend", return_value=backend):
+                return runner.invoke(find_cmd, args)
+
+        selector = "app://notepad.exe/Button[@name=\"Save\"]"
+        explicit = run(["--selector", selector, "--json"])
+        auto = run([selector, "--json"])
+        assert explicit.exit_code == 0 and auto.exit_code == 0, (
+            explicit.output, auto.output)
+        assert json.loads(explicit.output)["elements"] == \
+            json.loads(auto.output)["elements"]


### PR DESCRIPTION
## What

Implements **strategy auto-detection** (section 4) of the unified find engine (#809): a bare `naturo find <query>` now routes itself to the right locator strategy from the query's shape, so callers no longer have to spell out `--image`/`--selector`.

| Input shape | Strategy |
|-------------|----------|
| starts with `app://` or `@` | selector resolution (was: treated as a text query → no match) |
| path ending `.png`/`.jpg`/`.jpeg`/`.bmp`/`.gif`/`.tif`/`.tiff`/`.webp` | image template match |
| everything else | UIA tree search (unchanged) |

```bash
naturo find button.png                       # → image template match
naturo find 'app://notepad.exe/Edit'         # → selector resolution
naturo find @save-btn                        # → saved selector
naturo find "Save"   /   "Button:Save"       # → tree search (unchanged)
```

Auto-detection only fires when **no** explicit `--image`/`--selector`/`--ai` flag is given (explicit flags always win), and only for unambiguous shapes — an ordinary name/role query is never hijacked. The detected query is moved into the matching strategy flag, so the existing `_find_with_image`/`_find_with_selector` dispatch (and its conflict/error handling) runs unchanged — no new engine code.

The `//` shorthand is intentionally *not* auto-detected (only `app://`/`@` are, per the #809 table); it stays available via the explicit `--selector` flag.

## How tested

New hermetic module `tests/test_find_autodetect_1144.py` (27 tests, no DLL/desktop — runs on every CI platform):
- unit coverage of the shape classifier (`_detect_query_strategy`): selector / image / text-fall-through cases;
- routing tests stubbing the strategy helpers (image-path → image, `app://`/`@` → selector, `-q/--query` auto-detects too);
- text query (`Save`) is **not** hijacked → reaches tree search;
- explicit `--selector`/`--ai` precedence preserved;
- end-to-end parity: an auto-detected selector yields the same envelope as the explicit `--selector` flag.

Gate (run from the worktree root):
- `ruff check naturo/` → All checks passed
- `mypy naturo/` → no errors in `naturo/` (only a local-env false positive from the `mcp` package's py3.10 syntax under the 3.9 target; `mcp` is absent on CI's lint job, which installs only ruff+mypy)
- `python -m pytest tests/ -m "not desktop"` → **6076 passed**, 5 failed, 625 errors. The failures/errors are all pre-existing, env-only, and unrelated to this change: `test_verify.py` NonWindows (#1100) + `test_win32_hybrid.py` Linux/no-core (#1133) hermeticity bugs that fail on a real Windows desktop, a flaky `test_agent::test_total_time_recorded`, a DLL-version mismatch, and PermissionError env errors — identical with changes reverted. New tests collection-only verified (no Windows/optional deps).

Docs: README find examples + CLI `--help` updated to describe auto-detection.

Part of #809.
