### PR TITLE
fix: validate wait duration upper bound + non-finite to keep --json contract (fixes #1164)

### DIFF
--- a/naturo/cli/wait_cmd.py
+++ b/naturo/cli/wait_cmd.py
@@ -1,5 +1,6 @@
 """CLI wait command — wait for a duration, or for elements/windows to appear/disappear."""
 from naturo.cli._jsonio import json_dumps
+import math
 import time
 
 from naturo.cli.error_helpers import build_error_object, json_error as _json_error_str
@@ -82,7 +83,40 @@ def wait(ctx, duration, element, window_title, gone, timeout, interval,
             sys.exit(1)
             return
 
-        time.sleep(duration)
+        # (#1164) Reject non-finite durations (NaN/inf) up front. `duration < 0`
+        # above lets NaN through (every comparison with NaN is False), and both
+        # NaN and inf would otherwise crash `time.sleep` below with a raw
+        # ValueError/OverflowError — leaking a traceback and, under -j, emitting
+        # no JSON envelope at all (a broken --json contract).
+        if not math.isfinite(duration):
+            msg = f"Duration must be a finite number, got {duration}"
+            if json_output:
+                click.echo(_json_error_str("INVALID_INPUT", msg))
+            else:
+                click.echo(f"Error: {msg}", err=True)
+            sys.exit(1)
+            return
+
+        # (#1164) `time.sleep` converts the duration to an int64-nanosecond
+        # deadline and raises OverflowError for values past the platform sleep
+        # limit (~9.22e9 s). Translate that into the same structured
+        # INVALID_INPUT contract as the bounds checks above so a huge duration
+        # never leaks a raw traceback (and always emits JSON under -j). The
+        # error CODE is platform-invariant even though the exact threshold is
+        # not, so the bad-input contract is identical on every OS.
+        try:
+            time.sleep(duration)
+        except (OverflowError, ValueError):
+            msg = (
+                f"Duration too large: {duration}s exceeds the maximum sleep "
+                f"supported on this platform"
+            )
+            if json_output:
+                click.echo(_json_error_str("INVALID_INPUT", msg))
+            else:
+                click.echo(f"Error: {msg}", err=True)
+            sys.exit(1)
+            return
         if json_output:
             # Canonical success envelope shared with the predicate sub-modes
             # (#895): the predicate-only ``found``/``warnings`` keys are present

--- a/tests/test_wait_cmd.py
+++ b/tests/test_wait_cmd.py
@@ -69,6 +69,42 @@ class TestWaitDuration:
         assert result.exit_code != 0
         assert "INVALID_INPUT" in result.output
 
+    # (#1164) Upper-bound / non-finite duration must yield a structured
+    # validation error, never a raw OverflowError/ValueError traceback — and
+    # under -j a JSON envelope must still be emitted (the broken-contract bug).
+    def test_huge_duration_rejected(self, runner):
+        """A duration past the platform sleep limit is rejected, not crashed."""
+        result = runner.invoke(wait, ["1e10"])
+        assert result.exit_code != 0
+        assert result.exception is None or isinstance(result.exception, SystemExit)
+        assert "Error" in result.output
+        assert "Traceback" not in result.output
+
+    def test_huge_duration_rejected_json(self, runner):
+        """Under -j the huge-duration error is a valid INVALID_INPUT envelope."""
+        result = runner.invoke(wait, ["1e10", "--json"])
+        assert result.exit_code != 0
+        assert result.exception is None or isinstance(result.exception, SystemExit)
+        assert "Traceback" not in result.output
+        data = json.loads(result.output)
+        assert data["success"] is False
+        assert data["error"]["code"] == "INVALID_INPUT"
+        assert data["error"]["category"] == "validation"
+
+    def test_infinite_duration_rejected_json(self, runner):
+        result = runner.invoke(wait, ["inf", "--json"])
+        assert result.exit_code != 0
+        data = json.loads(result.output)
+        assert data["success"] is False
+        assert data["error"]["code"] == "INVALID_INPUT"
+
+    def test_nan_duration_rejected_json(self, runner):
+        result = runner.invoke(wait, ["nan", "--json"])
+        assert result.exit_code != 0
+        data = json.loads(result.output)
+        assert data["success"] is False
+        assert data["error"]["code"] == "INVALID_INPUT"
+
 
 # ---------------------------------------------------------------------------
 # No arguments


### PR DESCRIPTION
## What
`naturo wait <huge duration>` (e.g. `1e10`, `999999999999`) raised an uncaught `OverflowError` from `time.sleep` and leaked a raw Python traceback. Under `--json` this broke the JSON-output contract entirely — **no** envelope was emitted, just a stack trace on stderr (exit 1). `nan` also slipped past the existing lower-bound check (`nan < 0` is `False`) and crashed with a `ValueError`. Same class as #1029 / #1031.

## How
In `wait`'s duration mode (`naturo/cli/wait_cmd.py`):
- Reject **non-finite** durations (NaN/inf) up front → structured `INVALID_INPUT` ("Duration must be a finite number").
- Wrap `time.sleep(duration)` in `try/except (OverflowError, ValueError)` → structured `INVALID_INPUT` ("Duration too large: …s exceeds the maximum sleep supported on this platform").

Both reuse the same `INVALID_INPUT` / `category: validation` envelope as the existing `duration < 0` check, so a bad duration yields a clean structured error (stdout JSON under `-j`, `Error:` on stderr otherwise, exit 1) — never a traceback. The error **code** is platform-invariant even though the exact overflow threshold is not; the duration path has no platform gate, so the bad-input contract is identical on every OS.

## How tested
- New tests in `tests/test_wait_cmd.py::TestWaitDuration`: huge duration (plain + `-j`), `inf` (`-j`), `nan` (`-j`) — assert structured `INVALID_INPUT`/`validation` envelope, exit 1, and **no** `Traceback`.
- `tests/test_wait_cmd.py` — 41 passed.
- End-to-end on a real desktop: `naturo --json wait 1e10` → `{"success": false, "error": {"code": "INVALID_INPUT", "category": "validation", ...}}`, rc=1, no traceback; `naturo --json wait 0.01` still succeeds.
- `ruff check naturo/` clean; `mypy` clean on the changed file.
- Full non-desktop `tests/` suite: 6742 passed (remaining failures/errors are pre-existing on develop / environmental: a stale local DLL version-consistency check and shared-temp-dir permission contention from concurrent loop cycles — confirmed unrelated to this change).