### PR TITLE
feat: add naturo find --ocr text finding via RapidOCR (fixes #1060)

### DIFF
--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -166,7 +166,8 @@ Search for UI elements matching a query.
 | `--image` | path | Locate a template image (PNG/JPG) on the target window or screen via normalized cross-correlation (no UIA tree needed) |
 | `--threshold` | float | Minimum match score in [0.0, 1.0] for `--image` (higher is stricter, default `0.9`) |
 | `--selector` | text | Resolve a unified selector path to an element (the same strategy `click`/`type` use). URI (`app://proc.exe/Button[@name="Save"]`), descendant shorthand (`//Edit[@name="Search"]`), or saved (`@app/name`) |
-| `--screenshot` | path | Match against this existing screenshot instead of capturing live (for `--ai` and `--image`). With `--image` the screenshot is the haystack, coordinates are screenshot-relative, and window-targeting flags are rejected |
+| `--ocr` | boolean | Find on-screen text by OCR (for Canvas/game/custom-drawn controls UIA can't see). The positional `QUERY` is the text to locate; returns bounding boxes. Requires `pip install naturo[ocr]` |
+| `--screenshot` | path | Match against this existing screenshot instead of capturing live (for `--ai`, `--image`, and `--ocr`). With `--image`/`--ocr` the screenshot is the haystack, coordinates are screenshot-relative, and window-targeting flags are rejected |
 | `--app` | text | Target app window |
 | `--app-id` | text | Stable app/window ID from "naturo app list" output (e.g. a1) |
 | `--json`, `-j` | boolean | JSON output |
@@ -194,6 +195,8 @@ naturo find --image btn.png --screenshot saved.png  # match offline against a sa
 naturo find --selector '//Button[@name="Save"]'   # resolve a selector path
 naturo find --selector 'app://notepad.exe/Edit[@automationid="15"]'
 naturo find --selector @chrome/login-button --all  # every match of a saved selector
+naturo find --ocr "Start" --app game.exe          # OCR on-screen text in a window
+naturo find --ocr "Score" --screenshot shot.png --all  # every OCR match in an image
 ```
 
 Found matches get `eN` refs in the snapshot (like a normal `find`), so you can
@@ -207,6 +210,18 @@ regression fixtures — and the coordinates are then relative to the screenshot
 are rejected. With `--selector` the element is resolved the
 same way `click`/`type` resolve it (URI / XML / `//` shorthand / `@named`, with
 flexible app-name matching), so a path that clicks will also `find`.
+
+With `--ocr` the positional `QUERY` is the text to locate: naturo runs OCR over
+the target window/screen (or a `--screenshot`) via the optional RapidOCR engine
+and returns the bounding box of every region whose recognised text contains the
+query (case-insensitive), highest-confidence first — reaching Canvas / game /
+custom-drawn text the accessibility tree cannot see. Coordinates follow the same
+rules as `--image` (`screen` for a live capture, `screenshot` for `--screenshot`),
+and the JSON envelope adds `text`, `center_x`, `center_y`, and the recognition
+`score`. The engine ships in the optional extra: `pip install naturo[ocr]`
+(offline, bundled ONNX models — no network or system Tesseract). When it is
+absent the command returns a recoverable `OCR_NOT_AVAILABLE` error with the
+install hint.
 
 ## `naturo get`
 

--- a/naturo/cli/core/_find.py
+++ b/naturo/cli/core/_find.py
@@ -69,6 +69,10 @@ def _detect_query_strategy(query: str) -> str | None:
                    'URI: app://notepad.exe/Button[@name="Save"]. '
                    'Short: //Edit[@name="Search"] (any app, descendant search). '
                    "Saved: @app/name. App names are flexible: chrome, chrome.exe, Chrome.")
