### PR TITLE
test: make test_win32_hybrid hermetic on Windows desktop (fixes #1133)

### DIFF
--- a/tests/test_win32_hybrid.py
+++ b/tests/test_win32_hybrid.py
@@ -124,22 +124,34 @@ def test_tag_uia_source_recursive():
     assert child.name == "[uia] Cell A1"
 
 
-# ── enumerate_hybrid_tree (mocked, platform-independent) ──────────────────
+# ── enumerate_hybrid_tree (platform-forced, host-independent) ─────────────
 
 
-def test_hybrid_tree_returns_none_on_linux():
-    """On non-Windows, enumerate_hybrid_tree should return None."""
+def test_hybrid_tree_returns_none_on_non_windows():
+    """On non-Windows platforms, enumerate_hybrid_tree returns None.
+
+    ``platform.system()`` is forced to a non-Windows value so the non-Windows
+    contract is asserted deterministically regardless of the host OS. Without
+    this pin the test reddens on a real Windows desktop, where the function
+    performs live HWND enumeration and returns a tree (#1133).
+    """
     from naturo.bridge import enumerate_hybrid_tree
-    # We're running on Linux in CI, so this should return None
-    result = enumerate_hybrid_tree(hwnd=12345, depth=3, core=None)
+    with patch("naturo.bridge._tree.platform.system", return_value="Linux"):
+        result = enumerate_hybrid_tree(hwnd=12345, depth=3, core=None)
     assert result is None
 
 
-def test_hybrid_tree_returns_none_without_core():
-    """Without a NaturoCore instance, hybrid degrades to pure Win32."""
+def test_hybrid_tree_returns_none_on_non_windows_without_core():
+    """Without a NaturoCore instance, the non-Windows path still returns None.
+
+    ``platform.system()`` is forced to a non-Windows value so the assertion
+    holds on any host; on Windows the function enumerates the real HWND tree
+    even with ``core=None`` (pure Win32), so the platform must be pinned (#1133).
+    """
     from naturo.bridge import enumerate_hybrid_tree
-    result = enumerate_hybrid_tree(hwnd=0, depth=3, core=None)
-    assert result is None  # Linux: returns None
+    with patch("naturo.bridge._tree.platform.system", return_value="Linux"):
+        result = enumerate_hybrid_tree(hwnd=0, depth=3, core=None)
+    assert result is None
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## What
Two module-level tests in `tests/test_win32_hybrid.py` hardcoded the *non-Windows* outcome of `enumerate_hybrid_tree` (`assert result is None`) without gating to non-Windows:
- `test_hybrid_tree_returns_none_on_linux`
- `test_hybrid_tree_returns_none_without_core`

On a real Windows desktop `enumerate_hybrid_tree` performs live Win32 HWND enumeration and returns a tree (as `TestHybridTreeLive` asserts), so both **fail on Windows** while staying **green on headless Linux CI** — the same false-confidence class as #1100. They reddened every `@desktop`-capable Dev/QA run, masking real regressions behind expected-red noise.

## How fixed
Force `platform.system()` to a non-Windows value via `patch("naturo.bridge._tree.platform.system", return_value="Linux")` so the asserted non-Windows branch (`_tree.py:263`) runs deterministically regardless of host OS — the #1100 approach. Renamed away from the misleading `_on_linux` suffix to `_on_non_windows` / `_on_non_windows_without_core`.

Test-only change; no production code touched.

## How tested
- The two fixed tests now **pass on a real Windows desktop** (previously failed): `2 passed in 0.20s`.
- `python -m pytest tests/test_win32_hybrid.py --collect-only` → 16 tests collected (cross-platform collection clean).
- `python -m ruff check naturo/` → All checks passed.
- Full suite `python -m pytest tests/ -m "not desktop"` (private --basetemp): **6727 passed**, 171 skipped, 1 xfailed, 1 xpassed; remaining failures are unrelated pre-existing Windows-desktop-only non-hermetic tests in other modules (none in test_win32_hybrid.py).