### PR TITLE
fix: harden electron process-info decode against non-UTF-8 stdout + make app_id/electron tests hermetic (fixes #1156)

### DIFF
--- a/naturo/electron.py
+++ b/naturo/electron.py
@@ -92,9 +92,10 @@ def _get_process_command_line(pid: int) -> Optional[str]:
             ],
             capture_output=True,
             text=True,
+            errors="replace",
             timeout=5,
         )
-        for line in result.stdout.splitlines():
+        for line in (result.stdout or "").splitlines():
             if line.startswith("CommandLine="):
                 return line[len("CommandLine=") :]
     except (subprocess.TimeoutExpired, OSError):
@@ -124,9 +125,10 @@ def _get_process_exe_path(pid: int) -> Optional[str]:
             ],
             capture_output=True,
             text=True,
+            errors="replace",
             timeout=5,
         )
-        for line in result.stdout.splitlines():
+        for line in (result.stdout or "").splitlines():
             if line.startswith("ExecutablePath="):
                 return line[len("ExecutablePath=") :]
     except (subprocess.TimeoutExpired, OSError):
@@ -155,9 +157,14 @@ def _bulk_get_process_info() -> Dict[int, Dict[str, str]]:
             ],
             capture_output=True,
             text=True,
+            # (#1156) Decode defensively: a process whose command line or path
+            # contains non-UTF-8 bytes (common on Windows for legacy-codepage
+            # apps) would otherwise raise UnicodeDecodeError in the reader
+            # thread, leaving ``stdout`` as ``None`` and crashing the parse.
+            errors="replace",
             timeout=15,
         )
-        lines = result.stdout.strip().splitlines()
+        lines = (result.stdout or "").strip().splitlines()
         # CSV header line: Node,CommandLine,ExecutablePath,ProcessId
         header_idx = -1
         for i, line in enumerate(lines):
@@ -206,10 +213,11 @@ def _find_processes_by_name(name: str) -> List[Dict[str, Any]]:
             ["tasklist", "/FO", "CSV", "/NH"],
             capture_output=True,
             text=True,
+            errors="replace",
             timeout=10,
         )
         name_lower = name.lower()
-        for line in result.stdout.splitlines():
+        for line in (result.stdout or "").splitlines():
             line = line.strip()
             if not line:
                 continue
@@ -434,6 +442,7 @@ def list_electron_apps() -> Dict[str, Any]:
             ["tasklist", "/FO", "CSV", "/NH"],
             capture_output=True,
             text=True,
+            errors="replace",
             timeout=10,
         )
     except (subprocess.TimeoutExpired, OSError):
@@ -441,7 +450,7 @@ def list_electron_apps() -> Dict[str, Any]:
 
     # Group processes by executable name
     exe_groups: Dict[str, List[int]] = {}
-    for line in result.stdout.splitlines():
+    for line in (result.stdout or "").splitlines():
         line = line.strip()
         if not line:
             continue

--- a/tests/test_app_ids.py
+++ b/tests/test_app_ids.py
@@ -6,6 +6,7 @@ import json
 import time
 from dataclasses import dataclass
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -206,15 +207,21 @@ class TestResolveAppIdHelper:
             return AppIdMap(session=session, storage_root=tmp_storage)
 
         app_ids_mod.get_app_id_map = _patched
-        try:
-            app, hwnd, pid = _resolve_app_id("a1", None, None, None, False)
-            # (#573) app must be None — process_name may be a full path that
-            # breaks fuzzy matching downstream.  hwnd + pid suffice.
-            assert app is None
-            assert hwnd == 999
-            assert pid == 42
-        finally:
-            app_ids_mod.get_app_id_map = orig_factory
+        # (#1156) Treat the synthetic stored window as alive so the #788
+        # stale-window guard (a live ``user32.IsWindow`` call) does not make
+        # this host-state-dependent on a real desktop.
+        with patch(
+            "naturo.cli.interaction._common._is_hwnd_alive", return_value=True
+        ):
+            try:
+                app, hwnd, pid = _resolve_app_id("a1", None, None, None, False)
+                # (#573) app must be None — process_name may be a full path that
+                # breaks fuzzy matching downstream.  hwnd + pid suffice.
+                assert app is None
+                assert hwnd == 999
+                assert pid == 42
+            finally:
+                app_ids_mod.get_app_id_map = orig_factory
 
     def test_resolve_full_path_process_name_does_not_leak(self, tmp_storage):
         """#573: Full path in process_name must not become the app filter."""
@@ -237,13 +244,21 @@ class TestResolveAppIdHelper:
             return AppIdMap(session=session, storage_root=tmp_storage)
 
         app_ids_mod.get_app_id_map = _patched
