### PR TITLE
fix: honor --backend/--depth in find --selector (refs #1169)

### DIFF
--- a/naturo/cli/core/_find.py
+++ b/naturo/cli/core/_find.py
@@ -194,6 +194,7 @@ def find_cmd(query: str | None, query_opt: str | None, find_all: bool, role: str
         _find_with_selector(
             selector, find_all,
             app=app, window_title=window_title, hwnd=hwnd, pid=pid,
+            depth=depth, method=backend,
             limit=limit, json_output=json_output,
         )
         return
@@ -821,6 +822,8 @@ def _find_with_selector(
     window_title: str | None,
     hwnd: int | None,
     pid: int | None,
+    depth: int,
+    method: str,
     limit: int,
     json_output: bool,
 ) -> None:
@@ -847,6 +850,13 @@ def _find_with_selector(
         window_title: Target window title substring.
         hwnd: Target window handle.
         pid: Target process ID.
+        depth: Maximum tree depth to traverse (the ``--depth`` option).
+        method: Accessibility backend to use (the ``--backend``/``--method``
+            option, e.g. ``"auto"``/``"uia"``/``"msaa"``). Forwarded to
+            ``get_element_tree`` so the selector path resolves over the SAME
+            tree the text-query path does — without it the fetch silently fell
+            to the backend's ``"uia"`` default (UIA only, no hybrid fallback),
+            and selectors over WinUI/XAML apps matched nothing (#1169).
         limit: Maximum number of matches to return.
         json_output: Whether to emit JSON.
 
@@ -890,7 +900,8 @@ def _find_with_selector(
 
     try:
         tree = backend.get_element_tree(
-            app=app, window_title=window_title, hwnd=hwnd, pid=pid, depth=20,
+            app=app, window_title=window_title, hwnd=hwnd, pid=pid,
+            depth=depth, backend=method,
         )
     except _common.WindowNotFoundError as exc:
         _emit_error("WINDOW_NOT_FOUND", str(exc))

--- a/tests/test_find_selector_backend_depth_1169.py
+++ b/tests/test_find_selector_backend_depth_1169.py
@@ -1,0 +1,115 @@
+"""Tests for ``naturo find --selector`` honoring ``--backend`` and ``--depth`` (#1169).
+
+The unified find engine's selector strategy (#1061) silently ignored two
+documented, already-parsed ``find`` options on its tree-fetch:
+
+* ``--backend`` / ``--method`` — the selector path called
+  ``backend.get_element_tree(...)`` without forwarding the chosen accessibility
+  backend, so it always ran the backend default (``"uia"`` — UIA only, no
+  fallback), while the text-query path forwards ``backend="auto"`` (UIA first,
+  then hybrid Win32+UIA / IA2 / JAB / MSAA). On WinUI/XAML apps (e.g. Windows 11
+  Notepad) pure UIA returns a shallow tree, so ``find --selector '//Document'``
+  resolved nothing while ``find 'role:Document'`` (auto) matched the same window
+  — the by-scope/by-strategy divergence reported in #1169 facet 1.
+* ``--depth`` — the selector path hardcoded ``depth=20``, so a user-supplied
+  ``--depth`` was ignored.
+
+These tests stub ``backend.get_element_tree`` so they need neither a desktop
+session nor the native DLL, and pin the Option-Coverage contract: every
+documented option the selector mode can touch is explicitly honored, not
+silently dropped to a default path that returns confidently-wrong output
+(the #1070 lesson).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+from click.testing import CliRunner
+from unittest.mock import MagicMock, patch
+
+from naturo.cli.core import find_cmd
+
+
+@dataclass
+class _FakeElement:
+    """Minimal stand-in for a backend ``ElementInfo`` node."""
+
+    role: str
+    name: str = ""
+    id: str = ""
+    value: str = ""
+    x: int = 0
+    y: int = 0
+    width: int = 0
+    height: int = 0
+    children: list = field(default_factory=list)
+    properties: dict = field(default_factory=dict)
+
+
+def _sample_tree() -> _FakeElement:
+    return _FakeElement(
+        role="Window", name="Untitled - Notepad", width=800, height=600,
+        children=[
+            _FakeElement(role="Button", name="Save", x=700, y=8, width=60, height=24),
+        ],
+    )
+
+
+def _backend_returning(tree) -> MagicMock:
+    backend = MagicMock()
+    backend.get_element_tree.return_value = tree
+    return backend
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _invoke(runner, backend, args):
+    with patch("naturo.cli.core._common._platform_supports_gui", return_value=True), \
+         patch("naturo.cli.core._common._get_backend", return_value=backend):
+        return runner.invoke(find_cmd, args)
+
+
+class TestSelectorForwardsBackendAndDepth:
+    """``find --selector`` must forward ``--backend`` and ``--depth`` to the tree fetch."""
+
+    def test_explicit_backend_is_forwarded(self, runner) -> None:
+        backend = _backend_returning(_sample_tree())
+        result = _invoke(
+            runner, backend,
+            ["--selector", "//Button", "--backend", "msaa", "--json"],
+        )
+        assert result.exit_code == 0, result.output
+        backend.get_element_tree.assert_called_once()
+        assert backend.get_element_tree.call_args.kwargs["backend"] == "msaa"
+
+    def test_explicit_depth_is_forwarded(self, runner) -> None:
+        backend = _backend_returning(_sample_tree())
+        result = _invoke(
+            runner, backend,
+            ["--selector", "//Button", "--depth", "35", "--json"],
+        )
+        assert result.exit_code == 0, result.output
+        assert backend.get_element_tree.call_args.kwargs["depth"] == 35
+
+    def test_default_backend_is_auto_not_uia_only(self, runner) -> None:
+        """With no ``--backend`` the selector path must use the CLI default ``auto``.
+
+        Regression guard for #1169 facet 1: the selector path previously omitted
+        ``backend=`` and fell to the backend's ``"uia"`` default (UIA only), so a
+        WinUI/XAML element visible to ``auto``'s hybrid fallback resolved to
+        ``SELECTOR_NOT_FOUND``. It must match the text-query path's ``auto``.
+        """
+        backend = _backend_returning(_sample_tree())
+        result = _invoke(runner, backend, ["--selector", "//Button", "--json"])
+        assert result.exit_code == 0, result.output
+        assert backend.get_element_tree.call_args.kwargs["backend"] == "auto"
+
+    def test_default_depth_matches_cli_default(self, runner) -> None:
+        backend = _backend_returning(_sample_tree())
+        result = _invoke(runner, backend, ["--selector", "//Button", "--json"])
+        assert result.exit_code == 0, result.output
+        assert backend.get_element_tree.call_args.kwargs["depth"] == 20


### PR DESCRIPTION
## What
`naturo find --selector` silently ignored two documented, already-parsed `find`
options on its UI-tree fetch:

- **`--backend` / `--method`** — the selector path called
  `backend.get_element_tree(...)` *without* forwarding the chosen accessibility
  backend, so it always ran the Windows backend's parameter default
  (`backend="uia"` — UIA only, **no** hybrid fallback). The text-query path
  forwards `backend="auto"` (UIA first, then hybrid Win32+UIA / IA2 / JAB / MSAA).
  On WinUI/XAML apps (e.g. Windows 11 Notepad) pure UIA returns a shallow tree,
  so `find --selector '//Document'` resolved `SELECTOR_NOT_FOUND` while
  `find 'role:Document'` (auto) matched the same window — the by-scope/by-strategy
  divergence reported in **#1169 facet 1**.
- **`--depth`** — the selector path hardcoded `depth=20`, so a user-supplied
  `--depth` was ignored.

The fix threads `--backend` and `--depth` from `find_cmd` into
`_find_with_selector`, so the selector strategy resolves over the **same** tree
the text-query strategy does. This is the Option-Coverage contract (every
documented option a mode can touch is explicitly honored, not silently dropped
to a default that returns confidently-wrong output — the #1070 lesson) and the
Never-Lie principle (a silently-ignored flag yields confidently-wrong results).

Scope note: this fixes the root cause of #1169 **facet 1** (role-only/by-scope
divergence) by aligning the backend strategy. **Facet 2** (no-scope short-form
"any app" desktop-wide enumeration) is a separate behavior and is **not** changed
here; it stays tracked on #1169 for a follow-up + live verification.

## How tested
- New hermetic test `tests/test_find_selector_backend_depth_1169.py` (mocks
  `backend.get_element_tree`, no desktop/DLL — runs on every CI platform):
  - `--backend msaa` is forwarded as `backend="msaa"`.
  - `--depth 35` is forwarded as `depth=35`.
  - with no `--backend`, the selector path uses the CLI default `"auto"` (not the
    backend's `"uia"`-only default) — regression guard for #1169 facet 1.
  - default depth matches the CLI default (20).
- `ruff check naturo/` — All checks passed.
- `mypy naturo/cli/core/_find.py` — Success: no issues found.
- Full non-desktop suite: `python -m pytest tests/ -m "not desktop"` —
  **6116 passed**, 171 skipped, 167 deselected, 1 xfailed, 1 xpassed. The 2
  failures + 646 errors are pre-existing/environmental on this headless runner,
  unrelated to this diff (which touches only `_find_with_selector`):
  `test_version_consistency::test_python_version_matches_dll_version`
  (gitignored local DLL is 0.3.0 vs package 0.3.1 — CI builds it fresh),
  `test_agent::test_total_time_recorded` (Windows clock-granularity timing flake,
  `total_time==0.0`), and 646 `PermissionError`s across ~60 unrelated modules
  (sandbox filesystem restriction). All `find`/selector test modules pass,
  including the new test (`--collect-only` clean for CI cross-platform collection).

## Notes for review
This changes the **default** accessibility backend of `find --selector` from
UIA-only to `auto` (matching `find <query>`), so it is a user-observable behavior
change on a public command. Auto-merge is **OFF** pending @AcePeak sign-off.
Live-desktop verification of the #1169 facet-1 repro is recommended before the
issue is closed (QA).
