### PR TITLE
fix: reject non-positive find --limit with INVALID_INPUT (fixes #1173)

### DIFF
--- a/naturo/cli/core/_find.py
+++ b/naturo/cli/core/_find.py
@@ -153,6 +153,23 @@ def find_cmd(query: str | None, query_opt: str | None, find_all: bool, role: str
             raise SystemExit(1)
         hwnd = entry.handle
 
+    # (#1173) Validate --limit up front, before any strategy dispatch and before
+    # the platform/GUI gate. --limit feeds every find strategy — the tree/image
+    # paths pass it as a counter-based ``max_results`` (a non-positive value
+    # collapses the set to empty) and the selector path uses a literal ``[:limit]``
+    # slice (a negative value slices from the end → a non-empty but silently-wrong
+    # set). Both are silent-misleading-results, so reject ``--limit < 1`` here with
+    # the same INVALID_INPUT envelope its siblings --depth/--threshold use. Placing
+    # it before the GUI gate keeps the bad-input → error-code contract platform-
+    # invariant (same code on headless CI as on a Windows desktop).
+    if limit < 1:
+        msg = f"--limit must be a positive integer, got {limit}"
+        if json_output:
+            click.echo(_common._json_error_str("INVALID_INPUT", msg))
+        else:
+            click.echo(f"Error: {msg}", err=True)
+        raise SystemExit(1)
+
     # (#1144 / #809 §4) Strategy auto-detection — when the caller gives a bare
     # query and no explicit strategy flag, infer the locator strategy from the
     # query's shape so `naturo find button.png` and `naturo find app://…` reach

--- a/tests/test_find_limit_validation_1173.py
+++ b/tests/test_find_limit_validation_1173.py
@@ -1,0 +1,91 @@
+"""Regression tests for #1173 — ``naturo find --limit`` must reject < 1.
+
+Before this fix, ``--limit 0`` / ``--limit -3`` were accepted silently and
+collapsed the result set to an empty (or, on the selector path, a *negatively
+sliced* and silently-wrong) set while still reporting ``success: true`` — a
+silent-misleading-result. Its sibling numeric options ``--depth`` and
+``--threshold`` already rejected out-of-range input with a clean
+``INVALID_INPUT`` envelope; ``--limit`` now matches them.
+
+The validation is centralised *before any strategy dispatch* (tree / selector /
+image / ai) and *before* the platform/GUI gate, so:
+
+* every find strategy rejects a non-positive ``--limit`` identically, and
+* the bad-input → error-code contract is platform-invariant — these tests run
+  the real validation path with no platform mock, so they behave the same on a
+  headless Linux/macOS CI runner as on a Windows desktop.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from naturo.cli.core import find_cmd
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _error(result) -> dict:
+    """Parse the JSON error envelope emitted on stdout."""
+    return json.loads(result.output)["error"]
+
+
+@pytest.mark.parametrize("bad_limit", ["0", "-1", "-3", "-100"])
+def test_tree_path_rejects_non_positive_limit(runner, bad_limit) -> None:
+    """Default tree-search path: ``--limit < 1`` is INVALID_INPUT, not empty success."""
+    result = runner.invoke(
+        find_cmd, ["--all", "--app", "notepad", "--limit", bad_limit, "--json"]
+    )
+    assert result.exit_code == 1
+    err = _error(result)
+    assert err["code"] == "INVALID_INPUT"
+    # Assert the derived taxonomy (category + recoverable), not just the envelope
+    # shape — these come from INVALID_INPUT being a registered ErrorCode, so a
+    # bare-string code would silently degrade them (EVOLUTION error-code class).
+    assert err["category"] == "validation"
+    assert err["recoverable"] is False
+    assert bad_limit in err["message"]
+    assert "--limit" in err["message"]
+
+
+@pytest.mark.parametrize("bad_limit", ["0", "-3"])
+def test_selector_path_rejects_non_positive_limit(runner, bad_limit) -> None:
+    """Selector path uses a literal ``[:limit]`` slice — a negative limit would
+    slice from the end and return a *non-empty but silently-wrong* set. The
+    up-front guard must fire before that path is ever reached."""
+    result = runner.invoke(
+        find_cmd, ["--selector", "//Button", "--limit", bad_limit, "--json"]
+    )
+    assert result.exit_code == 1
+    assert _error(result)["code"] == "INVALID_INPUT"
+
+
+@pytest.mark.parametrize("bad_limit", ["0", "-3"])
+def test_image_path_rejects_non_positive_limit(runner, bad_limit) -> None:
+    """Image-template path: validation fires before the template is even loaded,
+    so no real image file (and no temp dir) is needed."""
+    result = runner.invoke(
+        find_cmd,
+        ["--image", "anything.png", "--limit", bad_limit, "--json"],
+    )
+    assert result.exit_code == 1
+    assert _error(result)["code"] == "INVALID_INPUT"
+
+
+@pytest.mark.parametrize("good_limit", ["1", "100"])
+def test_positive_limit_is_not_rejected_by_validation(runner, good_limit) -> None:
+    """A valid ``--limit`` (including the inclusive lower bound ``1``) must not be
+    turned away by the new guard. We assert the failure (if any) is *not* the
+    limit-validation error — the command may still fail later for environment
+    reasons, but never with the --limit message."""
+    result = runner.invoke(
+        find_cmd, ["--all", "--app", "does-not-exist", "--limit", good_limit, "--json"]
+    )
+    if result.exit_code != 0 and result.output.strip():
+        message = json.loads(result.output).get("error", {}).get("message", "")
+        assert "--limit must be a positive integer" not in message


### PR DESCRIPTION
## What

`naturo find --limit` accepted **0 / negative** values silently and returned a misleading `success:true` / `count:0` (or, on the selector path, a non-empty but silently-wrong set) — a *silent-misleading-result*, the failure class the SOUL "Never Lie" rule treats as severe. Its sibling numeric options `--depth` and `--threshold` already reject out-of-range input with a clean `INVALID_INPUT` envelope; `--limit` now matches them.

Fixes #1173.

## How

Validate `--limit >= 1` **centrally, up front** — before any strategy dispatch (tree / selector / image / ai) and before the platform/GUI gate — emitting the same registered `INVALID_INPUT` / `category:validation` / `recoverable:false` envelope as `--depth`/`--threshold`:

```
--limit must be a positive integer, got -3
```

- **Central, not per-site:** `--limit` feeds every strategy — the tree/image paths pass it as a counter-based `max_results` (a non-positive value collapses the set to empty) and the selector path uses a literal `[:limit]` slice (a negative value slices from the end → a non-empty but silently-wrong set, per the issue's secondary note). One up-front guard covers all paths instead of patching each truncation site.
- **Platform-invariant validation order:** placing the check before the GUI gate keeps the bad-input → error-code contract identical on headless Linux/macOS CI and on a Windows desktop (EVOLUTION recurring class).
- **Registered code, not a bare string:** uses the existing `INVALID_INPUT` `ErrorCode`, so `category`/`recoverable` are correctly derived (asserted in tests, not just envelope shape).

No new flag, parameter, return type, or exported symbol; `--limit` already functioned for positive values. This tightens input validation on an existing flag — a bug fix, not a public-surface addition.

## How tested

- New hermetic regression suite `tests/test_find_limit_validation_1173.py` (10 cases): tree / selector / image dispatch paths all reject `0`/`-1`/`-3`/`-100` with `INVALID_INPUT`+`validation`+`recoverable:false`; inclusive lower bound `--limit 1` and `--limit 100` are **not** rejected. No platform mock → runs the real gate path on CI.
- Quality gate (run from worktree root, `PYTHONPATH=$(pwd)`):
  - `ruff check naturo/` → **All checks passed!**
  - `mypy naturo/cli/core/_find.py` → **Success: no issues found** (full `mypy naturo/` is blocked locally only by a third-party `mcp` package using 3.10 match-syntax under the repo's `python_version=3.9` config — pre-existing, green on CI).
  - `python -m pytest tests/ -m "not desktop" --basetemp=<isolated>` → **6757 passed**, 171 skipped; the only red is the 2 pre-existing host-locale/clock failures already filed as **#1175** (`test_cost_guardrails.py` cp936 `UnicodeDecodeError` + `test_agent.py::test_total_time_recorded` clock flake) — both confirmed on clean `develop` HEAD, unrelated to this change.
- Real CLI on the desktop: `find --all --app notepad --limit 0/-3 --json` → `INVALID_INPUT`/`validation`; `--limit 100` proceeds past the guard.

## Independent verification (Step 3.5 — fresh-context adversarial sub-agent)

**Verdict: PASS.** An independent verifier (brand-new context, did not write the code) confirmed env resolution under the worktree, then:
- **Reproduced the original bug** (fix stashed): `--limit 0` / `--limit -3` returned `success:true` / `count:0` with a real notepad window present (so the empty set came purely from the bad limit).
- **Confirmed the fix** (restored): both → `INVALID_INPUT`/`validation`/exit 1; `--limit 100` returns 44 real elements (guard does not over-reject).
- **Tried to break it:** selector path (`--selector //Button --limit -3`) and image path (`--image anything.png --limit 0`) both caught **before** their truncation/template logic; `--limit 1` accepted, `-1`/`-100` rejected; envelope byte-for-byte identical to `--depth -5` / `--threshold 1.5`; guard sits before auto-detection so even auto-detected `app://…` / `.png` queries with bad limits are caught; AI path caught; non-integer caught by click.
- **Platform-invariance proven concretely:** forcing `_platform_supports_gui→False` (simulating headless CI) still returned `INVALID_INPUT` for a bad limit while a valid limit then hit the downstream `PLATFORM_ERROR` gate — directly proving validation precedes the gate. `pytest tests/test_find_limit_validation_1173.py` → all pass.
- Recurring-bug-class check (error-attribution / code-registration / validation-order / option-coverage): all PASS.

The verifier's two minor hardening notes (assert `recoverable`; pin the inclusive `--limit 1` boundary) were both addressed before this PR.