-        try:
-            app, hwnd, pid = _resolve_app_id("a1", None, None, None, False)
-            assert app is None, "app must not be set to full process path"
-            assert hwnd == 5555
-            assert pid == 100
-        finally:
-            app_ids_mod.get_app_id_map = orig_factory
+        # (#1156) Neutralize the live HWND liveness check: on a real desktop
+        # ``_is_hwnd_alive(5555)`` calls ``user32.IsWindow`` and returns False
+        # for this synthetic handle, tripping the #788 stale-window guard and
+        # making the test depend on host window state. This test asserts the
+        # #573 no-leak contract, so treat the stored window as alive.
+        with patch(
+            "naturo.cli.interaction._common._is_hwnd_alive", return_value=True
+        ):
+            try:
+                app, hwnd, pid = _resolve_app_id("a1", None, None, None, False)
+                assert app is None, "app must not be set to full process path"
+                assert hwnd == 5555
+                assert pid == 100
+            finally:
+                app_ids_mod.get_app_id_map = orig_factory
 
     def test_resolve_error_exits(self, tmp_storage):
         """On invalid app_id, _resolve_app_id exits with error."""

--- a/tests/test_electron.py
+++ b/tests/test_electron.py
@@ -43,10 +43,13 @@ class TestDetectElectronApp:
         assert result["processes"] == []
         assert result["debug_port"] is None
 
+    @patch("naturo.electron._bulk_get_process_info", return_value={})
     @patch("naturo.electron._find_debug_port_from_cmdline")
     @patch("naturo.electron._is_electron_process")
     @patch("naturo.electron._find_processes_by_name")
-    def test_electron_detected(self, mock_find, mock_is_electron, mock_port):
+    def test_electron_detected(
+        self, mock_find, mock_is_electron, mock_port, mock_bulk,
+    ):
         """Correctly identifies an Electron process."""
         from naturo.electron import detect_electron_app
 
@@ -59,9 +62,10 @@ class TestDetectElectronApp:
         assert result["debug_port"] == 9229
         assert result["main_pid"] == 1234
 
+    @patch("naturo.electron._bulk_get_process_info", return_value={})
     @patch("naturo.electron._is_electron_process")
     @patch("naturo.electron._find_processes_by_name")
-    def test_not_electron(self, mock_find, mock_is_electron):
+    def test_not_electron(self, mock_find, mock_is_electron, mock_bulk):
         """Non-Electron process correctly identified."""
         from naturo.electron import detect_electron_app
 
@@ -70,10 +74,13 @@ class TestDetectElectronApp:
         result = detect_electron_app("notepad")
         assert result["is_electron"] is False
 
+    @patch("naturo.electron._bulk_get_process_info", return_value={})
     @patch("naturo.electron._find_debug_port_from_cmdline")
     @patch("naturo.electron._is_electron_process")
     @patch("naturo.electron._find_processes_by_name")
-    def test_electron_no_debug_port(self, mock_find, mock_is_electron, mock_port):
+    def test_electron_no_debug_port(
+        self, mock_find, mock_is_electron, mock_port, mock_bulk,
+    ):
         """Electron app running without debug port."""
         from naturo.electron import detect_electron_app
 
@@ -174,6 +181,17 @@ class TestListElectronApps:
         from naturo.electron import list_electron_apps
 
         mock_run.return_value = MagicMock(stdout="")
+        result = list_electron_apps()
+        assert result["count"] == 0
+        assert result["apps"] == []
+
+    @patch("naturo.electron._bulk_get_process_info", return_value={})
+    @patch("naturo.electron.subprocess.run")
+    def test_none_stdout_yields_no_apps(self, mock_run, mock_bulk):
+        """#1156: a None tasklist stdout must not crash the scan."""
+        from naturo.electron import list_electron_apps
+
+        mock_run.return_value = MagicMock(stdout=None)
         result = list_electron_apps()
         assert result["count"] == 0
         assert result["apps"] == []
@@ -513,6 +531,58 @@ class TestInternalHelpers:
 
         mock_run.side_effect = subprocess.TimeoutExpired("wmic", 15)
         assert _bulk_get_process_info() == {}
