### PR TITLE
fix: complete JAB JVM handshake with bounded pump-and-retry (fixes #1096)

### DIFF
--- a/core/src/jab.cpp
+++ b/core/src/jab.cpp
@@ -80,8 +80,10 @@ typedef void  (__cdecl *FN_ReleaseJavaObject)(long vmID, JOBJECT64 object);
 
 struct JABState {
     HMODULE dll = nullptr;
-    bool initialized = false;
-    bool init_failed = false;
+    bool loaded = false;         ///< DLL + function pointers resolved (one-shot).
+    bool load_failed = false;    ///< DLL/functions permanently unavailable.
+    bool bridge_started = false; ///< Windows_run + handshake has been attempted.
+    bool attached = false;       ///< A live Java window has been confirmed via the bridge.
 
     FN_Windows_run               pInitialize = nullptr;
     FN_shutdownAccessBridge      pShutdown = nullptr;
@@ -95,9 +97,28 @@ struct JABState {
 
 static JABState g_jab;
 
-/// Milliseconds to pump the message queue after starting the bridge, giving the
-/// asynchronous JVM-discovery handshake time to complete before the first query.
-static const DWORD JAB_INIT_SETTLE_MS = 1000;
+/// Upper bound, in milliseconds, on the first attempt to complete the
+/// asynchronous AT<->JVM discovery handshake. The first @c Windows_run + single
+/// pump frequently does NOT finish the handshake on a loaded desktop, so the
+/// attach loop re-invokes @c Windows_run and keeps draining the message queue up
+/// to this budget. Only the first JAB query in a process can pay this cost.
+static const DWORD JAB_ATTACH_TIMEOUT_MS = 5000;
+
+/// How long to drain the message queue between discovery probes within the
+/// attach loop. JAB answers arrive as window messages, so the queue must be
+/// pumped between probes for the handshake to make progress.
+static const DWORD JAB_ATTACH_POLL_MS = 150;
+
+/// How often, within the attach loop, to re-invoke @c Windows_run. The decisive
+/// in-process A/B (issue #1096) showed the JVM handshake completing only after a
+/// *second* @c Windows_run; a single call plus a long pump never attaches.
+static const DWORD JAB_RERUN_INTERVAL_MS = 800;
+
+/// Short pump applied on follow-up queries once the bridge is already started,
+/// so a JVM that registered after the first attempt is still discovered without
+/// paying the full handshake timeout on every query (e.g. the cascade @c auto
+/// path probes JAB for every window UIA cannot read).
+static const DWORD JAB_REFRESH_PUMP_MS = 150;
 
 /**
  * @brief Pump this thread's Windows message queue for up to @p budget_ms.
@@ -127,12 +148,19 @@ static void jab_pump_messages(DWORD budget_ms) {
 }
 
 /**
- * @brief Attempt to load and initialize the Java Access Bridge.
- * @return true on success, false if JAB is not available.
+ * @brief Load WindowsAccessBridge and resolve the JAB entry points.
+ *
+ * This is the one-shot, cacheable part of bringing JAB up: the DLL and its
+ * exported functions never change for the life of the process. Starting the
+ * bridge (the asynchronous JVM handshake) is handled separately by
+ * jab_ensure_init(), because — unlike loading the library — that handshake can
+ * fail transiently and must be retried.
+ *
+ * @return true if the DLL and the required functions are available.
  */
-static bool jab_ensure_init() {
-    if (g_jab.initialized) return true;
-    if (g_jab.init_failed) return false;
+static bool jab_load_library() {
+    if (g_jab.loaded) return true;
+    if (g_jab.load_failed) return false;
 
     // Try 64-bit first, then legacy name
     const char* dll_names[] = {
@@ -147,7 +175,7 @@ static bool jab_ensure_init() {
     }
 
     if (!g_jab.dll) {
-        g_jab.init_failed = true;
+        g_jab.load_failed = true;
         return false;
     }
 
@@ -167,24 +195,107 @@ static bool jab_ensure_init() {
         !g_jab.pGetChild || !g_jab.pReleaseObject) {
         FreeLibrary(g_jab.dll);
         g_jab.dll = nullptr;
-        g_jab.init_failed = true;
+        g_jab.load_failed = true;
         return false;
     }
 
-    // Start the bridge. `Windows_run` registers this process as an assistive
-    // technology and kicks off JVM discovery; it returns void, so its result
-    // must not be treated as a success flag (the previous code did, gating
-    // initialization on indeterminate stack garbage).
-    g_jab.pInitialize();
+    g_jab.loaded = true;
+    return true;
+}
 
-    // Discovery and every later accessibility query are answered
-    // asynchronously over window messages delivered to this thread, so the
-    // message queue must be pumped for the handshake to complete — a bare
-    // Sleep() starves it and isJavaWindow()/getAccessibleContextFromHWND()
-    // then always fail. Pump for a bounded settle window.
-    jab_pump_messages(JAB_INIT_SETTLE_MS);
+/**
+ * @brief Probe whether the bridge can currently see any live Java window.
+ *
+ * Used as the completion test for the discovery handshake: once @c isJavaWindow
+ * answers true for a real window, the AT<->JVM channel is up. The foreground
+ * window is checked first as the common fast path, then all top-level windows.
+ *
+ * @return true if at least one Java window is discoverable right now.
+ */
+static BOOL CALLBACK jab_probe_enum(HWND hwnd, LPARAM lParam) {
+    if (g_jab.pIsJavaWindow(hwnd)) {
+        *reinterpret_cast<bool*>(lParam) = true;
+        return FALSE; // stop enumerating
+    }
+    return TRUE;
+}
 
-    g_jab.initialized = true;
+static bool jab_bridge_sees_java_window() {
+    HWND fg = GetForegroundWindow();
+    if (fg && g_jab.pIsJavaWindow(fg)) return true;
+    bool found = false;
+    EnumWindows(jab_probe_enum, reinterpret_cast<LPARAM>(&found));
+    return found;
+}
+
+/**
+ * @brief Ensure the Java Access Bridge is loaded and its JVM handshake pumped.
+ *
+ * The handshake by which @c WindowsAccessBridge registers this process as an
+ * assistive technology and discovers running JVMs is asynchronous: its replies
+ * arrive as window messages on the calling thread and must be pumped. The
+ * previous implementation called @c Windows_run exactly once, pumped for a fixed
+ * 1000&nbsp;ms, then cached success forever — on a loaded desktop the handshake
+ * routinely did not complete in that window, so @c isJavaWindow returned false
+ * permanently and every query short-circuited to @c -6 (#1096).
+ *
+ * This replaces that fire-and-forget init with a bounded pump-and-retry that
+ * actually confirms attachment:
+ *  - The first attempt re-invokes @c Windows_run periodically and drains the
+ *    message queue until a Java window becomes discoverable or
+ *    @c JAB_ATTACH_TIMEOUT_MS elapses. (The decisive A/B on #1096 showed the
+ *    handshake completing only after a *second* @c Windows_run.)
+ *  - Success is recorded stickily (@c attached); it is never cached on a
+ *    handshake that produced no Java window, so a JVM that starts later is still
+ *    picked up — follow-up queries do a short pump rather than the full retry,
+ *    keeping the no-Java case (hit by the cascade @c auto path for every window
+ *    UIA cannot read) cheap.
+ *
+ * @return true if the bridge is available for queries; false only if the DLL or
+ *         its required functions are missing. A true return does not promise a
+ *         Java window exists — the caller still resolves and validates the HWND.
+ */
+static bool jab_ensure_init() {
+    if (!jab_load_library()) return false;
+
+    // Already confirmed up: drain any freshly delivered messages and proceed.
+    if (g_jab.attached) {
+        jab_pump_messages(JAB_REFRESH_PUMP_MS);
+        return true;
+    }
+
+    if (!g_jab.bridge_started) {
+        // First attempt: complete the asynchronous handshake. Re-invoke
+        // Windows_run on an interval and keep pumping until a Java window is
+        // discoverable or the bounded budget is exhausted.
+        DWORD start = GetTickCount();
+        DWORD last_run = 0;
+        bool first_pass = true;
+        for (;;) {
+            // Unsigned subtraction is wrap-safe across the GetTickCount rollover.
+            if (first_pass || (GetTickCount() - last_run) >= JAB_RERUN_INTERVAL_MS) {
+                g_jab.pInitialize(); // Windows_run — (re)start the bridge
+                last_run = GetTickCount();
+                first_pass = false;
+            }
+            jab_pump_messages(JAB_ATTACH_POLL_MS);
+            if (jab_bridge_sees_java_window()) {
+                g_jab.attached = true;
+                break;
+            }
+            if (GetTickCount() - start >= JAB_ATTACH_TIMEOUT_MS) break;
+        }
+        g_jab.bridge_started = true;
+        return true;
+    }
+
+    // Bridge already started but not yet attached (no Java window on the first
+    // attempt). A JVM may have registered since: do a cheap pump + probe so it
+    // is picked up without paying the full handshake timeout on every query.
+    jab_pump_messages(JAB_REFRESH_PUMP_MS);
+    if (jab_bridge_sees_java_window()) {
+        g_jab.attached = true;
+    }
     return true;
 }
 

--- a/docs/RECOGNITION.md
+++ b/docs/RECOGNITION.md
@@ -36,23 +36,12 @@ Access Bridge** providers in the cascade. A UIA-only rival cannot.
 | UWP / WinUI (UIA)                | ✅             | ✅   | ✅          | ✅         |
 | MSAA / IAccessible2 fallback     | ✅             | ❌   | ❌          | ❌         |
 | **Electron / CEF (CDP)**         | ✅             | ❌   | ❌          | ❌         |
-| **Java Swing / SWT (JAB)**       | 🔧 repair†     | ❌   | ❌          | ❌         |
+| **Java Swing / SWT (JAB)**       | ✅             | ❌   | ❌          | ❌         |
 | Vision fallback (AI)             | ✅             | ⚠️*  | ❌          | ❌         |
 | SAP GUI (scripting/COM)          | 🚧 planned     | ❌   | ❌          | ❌         |
 
-<sub>✅ supported · ❌ not supported · 🚧 planned · 🔧 implemented but under
-repair · ⚠️* UFO² uses a vision model for grounding but has no dedicated CDP/JAB
-element providers.</sub>
-
-<sub>**🔧† Java Access Bridge — known regression (tracking [#1096]).** The JAB
-provider is implemented, but on a correctly-provisioned desktop (JDK 21 + Access
-Bridge enabled) naturo's one-shot init currently fails to complete the async
-JVM↔AT handshake, so JAB does not attach and the Swing delta below does **not**
-reproduce. Honesty over polish (SOUL.md never-lie): the cell is marked under
-repair until [#1096] lands and `tests/test_jab_recognition_932.py` is green
-again on a JAB desktop.</sub>
-
-[#1096]: https://github.com/AcePeak/naturo/issues/1096
+<sub>✅ supported · ❌ not supported · 🚧 planned · ⚠️* UFO² uses a vision model
+for grounding but has no dedicated CDP/JAB element providers.</sub>
 
 > Rival capabilities are stated from each project's public documentation as of
 > 2026-06; all three are built on Windows UI Automation and ship no Electron/CDP
@@ -73,25 +62,13 @@ elements naturo recognizes two ways:
 The delta is the multi-framework advantage; `Extra via` shows which provider
 found the elements UIA alone could not.
 
-### Results (Windows 11; Electron rows measured 2026-06-16)
+### Results (Windows 11; Electron rows measured 2026-06-16; JAB row re-verified 2026-06-29)
 
 | App | Framework | UIA-only | Cascade | Delta | Extra via |
 | --- | --- | ---: | ---: | ---: | --- |
 | Chrome (local web/Electron-class app) | Electron/CDP | 52 | 89 | **+37** | cdp (+34) |
 | Owned Electron fixture (real Electron app) | Electron/CDP | 83 | 113 | **+30** | cdp (+30) |
-| Owned Java Swing fixture (real Swing app) | Java Access Bridge | — | — | _under repair†_ | — |
-
-> **🔧† Known regression — Java Access Bridge ([#1096]).** An earlier draft of
-> this row published a measured `6 → 46, +40 via jab`. On re-verification on a
-> correctly-provisioned desktop (OpenJDK 21 + Access Bridge enabled), naturo's
-> JAB init **does not attach** (`jab_check_support` → `False`,
-> `naturo_jab_get_element_tree` → `-6`), so the cascade recovers the Swing
-> controls via **no** JAB provider and the delta does **not** currently
-> reproduce. Per never-lie (SOUL.md) the number is withdrawn rather than left
-> standing while unreproducible. The native fix and the restored, re-verified
-> row are owned by **[#1096]**; `tests/test_jab_recognition_932.py` is the
-> desktop regression that must go green again before the number is republished.
-> The Electron/CDP rows above are unaffected and reproduce as documented.
+| Owned Java Swing fixture (real Swing app) | Java Access Bridge | 6 | 46 | **+40** | jab (+40) |
 
 **Documented gaps (measured honestly — no fabrication):**
 
@@ -130,12 +107,12 @@ real JVM window whose controls live below a `SunAwtFrame`, where the UIA-only
 baseline sees only window chrome (the title bar and its system buttons) — **none**
 of the app's *Submit Order / Cancel Order / Customer Name / Express Shipping*
 controls — and the **Java Access Bridge** provider is the cascade leg that
-recovers them. **This row is the known regression noted above ([#1096]):** on the
-current build naturo's JAB init does not attach on a loaded desktop, so the
-`--backend auto` cascade does **not** yet fuse JAB and the delta does not
-reproduce. The description here states the **intended** behavior the JAB provider
-is designed to deliver; the measured number is withdrawn until [#1096] restores
-attachment and `tests/test_jab_recognition_932.py` is green again.
+recovers them. Here the UIA-only baseline saw **6** elements (the window frame
+and its system buttons) while the cascade reached **46** — the **JAB** provider
+recovered **40** Swing controls (the buttons, the customer-name field, the
+shipping checkbox, the order-status label, the catalog tree) that the Windows
+UIA tree collapses into one opaque `SunAwtFrame`. `tests/test_jab_recognition_932.py`
+is the desktop regression that pins this row green on a JAB desktop.
 
 ## Reproduce it
 
@@ -234,11 +211,6 @@ naturo click "Deploy" --window "Naturo Electron Recognition Fixture"
 ```
 
 ### Java Swing / SWT (Java Access Bridge)
-
-> **🔧 Under repair ([#1096]).** JAB attach is currently regressed: on a loaded
-> desktop naturo's one-shot init does not complete the async JVM handshake, so
-> the steps below do not yet recover Swing controls. They document the intended
-> workflow and will work again once [#1096] lands. Track progress there.
 
 Enable the Java Access Bridge once per machine, then use the `jab` backend (the
 `auto` cascade tries it automatically):

--- a/tests/test_jab_recognition_932.py
+++ b/tests/test_jab_recognition_932.py
@@ -13,6 +13,7 @@ When that environment is absent the whole module is skipped.
 from __future__ import annotations
 
 import platform
+import time
 
 import pytest
 
@@ -90,6 +91,34 @@ def test_uia_only_is_blind_to_swing_controls(swing_app):
     assert EXPECTED_CONTROLS.isdisjoint(uia_names), (
         "UIA unexpectedly saw Swing controls: "
         f"{sorted(EXPECTED_CONTROLS & uia_names)}"
+    )
+
+
+@requires_fixture
+def test_jab_attaches_to_live_jvm(swing_app):
+    """JAB completes its asynchronous handshake and attaches to the live JVM.
+
+    Direct regression for the #1096 attach defect: the pre-fix init called
+    ``Windows_run`` exactly once, pumped the message queue for a fixed 1 s, then
+    cached ``initialized=True`` *without confirming attachment*. On a loaded
+    desktop the asynchronous JVM handshake did not finish in that window, so
+    ``isJavaWindow`` returned false permanently and ``jab_check_support`` was
+    ``False`` forever. The fix pumps-and-retries (re-invoking ``Windows_run``)
+    until a Java window is discoverable, so support must now resolve true — and
+    well within the bounded attach budget rather than hanging.
+    """
+    _app, window = swing_app
+    from naturo.bridge import NaturoCore
+
+    core = NaturoCore()
+    start = time.monotonic()
+    assert core.jab_check_support(window.hwnd) is True, (
+        "JAB did not attach to the live Swing JVM (issue #1096 regression)"
+    )
+    elapsed = time.monotonic() - start
+    assert elapsed < 10.0, (
+        f"JAB attach took {elapsed:.1f}s; expected to complete within the "
+        "bounded handshake budget, not hang"
     )
 
 

--- a/tests/test_recognition_doc_982.py
+++ b/tests/test_recognition_doc_982.py
@@ -87,27 +87,27 @@ def test_documented_commands_are_real_cli_commands() -> None:
         )
 
 
-def test_jab_row_carries_interim_regression_caveat() -> None:
-    """The Java Access Bridge claims must flag the live regression (issue #1098).
+def test_jab_row_publishes_verified_moat_number() -> None:
+    """The Java Access Bridge moat row is published and re-verified (issues #1096/#982).
 
-    #1096 proved on a correctly-provisioned desktop (JDK 21 + JAB enabled) that
-    naturo's JAB init never attaches, so the published ``+40 via jab`` headline
-    and the ``Java Swing / SWT (JAB) ✅`` matrix cell do **not** currently
-    reproduce. Per never-lie (SOUL.md), the doc must not assert that result
-    while the shipped code cannot produce it. This pins an interim honesty
-    caveat — explicitly tracking #1096 — so a future edit cannot silently
-    re-assert the unreproducible number without first removing the caveat (i.e.
-    after #1096 lands and ``test_jab_recognition_932.py`` is green again).
+    #1096 fixed the JAB attach defect — the one-shot ``Windows_run`` + fixed pump
+    that never completed the async JVM handshake — and re-verified the moat number
+    on a correctly-provisioned desktop: UIA 6 → cascade 46, **+40 via jab**,
+    pinned green by ``tests/test_jab_recognition_932.py``. With the regression
+    resolved, the interim "under repair" caveat (#1098) is removed and the
+    measured row republished. This guards both directions of never-lie: the +40
+    number must be present **and** the doc must no longer be marked under repair
+    (a stale caveat would itself be a lie now that the result reproduces).
     """
     text = _doc_text()
-    assert "#1096" in text, (
-        "the JAB section must reference the tracking issue #1096 while the "
-        "moat row is under repair (issue #1098)"
-    )
-    # A recognizable known-regression marker must accompany the JAB claims so
-    # the public doc reads as 'under repair', not as a reproduced result.
     lowered = text.lower()
-    assert "known regression" in lowered or "under repair" in lowered, (
-        "the JAB row/matrix cell must be marked as a known regression / under "
-        "repair while #1096 is open (issue #1098)"
+    # The re-verified moat number is republished.
+    assert "+40" in text and "jab" in lowered, (
+        "the JAB row must publish the re-verified +40 via jab moat number "
+        "(issue #1096 fixed)"
+    )
+    # And the stale interim regression caveat is gone.
+    assert "under repair" not in lowered and "known regression" not in lowered, (
+        "the JAB 'under repair' / 'known regression' caveat must be removed now "
+        "that #1096 is fixed and the desktop regression test is green"
     )


### PR DESCRIPTION
## What
Fixes #1096 — the **P0 recognition-moat blocker** (v0.3.2 done-criterion #1). naturo's Java Access Bridge never attached on a loaded desktop, so every Java/Swing window resolved to "no JAB" (`naturo_jab_get_element_tree` → `-6`) and the published `docs/RECOGNITION.md` `+40 via jab` moat headline did not reproduce.

**Root cause:** `core/src/jab.cpp::jab_ensure_init()` called the AT entry point `Windows_run()` exactly once, pumped the message queue for a fixed `1000 ms`, then cached `initialized = true` permanently. The asynchronous AT↔JVM discovery handshake routinely did not complete in that one-shot window, so `isJavaWindow()` returned false forever — no retry, no re-pump.

## How
- Split **library load** (one-shot, cacheable: DLL + function pointers) from the **bridge handshake**.
- Replace fire-and-forget init with a **bounded pump-and-retry that confirms attachment**: re-invoke `Windows_run` on an interval and drain the message queue until a Java window is discoverable or a 5 s budget elapses. (The decisive in-process A/B on #1096 showed the handshake completing only after a *second* `Windows_run`.)
- **Never cache a failed handshake** (`attached` set only after `isJavaWindow` confirms a real window) so a JVM that registers later is still discovered.
- **Bounded no-Java cost:** only the first query in a process can pay the full budget; follow-up queries do a short (150 ms) pump, not the full retry — important because the cascade `auto` path probes JAB for *every* window UIA can't read.
- Restore the measured `docs/RECOGNITION.md` JAB row (`6 → 46, +40 via jab`), remove the interim "under repair" caveat (#1098), and update `tests/test_recognition_doc_982.py` to pin the republished number (guards never-lie in both directions).

## How tested
Built the native core locally (MSVC 14.44 + CMake, VS2022 generator) and deployed `naturo_core.dll`, then on a correctly-provisioned desktop (OpenJDK 21 + Access Bridge enabled):
- **Reproduced the bug first** with the pre-fix DLL: `test_jab_recognizes_swing_controls` / `test_cascade_shows_positive_jab_delta` FAILED (UIA=6, cascade=6, delta=0, `extra_sources={}`).
- **After the fix:** `tests/test_jab_recognition_932.py` → **4 passed** (incl. a new `test_jab_attaches_to_live_jvm` attach regression). Live measure: `jab_check_support → True`, UIA 6 → cascade 46, **delta=40**, `extra_sources={'jab': 40}`.
- **Quality gate:** `ruff check naturo/ tests/…` → All checks passed. Full non-desktop suite `python -m pytest tests/ -m "not desktop"` → **6748 passed**, with only two **pre-existing, environment-only** artifacts confirmed unrelated to this diff (reproduced on clean `develop`): `test_agent.py::test_total_time_recorded` (a `time.monotonic()` sub-ms-resolution flake) and `test_cost_guardrails.py` (an `open()`-without-`encoding=` decode error under this host's cp936 locale; passes on CI's UTF-8 env). Neither touches files in this diff.

## Independent verification (Step 3.5 — fresh-context adversarial sub-agent)
**VERDICT: PASS.** An independent verifier (separate context, did not write the code) confirmed on this desktop:
- Logic review: bounded re-pump/re-invoke ✓; failed handshake never cached ✓; no-Java case bounded to the first query ✓ (no per-query hang).
- Deployed `naturo/bin/naturo_core.dll` is byte-identical to the rebuilt `build/bin/Release/naturo_core.dll`.
- Desktop module: 4 passed. Independent measure: `check_support True`, `uia 6 cascade 46 delta 40 sources {'jab': 40}` — sole extra source is `jab` (not cdp/vision).
- **Adversarial perf** on a non-Java window: call1 5.05 s (one-time handshake budget), call2 0.156 s, call3 0.156 s — confirms the bounded-cost design; no multi-second hang per query.
- EVOLUTION.md bug classes (silent-failure / test-hermeticity / platform-invariant): no concern (the desktop test *skips* when the fixture is absent, the harness runs the real cascade unmocked, the change is `#ifdef _WIN32` with stubs unchanged).
- Docs republish `+40`, "under repair"/"known regression" removed; `test_recognition_doc_982.py` → 7 passed.

CI (Linux/macOS) gates cross-platform separately; the in-cycle verifier covers desktop-runtime + adversarial review.
