### PR TITLE
fix: resolve relative/~ browser --user-data-dir to absolute path (fixes #1139)

### DIFF
--- a/naturo/browser/_launcher.py
+++ b/naturo/browser/_launcher.py
@@ -269,7 +269,9 @@ def launch_chrome(
         profile: Chrome profile name or directory (e.g. "Work", "Profile 1").
             Resolved against the user data directory.
         user_data_dir: Custom user data directory. Overrides the default
-            Chrome profile location entirely.
+            Chrome profile location entirely. Relative and ``~`` paths are
+            resolved to an absolute path before launch, since Chrome rejects a
+            relative ``--user-data-dir``.
         extra_args: Additional Chrome command-line flags.
         url: Initial URL to open (default: ``about:blank``).
         chrome_path: Explicit path to Chrome binary. If ``None``,
@@ -307,7 +309,13 @@ def launch_chrome(
 
     # Profile handling
     if user_data_dir:
-        args.append(f"--user-data-dir={user_data_dir}")
+        # Chrome requires --user-data-dir to be absolute: it resolves a relative
+        # value against its own working directory (not naturo's) and in practice
+        # rejects it outright, exiting with code 21 before CDP comes up (#1139).
+        # Resolve here so relative/``~`` paths just work and the user is not left
+        # with an opaque "Chrome exited with code 21" failure.
+        abs_user_data_dir = os.path.abspath(os.path.expanduser(user_data_dir))
+        args.append(f"--user-data-dir={abs_user_data_dir}")
         if profile:
             # When user_data_dir is explicit, use profile as-is
             args.append(f"--profile-directory={profile}")

--- a/tests/test_browser_launcher.py
+++ b/tests/test_browser_launcher.py
@@ -348,7 +348,7 @@ class TestLaunchChrome:
         mock_popen.return_value = MagicMock(pid=100)
         launch_chrome(user_data_dir="/tmp/my-profile")
         args = mock_popen.call_args[0][0]
-        assert "--user-data-dir=/tmp/my-profile" in args
+        assert f"--user-data-dir={os.path.abspath('/tmp/my-profile')}" in args
 
     @patch("naturo.browser._launcher._wait_for_cdp")
     @patch("subprocess.Popen")
@@ -357,8 +357,48 @@ class TestLaunchChrome:
         mock_popen.return_value = MagicMock(pid=100)
         launch_chrome(user_data_dir="/tmp/data", profile="Profile 1")
         args = mock_popen.call_args[0][0]
-        assert "--user-data-dir=/tmp/data" in args
+        # An already-absolute path is passed through unchanged (abspath is
+        # idempotent for it). Compute the expected value the same way the
+        # launcher does so the assertion holds on both POSIX and Windows CI
+        # lanes (#946: WindowsPath vs POSIX slashes).
+        assert f"--user-data-dir={os.path.abspath('/tmp/data')}" in args
         assert "--profile-directory=Profile 1" in args
+
+    @patch("naturo.browser._launcher._wait_for_cdp")
+    @patch("subprocess.Popen")
+    @patch("naturo.browser._launcher.find_chrome", return_value="/usr/bin/chrome")
+    def test_launch_resolves_relative_user_data_dir(self, mock_find, mock_popen, mock_wait):
+        """Regression #1139: a relative ``--user-data-dir`` must reach Chrome as
+        an absolute path.
+
+        Chrome rejects a relative ``--user-data-dir`` (exits with code 21 before
+        CDP becomes available), so naturo must resolve it against its own working
+        directory before launch — otherwise the user gets an opaque failure.
+        """
+        mock_popen.return_value = MagicMock(pid=100)
+        launch_chrome(user_data_dir=os.path.join(".work", "_qa_chrome"))
+        args = mock_popen.call_args[0][0]
+        udd_arg = next(a for a in args if a.startswith("--user-data-dir="))
+        resolved = udd_arg.split("=", 1)[1]
+        assert os.path.isabs(resolved), f"expected absolute path, got {resolved!r}"
+        assert resolved == os.path.abspath(os.path.join(".work", "_qa_chrome"))
+
+    @patch("naturo.browser._launcher._wait_for_cdp")
+    @patch("subprocess.Popen")
+    @patch("naturo.browser._launcher.find_chrome", return_value="/usr/bin/chrome")
+    def test_launch_expands_user_in_user_data_dir(self, mock_find, mock_popen, mock_wait):
+        """A ``~``-prefixed ``--user-data-dir`` is expanded to the home directory
+        and passed as an absolute path."""
+        mock_popen.return_value = MagicMock(pid=100)
+        launch_chrome(user_data_dir=os.path.join("~", "chrome-profile"))
+        args = mock_popen.call_args[0][0]
+        udd_arg = next(a for a in args if a.startswith("--user-data-dir="))
+        resolved = udd_arg.split("=", 1)[1]
+        assert "~" not in resolved
+        assert os.path.isabs(resolved)
+        assert resolved == os.path.abspath(
+            os.path.expanduser(os.path.join("~", "chrome-profile"))
+        )
 
     @patch("naturo.browser._launcher._wait_for_cdp")
     @patch("subprocess.Popen")


### PR DESCRIPTION
## What
`naturo browser launch --user-data-dir <relative-path>` failed opaquely with `Chrome exited with code 21 before CDP became available`. Chrome requires `--user-data-dir` to be **absolute** (it resolves a relative value against its own cwd, not naturo's, and rejects it with exit 21). naturo forwarded the value verbatim.

This resolves `--user-data-dir` to an absolute path before launch via `os.path.abspath(os.path.expanduser(...))`, so relative and `~` paths just work. An already-absolute path is unchanged (abspath is idempotent). Docstring updated.

## How tested
- New regression tests in `tests/test_browser_launcher.py`:
  - `test_launch_resolves_relative_user_data_dir` — relative path reaches Chrome absolute.
  - `test_launch_expands_user_in_user_data_dir` — `~` is expanded and absolute.
  - Existing absolute-path assertions updated to compute the expected value the same way the launcher does, keeping them green on both POSIX and Windows CI lanes (#946).
- Gate: `ruff check naturo/` clean; `mypy naturo/` clean for naturo code; `python -m pytest tests/test_browser_launcher.py` → 59 passed. Full `python -m pytest tests/ -m 'not desktop'` → 6704 passed (remaining failures are pre-existing desktop-environment-specific tests, confirmed independent of this change).

Closes #1139.