+
+    @patch("naturo.electron.subprocess.run")
+    def test_bulk_get_process_info_none_stdout(self, mock_run):
+        """#1156: stdout=None (non-UTF-8 decode failure) must not crash.
+
+        When a process command line contains non-UTF-8 bytes, the reader
+        thread can raise ``UnicodeDecodeError`` and leave ``result.stdout``
+        as ``None``. The parse must degrade gracefully to an empty result
+        instead of raising ``AttributeError: 'NoneType' object has no
+        attribute 'strip'``.
+        """
+        from naturo.electron import _bulk_get_process_info
+
+        mock_run.return_value = MagicMock(stdout=None)
+        assert _bulk_get_process_info() == {}
+
+    @patch("naturo.electron.subprocess.run")
+    def test_find_processes_by_name_none_stdout(self, mock_run):
+        """#1156: stdout=None must yield no processes, not crash."""
+        from naturo.electron import _find_processes_by_name
+
+        mock_run.return_value = MagicMock(stdout=None)
+        assert _find_processes_by_name("Code") == []
+
+    @patch("naturo.electron.subprocess.run")
+    def test_get_process_command_line_none_stdout(self, mock_run):
+        """#1156: stdout=None must yield None, not crash."""
+        from naturo.electron import _get_process_command_line
+
+        mock_run.return_value = MagicMock(stdout=None)
+        assert _get_process_command_line(1234) is None
+
+    @patch("naturo.electron.subprocess.run")
+    def test_get_process_exe_path_none_stdout(self, mock_run):
+        """#1156: stdout=None must yield None, not crash."""
+        from naturo.electron import _get_process_exe_path
+
+        mock_run.return_value = MagicMock(stdout=None)
+        assert _get_process_exe_path(1234) is None
+
+    @patch("naturo.electron.subprocess.run")
+    def test_decode_uses_replace_errors(self, mock_run):
+        """#1156: subprocess output is decoded with errors='replace'.
+
+        Pins the defensive-decode contract so a future refactor cannot
+        silently drop it and reintroduce the reader-thread crash.
+        """
+        from naturo.electron import _bulk_get_process_info
+
+        mock_run.return_value = MagicMock(stdout="")
+        _bulk_get_process_info()
+        assert mock_run.call_args.kwargs.get("errors") == "replace"
 
     @patch("naturo.electron._get_process_command_line")
     def test_find_debug_port_from_cmdline(self, mock_cmdline):


### PR DESCRIPTION
## What
Fixes #1156 — two defects surfaced by running the full `-m "not desktop"` suite on a real Windows desktop:

### 1. Product robustness — `_bulk_get_process_info` (and 4 sibling helpers) crash on non-UTF-8 process output
All five `subprocess.run` callsites in `naturo/electron.py` decoded `wmic`/`tasklist` output with `text=True` (locale codepage). A process whose command line or path contains non-UTF-8 bytes — common on Windows for legacy-codepage apps — makes the reader thread raise `UnicodeDecodeError`, leaving `result.stdout` as `None`, so the subsequent `.strip()`/`.splitlines()` crashes with `AttributeError: 'NoneType' object has no attribute 'strip'`. This is a latent product bug that bites Electron detection on any such machine.

**Fix:** decode defensively with `errors="replace"` (degrade to replacement chars instead of crashing the reader thread) and guard every dereference with `(result.stdout or "")`. Applied to all five callsites so no sibling repeats the bug.

### 2. Test hermeticity — 4 tests green on Linux CI, red on a real Windows desktop (#1100/#1133 family)
- `test_app_ids`: both `_resolve_app_id` contract tests passed a synthetic HWND that the #788 stale-window guard (`user32.IsWindow`) rejects on a live desktop → `sys.exit(1)`. They pass on Linux only because `_is_hwnd_alive` returns `True` there. Mock `_is_hwnd_alive` so they assert the #573 no-leak contract deterministically on every OS.
- `test_electron` `detect_*` tests reached the un-mocked `_bulk_get_process_info` (live `wmic`), making them host-state-dependent. Mock it like the existing `test_uses_single_bulk_query_for_many_pids` already does.

## How tested
- TDD: 6 new tests (5 None-stdout/decode-contract + 1 `errors='replace'` pin) all **fail on the pre-fix code** (AttributeError) and pass after. Verified by stashing the product change.
- `python -m ruff check naturo/` → clean; `python -m mypy naturo/electron.py naturo/cli/interaction/_common.py` → clean.
- Full suite: `python -m pytest tests/ -m "not desktop"` → **6732 passed**, 171 skipped, 1 xfailed/1 xpassed. The 4 remaining failures + 11 errors (test_agent timing flake, test_verify NonWindows #1100, test_version_consistency stale-local-DLL, test_cost_guardrails yaml/env) are **pre-existing and identical on clean origin/develop** (verified by stashing) — this change adds zero failures and removes the #1156 ones.
- New tests collect cleanly (`--collect-only`, no Windows/optional deps).

No public-API change (internal subprocess hardening + test-only edits).