### PR TITLE
docs: fix find --help bare @save-btn saved-selector examples to @app/name (fixes #1146)

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ naturo press ctrl+s
 naturo find "Edit:filename"                # UIA tree search (name / role:name)
 naturo find button.png                     # image template match (.png/.jpg/…)
 naturo find 'app://notepad.exe/Edit'       # resolve a selector path
-naturo find @save-btn                      # resolve a saved @named selector
+naturo find @notepad/save-btn              # resolve a saved selector (@app/name)
 
 # App management
 naturo app launch "notepad"

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -165,7 +165,7 @@ Search for UI elements matching a query.
 | `--ai` | boolean | Use AI vision to find element by natural language |
 | `--image` | path | Locate a template image (PNG/JPG) on the target window or screen via normalized cross-correlation (no UIA tree needed) |
 | `--threshold` | float | Minimum match score in [0.0, 1.0] for `--image` (higher is stricter, default `0.9`) |
-| `--selector` | text | Resolve a unified selector path to an element (the same strategy `click`/`type` use). URI (`app://proc.exe/Button[@name="Save"]`), descendant shorthand (`//Edit[@name="Search"]`), or saved (`@name`) |
+| `--selector` | text | Resolve a unified selector path to an element (the same strategy `click`/`type` use). URI (`app://proc.exe/Button[@name="Save"]`), descendant shorthand (`//Edit[@name="Search"]`), or saved (`@app/name`) |
 | `--screenshot` | path | Match against this existing screenshot instead of capturing live (for `--ai` and `--image`). With `--image` the screenshot is the haystack, coordinates are screenshot-relative, and window-targeting flags are rejected |
 | `--app` | text | Target app window |
 | `--app-id` | text | Stable app/window ID from "naturo app list" output (e.g. a1) |
@@ -193,7 +193,7 @@ naturo find --image btn.png --threshold 0.85      # looser match threshold
 naturo find --image btn.png --screenshot saved.png  # match offline against a saved screenshot
 naturo find --selector '//Button[@name="Save"]'   # resolve a selector path
 naturo find --selector 'app://notepad.exe/Edit[@automationid="15"]'
-naturo find --selector @login-button --all        # every match of a saved selector
+naturo find --selector @chrome/login-button --all  # every match of a saved selector
 ```
 
 Found matches get `eN` refs in the snapshot (like a normal `find`), so you can

--- a/naturo/cli/core/_find.py
+++ b/naturo/cli/core/_find.py
@@ -29,7 +29,7 @@ def _detect_query_strategy(query: str) -> str | None:
 
     Returns:
         ``"selector"`` for a unified-selector path (an ``app://…`` URI or an
-        ``@name`` saved-selector ref), ``"image"`` for a template-image file
+        ``@app/name`` saved-selector ref), ``"image"`` for a template-image file
         path (extension in :data:`_IMAGE_QUERY_EXTENSIONS`), or ``None`` for an
         ordinary text/role query.
     """
@@ -68,7 +68,7 @@ def _detect_query_strategy(query: str) -> str | None:
                    "click/type use). "
                    'URI: app://notepad.exe/Button[@name="Save"]. '
                    'Short: //Edit[@name="Search"] (any app, descendant search). '
-                   "Saved: @name. App names are flexible: chrome, chrome.exe, Chrome.")
+                   "Saved: @app/name. App names are flexible: chrome, chrome.exe, Chrome.")
 @click.option("--screenshot", type=click.Path(), default=None,
               help="Match against this existing screenshot instead of capturing "
                    "live (for --ai and --image modes). With --image the screenshot "
@@ -112,7 +112,7 @@ def find_cmd(query: str | None, query_opt: str | None, find_all: bool, role: str
     \b
     Strategy auto-detection: a bare query routes itself by shape, so you can skip
     the explicit flag —
-        app://… or @name        -> selector resolution (same as --selector)
+        app://… or @app/name    -> selector resolution (same as --selector)
         path ending .png/.jpg/… -> image template match (same as --image)
         anything else           -> UIA tree search
     Explicit --image/--selector/--ai always take precedence.
@@ -131,7 +131,7 @@ def find_cmd(query: str | None, query_opt: str | None, find_all: bool, role: str
         naturo find submit.png                   # auto-detected image template match
         naturo find --image icon.png --app Notepad --all  # all matches in app
         naturo find 'app://notepad.exe/Edit'     # auto-detected selector resolution
-        naturo find @save-btn                    # auto-detected saved selector
+        naturo find @notepad/save-btn            # auto-detected saved selector (@app/name)
         naturo find --selector '//Button[@name="Save"]'   # resolve a selector path
     """
     # (#752) Auto-detect app ID pattern (a1, a2, ...) in --app flag

--- a/tests/test_find_help_selector_examples_1146.py
+++ b/tests/test_find_help_selector_examples_1146.py
@@ -1,0 +1,65 @@
+"""Regression test for #1146.
+
+`naturo find --help` documented a bare ``@save-btn`` / ``@name`` saved-selector
+form, but the resolver requires the two-part ``@app/name`` shape and rejects the
+bare form at parse time with::
+
+    Invalid selector reference '@save-btn': expected @app/name format
+
+A user copy-pasting the documented example hit an error. This test pins the help
+text to the actual parse contract: every saved-selector (``@...``) example shown
+in ``find``'s help must be in a format the resolver accepts.
+"""
+from __future__ import annotations
+
+import re
+
+import click
+import pytest
+
+from naturo.cli.core import find_cmd
+from naturo.cli.selector_cmd import resolve_named_selector
+
+# A standalone saved-selector argument: an ``@`` token preceded by whitespace
+# (so XPath attribute syntax like ``[@name="Save"]`` — preceded by ``[`` — is
+# excluded) and made of name chars, optionally with one ``/`` separator.
+_SAVED_SELECTOR_RE = re.compile(r"(?:^|\s)(@[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)?)")
+
+
+def _find_help_text() -> str:
+    """All saved-selector-bearing help a user sees in ``naturo find --help``:
+    the command docstring plus every option's ``help`` string (the ``--selector``
+    option, for one, documents the saved form there — not in the docstring)."""
+    parts = [find_cmd.help or ""]
+    parts.extend(param.help or "" for param in find_cmd.params
+                 if isinstance(param, click.Option))
+    return "\n".join(parts)
+
+
+def _saved_selector_examples() -> list[str]:
+    return _SAVED_SELECTOR_RE.findall(_find_help_text())
+
+
+def test_find_help_advertises_saved_selector_examples() -> None:
+    """Guard against the regex silently matching nothing (which would make the
+    contract assertion below vacuously pass)."""
+    assert _saved_selector_examples(), (
+        "expected at least one '@...' saved-selector example in find --help"
+    )
+
+
+@pytest.mark.parametrize("reference", _saved_selector_examples())
+def test_find_help_saved_selector_examples_parse(reference: str) -> None:
+    """Every ``@...`` example in find's help must satisfy the resolver's
+    ``@app/name`` parse contract (a missing selector raises ``KeyError`` — that
+    is fine; an invalid *format* raises ``ValueError`` — that is the #1146 bug)."""
+    try:
+        resolve_named_selector(reference)
+    except ValueError as exc:  # invalid format == documented-but-rejected
+        pytest.fail(
+            f"find --help shows saved-selector example {reference!r} that the "
+            f"resolver rejects as malformed: {exc}"
+        )
+    except KeyError:
+        # Well-formed @app/name, just not a real saved selector — acceptable.
+        pass


### PR DESCRIPTION
## What
`naturo find --help` (and the README / CLI reference) advertised a **bare** `@save-btn` / `@name` saved-selector form, but the resolver requires the two-part `@app/name` shape and rejects the bare form at parse time:

```
Invalid selector reference '@save-btn': expected @app/name format
```

A user copy-pasting the documented example hit an error (#1146). This corrects every saved-selector example in find's help surface to the real `@app/name` contract. **Pure docs/help-text fix — no behavior change, no public API change.**

Spots corrected in `naturo/cli/core/_find.py`:
- the `--selector` option help (`Saved: @name.` -> `Saved: @app/name.`)
- the auto-detect description (`app://… or @name` -> `@app/name`)
- the `@save-btn` example (-> `@notepad/save-btn`)
- the `_detect_query_strategy` docstring form

Plus matching `README.md` and `docs/CLI_REFERENCE.md` examples.

## How tested
- New regression test `tests/test_find_help_selector_examples_1146.py` walks **every** `@...` example in find's help (command docstring **and** every option's help string, so the `--selector` option help is covered) and asserts the resolver accepts each format (a `KeyError` not-found is fine; a `ValueError` malformed-format is the #1146 bug). It would fail on the old bare `@name`.
- ruff: clean. mypy: clean (only a pre-existing unrelated site-packages `mcp/fastmcp` Py3.10-match error).
- Full non-desktop suite: `python -m pytest tests/ -m "not desktop"` -> 6103 passed; the 2 failures (`test_version_consistency` stale local DLL, `test_agent::test_total_time_recorded` timing flake) + tmp-dir PermissionErrors are pre-existing on this live Windows desktop and reproduce on clean develop (green on CI).
- `--collect-only` on the new test: 4 tests collected, no Windows/optional deps.