### PR TITLE
test: make verify NonWindows tests hermetic by forcing platform.system() (fixes #1100)

### DIFF
--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1022,11 +1022,14 @@ class TestCaptureFocusStateNonWindows:
         from naturo.verify import _capture_focus_state
 
         backend = MagicMock(spec=[])
-        state = _capture_focus_state(backend)
+        # Force the non-Windows branch deterministically. Without this patch the
+        # test only passes when the host happens to be Linux/macOS; on a real
+        # Windows desktop it takes the Win32 path and fails (#1100).
+        with patch("platform.system", return_value="Linux"):
+            state = _capture_focus_state(backend)
 
         assert "platform" in state
-        # Linux returns "Linux", macOS returns "Darwin"
-        assert state["platform"] in ("Linux", "Darwin")
+        assert state["platform"] == "Linux"
 
 
 class TestCaptureUiTextsNonWindows:
@@ -1037,7 +1040,11 @@ class TestCaptureUiTextsNonWindows:
         from naturo.verify import _capture_ui_texts
 
         backend = MagicMock(spec=[])
-        result = _capture_ui_texts(backend, app="test")
+        # Force the non-Windows branch deterministically. Without this patch the
+        # function takes the Win32 EnumChildWindows path on a real Windows
+        # desktop and returns live window texts instead of {} (#1100).
+        with patch("platform.system", return_value="Linux"):
+            result = _capture_ui_texts(backend, app="test")
 
         assert result == {}
 


### PR DESCRIPTION
## What
Two tests in `tests/test_verify.py` asserted the *non-Windows* behavior of `naturo.verify._capture_focus_state` / `_capture_ui_texts` but never forced the platform gate, so they only passed when the host happened to be Linux/macOS:

- `TestCaptureFocusStateNonWindows::test_returns_platform_key_on_non_windows`
- `TestCaptureUiTextsNonWindows::test_returns_empty_dict_on_linux`

On a real Windows desktop the functions took the Win32 path and returned live window data, so the assertions failed — green on headless CI, **red on every `@desktop`-capable Dev/QA run** (the test-hermeticity / false-confidence-gate pattern, cf. #1069/#1074).

## How
Patch `platform.system()` → `"Linux"` inside both tests (`with patch(...)`) so the non-Windows branch runs deterministically on any host. Both functions use `import platform as _plat; _plat.system()`, so patching `platform.system` reaches them. `test_returns_empty_dict_without_target` is already hermetic — its no-target early return fires before the platform gate, so it returns `{}` on Windows too.

## How tested
- `ruff check naturo/` → clean
- `python -m pytest tests/test_verify.py` → **81 passed** (both fixed tests green on this Windows desktop)
- Full suite `python -m pytest tests/ -m "not desktop"` → **6099 passed**; the 2 failures + PermissionError errors are PRE-EXISTING and reproduce identically on clean `origin/develop` (verified by stash): `test_agent::test_total_time_recorded` (timing flake), `test_version_consistency` (stale local DLL 0.3.0 vs pkg 0.3.1), and tmp-dir `PermissionError`s that occur only on the live Windows desktop, never on Linux CI. This change adds **zero** failures and removes the 2 previously-red #1100 tests.
- `--collect-only` clean (no Windows/optional deps).

Test-only change — no product code, no public API touched.