### PR TITLE
fix: populate keyboard_shortcut from UIA AcceleratorKey/AccessKey (fixes #886)

### DIFF
--- a/core/src/element.cpp
+++ b/core/src/element.cpp
@@ -108,6 +108,74 @@ static const char* control_type_to_role(CONTROLTYPEID type) {
 }
 
 /**
+ * @brief Read a UIA element's keyboard shortcut (AcceleratorKey, else AccessKey).
+ *
+ * The UIA backend exposes two related accessibility properties: AcceleratorKey
+ * (the directly actionable invoke chord, e.g. "Ctrl+S") and AccessKey (the
+ * navigation mnemonic, e.g. "Alt+F"). AcceleratorKey is preferred when present
+ * because it is the shortcut a keyboard-only user actually presses to invoke the
+ * element; AccessKey is the fallback for menu mnemonics that have no accelerator.
+ * Returns an empty string when neither property is set — the common case for
+ * plain controls — which callers serialize as JSON ``null`` (#886).
+ *
+ * @param element The UIA element to query.
+ * @param use_cache Read pre-fetched cached properties (true) or live Current
+ *                  properties (false). When true, the cache request must include
+ *                  ``UIA_AcceleratorKeyPropertyId`` and ``UIA_AccessKeyPropertyId``.
+ * @return JSON-escaped shortcut string, or "" when none is present.
+ */
+static std::string read_keyboard_shortcut(IUIAutomationElement* element,
+                                           bool use_cache) {
+    BSTR accelerator_bstr = NULL;
+    if (use_cache) {
+        element->get_CachedAcceleratorKey(&accelerator_bstr);
+    } else {
+        element->get_CurrentAcceleratorKey(&accelerator_bstr);
+    }
+    std::string shortcut;
+    if (accelerator_bstr && SysStringLen(accelerator_bstr) > 0) {
+        shortcut = json_escape(accelerator_bstr);
+    }
+    if (accelerator_bstr) SysFreeString(accelerator_bstr);
+
+    if (shortcut.empty()) {
+        BSTR access_bstr = NULL;
+        if (use_cache) {
+            element->get_CachedAccessKey(&access_bstr);
+        } else {
+            element->get_CurrentAccessKey(&access_bstr);
+        }
+        if (access_bstr && SysStringLen(access_bstr) > 0) {
+            shortcut = json_escape(access_bstr);
+        }
+        if (access_bstr) SysFreeString(access_bstr);
+    }
+    return shortcut;
+}
+
+/**
+ * @brief Append a ``"keyboard_shortcut"`` JSON field for the given shortcut.
+ *
+ * Emits ``,"keyboard_shortcut":null`` for an empty shortcut and
+ * ``,"keyboard_shortcut":"<value>"`` otherwise, matching the MSAA/IA2 backends
+ * which always emit the field. The value is assumed already JSON-escaped.
+ *
+ * @param shortcut JSON-escaped shortcut string (empty for none).
+ * @param out Output string to append to.
+ */
+static void append_keyboard_shortcut_field(const std::string& shortcut,
+                                           std::string& out) {
+    out += ",\"keyboard_shortcut\":";
+    if (shortcut.empty()) {
+        out += "null";
+    } else {
+        out += "\"";
+        out += shortcut;
+        out += "\"";
+    }
+}
+
+/**
  * @brief Read cached properties from a UIAutomation element and append JSON.
  *
  * Uses get_CachedXxx methods which read from the pre-fetched cache,
@@ -155,6 +223,10 @@ static void append_element_json_cached(IUIAutomationElement* element,
         rect.right - rect.left,
         rect.bottom - rect.top);
     out += buf;
+
+    // (#886) Emit the keyboard shortcut so UIA elements expose the same
+    // accessibility metadata as the MSAA/IA2 backends instead of always null.
+    append_keyboard_shortcut_field(read_keyboard_shortcut(element, true), out);
 }
 
 /**
@@ -244,6 +316,10 @@ static void build_element_json_current(IUIAutomationTreeWalker* walker,
         rect.bottom - rect.top);
     out += buf;
 
+    // (#886) Emit the keyboard shortcut (live Current properties — this is the
+    // fallback path used when the cache request could not be created).
+    append_keyboard_shortcut_field(read_keyboard_shortcut(element, false), out);
+
     out += ",\"children\":[";
     if (depth > 1) {
         IUIAutomationElement* child = NULL;
@@ -285,6 +361,11 @@ static HRESULT create_element_cache_request(
     (*cache_request)->AddProperty(UIA_ControlTypePropertyId);
     (*cache_request)->AddProperty(UIA_AutomationIdPropertyId);
     (*cache_request)->AddProperty(UIA_BoundingRectanglePropertyId);
+    // (#886) Keyboard shortcut sources — AcceleratorKey (e.g. "Ctrl+S") and
+    // AccessKey (e.g. "Alt+F"); batched here so get_CachedAcceleratorKey/
+    // get_CachedAccessKey resolve without extra cross-process COM calls.
+    (*cache_request)->AddProperty(UIA_AcceleratorKeyPropertyId);
+    (*cache_request)->AddProperty(UIA_AccessKeyPropertyId);
 
     // Fetch direct children scope for tree walking
     (*cache_request)->put_TreeScope(TreeScope_Element);
@@ -574,7 +655,7 @@ NATURO_API int naturo_find_element(uintptr_t hwnd, const char* role,
     char buf[1024];
     snprintf(buf, sizeof(buf),
         "{\"id\":\"%s\",\"role\":\"%s\",\"name\":\"%s\",\"value\":null,"
-        "\"x\":%ld,\"y\":%ld,\"width\":%ld,\"height\":%ld,\"children\":[]}",
+        "\"x\":%ld,\"y\":%ld,\"width\":%ld,\"height\":%ld",
         found_aid.c_str(),
         control_type_to_role(found_ct),
         found_name.c_str(),
@@ -583,6 +664,10 @@ NATURO_API int naturo_find_element(uintptr_t hwnd, const char* role,
         found_rect.bottom - found_rect.top);
 
     std::string json(buf);
+    // (#886) Surface the keyboard shortcut on find results too, so
+    // `naturo find` exposes the same accessibility metadata as `see`.
+    append_keyboard_shortcut_field(read_keyboard_shortcut(found, use_cache), json);
+    json += ",\"children\":[]}";
 
     found->Release();
     root->Release();

--- a/naturo/mcp/_snapshot.py
+++ b/naturo/mcp/_snapshot.py
@@ -93,6 +93,7 @@ def register_snapshot_tools(server, _get_backend, _safe_tool):
 
             def _collect_elements(el, parent_id=None):
                 child_ids = [c.id for c in (el.children or [])]
+                props = getattr(el, "properties", {}) or {}
                 ui_map[el.id] = UIElement(
                     id=el.id,
                     element_id=el.id,
@@ -102,6 +103,10 @@ def register_snapshot_tools(server, _get_backend, _safe_tool):
                     frame=(el.x, el.y, el.width, el.height),
                     parent_id=parent_id,
                     children=child_ids,
+                    # (#886) Carry the UIA keyboard shortcut into the MCP uiMap
+                    # too — without this the MCP snapshot path drops the field
+                    # the CLI path now populates.
+                    keyboard_shortcut=props.get("keyboard_shortcut"),
                 )
                 for c in (el.children or []):
                     _collect_elements(c, parent_id=el.id)

--- a/tests/test_keyboard_shortcut_886.py
+++ b/tests/test_keyboard_shortcut_886.py
@@ -1,0 +1,207 @@
+"""Live UIA keyboard-shortcut recognition against an owned WPF fixture (#886).
+
+These prove that the UIA backend now populates the ``keyboard_shortcut`` field
+from the UIA ``AcceleratorKey`` / ``AccessKey`` properties.  Before #886 the
+UIA C++ backend never queried either property, so every element in a ``see``
+snapshot had ``keyboard_shortcut == null`` regardless of the app — a silent
+accessibility-metadata gap (the field looked supported but no data ever
+arrived).
+
+The fixture is a tiny WPF window driven by PowerShell + PresentationFramework
+(present on any interactive Windows desktop).  WPF lets us set the two UIA
+properties deterministically, which classic Win32 controls do not expose:
+
+* ``AutomationProperties.AcceleratorKey`` -> UIA AcceleratorKey (e.g. "Ctrl+S")
+* a ``_``-prefixed access key in the button content -> UIA AccessKey (e.g. "O")
+
+The tests are ``@pytest.mark.desktop`` because they launch a real GUI window and
+call the native DLL, so they run on an interactive Windows desktop, not on the
+headless CI runners.  When that environment is absent the whole module is
+skipped.
+"""
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+import subprocess
+import tempfile
+import time
+from typing import Optional
+
+import pytest
+
+from naturo.backends.base import ElementInfo, get_backend
+from naturo.errors import WindowNotFoundError
+
+pytestmark = pytest.mark.desktop
+
+#: Unique per-process window title so a fixture run never matches a stray window.
+_WINDOW_TITLE = f"naturo_ks_886_fixture_{os.getpid()}"
+
+#: WPF fixture source.  Three buttons exercise every branch of the shortcut
+#: resolution: AcceleratorKey only, AccessKey only, and both (accelerator wins).
+#: The DispatcherTimer is a backstop so an orphaned process self-exits even if
+#: teardown is skipped; ShowDialog keeps the UI thread pumping until then.
+_FIXTURE_PS1 = r"""
+Add-Type -AssemblyName PresentationFramework
+$w = New-Object System.Windows.Window
+$w.Title = "__TITLE__"; $w.Width = 420; $w.Height = 280
+$panel = New-Object System.Windows.Controls.StackPanel
+
+# AcceleratorKey only -> "Ctrl+S"
+$save = New-Object System.Windows.Controls.Button
+$save.Content = "SaveBtn"
+[System.Windows.Automation.AutomationProperties]::SetAcceleratorKey($save, "Ctrl+S")
+$panel.Children.Add($save) | Out-Null
+
+# AccessKey only (the leading underscore registers the WPF access key) -> "O"
+$open = New-Object System.Windows.Controls.Button
+$open.Content = "_OpenBtn"
+$panel.Children.Add($open) | Out-Null
+
+# Both set -> accelerator preferred -> "Ctrl+P"
+$print = New-Object System.Windows.Controls.Button
+$print.Content = "_PrintBtn"
+[System.Windows.Automation.AutomationProperties]::SetAcceleratorKey($print, "Ctrl+P")
+$panel.Children.Add($print) | Out-Null
+
+# Neither set -> stays null
+$plain = New-Object System.Windows.Controls.Button
+$plain.Content = "PlainBtn"
+$panel.Children.Add($plain) | Out-Null
+
+$w.Content = $panel
+$t = New-Object System.Windows.Threading.DispatcherTimer
+$t.Interval = [TimeSpan]::FromSeconds(60)
+$t.Add_Tick({ $w.Close() })
+$t.Start()
+$null = $w.ShowDialog()
+"""
+
+
+def _fixture_available() -> bool:
+    """Whether this host can launch the PowerShell/WPF fixture."""
+    return platform.system() == "Windows" and shutil.which("powershell") is not None
+
+
+requires_fixture = pytest.mark.skipif(
+    not _fixture_available(),
+    reason="requires an interactive Windows desktop with PowerShell + WPF",
+)
+
+
+def _buttons_by_name(tree: Optional[ElementInfo]) -> dict[str, Optional[str]]:
+    """Map each Button element's name to its resolved keyboard_shortcut.
+
+    Args:
+        tree: Root element tree from the backend, or ``None``.
+
+    Returns:
+        ``{button_name: keyboard_shortcut_or_None}`` for every Button in the
+        tree.  The shortcut lives in ``BaseElementInfo.properties`` after the
+        backend's post-processing.
+    """
+    found: dict[str, Optional[str]] = {}
+    stack = [tree]
+    while stack:
+        node = stack.pop()
+        if node is None:
+            continue
+        if node.role == "Button" and node.name:
+            props = getattr(node, "properties", {}) or {}
+            found[node.name] = props.get("keyboard_shortcut")
+        stack.extend(node.children or [])
+    return found
+
+
+@pytest.fixture(scope="module")
+def fixture_buttons():
+    """Launch the WPF fixture, collect its buttons' shortcuts, then tear down."""
+    if not _fixture_available():
+        pytest.skip("PowerShell/WPF fixture unavailable on this host")
+
+    script = _FIXTURE_PS1.replace("__TITLE__", _WINDOW_TITLE)
+    script_dir = tempfile.mkdtemp(prefix="naturo_ks_886_")
+    script_path = os.path.join(script_dir, "fixture.ps1")
+    with open(script_path, "w", encoding="utf-8") as handle:
+        handle.write(script)
+
+    proc = subprocess.Popen(
+        ["powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", script_path],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        backend = get_backend()
+        buttons: dict[str, Optional[str]] = {}
+        deadline = time.monotonic() + 30.0
+        while time.monotonic() < deadline:
+            try:
+                tree = backend.get_element_tree(
+                    window_title=_WINDOW_TITLE, depth=10, backend="uia",
+                )
+            except WindowNotFoundError:
+                tree = None  # window not up yet — keep polling
+            buttons = _buttons_by_name(tree)
+            # Wait until the WPF content (our four named buttons) has rendered,
+            # not just the window chrome.
+            if {"SaveBtn", "OpenBtn", "PrintBtn", "PlainBtn"} <= set(buttons):
+                break
+            time.sleep(0.5)
+        else:
+            pytest.fail(
+                f"WPF fixture window '{_WINDOW_TITLE}' did not expose its "
+                f"buttons; saw: {sorted(buttons)}"
+            )
+        yield buttons
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+        shutil.rmtree(script_dir, ignore_errors=True)
+
+
+@requires_fixture
+def test_accelerator_key_is_populated(fixture_buttons):
+    """A UIA AcceleratorKey surfaces as the element's keyboard_shortcut."""
+    assert fixture_buttons["SaveBtn"] == "Ctrl+S"
+
+
+@requires_fixture
+def test_access_key_is_used_as_fallback(fixture_buttons):
+    """With no AcceleratorKey, the UIA AccessKey is used instead."""
+    assert fixture_buttons["OpenBtn"] == "O"
+
+
+@requires_fixture
+def test_accelerator_key_preferred_over_access_key(fixture_buttons):
+    """When both properties are set, the actionable AcceleratorKey wins."""
+    assert fixture_buttons["PrintBtn"] == "Ctrl+P"
+
+
+@requires_fixture
+def test_element_without_shortcut_stays_none(fixture_buttons):
+    """An element with neither property keeps keyboard_shortcut == None.
+
+    This guards against the field being filled with a spurious value — the
+    "never lie" contract: absence of a shortcut must read as ``None``.
+    """
+    assert fixture_buttons["PlainBtn"] is None
+
+
+@requires_fixture
+def test_field_emitted_for_every_element(fixture_buttons):
+    """The regression itself: the UIA backend now participates in the contract.
+
+    Before #886 *no* UIA element carried a shortcut (the C++ backend never
+    queried the property), so at least one real value proves the backend now
+    emits the field rather than silently dropping it.
+    """
+    populated = {name: ks for name, ks in fixture_buttons.items() if ks}
+    assert populated, (
+        "no UIA element exposed a keyboard_shortcut — the backend is not "
+        "querying AcceleratorKey/AccessKey"
+    )

--- a/tests/test_mcp_snapshot.py
+++ b/tests/test_mcp_snapshot.py
@@ -124,6 +124,35 @@ class TestCreateSnapshot:
         assert data["element_count"] == 2  # root + child
         mock_manager.store_detection_result.assert_called_once()
 
+    def test_snapshot_carries_keyboard_shortcut_886(self, server, mock_backend, tmp_path):
+        """The MCP snapshot uiMap carries the UIA keyboard_shortcut (#886).
+
+        Mirrors the CLI snapshot path: a populated ``keyboard_shortcut`` on the
+        element tree must reach the stored ``UIElement`` so MCP agents see the
+        shortcut instead of a silent null.
+        """
+        png_file = tmp_path / "snap.png"
+        png_file.write_bytes(b"\x89PNGfake")
+
+        root = _make_element(id="e1", role="Button", name="Save")
+        root.properties = {"keyboard_shortcut": "Ctrl+S"}
+
+        mock_manager = MagicMock()
+        mock_manager.create_snapshot.return_value = "snap-886"
+        mock_snapshot = MagicMock()
+        mock_snapshot.screenshot_path = str(png_file)
+        mock_manager.get_snapshot.return_value = mock_snapshot
+        mock_backend.get_element_tree.return_value = root
+
+        mock_ui_element_cls = MagicMock()
+        with patch("naturo.snapshot.get_snapshot_manager", return_value=mock_manager), \
+             patch("naturo.models.snapshot.UIElement", mock_ui_element_cls):
+            _call_tool(server, "create_snapshot", {"depth": 5})
+
+        # The UIElement built for the element must carry the shortcut.
+        kwargs = mock_ui_element_cls.call_args.kwargs
+        assert kwargs.get("keyboard_shortcut") == "Ctrl+S"
+
     def test_no_base64_when_screenshot_missing(self, server, mock_backend):
         mock_manager = MagicMock()
         mock_manager.create_snapshot.return_value = "snap-003"


### PR DESCRIPTION
## What
`naturo see` exposes a `keyboardShortcut` field on every element, but the **UIA backend** — the default for all standard Windows apps — never populated it: `core/src/element.cpp` never queried `UIA_AcceleratorKeyPropertyId` or `UIA_AccessKeyPropertyId`, so the field was `null` in 100% of UIA elements (87,196 records across the historical corpus). The field looked supported (schema, model, `tests/test_shortcuts.py`, MSAA/IA2 backends all emit it) but no data ever arrived — a silent accessibility-metadata gap that breaks keyboard-only agent paths and `menu-inspect`.

## How
- New shared `read_keyboard_shortcut()` helper: prefers **AcceleratorKey** (the actionable chord, e.g. `Ctrl+S`), falls back to **AccessKey** (the mnemonic, e.g. `Alt+F`), returns empty → JSON `null`.
- Emit the field in all three UIA element-JSON emitters: the cached tree builder (`see`), the Current-property fallback builder, and the `naturo_find_element` emitter (so `find` gets parity too).
- Batch both properties into the shared cache request (no extra cross-process COM calls).
- Carry `keyboard_shortcut` through the **MCP** snapshot `uiMap` builder (`naturo/mcp/_snapshot.py`), which dropped the field where the CLI path now populates it (sibling-leak found by the independent verifier).

BSTRs are NULL-guarded and freed; an empty/zero-length value is treated as absent (no spurious shortcut — the "never lie" contract).

## How tested
- Rebuilt the native core (MSVC 14.44 + CMake) and ran the new `tests/test_keyboard_shortcut_886.py` (`@pytest.mark.desktop`, 5/5 pass) against an **owned WPF fixture** that deterministically sets the UIA properties.
- Hermetic MCP plumbing test added (`test_snapshot_carries_keyboard_shortcut_886`).
- Full non-desktop suite: **6769 passed** (`pytest tests/ -m "not desktop"`); the only reds are pre-existing host-locale/clock flakes tracked in #1175 (`test_total_time_recorded`) + ambient process/capture flakes that pass in isolation — none touch this code path. `ruff` clean. New tests are collection-safe and deselected under `-m "not desktop"`.

## Independent verification (Step 3.5 — fresh-context adversarial sub-agent): **PASS**
Built the fix DLL itself and ran a **discriminating negative control** on the same WPF fixture:

| Button | PRE-fix DLL | POST-fix DLL |
|---|---|---|
| AcceleratorKey only | `null` | `Ctrl+S` |
| AccessKey only | `null` | `O` |
| both set | `null` | `Ctrl+P` (accelerator wins) |
| neither | `null` | `null` |

Pre-fix: every element null (original bug reproduced). Post-fix: populated exactly as designed → population is the fix's effect, not ambient. Confirmed the value reaches `see -j` (`keyboard_shortcut`), the desktop test FAILS on the pre-fix DLL (not a tautology), CI-collection safe, no BSTR leak, `buf[1024]` restructure preserves valid JSON. The MCP sibling gap it flagged is fixed in this PR.

## Public-API note
Not a public-API change: this populates an **already-documented output field** (in the schema/model and already emitted by MSAA/IA2) by fixing the UIA backend to honor the existing contract. No new flag/parameter/exported symbol, no error code, no previously-inert input option made functional → `--auto` eligible.
