### PR TITLE
fix: categorize UNKNOWN_OPTION/UNKNOWN_COMMAND as validation, not unknown (fixes #1162)

### DIFF
--- a/naturo/cli/__init__.py
+++ b/naturo/cli/__init__.py
@@ -24,6 +24,7 @@ if sys.platform == "win32" and not os.environ.get("PYTHONUTF8"):
 import click
 from naturo.version import __version__
 from naturo.cli.error_helpers import json_error
+from naturo.errors import ErrorCode
 from naturo.cli.fuzzy_group import FuzzyGroup
 
 from naturo.cli.core import capture, list_cmd, see, find_cmd, menu_inspect, highlight
@@ -417,13 +418,13 @@ def _emit_usage_error_json(exc: click.UsageError) -> None:
     # set" for a nested subcommand.
     help_target = "naturo" if exc.ctx is None else exc.ctx.command_path
     if isinstance(exc, click.NoSuchOption):
-        code = "UNKNOWN_OPTION"
+        code = ErrorCode.UNKNOWN_OPTION
         action = f"Run '{help_target} --help' to see the available options."
     elif message.startswith("No such command"):
-        code = "UNKNOWN_COMMAND"
+        code = ErrorCode.UNKNOWN_COMMAND
         action = f"Run '{help_target} --help' for the command list."
     else:
-        code = "INVALID_INPUT"
+        code = ErrorCode.INVALID_INPUT
         action = f"Run '{help_target} --help' for usage."
     click.echo(json_error(code, message, suggested_action=action))
     # Contract exit code is 1 (runtime error), not Click's UsageError 2 — same

--- a/naturo/errors.py
+++ b/naturo/errors.py
@@ -39,6 +39,12 @@ class ErrorCode:
     INVALID_INPUT = "INVALID_INPUT"
     INVALID_COORDINATES = "INVALID_COORDINATES"
 
+    # Parse-time usage errors (Click) — a user typo'd a flag or a subcommand.
+    # Emitted by ``naturo.cli._emit_usage_error_json``; same validation class as
+    # INVALID_INPUT (#1162).
+    UNKNOWN_OPTION = "UNKNOWN_OPTION"
+    UNKNOWN_COMMAND = "UNKNOWN_COMMAND"
+
     # Image-matching errors (naturo find/click --image, #1059)
     INVALID_TEMPLATE = "INVALID_TEMPLATE"
     INVALID_SCREENSHOT = "INVALID_SCREENSHOT"
@@ -127,6 +133,10 @@ _ERROR_CATEGORIES: dict[str, str] = {
     ErrorCode.REGISTRY_HAS_SUBKEYS: ErrorCategory.IO,
     ErrorCode.INVALID_INPUT: ErrorCategory.VALIDATION,
     ErrorCode.INVALID_COORDINATES: ErrorCategory.VALIDATION,
+    # A typo'd flag / subcommand is a user usage mistake — the same validation
+    # class as INVALID_INPUT, emitted by the same parse-time path (#1162).
+    ErrorCode.UNKNOWN_OPTION: ErrorCategory.VALIDATION,
+    ErrorCode.UNKNOWN_COMMAND: ErrorCategory.VALIDATION,
     # Image-matching codes (#1059): a template/screenshot the user supplied that
     # cannot be decoded is a validation fault; a missing optional matcher
     # dependency is configuration; a GUI-less platform is environment.

--- a/tests/test_subcommand_usage_error_json_872.py
+++ b/tests/test_subcommand_usage_error_json_872.py
@@ -121,6 +121,50 @@ class TestSubcommandUsageErrorJson:
         assert "bogus-subcmd" in data["error"]["message"]
 
 
+class TestUsageErrorCategory:
+    """Every parse-time usage error is a ``validation`` failure (#1162).
+
+    ``UNKNOWN_OPTION`` and ``UNKNOWN_COMMAND`` are user usage mistakes — a
+    typo'd flag or subcommand — exactly like the ``INVALID_INPUT`` produced by
+    the same :func:`naturo.cli._emit_usage_error_json` path. All three must carry
+    ``category: "validation"`` so ``-j`` consumers can distinguish a user-fixable
+    input mistake from a genuinely-unexpected internal failure (``"unknown"``).
+    Before #1162 the two ``UNKNOWN_*`` codes were bare string literals absent
+    from the :data:`naturo.errors._ERROR_CATEGORIES` map, so they degraded to
+    ``"unknown"``.
+    """
+
+    def _category(self, monkeypatch, capsys, argv):
+        code = _run(monkeypatch, argv)
+        data = json.loads(capsys.readouterr().out)
+        assert code == 1
+        assert data["success"] is False
+        return data["error"]["code"], data["error"]["category"]
+
+    def test_unknown_option_is_validation(self, monkeypatch, capsys):
+        code, category = self._category(
+            monkeypatch, capsys, ["type", "--bogus-flag-xyz", "-j"]
+        )
+        assert code == "UNKNOWN_OPTION"
+        assert category == "validation"
+
+    def test_unknown_command_is_validation(self, monkeypatch, capsys):
+        code, category = self._category(
+            monkeypatch, capsys, ["app", "bogus-subcmd", "-j"]
+        )
+        assert code == "UNKNOWN_COMMAND"
+        assert category == "validation"
+
+    def test_invalid_input_stays_validation(self, monkeypatch, capsys):
+        # The sibling parse error from the same function — pins the parity that
+        # #1162 restores (all three usage errors share one category).
+        code, category = self._category(
+            monkeypatch, capsys, ["see", "--hwnd", "abc", "-j"]
+        )
+        assert code == "INVALID_INPUT"
+        assert category == "validation"
+
+
 class TestFlagPositionVariants:
     """``-j`` works before or after the subcommand (issue body)."""
 


### PR DESCRIPTION
## What
`naturo <cmd> --bad-flag -j` and `naturo <group> <bad-subcmd> -j` emitted
`"category": "unknown"` in the JSON error envelope, while the sibling
`INVALID_INPUT` produced by the **same** parse-time path
(`_emit_usage_error_json`) correctly emitted `"category": "validation"`. All
three are user usage mistakes, but two landed in the meaningless catch-all
bucket alongside genuinely-unexpected internal failures (`UNKNOWN_ERROR`), so a
`-j` consumer could not tell a user-fixable input mistake from "naturo broke".

Root cause: `UNKNOWN_OPTION` / `UNKNOWN_COMMAND` were bare string literals absent
from the `ErrorCode` enum and the `_ERROR_CATEGORIES` map, so `category_for_code`
fell back to `UNKNOWN`. Lateral follow-up to #1101 (which fixed only `ErrorCode`
enum members).

## How
- Register `UNKNOWN_OPTION` and `UNKNOWN_COMMAND` as first-class `ErrorCode`
  members and map both to `ErrorCategory.VALIDATION` (`naturo/errors.py`).
- Emit them (and `INVALID_INPUT`) via the `ErrorCode` members instead of raw
  string literals in `_emit_usage_error_json` (`naturo/cli/__init__.py`), so no
  code string can drift off-taxonomy again.
- `recoverable` is unchanged (`false`) to keep exact parity with the
  `INVALID_INPUT` sibling — no `_RECOVERY_HINTS` entry added.

The #1101 completeness test (`test_error_category_completeness_1101.py`) now
auto-covers the two new codes (every `ErrorCode` member must map to a non-unknown
category), permanently guarding against re-drift.

## How tested
- New `TestUsageErrorCategory` in `tests/test_subcommand_usage_error_json_872.py`
  asserts `category == "validation"` end-to-end (through the console-script
  wrapper) for `UNKNOWN_OPTION`, `UNKNOWN_COMMAND`, and the `INVALID_INPUT`
  sibling. Red before the fix (UNKNOWN_* → "unknown"), green after.
- ruff: clean. mypy: clean on changed files.
- Full `tests/` suite: 6123 passed (pre-existing-only env failures: stale local
  DLL version check + an agent-timing flake + temp-dir PermissionErrors from
  concurrent cron cycles — all reproduce identically on pristine develop and are
  green on CI, which builds a fresh DLL).
- Live repro on Windows desktop: all three usage-error codes now emit
  `category: "validation"`.
