### PR TITLE
fix: decode native window titles via OS ANSI codepage, not UTF-8-mode locale (fixes #1150)

### DIFF
--- a/naturo/bridge/_models.py
+++ b/naturo/bridge/_models.py
@@ -5,26 +5,62 @@ parsing utilities used throughout the bridge package.
 """
 from __future__ import annotations
 
+import ctypes
 import json
 import logging
 import re
+import sys
 from dataclasses import dataclass, field
 from typing import Optional
 
 logger = logging.getLogger(__name__)
 
 
-def _decode_native(raw: bytes) -> str:
-    """Decode bytes from native DLL, trying UTF-8 first then system codepage.
+def _system_ansi_encoding() -> str:
+    """Return the OS ANSI codepage as a Python codec name (e.g. ``"cp936"``).
 
-    On Chinese Windows the DLL may return GBK/CP936 encoded strings.
+    On Windows the active ANSI codepage is read from the Win32 ``GetACP`` API.
+    ``locale.getpreferredencoding`` must NOT be used for this on Windows because
+    it returns ``"utf-8"`` under Python UTF-8 mode (``PYTHONUTF8=1`` / ``-X
+    utf8``) regardless of the OS codepage; trusting it there re-decodes ANSI
+    (e.g. CP936/GBK) bytes from the native core as UTF-8 and corrupts every
+    non-ASCII character to U+FFFD (#1150). Off Windows there is no ANSI
+    codepage, so the locale preferred encoding is used, defaulting to
+    ``"cp936"`` when it cannot be resolved.
+
+    Returns:
+        A codec name suitable for ``bytes.decode``.
+    """
+    if sys.platform == "win32":
+        try:
+            acp = ctypes.windll.kernel32.GetACP()  # type: ignore[attr-defined]
+            if acp:
+                return f"cp{acp}"
+        except (OSError, AttributeError, ValueError):
+            pass
+    import locale
+    return locale.getpreferredencoding(False) or "cp936"
+
+
+def _decode_native(raw: bytes) -> str:
+    """Decode bytes from the native DLL, trying UTF-8 then the OS ANSI codepage.
+
+    On a non-UTF-8 Windows desktop (e.g. CP936/GBK on a Chinese-locale system)
+    the native core may emit narrow strings in the system ANSI codepage rather
+    than UTF-8. A strict UTF-8 decode is attempted first; on failure the bytes
+    are decoded with the OS ANSI codepage resolved by ``_system_ansi_encoding``
+    (see #1150 for why ``locale.getpreferredencoding`` is unsafe here).
+
+    Args:
+        raw: Raw bytes returned by the native library.
+
+    Returns:
+        The decoded string.
     """
     try:
         return raw.decode("utf-8")
     except UnicodeDecodeError:
-        import locale
-        encoding = locale.getpreferredencoding(False) or "cp936"
-        return raw.decode(encoding, errors="replace")
+        return raw.decode(_system_ansi_encoding(), errors="replace")
 
 
 def _safe_json_loads(s: str):

--- a/tests/test_bridge_models.py
+++ b/tests/test_bridge_models.py
@@ -1,7 +1,7 @@
 """Tests for naturo.bridge._models — WindowInfo, ElementInfo, and parsing helpers."""
 
 import json
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -11,6 +11,7 @@ from naturo.bridge._models import (
     _decode_native,
     _parse_element,
     _safe_json_loads,
+    _system_ansi_encoding,
     populate_hierarchy,
 )
 
@@ -50,6 +51,72 @@ class TestDecodeNative:
 
     def test_ascii_bytes(self):
         assert _decode_native(b"Notepad") == "Notepad"
+
+    def test_ansi_fallback_ignores_utf8_mode_locale_on_windows(self):
+        """#1150: the ANSI fallback must use the OS codepage (GetACP), not
+        ``locale.getpreferredencoding``.
+
+        Under Python UTF-8 mode (``PYTHONUTF8=1`` / ``-X utf8``)
+        ``locale.getpreferredencoding`` returns ``"utf-8"`` regardless of the
+        OS ANSI codepage, so the old fallback re-decoded GBK title bytes as
+        UTF-8 and corrupted every non-ASCII character to U+FFFD.  The decoded
+        title must instead match the true Win32 wide-API value.
+        """
+        title = "无标题 - Notepad"
+        raw = b'[{"hwnd": 1, "title": "' + title.encode("gbk") + b'"}]'
+        fake_windll = MagicMock()
+        fake_windll.kernel32.GetACP.return_value = 936
+        with patch("naturo.bridge._models.sys.platform", "win32"), patch(
+            "naturo.bridge._models.ctypes.windll", fake_windll, create=True
+        ), patch("locale.getpreferredencoding", return_value="utf-8"):
+            result = _decode_native(raw)
+        assert title in result
+        assert "�" not in result
+
+
+# ---------------------------------------------------------------------------
+# _system_ansi_encoding
+# ---------------------------------------------------------------------------
+
+class TestSystemAnsiEncoding:
+    """Tests for _system_ansi_encoding OS-codepage resolution (#1150)."""
+
+    def test_windows_prefers_getacp_over_locale(self):
+        """On Windows the OS ANSI codepage comes from GetACP, never locale.
+
+        This is the crux of #1150: ``locale.getpreferredencoding`` reports
+        ``"utf-8"`` under Python UTF-8 mode even on a CP936 desktop, so it
+        cannot be trusted to detect the codepage of the native DLL's bytes.
+        """
+        fake_windll = MagicMock()
+        fake_windll.kernel32.GetACP.return_value = 936
+        with patch("naturo.bridge._models.sys.platform", "win32"), patch(
+            "naturo.bridge._models.ctypes.windll", fake_windll, create=True
+        ), patch("locale.getpreferredencoding", return_value="utf-8"):
+            assert _system_ansi_encoding() == "cp936"
+
+    def test_windows_falls_back_to_locale_when_getacp_unavailable(self):
+        """If GetACP cannot be called, fall back to the locale encoding."""
+        fake_windll = MagicMock()
+        fake_windll.kernel32.GetACP.side_effect = OSError("boom")
+        with patch("naturo.bridge._models.sys.platform", "win32"), patch(
+            "naturo.bridge._models.ctypes.windll", fake_windll, create=True
+        ), patch("locale.getpreferredencoding", return_value="gbk"):
+            assert _system_ansi_encoding() == "gbk"
+
+    def test_non_windows_uses_locale(self):
+        """Off Windows there is no ANSI codepage; use the locale encoding."""
+        with patch("naturo.bridge._models.sys.platform", "linux"), patch(
+            "locale.getpreferredencoding", return_value="utf-8"
+        ):
+            assert _system_ansi_encoding() == "utf-8"
+
+    def test_defaults_to_cp936_when_no_encoding_resolved(self):
+        """When neither GetACP nor locale yields an encoding, default to cp936."""
+        with patch("naturo.bridge._models.sys.platform", "linux"), patch(
+            "locale.getpreferredencoding", return_value=""
+        ):
+            assert _system_ansi_encoding() == "cp936"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What
Non-ASCII (e.g. CJK) window titles were irreversibly corrupted to U+FFFD mojibake in `list windows`, `list apps`, `app windows`, and `app find` output (#1150) — a never-lie / data-correctness defect, baked into the on-disk JSON.

## Root cause
The native core emits narrow strings in the system **ANSI codepage** (e.g. CP936/GBK on a Chinese-locale desktop). `_decode_native` tries strict UTF-8 first, then falls back to the system encoding — but it resolved that encoding via `locale.getpreferredencoding(False)`, which returns **`"utf-8"` under Python UTF-8 mode** (`PYTHONUTF8=1` / `-X utf8`) regardless of the OS codepage. So the GBK title bytes were re-decoded as UTF-8 with `errors="replace"`, destroying every non-ASCII character.

Proven on the real desktop (GetACP()=936) under `PYTHONUTF8=1`:
- `无标题` (GBK `ce de b1 ea cc e2`) → old path → `U+FFFD U+07B1 U+FFFD U+FFFD U+FFFD` — byte-for-byte the corruption reported in #1150.

## Fix
Resolve the ANSI-fallback codepage from the Win32 **`GetACP`** API (new `_system_ansi_encoding`), independent of Python UTF-8 mode. Applied at the single shared decode boundary `_decode_native`, so `list windows` / `list apps` / `app windows` / `find` are all fixed at once. Off Windows the locale encoding is used (default `cp936`), preserving prior behavior. No public API / CLI change.

After the fix (same desktop, `PYTHONUTF8=1`): `无标题` decodes to `U+65E0 U+6807 U+9898`, zero U+FFFD. Title-by-true-name matching is restored as a consequence (titles are no longer mangled).

## How tested
- TDD: added a failing test first, then the fix.
- New hermetic tests (cross-platform; patch `sys.platform` + `ctypes.windll`): `TestDecodeNative::test_ansi_fallback_ignores_utf8_mode_locale_on_windows`, `TestSystemAnsiEncoding` (GetACP-over-locale, GetACP-unavailable fallback, non-Windows, cp936 default).
- `tests/test_bridge_models.py` → 48 passed.
- Real-desktop end-to-end proof under `PYTHONUTF8=1` (above).
- `ruff check naturo/` clean; `mypy naturo/bridge/_models.py` clean.
- Full suite: `python -m pytest tests/ -m "not desktop"` → **6724 passed**, 6 failed / 11 errored. All 6+11 are **pre-existing & identical on clean origin/develop** (verified by re-running them with my diff stashed): test_app_ids = #1156, test_verify NonWindows = #1100, an agent-timing flake, a DLL-version-mismatch check, and cost-guardrails yaml — all real-desktop/environmental, not on CI (develop is green). My change adds zero failures.

## Note (residual, out of scope)
This recovers all titles representable in the OS ANSI codepage (every case in #1150). Characters *outside* the ANSI codepage are already lost at the native narrow-string boundary; emitting UTF-8 directly from the DLL (`GetWindowTextW` + `WideCharToMultiByte(CP_UTF8, …)`) is the long-term hardening and depends on a native-core build path (#1097).
