### PR TITLE
fix: validate visual --threshold to [0.0, 1.0] range (fixes #1149)

### DIFF
--- a/naturo/cli/visual_cmd.py
+++ b/naturo/cli/visual_cmd.py
@@ -89,7 +89,7 @@ def _parse_region(value: str) -> tuple[int, int, int, int]:
 @click.argument("name")
 @click.option("--current", required=True, type=click.Path(exists=True),
               help="Path to current screenshot to compare.")
-@click.option("--threshold", type=float, default=0.95,
+@click.option("--threshold", type=click.FloatRange(0.0, 1.0), default=0.95,
               help="Similarity threshold (0.0-1.0, default 0.95).")
 @click.option("--ignore-region", multiple=True,
               help="Region to mask (x,y,w,h). Repeatable.")
@@ -144,7 +144,8 @@ def visual_compare(name: str, current: str, threshold: float,
 @click.argument("image1", type=click.Path(exists=True))
 @click.argument("image2", type=click.Path(exists=True))
 @click.option("--output", "-o", type=click.Path(), help="Save diff image to path.")
-@click.option("--threshold", type=float, default=0.95, help="Similarity threshold.")
+@click.option("--threshold", type=click.FloatRange(0.0, 1.0), default=0.95,
+              help="Similarity threshold (0.0-1.0, default 0.95).")
 @click.option("-j", "--json", "json_output", is_flag=True, help="Output JSON.")
 def visual_diff(image1: str, image2: str, output: Optional[str],
                 threshold: float, json_output: bool):
@@ -248,7 +249,8 @@ def visual_delete(name: str, force: bool, json_output: bool):
 @click.argument("names", nargs=-1)
 @click.option("--current-dir", type=click.Path(exists=True),
               help="Directory containing current screenshots (name.png).")
-@click.option("--threshold", type=float, default=0.95, help="Similarity threshold.")
+@click.option("--threshold", type=click.FloatRange(0.0, 1.0), default=0.95,
+              help="Similarity threshold (0.0-1.0, default 0.95).")
 @click.option("--ignore-region", multiple=True,
               help="Region to mask globally (x,y,w,h). Repeatable.")
 @click.option("--output", "-o", type=click.Path(), default=None,

--- a/naturo/visual.py
+++ b/naturo/visual.py
@@ -546,6 +546,38 @@ class Suite:
     threshold: float = 0.95
 
 
+def _validate_suite_threshold(value: object, context: str) -> float:
+    """Validate a suite-sourced threshold is a real number in ``[0.0, 1.0]``.
+
+    Similarity is a fraction in ``[0, 1]``, so a threshold outside that range
+    silently breaks every comparison (``> 1.0`` fails identical images, ``< 0.0``
+    passes everything). Rejecting it here keeps the JSON ``threshold`` field held
+    to the same contract Click's ``FloatRange`` enforces on the ``--threshold``
+    flag (#1149).
+
+    Args:
+        value: The threshold sourced from the suite JSON (any JSON type).
+        context: Human-readable description of where the value came from, used
+            in the error message (e.g. ``"suite threshold"``).
+
+    Returns:
+        The validated threshold as a float.
+
+    Raises:
+        ValueError: If the value is not a real number in ``[0.0, 1.0]``.
+    """
+    # ``bool`` is a subclass of ``int`` — reject ``true``/``false`` explicitly.
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(
+            f"{context} must be a number in the range 0.0-1.0, got: {value!r}"
+        )
+    if not 0.0 <= value <= 1.0:
+        raise ValueError(
+            f"{context} {float(value)} is not in the range 0.0<=x<=1.0"
+        )
+    return float(value)
+
+
 def load_suite(path: str | Path) -> Suite:
     """Load a visual regression suite from a JSON file.
 
@@ -557,7 +589,8 @@ def load_suite(path: str | Path) -> Suite:
 
     Raises:
         FileNotFoundError: If the suite file does not exist.
-        ValueError: If the suite JSON is invalid.
+        ValueError: If the suite JSON is invalid (malformed structure or a
+            threshold outside the documented ``[0.0, 1.0]`` range).
     """
     p = Path(path)
     if not p.exists():
@@ -569,18 +602,25 @@ def load_suite(path: str | Path) -> Suite:
     if "tests" not in data or not isinstance(data["tests"], list):
         raise ValueError("Suite JSON must contain a 'tests' array")
 
-    suite_threshold = data.get("threshold", 0.95)
+    suite_threshold = _validate_suite_threshold(
+        data.get("threshold", 0.95), "suite threshold"
+    )
     tests = []
     for t in data["tests"]:
         if "name" not in t or "current" not in t:
             raise ValueError("Each test must have 'name' and 'current' fields")
+        test_threshold = t.get("threshold")
+        if test_threshold is not None:
+            test_threshold = _validate_suite_threshold(
+                test_threshold, f"test {t['name']!r} threshold"
+            )
         regions = None
         if "ignore_regions" in t:
             regions = [tuple(r) for r in t["ignore_regions"]]
         tests.append(SuiteTest(
             name=t["name"],
             current=t["current"],
-            threshold=t.get("threshold"),
+            threshold=test_threshold,
             ignore_regions=regions,
         ))
 

--- a/tests/test_visual.py
+++ b/tests/test_visual.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
@@ -24,6 +25,33 @@ pytestmark = pytest.mark.skipif(not _HAS_PIL, reason="Pillow not installed")
 @pytest.fixture()
 def runner():
     return CliRunner()
+
+
+def _invoke_run(monkeypatch, capsys, argv: list[str]) -> tuple[int, str, str]:
+    """Drive the real console-script entry point ``naturo.cli.run``.
+
+    ``CliRunner(main)`` dispatches the Click group directly and therefore lets
+    Click handle parse-time usage errors itself (plain text, exit 2). Production
+    instead goes through :func:`naturo.cli.run`, which wraps every usage error in
+    the ``-j`` JSON envelope (``INVALID_INPUT``, exit 1). Tests that assert that
+    envelope must exercise this wrapper, not the bare group.
+
+    Args:
+        monkeypatch: pytest monkeypatch fixture, used to set ``sys.argv``.
+        capsys: pytest capture fixture for stdout/stderr.
+        argv: Arguments after the program name (e.g. ``["-j", "visual", ...]``).
+
+    Returns:
+        Tuple of (exit_code, stdout, stderr).
+    """
+    from naturo.cli import run
+
+    monkeypatch.setattr(sys, "argv", ["naturo", *argv])
+    with pytest.raises(SystemExit) as exc_info:
+        run()
+    captured = capsys.readouterr()
+    code = exc_info.value.code
+    return (code if isinstance(code, int) else 0), captured.out, captured.err
 
 
 @pytest.fixture()
@@ -307,6 +335,107 @@ class TestVisualCLI:
         assert "report" in result.output
 
 
+# ── Threshold range validation (#1149) ──────────────────────────────────────
+
+
+class TestThresholdRangeValidation:
+    """#1149: ``--threshold`` must be validated to its documented ``[0.0, 1.0]``
+    range. An out-of-range value (e.g. typing ``95`` for ``0.95``) previously
+    made pixel-identical images report ``match: false`` — a guaranteed false
+    CI regression — instead of erroring.
+    """
+
+    def test_compare_threshold_above_one_human_exit2(
+        self, runner, tmp_dirs, red_image, red_copy
+    ):
+        runner.invoke(main, ["visual", "baseline", "s1", "--from", str(red_image)])
+        result = runner.invoke(main, [
+            "visual", "compare", "s1", "--current", str(red_copy),
+            "--threshold", "95",
+        ])
+        # Click rejects at parse time (exit 2); identical images are never
+        # reported as a mismatch.
+        assert result.exit_code == 2
+        assert "0.0" in result.output and "1.0" in result.output
+        assert "PASS" not in result.output and "FAIL" not in result.output
+
+    def test_compare_threshold_below_zero_human_exit2(
+        self, runner, tmp_dirs, red_image, red_copy
+    ):
+        runner.invoke(main, ["visual", "baseline", "s1", "--from", str(red_image)])
+        result = runner.invoke(main, [
+            "visual", "compare", "s1", "--current", str(red_copy),
+            "--threshold", "-0.5",
+        ])
+        assert result.exit_code == 2
+        assert "FAIL" not in result.output
+
+    def test_compare_threshold_in_range_still_passes(
+        self, runner, tmp_dirs, red_image, red_copy
+    ):
+        runner.invoke(main, ["visual", "baseline", "s1", "--from", str(red_image)])
+        result = runner.invoke(main, [
+            "visual", "compare", "s1", "--current", str(red_copy),
+            "--threshold", "0.95",
+        ])
+        assert result.exit_code == 0
+        assert "PASS" in result.output
+
+    def test_compare_threshold_boundary_values_accepted(
+        self, runner, tmp_dirs, red_image, red_copy
+    ):
+        """The inclusive bounds 0.0 and 1.0 are valid thresholds."""
+        runner.invoke(main, ["visual", "baseline", "s1", "--from", str(red_image)])
+        for thr in ("0.0", "1.0"):
+            result = runner.invoke(main, [
+                "visual", "compare", "s1", "--current", str(red_copy),
+                "--threshold", thr,
+            ])
+            assert result.exit_code == 0, f"threshold {thr} should be accepted"
+
+    def test_compare_threshold_above_one_json_envelope(
+        self, monkeypatch, capsys, tmp_dirs, red_image, red_copy
+    ):
+        """The real ``run()`` entry maps the parse error to an INVALID_INPUT
+        envelope (exit 1), not a manufactured ``match: false``."""
+        code, out, _ = _invoke_run(monkeypatch, capsys, [
+            "-j", "visual", "compare", "s1", "--current", str(red_copy),
+            "--threshold", "95",
+        ])
+        assert code == 1
+        data = json.loads(out)
+        assert data["success"] is False
+        assert data["error"]["code"] == "INVALID_INPUT"
+        assert "match" not in data
+
+    def test_diff_threshold_out_of_range_json_envelope(
+        self, monkeypatch, capsys, red_image, red_copy
+    ):
+        code, out, _ = _invoke_run(monkeypatch, capsys, [
+            "-j", "visual", "diff", str(red_image), str(red_copy),
+            "--threshold", "2.0",
+        ])
+        assert code == 1
+        data = json.loads(out)
+        assert data["success"] is False
+        assert data["error"]["code"] == "INVALID_INPUT"
+        assert "match" not in data
+
+    def test_report_threshold_out_of_range_json_envelope(
+        self, monkeypatch, capsys, tmp_dirs, tmp_path
+    ):
+        current = tmp_path / "current"
+        current.mkdir()
+        code, out, _ = _invoke_run(monkeypatch, capsys, [
+            "-j", "visual", "report", "--current-dir", str(current),
+            "--threshold", "50",
+        ])
+        assert code == 1
+        data = json.loads(out)
+        assert data["success"] is False
+        assert data["error"]["code"] == "INVALID_INPUT"
+
+
 # ── Enterprise feature tests ────────────────────────────────────────────────
 
 
@@ -403,6 +532,71 @@ class TestSuiteLoading:
         }))
         with pytest.raises(ValueError, match="current"):
             visual_mod.load_suite(suite_file)
+
+    def test_load_top_level_threshold_above_one_rejected(self, tmp_path):
+        """#1149: an out-of-range top-level suite threshold is rejected at load."""
+        suite_file = tmp_path / "thr.json"
+        suite_file.write_text(json.dumps({
+            "threshold": 95,
+            "tests": [{"name": "s1", "current": "shots/s1.png"}],
+        }))
+        with pytest.raises(ValueError, match="0.0"):
+            visual_mod.load_suite(suite_file)
+
+    def test_load_top_level_threshold_below_zero_rejected(self, tmp_path):
+        suite_file = tmp_path / "thr_neg.json"
+        suite_file.write_text(json.dumps({
+            "threshold": -0.5,
+            "tests": [{"name": "s1", "current": "shots/s1.png"}],
+        }))
+        with pytest.raises(ValueError, match="range"):
+            visual_mod.load_suite(suite_file)
+
+    def test_load_per_test_threshold_out_of_range_rejected(self, tmp_path):
+        """#1149: a per-test out-of-range threshold is rejected at load too."""
+        suite_file = tmp_path / "thr_test.json"
+        suite_file.write_text(json.dumps({
+            "threshold": 0.95,
+            "tests": [{"name": "s1", "current": "shots/s1.png", "threshold": 2.0}],
+        }))
+        with pytest.raises(ValueError, match="s1"):
+            visual_mod.load_suite(suite_file)
+
+    def test_load_non_numeric_threshold_rejected(self, tmp_path):
+        """A non-numeric threshold is rejected cleanly, not via a later TypeError."""
+        suite_file = tmp_path / "thr_str.json"
+        suite_file.write_text(json.dumps({
+            "threshold": "0.95",
+            "tests": [{"name": "s1", "current": "shots/s1.png"}],
+        }))
+        with pytest.raises(ValueError, match="number"):
+            visual_mod.load_suite(suite_file)
+
+    def test_load_boundary_thresholds_accepted(self, tmp_path):
+        """Inclusive bounds 0.0 and 1.0 load successfully."""
+        suite_file = tmp_path / "thr_bounds.json"
+        suite_file.write_text(json.dumps({
+            "threshold": 1.0,
+            "tests": [{"name": "s1", "current": "shots/s1.png", "threshold": 0.0}],
+        }))
+        suite = visual_mod.load_suite(suite_file)
+        assert suite.threshold == 1.0
+        assert suite.tests[0].threshold == 0.0
+
+    def test_suite_cli_out_of_range_threshold_json_envelope(self, runner, tmp_path):
+        """``visual suite`` surfaces an out-of-range JSON threshold as
+        INVALID_INPUT rather than running a poisoned suite (#1149)."""
+        suite_file = tmp_path / "suite.json"
+        suite_file.write_text(json.dumps({
+            "name": "Poisoned",
+            "threshold": 95,
+            "tests": [{"name": "s1", "current": str(tmp_path / "s1.png")}],
+        }))
+        result = runner.invoke(main, ["visual", "suite", str(suite_file), "--json"])
+        assert result.exit_code == 1
+        data = json.loads(result.output)
+        assert data["success"] is False
+        assert data["error"]["code"] == "INVALID_INPUT"
 
 
 class TestRunSuite:


### PR DESCRIPTION
## What
`--threshold` on `visual compare` / `visual diff` / `visual report` (and the suite JSON `threshold` field, top-level and per-test) was **not validated** to its documented `0.0–1.0` range. Since similarity is a fraction in `[0, 1]`:
- `threshold > 1.0` (e.g. typing `95` instead of `0.95`) made **pixel-identical images report `match: false`** — a guaranteed false CI regression on every comparison via `visual suite`.
- `threshold < 0.0` made every comparison trivially pass.

Fixes #1149.

## How
- `visual compare/diff/report`: `--threshold` now uses `click.FloatRange(0.0, 1.0)`. Out-of-range values are rejected at parse time; the existing `run()` wrapper maps the usage error to the `INVALID_INPUT` envelope (exit 1) in `-j` mode, and human mode gets Click's well-worded range error (exit 2). Inclusive bounds `0.0`/`1.0` remain valid.
- `visual suite`: the JSON-sourced threshold (top-level **and** per-test `tests[].threshold`) is validated in `load_suite` via a new private `_validate_suite_threshold`, raising `ValueError` (already surfaced by the CLI as `INVALID_INPUT`) instead of running a poisoned suite. Non-numeric thresholds (e.g. `"0.95"`, `true`) are rejected cleanly rather than crashing later with a `TypeError`.

Not a public-API change: `--threshold` already functioned (this enforces its already-documented `0.0–1.0` contract); the new helper is private. Genuine mismatches still exit non-zero as before — only out-of-range thresholds stop manufacturing false results.

## How tested
- New `TestThresholdRangeValidation` (compare/diff/report): out-of-range rejected in human mode (exit 2) and `-j` mode (`INVALID_INPUT` envelope via the real `run()` entry point, exit 1, no fabricated `match` field); in-range and boundary `0.0`/`1.0` still pass.
- New `TestSuiteLoading` cases: out-of-range top-level/per-test/non-numeric thresholds raise at load; boundary values load; `visual suite --json` surfaces `INVALID_INPUT`.
- Gate: `ruff check naturo/` clean; `mypy` clean on changed files; full `python -m pytest tests/ -m "not desktop"` → **6717 passed**, 8 failed/11 errored all pre-existing and desktop/env-specific (proven via stash-and-rerun on clean develop: same set reproduces; #1100/#1133 hermeticity, test_cost_guardrails config, DLL version, app-id hwnd, agent timing — none touch `visual`).