+@click.option("--ocr", is_flag=True,
+              help="Find on-screen text by OCR (for Canvas/game/custom-drawn "
+                   "controls UIA can't see). The positional QUERY is the text to "
+                   "locate; returns bounding boxes. Requires 'pip install naturo[ocr]'.")
 @click.option("--screenshot", type=click.Path(), default=None,
               help="Match against this existing screenshot instead of capturing "
                    "live (for --ai and --image modes). With --image the screenshot "
@@ -98,7 +102,7 @@ def _detect_query_strategy(query: str) -> str | None:
 def find_cmd(query: str | None, query_opt: str | None, find_all: bool, role: str | None,
              actionable: bool, depth: int, limit: int, ai: bool,
              image_template: str | None, threshold: float, selector: str | None,
-             ai_provider: str, ai_model: str | None, ai_api_key: str | None,
+             ocr: bool, ai_provider: str, ai_model: str | None, ai_api_key: str | None,
              screenshot: str | None, app: str | None, app_id: str | None,
              window_title: str | None, hwnd: int | None, pid: int | None,
              json_output: bool, backend: str) -> None:
@@ -106,6 +110,8 @@ def find_cmd(query: str | None, query_opt: str | None, find_all: bool, role: str
 
     Supports fuzzy name matching, role filtering, and combined queries.
     Use --ai for natural language element finding powered by AI vision.
+    Use --ocr to locate on-screen text the accessibility tree cannot see
+    (Canvas/game/custom-drawn controls); requires 'pip install naturo[ocr]'.
     Use --backend msaa for legacy applications that lack UIA support.
     Use --backend ia2 for IA2-enabled apps (Firefox, Thunderbird, LibreOffice).
 
@@ -133,6 +139,8 @@ def find_cmd(query: str | None, query_opt: str | None, find_all: bool, role: str
         naturo find 'app://notepad.exe/Edit'     # auto-detected selector resolution
         naturo find @notepad/save-btn            # auto-detected saved selector (@app/name)
         naturo find --selector '//Button[@name="Save"]'   # resolve a selector path
+        naturo find --ocr "Start" --app game.exe          # OCR text on a window
+        naturo find --ocr "Score" --screenshot shot.png   # OCR text in a saved image
     """
     # (#752) Auto-detect app ID pattern (a1, a2, ...) in --app flag
     from naturo.cli.options import maybe_promote_app_to_app_id
@@ -179,7 +187,7 @@ def find_cmd(query: str | None, query_opt: str | None, find_all: bool, role: str
     # detected query is moved into the matching strategy flag so the existing
     # dispatch (and its conflict checks) handle it unchanged.
     _auto_query = query if query is not None else query_opt
-    if (selector is None and image_template is None and not ai
+    if (selector is None and image_template is None and not ai and not ocr
             and not find_all and _auto_query is not None):
         detected = _detect_query_strategy(_auto_query)
         if detected == "selector":
@@ -199,6 +207,8 @@ def find_cmd(query: str | None, query_opt: str | None, find_all: bool, role: str
             conflict = "--selector and --ai are mutually exclusive; choose one find strategy."
         elif image_template is not None:
             conflict = "--selector and --image are mutually exclusive; choose one find strategy."
+        elif ocr:
+            conflict = "--selector and --ocr are mutually exclusive; choose one find strategy."
         elif query is not None or query_opt is not None:
             conflict = ("--selector takes no text query; it resolves a selector path, "
                         "not a named element.")
@@ -222,6 +232,13 @@ def find_cmd(query: str | None, query_opt: str | None, find_all: bool, role: str
     if image_template is not None:
         if ai:
             msg = "--image and --ai are mutually exclusive; choose one find strategy."
+            if json_output:
+                click.echo(_common._json_error_str("INVALID_INPUT", msg))
+            else:
+                click.echo(f"Error: {msg}", err=True)
+            raise SystemExit(1)
+        if ocr:
+            msg = "--image and --ocr are mutually exclusive; choose one find strategy."
             if json_output:
                 click.echo(_common._json_error_str("INVALID_INPUT", msg))
             else:
@@ -255,6 +272,33 @@ def find_cmd(query: str | None, query_opt: str | None, find_all: bool, role: str
         query = None
     if query_opt is not None and not query_opt.strip():
         query_opt = None
+    # OCR text-finding mode — recognise on-screen text and return the bounding
+    # boxes of regions matching the query (#1060).  Dispatched before query
+    # resolution because, like --image, it owns its own targeting and treats
+    # --all as "every match" rather than a wildcard text query.
+    if ocr:
+        if ai:
+            msg = "--ocr and --ai are mutually exclusive; choose one find strategy."
+            if json_output:
+                click.echo(_common._json_error_str("INVALID_INPUT", msg))
+            else:
+                click.echo(f"Error: {msg}", err=True)
+            raise SystemExit(1)
+        ocr_query = query if query is not None else query_opt
+        if ocr_query is None or not ocr_query.strip():
+            msg = ("--ocr needs the text to find. Provide it as the positional "
+                   "QUERY or via --query/-q (e.g. naturo find --ocr \"Start\").")
+            if json_output:
+                click.echo(_common._json_error_str("INVALID_INPUT", msg))
+            else:
+                click.echo(f"Error: {msg}", err=True)
+            raise SystemExit(1)
+        _find_with_ocr(
+            ocr_query, find_all,
+            app=app, window_title=window_title, hwnd=hwnd, pid=pid,
+            screenshot=screenshot, limit=limit, json_output=json_output,
+        )
+        return
 
     # Resolve query: --all flag → wildcard, --query option → override positional
     if find_all:
@@ -880,6 +924,243 @@ def _find_with_image(
             click.echo("Coordinates are relative to the supplied screenshot "
                        "(not screen-absolute).")
         click.echo("Tip: use 'naturo click e<N>' to interact with a match.")
+
+
+def _find_with_ocr(
+    text: str,
+    find_all: bool,
+    *,
+    app: str | None,
+    window_title: str | None,
+    hwnd: int | None,
+    pid: int | None,
+    screenshot: str | None,
+    limit: int,
+    json_output: bool,
+) -> None:
+    """Locate on-screen text by OCR (naturo find --ocr).
+
+    Recognises text on the target window, screen, or a supplied screenshot via
+    the optional RapidOCR engine and reports each region whose text matches
+    ``text`` as a snapshot element with a stable ``eN`` ref, so matches can be
+    acted on with ``naturo click eN`` — the contract the text/image/selector
+    strategies share.
+
+    The haystack is, in order of precedence:
+
+    * the image at ``screenshot`` when given (offline/deterministic matching —
+      coordinates are relative to the screenshot's top-left, origin ``(0, 0)``);
+    * a specific window when any of app/window/hwnd/pid is given;
+    * otherwise the primary screen.
+
+    Each distinct failure source carries its own error code: a missing OCR engine
+    → ``OCR_NOT_AVAILABLE`` (recoverable, with the install hint); a
+    ``--screenshot`` combined with window-targeting flags → ``INVALID_INPUT``; a
+    missing screenshot → ``FILE_NOT_FOUND``; a live-capture fault →
+    ``CAPTURE_FAILED``; an OCR engine fault → ``OCR_FAILED``.
+
+    Validation that does not depend on a live desktop (the ``--screenshot``
+    conflict and existence checks) runs *before* the GUI-platform gate so a given
+    bad input yields the same error code on every OS (#1072), and the offline
+    ``--screenshot`` path is exempt from the gate entirely.
+
+    Args:
+        text: The text to locate (case-insensitive substring match).
+        find_all: When True, report every matching region; otherwise the single
+            highest-confidence match.
+        app: Target app name/partial match.
+        window_title: Target window title substring.
+        hwnd: Target window handle.
+        pid: Target process ID.
+        screenshot: Optional path to an existing screenshot to OCR instead of
+            capturing live. Incompatible with the window-targeting flags
+            (app/window/hwnd/pid), which are rejected rather than silently
+            ignored, since the screenshot is the haystack.
+        limit: Maximum number of matches to return.
+        json_output: Whether to emit JSON.
+
+    Raises:
+        SystemExit: With status 1 on any of the failure sources above or on a
+            platform without GUI support (live path only).
+    """
+    import os
+
+    def _emit(code: str, message: str) -> NoReturn:
+        if json_output:
+            click.echo(_common._json_error_str(code, message))
+        else:
+            click.echo(f"Error: {message}", err=True)
+        raise SystemExit(1)
+
+    # Offline-input validation first, so the bad-input → code contract is the same
+    # on every OS; the offline path needs no live capture and skips the GUI gate.
+    if screenshot is not None:
+        if hwnd or app or window_title or pid:
+            _emit(
+                "INVALID_INPUT",
+                "--screenshot matches against the supplied image, so "
+                "--app/--window/--hwnd/--pid do not apply; drop those flags to "
+                "OCR the screenshot, or drop --screenshot to capture a live window.",
+            )
+        if not os.path.exists(screenshot):
+            _emit("FILE_NOT_FOUND", f"Screenshot file not found: {screenshot}")
+    elif not _common._platform_supports_gui():
+        _emit("PLATFORM_ERROR", _common._platform_error_msg("OCR text finding"))
+
+    # Acquire the haystack image path and its coordinate origin. The supplied
+    # screenshot is used directly (origin 0,0); otherwise a live window/screen
+    # capture is written to a temp file that is removed once OCR has read it.
+    from naturo.ocr_match import OCRNotAvailableError, find_text
+
+    target_hwnd = hwnd
+    temp_path: str | None = None
+    if screenshot is not None:
+        haystack_path = screenshot
+        origin_x, origin_y = 0, 0
+        target_hwnd = None
+    else:
+        backend = _common._get_backend(json_output)
+        targeted = bool(hwnd or app or window_title or pid)
+        import tempfile
+        fd, temp_path = tempfile.mkstemp(suffix=".png")
+        os.close(fd)
+        try:
+            if targeted:
+                if not target_hwnd and hasattr(backend, "_resolve_hwnd"):
+                    target_hwnd = backend._resolve_hwnd(
+                        app=app, window_title=window_title, pid=pid)
+                if not target_hwnd:
+                    target = app or window_title or (f"pid={pid}" if pid else "target")
+                    _cleanup_temp(temp_path)
+                    _emit("WINDOW_NOT_FOUND", f"Window not found: {target}")
+                backend.capture_window(hwnd=target_hwnd, output_path=temp_path)
+                origin_x, origin_y = _window_origin(target_hwnd)
+            else:
+                backend.capture_screen(screen_index=0, output_path=temp_path)
+                origin_x, origin_y = _monitor_origin(backend, 0)
+        except SystemExit:
+            raise
+        except Exception as e:
+            _cleanup_temp(temp_path)
+            _emit("CAPTURE_FAILED", f"Screen capture failed: {e}")
+        haystack_path = temp_path
+
+    # Read haystack dimensions for the snapshot root (best-effort).
+    haystack_width, haystack_height = 0, 0
+    try:
+        from PIL import Image
+        with Image.open(haystack_path) as hay:
+            haystack_width, haystack_height = hay.width, hay.height
+    except Exception as exc:
+        _common.logger.debug("Haystack dimension read failed for %s: %s",
+                             haystack_path, exc)
+
+    try:
+        matches = find_text(haystack_path, text, find_all=find_all, max_results=limit)
+    except OCRNotAvailableError as exc:
+        _emit("OCR_NOT_AVAILABLE", str(exc))
+    except Exception as exc:
+        _emit("OCR_FAILED", f"OCR text recognition failed: {exc}")
+    finally:
+        # Remove the temp capture once OCR has read it (no-op for --screenshot).
+        _cleanup_temp(temp_path)
+
+    # Register matches as snapshot elements so `naturo click eN` works, mirroring
+    # the image strategy's ref bookkeeping.
+    from naturo.bridge import ElementInfo as BridgeElementInfo
+    from naturo.snapshot import get_snapshot_manager
+    from naturo.models.snapshot import UIElement
+    from naturo.refs import assign_stable_refs
+
+    children = [
+        BridgeElementInfo(
+            id=str(i),
+            role="Text",
+            name=m.text,
+            value=f"{m.score:.4f}",
+            x=origin_x + m.x,
+            y=origin_y + m.y,
+            width=m.width,
+            height=m.height,
+            parent_id="0",
+            hwnd=target_hwnd or 0,
+        )
+        for i, m in enumerate(matches, start=1)
+    ]
+    root = BridgeElementInfo(
+        id="0",
+        role="Pane",
+        name="ocr-match",
+        value=None,
+        x=origin_x,
+        y=origin_y,
+        width=haystack_width,
+        height=haystack_height,
+        children=children,
+        hwnd=target_hwnd or 0,
+    )
+
+    mgr = get_snapshot_manager()
+    snapshot_id = mgr.create_snapshot()
+    element_id_to_ref: dict[int, str] = {}
+    ui_map, ref_map = assign_stable_refs(root, UIElement, element_obj_to_ref=element_id_to_ref)
+    mgr.store_detection_result(snapshot_id, ui_map)
+    mgr.store_ref_map(snapshot_id, ref_map)
+
+    if json_output:
+        data = [
+            {
+                "ref": element_id_to_ref.get(id(child), child.id),
+                "role": child.role,
+                "text": child.name,
+                "x": child.x,
+                "y": child.y,
+                "width": child.width,
+                "height": child.height,
+                "center_x": child.x + child.width // 2,
+                "center_y": child.y + child.height // 2,
+                "score": round(m.score, 4),
+            }
+            for child, m in zip(children, matches)
+        ]
+        click.echo(json_dumps({
+            "success": True,
+            "elements": data,
+            "count": len(data),
+            "snapshot_id": snapshot_id,
+            "coordinate_frame": "screenshot" if screenshot is not None else "screen",
+        }, indent=2))
+    else:
+        if not matches:
+            click.echo(f"No on-screen text matching: {text}")
+            return
+        for child, m in zip(children, matches):
+            ref = element_id_to_ref.get(id(child), "?")
+            click.echo(
+                f"  {ref}. [Text] \"{child.name}\" "
+                f"({child.x},{child.y} {child.width}x{child.height}) score={m.score:.3f}"
+            )
+        click.echo(f"\n{len(matches)} match(es) found.")
+        click.echo(f"Snapshot: {snapshot_id}")
+        if screenshot is not None:
+            click.echo("Coordinates are relative to the supplied screenshot "
+                       "(not screen-absolute).")
+        click.echo("Tip: use 'naturo click e<N>' to interact with a match.")
+
+
+def _cleanup_temp(path: str | None) -> None:
+    """Remove a temporary capture file, ignoring a missing/locked file.
+
+    Args:
+        path: Path to the temp file, or None when no temp capture was made.
+    """
+    if not path:
+        return
+    try:
+        import os
+        os.remove(path)
+    except OSError:
+        pass
 
 
 def _find_with_selector(

--- a/naturo/cli/error_helpers.py
+++ b/naturo/cli/error_helpers.py
@@ -236,6 +236,18 @@ _RECOVERY_HINTS: dict[str, tuple[str, bool]] = {
         "'naturo mcp install' to install MCP dependencies.",
         False,
     ),
+    "OCR_NOT_AVAILABLE": (
+        "The optional OCR engine is not installed. Install it with "
+        "'pip install naturo[ocr]' (RapidOCR — offline, bundled ONNX models), "
+        "then retry 'naturo find --ocr'.",
+        True,
+    ),
+    "OCR_FAILED": (
+        "OCR text recognition failed. Verify the target window/screenshot is "
+        "readable and contains visible text, then retry. For a saved image use "
+        "'naturo find --ocr <text> --screenshot <file>'.",
+        True,
+    ),
     "INSTALL_FAILED": (
         "Package installation failed. Check network connectivity and pip configuration.",
         True,

--- a/naturo/errors.py
+++ b/naturo/errors.py
@@ -69,6 +69,9 @@ class ErrorCode:
     SELECTOR_REF_ERROR = "SELECTOR_REF_ERROR"
     INVALID_SELECTOR = "INVALID_SELECTOR"
     TREE_ERROR = "TREE_ERROR"
+    # OCR text-finding errors (naturo find --ocr, #1060)
+    OCR_NOT_AVAILABLE = "OCR_NOT_AVAILABLE"
+    OCR_FAILED = "OCR_FAILED"
 
     # Dialog errors
     DIALOG_NOT_FOUND = "DIALOG_NOT_FOUND"
@@ -183,6 +186,11 @@ _ERROR_CATEGORIES: dict[str, str] = {
     ErrorCode.SELECTOR_REF_ERROR: ErrorCategory.SESSION,
     ErrorCode.INVALID_SELECTOR: ErrorCategory.VALIDATION,
     ErrorCode.TREE_ERROR: ErrorCategory.AUTOMATION,
+    # OCR text-finding (#1060): a missing optional OCR engine is a configuration
+    # gap (like MISSING_DEPENDENCY); an engine fault at run time is an automation
+    # operation failure (alongside CAPTURE_FAILED).
+    ErrorCode.OCR_NOT_AVAILABLE: ErrorCategory.CONFIGURATION,
+    ErrorCode.OCR_FAILED: ErrorCategory.AUTOMATION,
     ErrorCode.DIALOG_NOT_FOUND: ErrorCategory.AUTOMATION,
     ErrorCode.DEPENDENCY_MISSING: ErrorCategory.CONFIGURATION,
     ErrorCode.NO_DESKTOP_SESSION: ErrorCategory.ENVIRONMENT,

--- a/naturo/ocr_match.py
+++ b/naturo/ocr_match.py
@@ -1,0 +1,169 @@
+"""OCR-based on-screen text finding for ``naturo find --ocr`` (#1060, part of #809).
+
+This is the engine behind ``naturo find --ocr "text"``. It runs optical character
+recognition over a window/screen/screenshot image and returns the bounding boxes
+of every recognised text region whose content matches the query — letting naturo
+target Canvas / game / Flash / custom-drawn controls that expose nothing to the
+accessibility tree (UIA / MSAA / IA2 / JAB / CDP).
+
+Engine
+------
+The OCR backend is **RapidOCR** (``rapidocr-onnxruntime``), installed via the
+optional extra ``naturo[ocr]``:
+
+* MIT/Apache-licensed and fully **offline** — it bundles ONNX detection /
+  recognition models, so there is no network call and no system Tesseract to
+  install;
+* strong on both Latin and Chinese text.
+
+The extra is optional so the base install stays lean: when it is absent the CLI
+emits a recoverable ``OCR_NOT_AVAILABLE`` error pointing at the install command,
+rather than failing opaquely (the agent self-correction contract).
+
+The matcher operates purely in image coordinates (origin at the image's
+top-left). The CLI layer translates those into screen-absolute coordinates by
+adding the captured window/monitor origin, exactly as the ``--image`` path does.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Optional
+
+
+class OCRNotAvailableError(RuntimeError):
+    """Raised when the optional OCR engine (RapidOCR) is not installed.
+
+    The CLI maps this to the recoverable ``OCR_NOT_AVAILABLE`` error code with an
+    install hint, so a caller can fix it with ``pip install naturo[ocr]``.
+    """
+
+
+@dataclass(frozen=True)
+class TextMatch:
+    """A single OCR text match within the haystack image (origin at top-left).
+
+    Attributes:
+        text: The recognised text of the matched region.
+        x: Left edge of the bounding box, in image pixels.
+        y: Top edge of the bounding box, in image pixels.
+        width: Bounding-box width in pixels.
+        height: Bounding-box height in pixels.
+        score: The engine's recognition confidence in ``[0.0, 1.0]``.
+    """
+
+    text: str
+    x: int
+    y: int
+    width: int
+    height: int
+    score: float
+
+
+# Type alias for an OCR engine callable: given an image path it returns the
+# RapidOCR result — either ``(detections, elapse)`` or just ``detections`` — where
+# each detection is ``[box, text, score]`` and ``box`` is four ``[x, y]`` corner
+# points. Injectable so the recognition→coordinate logic is testable without the
+# heavy optional dependency installed.
+OCREngine = Callable[[str], Any]
+
+
+def load_engine() -> OCREngine:
+    """Load the RapidOCR engine, or raise if the optional extra is missing.
+
+    Returns:
+        A callable OCR engine that maps an image path to RapidOCR detections.
+
+    Raises:
+        OCRNotAvailableError: When ``rapidocr-onnxruntime`` is not installed.
+    """
+    try:
+        from rapidocr_onnxruntime import RapidOCR  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise OCRNotAvailableError(
+            "OCR text finding requires the optional RapidOCR engine, which is not "
+            "installed. Install it with 'pip install naturo[ocr]' (offline, "
+            "bundled ONNX models — no network or system Tesseract needed)."
+        ) from exc
+    return RapidOCR()
+
+
+def _iter_detections(raw_result: Any) -> list[Any]:
+    """Normalise a RapidOCR result into a list of ``[box, text, score]`` items.
+
+    RapidOCR returns ``(detections, elapse_times)`` and ``detections`` is ``None``
+    when no text is found. This unwraps both shapes defensively so the matcher
+    never trips on the no-text case.
+
+    Args:
+        raw_result: The raw value returned by the OCR engine call.
+
+    Returns:
+        A list of detection items (possibly empty).
+    """
+    detections = raw_result
+    if isinstance(raw_result, tuple):
+        detections = raw_result[0] if raw_result else None
+    return list(detections) if detections else []
+
+
+def find_text(
+    image_path: str,
+    query: str,
+    *,
+    find_all: bool = False,
+    max_results: int = 50,
+    engine: Optional[OCREngine] = None,
+) -> list[TextMatch]:
+    """Locate on-screen text matching ``query`` in the image at ``image_path``.
+
+    Runs OCR over the whole image, then keeps the regions whose recognised text
+    contains ``query`` as a case-insensitive substring. Matches are returned
+    highest-confidence first.
+
+    Args:
+        image_path: Path to the haystack image (a window/screen capture or a
+            supplied screenshot).
+        query: The text to search for (case-insensitive substring match).
+        find_all: When True, return every matching region; otherwise only the
+            single highest-confidence match.
+        max_results: Maximum number of matches to return.
+        engine: Optional pre-loaded OCR engine. Loaded via :func:`load_engine`
+            when omitted (the production path); injectable for testing.
+
+    Returns:
+        The matching :class:`TextMatch` regions in image coordinates, ordered by
+        descending confidence and truncated to ``max_results``.
+
+    Raises:
+        OCRNotAvailableError: When no engine is supplied and the optional RapidOCR
+            extra is not installed.
+    """
+    ocr_engine = engine if engine is not None else load_engine()
+    detections = _iter_detections(ocr_engine(image_path))
+
+    needle = query.casefold()
+    matches: list[TextMatch] = []
+    for item in detections:
+        # Each detection is ``[box, text, score]``; box is four [x, y] corners.
+        box, text, score = item[0], item[1], item[2]
+        if needle not in str(text).casefold():
+            continue
+        xs = [float(point[0]) for point in box]
+        ys = [float(point[1]) for point in box]
+        left, top = min(xs), min(ys)
+        right, bottom = max(xs), max(ys)
+        matches.append(
+            TextMatch(
+                text=str(text),
+                x=int(round(left)),
+                y=int(round(top)),
+                width=int(round(right - left)),
+                height=int(round(bottom - top)),
+                score=float(score),
+            )
+        )
+
+    matches.sort(key=lambda match: match.score, reverse=True)
+    if not find_all:
+        matches = matches[:1]
+    return matches[:max_results]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,10 +67,14 @@ mcp = [
 cdp = [
     "websocket-client>=1.0,<2.0",
 ]
-ocr = [
-    "rapidocr_onnxruntime>=1.3,<2.0",
-]
 annotate = [
+    "Pillow>=9.0,<12.0",
+]
+ocr = [
+    # RapidOCR backs `naturo see --ocr` (#1077) and `naturo find --ocr` (#1060):
+    # MIT/Apache-licensed, fully offline, bundling ONNX detection/recognition
+    # models (no network, no system Tesseract). Pillow reads the captured haystack.
+    "rapidocr-onnxruntime>=1.3,<2.0",
     "Pillow>=9.0,<12.0",
 ]
 desktop = [

--- a/tests/test_find_ocr_1060.py
+++ b/tests/test_find_ocr_1060.py
@@ -1,0 +1,285 @@
+"""Tests for ``naturo find --ocr`` OCR text finding (#1060, part of #809).
+
+``naturo find --ocr "text"`` recognises on-screen text via the optional RapidOCR
+engine and returns the bounding boxes of regions matching the query — so naturo
+can target Canvas / game / custom-drawn controls the accessibility tree cannot
+see. When the optional ``naturo[ocr]`` extra is absent the command must emit a
+recoverable ``OCR_NOT_AVAILABLE`` error with the install hint, never fail opaquely.
+
+These tests inject a fake OCR engine / patch the engine loader and the capture
+backend, so they need neither the RapidOCR dependency, a desktop session, nor the
+native core DLL — they run on every CI platform.
+"""
+from __future__ import annotations
+
+import json
+import sys
+
+import pytest
+
+# Pillow backs the haystack-dimension read; skip the whole module where absent.
+pytest.importorskip("PIL")
+
+from click.testing import CliRunner  # noqa: E402
+from PIL import Image  # noqa: E402
+from unittest.mock import MagicMock, patch  # noqa: E402
+
+from naturo.cli.core import find_cmd  # noqa: E402
+from naturo.errors import ErrorCategory, ErrorCode, category_for_code  # noqa: E402
+from naturo.ocr_match import (  # noqa: E402
+    OCRNotAvailableError,
+    TextMatch,
+    find_text,
+    load_engine,
+)
+
+
+def _detection(text: str, box: list[list[int]], score: float) -> list:
+    """Build one RapidOCR-shaped detection ``[box, text, score]``."""
+    return [box, text, score]
+
+
+def _quad(x: int, y: int, w: int, h: int) -> list[list[int]]:
+    """Four corner points (clockwise from top-left) for an axis-aligned box."""
+    return [[x, y], [x + w, y], [x + w, y + h], [x, y + h]]
+
+
+# ── 1. The recognition → coordinate logic (engine injected) ──────────────────
+
+
+class TestFindTextLogic:
+    """``find_text`` converts detections to matches without the real engine."""
+
+    def test_substring_match_is_case_insensitive(self) -> None:
+        def engine(_path):
+            return (
+                [
+                    _detection("Start Game", _quad(10, 20, 50, 18), 0.97),
+                    _detection("Quit", _quad(10, 60, 30, 18), 0.90),
+                ],
+                0.01,
+            )
+
+        matches = find_text("shot.png", "start", find_all=True, engine=engine)
+        assert len(matches) == 1
+        m = matches[0]
+        assert m.text == "Start Game"
+        assert (m.x, m.y, m.width, m.height) == (10, 20, 50, 18)
+        assert m.score == pytest.approx(0.97)
+
+    def test_results_sorted_by_descending_confidence(self) -> None:
+        def engine(_path):
+            return (
+                [
+                    _detection("score: 10", _quad(0, 0, 40, 12), 0.70),
+                    _detection("score: 20", _quad(0, 30, 40, 12), 0.95),
+                ],
+                0.01,
+            )
+
+        matches = find_text("shot.png", "score", find_all=True, engine=engine)
+        assert [round(m.score, 2) for m in matches] == [0.95, 0.70]
+
+    def test_find_all_false_returns_single_best(self) -> None:
+        def engine(_path):
+            return (
+                [
+                    _detection("score: 10", _quad(0, 0, 40, 12), 0.70),
+                    _detection("score: 20", _quad(0, 30, 40, 12), 0.95),
+                ],
+                0.01,
+            )
+
+        matches = find_text("shot.png", "score", find_all=False, engine=engine)
+        assert len(matches) == 1
+        assert matches[0].score == pytest.approx(0.95)
+
+    def test_no_text_detected_returns_empty(self) -> None:
+        # RapidOCR yields ``(None, elapse)`` when it finds no text at all.
+        matches = find_text("shot.png", "x", engine=lambda _p: (None, 0.0))
+        assert matches == []
+
+    def test_no_match_returns_empty(self) -> None:
+        def engine(_path):
+            return ([_detection("Hello", _quad(0, 0, 30, 12), 0.9)], 0.01)
+
+        assert find_text("shot.png", "absent", find_all=True, engine=engine) == []
+
+    def test_max_results_truncates(self) -> None:
+        def engine(_path):
+            return (
+                [_detection(f"item {i}", _quad(0, i * 10, 30, 8), 0.9) for i in range(5)],
+                0.01,
+            )
+
+        matches = find_text("shot.png", "item", find_all=True, max_results=2, engine=engine)
+        assert len(matches) == 2
+
+
+class TestLoadEngine:
+    """``load_engine`` fails clearly when the optional extra is missing."""
+
+    def test_missing_rapidocr_raises_ocr_not_available(self, monkeypatch) -> None:
+        # Force ``import rapidocr_onnxruntime`` to fail regardless of whether the
+        # extra happens to be installed in the test environment.
+        monkeypatch.setitem(sys.modules, "rapidocr_onnxruntime", None)
+        with pytest.raises(OCRNotAvailableError) as excinfo:
+            load_engine()
+        assert "naturo[ocr]" in str(excinfo.value)
+
+
+# ── 2. Error taxonomy ────────────────────────────────────────────────────────
+
+
+class TestErrorTaxonomy:
+    """The new codes are registered with the right category."""
+
+    def test_ocr_not_available_is_configuration(self) -> None:
+        assert category_for_code(ErrorCode.OCR_NOT_AVAILABLE) == ErrorCategory.CONFIGURATION
+
+    def test_ocr_failed_is_automation(self) -> None:
+        assert category_for_code(ErrorCode.OCR_FAILED) == ErrorCategory.AUTOMATION
+
+
+# ── 3. CLI dispatch and validation ───────────────────────────────────────────
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def screenshot(tmp_path):
+    path = tmp_path / "shot.png"
+    Image.new("RGB", (200, 100), "white").save(path)
+    return str(path)
+
+
+class TestOcrCliValidation:
+    """Input/strategy validation is platform-invariant and self-attributing."""
+
+    def test_engine_absent_yields_recoverable_ocr_not_available(
+        self, runner, screenshot
+    ) -> None:
+        # Offline --screenshot path needs no GUI gate, so this runs on every OS.
+        with patch(
+            "naturo.ocr_match.load_engine",
+            side_effect=OCRNotAvailableError("install naturo[ocr]"),
+        ):
+            result = runner.invoke(
+                find_cmd, ["--ocr", "Start", "--screenshot", screenshot, "--json"]
+            )
+        assert result.exit_code == 1
+        err = json.loads(result.output)["error"]
+        assert err["code"] == "OCR_NOT_AVAILABLE"
+        assert err["category"] == "configuration"
+        assert err["recoverable"] is True
+        assert err["suggested_action"]
+
+    def test_missing_text_is_invalid_input(self, runner, screenshot) -> None:
+        result = runner.invoke(find_cmd, ["--ocr", "--screenshot", screenshot, "--json"])
+        assert result.exit_code == 1
+        assert json.loads(result.output)["error"]["code"] == "INVALID_INPUT"
+
+    def test_screenshot_rejects_window_targeting_flags(self, runner, screenshot) -> None:
+        result = runner.invoke(
+            find_cmd,
+            ["--ocr", "Start", "--screenshot", screenshot, "--hwnd", "123", "--json"],
+        )
+        assert result.exit_code == 1
+        assert json.loads(result.output)["error"]["code"] == "INVALID_INPUT"
+
+    def test_missing_screenshot_is_file_not_found(self, runner, tmp_path) -> None:
+        result = runner.invoke(
+            find_cmd,
+            ["--ocr", "Start", "--screenshot", str(tmp_path / "nope.png"), "--json"],
+        )
+        assert result.exit_code == 1
+        assert json.loads(result.output)["error"]["code"] == "FILE_NOT_FOUND"
+
+    @pytest.mark.parametrize(
+        "extra_flag,template_needed",
+        [(["--ai"], False), (["--image"], True), (["--selector", "//Button"], False)],
+    )
+    def test_mutually_exclusive_strategies(
+        self, runner, screenshot, extra_flag, template_needed
+    ) -> None:
+        args = ["--ocr", "Start", "--json"]
+        if template_needed:
+            args = ["--ocr", "--image", screenshot, "--json"]
+        else:
+            args += extra_flag
+        result = runner.invoke(find_cmd, args)
+        assert result.exit_code == 1
+        assert json.loads(result.output)["error"]["code"] == "INVALID_INPUT"
+
+
+class TestOcrCliResults:
+    """Successful OCR builds the snapshot envelope with the right coordinates."""
+
+    def test_offline_screenshot_envelope(self, runner, screenshot) -> None:
+        def fake(path, text, *, find_all=False, max_results=50):
+            return [TextMatch(text="Start Game", x=10, y=20, width=50, height=18, score=0.97)]
+
+        with patch("naturo.ocr_match.find_text", side_effect=fake):
+            result = runner.invoke(
+                find_cmd, ["--ocr", "start", "--screenshot", screenshot, "--json"]
+            )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["success"] is True
+        assert payload["count"] == 1
+        assert payload["coordinate_frame"] == "screenshot"
+        el = payload["elements"][0]
+        assert el["text"] == "Start Game"
+        # Screenshot-relative coordinates: no window/monitor origin added.
+        assert (el["x"], el["y"]) == (10, 20)
+        assert el["center_x"] == 10 + 50 // 2
+        assert el["ref"]  # a stable eN ref for `naturo click`
+
+    def test_live_capture_adds_monitor_origin(self, runner) -> None:
+        """The live path is screen-absolute: the monitor origin is added to the
+        match coordinates (the contract the --image path shares)."""
+
+        def fake(path, text, *, find_all=False, max_results=50):
+            return [TextMatch(text="Score", x=5, y=5, width=40, height=12, score=0.88)]
+
+        backend = MagicMock()
+
+        def _capture_screen(screen_index: int = 0, output_path: str = "c.png"):
+            Image.new("RGB", (300, 200), "white").save(output_path)
+
+        backend.capture_screen.side_effect = _capture_screen
+        backend.list_monitors.return_value = [MagicMock(x=1000, y=500)]
+
+        with patch("naturo.cli.core._common._platform_supports_gui", return_value=True), \
+             patch("naturo.cli.core._common._get_backend", return_value=backend), \
+             patch("naturo.ocr_match.find_text", side_effect=fake):
+            result = runner.invoke(find_cmd, ["--ocr", "score", "--json"])
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["coordinate_frame"] == "screen"
+        el = payload["elements"][0]
+        assert (el["x"], el["y"]) == (1005, 505)
+
+    def test_no_match_is_success_with_zero_count(self, runner, screenshot) -> None:
+        with patch("naturo.ocr_match.find_text", return_value=[]):
+            result = runner.invoke(
+                find_cmd, ["--ocr", "absent", "--screenshot", screenshot, "--json"]
+            )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["success"] is True
+        assert payload["count"] == 0
+
+    def test_engine_fault_is_ocr_failed(self, runner, screenshot) -> None:
+        with patch("naturo.ocr_match.find_text", side_effect=RuntimeError("boom")):
+            result = runner.invoke(
+                find_cmd, ["--ocr", "x", "--screenshot", screenshot, "--json"]
+            )
+        assert result.exit_code == 1
+        err = json.loads(result.output)["error"]
+        assert err["code"] == "OCR_FAILED"
+        assert err["category"] == "automation"


### PR DESCRIPTION
## What

Adds an **OCR text-finding strategy** to the unified find engine (#809):
`naturo find --ocr "text"` recognises on-screen text and returns the bounding
boxes of regions matching the query — reaching Canvas / game / custom-drawn
controls that the accessibility tree (UIA/MSAA/IA2/JAB/CDP) cannot see. Closes
done-criterion #2 of the v0.3.2 sub-goal (find engine: `--selector` + `--image`
+ `--ocr`).

Engine: **RapidOCR** as the optional extra `naturo[ocr]` (MIT/Apache, fully
offline, bundled ONNX models — no network, no system Tesseract), per Ace's
decision on #1077.

### Surface added (why this PR is auto-merge OFF)
- New **CLI flag** `naturo find --ocr` (+ honours `--screenshot`, `--all`,
  `--limit`, `-j`).
- New **error codes** `OCR_NOT_AVAILABLE` (recoverable, with install hint) and
  `OCR_FAILED`.
- New **public module** `naturo.ocr_match` (`find_text`, `TextMatch`,
  `load_engine`, `OCRNotAvailableError`).
- New **optional extra** `naturo[ocr]`.

## How it works
- `naturo.ocr_match.find_text` runs OCR over the haystack and keeps regions
  whose recognised text contains the query (case-insensitive), highest
  confidence first. The engine is injectable so the recognition→coordinate logic
  is unit-tested without the optional dependency installed.
- Haystack precedence mirrors `--image`: `--screenshot` (offline,
  screenshot-relative coords) → targeted window → primary screen
  (screen-absolute coords, monitor/window origin added).
- Matches register as snapshot elements with stable `eN` refs, so
  `naturo click eN` works on a result.
- Per-source error attribution (#1067/#1070) and platform-invariant validation
  order (#1072): offline-input checks run before the GUI gate; the `--screenshot`
  path skips the gate entirely.

## How tested
- New `tests/test_find_ocr_1060.py` (20 tests, all pass): recognition→coords
  logic (substring/casefold, box→bbox, confidence sort, find_all, max_results,
  no-text); `load_engine` → `OCR_NOT_AVAILABLE` when the extra is absent; error
  taxonomy (categories); CLI dispatch (engine-absent recoverable envelope,
  missing-text/missing-screenshot/window-flag conflicts, strategy mutual
  exclusivity); success envelopes (offline screenshot-relative + live
  monitor-origin coords, no-match zero-count, engine-fault → `OCR_FAILED`).
- Quality gate: `ruff check naturo/` clean; `mypy` clean on changed files;
  full non-desktop suite `python -m pytest tests/ -m "not desktop"` →
  **6772 passed**, 171 skipped (pre-existing local-only failures unrelated to
  this diff: a stale local DLL version test [Windows-only, skipped on CI] and
  `test_cost_guardrails` gbk-codec config-read errors [CI is UTF-8]).
- `--collect-only` succeeds with `rapidocr`/`numpy` absent (no cross-platform
  collection break).

## Note for reviewers
**Auto-merge is OFF** — this adds public CLI/API surface (new `--ocr` flag, new
error codes, new module, new extra), which is a human-only sign-off per the
repo's public-API guardrail. End-to-end OCR against a real fixture (the
acceptance: "locates known on-screen text; returns coords") needs the
`naturo[ocr]` extra installed and is left for QA verification once approved.
