### PR TITLE
fix: read window titles via wide Win32 API to preserve non-codepage chars (fixes #1159)

### DIFF
--- a/core/src/window.cpp
+++ b/core/src/window.cpp
@@ -48,6 +48,49 @@ static std::string json_escape(const char* s) {
     return out;
 }
 
+/**
+ * @brief Convert a UTF-16 (wide) Win32 string to a UTF-8 narrow buffer.
+ *
+ * The narrow ``...A`` Win32 read APIs (``GetWindowTextA`` etc.) encode their
+ * result in the active ANSI codepage, which silently replaces every character
+ * outside that codepage (emoji, cross-script text) with ``'?'`` — irreversible
+ * data loss (#1159). Reading via the wide ``...W`` APIs and converting with
+ * ``WideCharToMultiByte(CP_UTF8)`` preserves the full Unicode title; the Python
+ * bridge already decodes core strings as UTF-8 first (``_decode_native``), so
+ * the round-trip is lossless.
+ *
+ * The output is always NUL-terminated. If the UTF-8 encoding does not fit in
+ * @p out_size, it is truncated on a UTF-8 character boundary (never mid
+ * multi-byte sequence) so the emitted JSON stays valid.
+ *
+ * @param wide     Source wide string (may be null or empty).
+ * @param out      Destination narrow buffer.
+ * @param out_size Size of @p out in bytes (including the NUL terminator).
+ */
+static void wide_to_utf8(const wchar_t* wide, char* out, size_t out_size) {
+    if (out_size == 0) return;
+    out[0] = '\0';
+    if (!wide || !wide[0]) return;
+
+    int needed = WideCharToMultiByte(CP_UTF8, 0, wide, -1, nullptr, 0, nullptr, nullptr);
+    if (needed <= 0) return;  // conversion failure — leave the empty string
+
+    std::string utf8(static_cast<size_t>(needed), '\0');
+    WideCharToMultiByte(CP_UTF8, 0, wide, -1, &utf8[0], needed, nullptr, nullptr);
+
+    size_t len = static_cast<size_t>(needed) - 1;  // exclude the NUL terminator
+    if (len >= out_size) {
+        len = out_size - 1;
+        // Back off so we never cut in the middle of a UTF-8 sequence:
+        // continuation bytes match 0b10xxxxxx (0x80..0xBF).
+        while (len > 0 && (static_cast<unsigned char>(utf8[len]) & 0xC0) == 0x80) {
+            --len;
+        }
+    }
+    memcpy(out, utf8.data(), len);
+    out[len] = '\0';
+}
+
 /** @brief Internal struct for collecting window data. */
 struct WindowData {
     uintptr_t hwnd;
@@ -85,7 +128,12 @@ static std::string window_to_json(const WindowData& w) {
  */
 static void fill_window_data(HWND hwnd, WindowData& wd) {
     wd.hwnd = (uintptr_t)hwnd;
-    GetWindowTextA(hwnd, wd.title, sizeof(wd.title));
+
+    wchar_t wtitle[512];
+    wtitle[0] = L'\0';
+    GetWindowTextW(hwnd, wtitle, static_cast<int>(ARRAYSIZE(wtitle)));
+    wide_to_utf8(wtitle, wd.title, sizeof(wd.title));
+
     GetWindowRect(hwnd, &wd.rect);
     wd.is_visible = IsWindowVisible(hwnd) != 0;
     wd.is_minimized = IsIconic(hwnd) != 0;
@@ -97,8 +145,12 @@ static void fill_window_data(HWND hwnd, WindowData& wd) {
     if (wd.pid) {
         HANDLE hproc = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, wd.pid);
         if (hproc) {
-            DWORD name_len = sizeof(wd.process_name);
-            if (!QueryFullProcessImageNameA(hproc, 0, wd.process_name, &name_len)) {
+            wchar_t wname[512];
+            wname[0] = L'\0';
+            DWORD name_len = static_cast<DWORD>(ARRAYSIZE(wname));
+            if (QueryFullProcessImageNameW(hproc, 0, wname, &name_len)) {
+                wide_to_utf8(wname, wd.process_name, sizeof(wd.process_name));
+            } else {
                 wd.process_name[0] = '\0';
             }
             CloseHandle(hproc);
@@ -118,8 +170,9 @@ static BOOL CALLBACK enum_windows_cb(HWND hwnd, LPARAM lparam) {
     if (!IsWindowVisible(hwnd)) return TRUE;
 
     // Skip windows with empty titles
-    char title[4];
-    if (GetWindowTextA(hwnd, title, sizeof(title)) == 0) return TRUE;
+    wchar_t title[4];
+    title[0] = L'\0';
+    if (GetWindowTextW(hwnd, title, static_cast<int>(ARRAYSIZE(title))) == 0) return TRUE;
 
     auto* ctx = reinterpret_cast<EnumContext*>(lparam);
     WindowData wd = {};

--- a/tests/test_window_title_unicode_1159.py
+++ b/tests/test_window_title_unicode_1159.py
@@ -1,0 +1,165 @@
+"""Live round-trip of non-codepage window titles through the native core (#1159).
+
+These prove that ``list_windows`` (and therefore ``app list`` / ``app windows``
+/ ``app find``, which all funnel through it) preserves window titles containing
+characters outside the active ANSI codepage — emoji and cross-script text.
+
+Before #1159 the native core read titles with the narrow ``GetWindowTextA``
+Win32 API, which encodes its result in the system ANSI codepage and silently
+replaces every character it cannot represent with ``'?'`` (U+003F) — *before*
+Python ever sees the bytes, so the loss is irreversible.  On a Chinese-locale
+(cp936) desktop that corrupts emoji, Japanese kana, etc.  The fix reads titles
+via the wide ``GetWindowTextW`` API and converts to UTF-8, which the Python
+bridge already decodes losslessly (``_decode_native`` tries UTF-8 first).
+
+The fixture is a tiny WinForms window driven by PowerShell (present on any
+interactive Windows desktop) whose title mixes a BMP emoji (U+2733), Japanese,
+Cyrillic, and an astral-plane emoji (U+1F600, a 4-byte UTF-8 / surrogate-pair
+case).  The tests are ``@pytest.mark.desktop`` because they launch a real GUI
+window and call the native DLL; when that environment is absent the whole
+module is skipped (it never runs on the headless CI runners).
+"""
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+import subprocess
+import tempfile
+import time
+from typing import Optional
+
+import pytest
+
+from naturo.backends.base import get_backend
+
+pytestmark = pytest.mark.desktop
+
+#: Characters chosen to exercise distinct UTF-8 widths and codepage gaps:
+#:   * U+2733 EIGHT SPOKED ASTERISK — BMP symbol absent from cp936 (the headline
+#:     data-loss case from the issue), 3-byte UTF-8.
+#:   * Japanese ideographs / Cyrillic — cross-script, present in cp936 but not in
+#:     a Western codepage; together they prove the path is codepage-independent.
+#:   * U+1F600 GRINNING FACE — astral plane, 4-byte UTF-8 / UTF-16 surrogate pair.
+_EMOJI_BMP = "✳"
+_JAPANESE = "日本語"
+_CYRILLIC = "Ки"
+_EMOJI_ASTRAL = "\U0001f600"
+
+#: Unique per-process marker (pure ASCII, so the host codepage cannot mangle it
+#: and a fixture run never matches a stray window).
+_MARKER = f"naturo_unicode_1159_{os.getpid()}"
+
+#: WinForms fixture.  ``-STA`` is required for WinForms message pumping; the
+#: Timer backstop is a one-shot so an orphaned process self-exits even if
+#: teardown is skipped.  The title is built from explicit code points rather
+#: than from literal characters in the script body, because Windows PowerShell
+#: reads a no-BOM ``.ps1`` as the active ANSI codepage and would itself mangle
+#: any non-codepage literal before the window is ever created — that would test
+#: PowerShell's file decoding, not naturo's core read path.
+_FIXTURE_PS1 = r"""
+Add-Type -AssemblyName System.Windows.Forms
+$title = "__MARKER__" + " " + [char]0x2733 + " " `
+    + [char]0x65E5 + [char]0x672C + [char]0x8A9E + " " `
+    + [char]0x041A + [char]0x0438 + " " `
+    + [System.Char]::ConvertFromUtf32(0x1F600)
+$form = New-Object System.Windows.Forms.Form
+$form.Text = $title
+$form.Width = 360
+$form.Height = 140
+$timer = New-Object System.Windows.Forms.Timer
+$timer.Interval = 60000
+$timer.Add_Tick({ $form.Close() })
+$timer.Start()
+$form.Add_Shown({ $form.Activate() })
+[System.Windows.Forms.Application]::Run($form)
+"""
+
+
+def _fixture_available() -> bool:
+    """Whether this host can launch the PowerShell/WinForms fixture."""
+    return platform.system() == "Windows" and shutil.which("powershell") is not None
+
+
+requires_fixture = pytest.mark.skipif(
+    not _fixture_available(),
+    reason="requires an interactive Windows desktop with PowerShell + WinForms",
+)
+
+
+@pytest.fixture(scope="module")
+def fixture_title() -> str:
+    """Launch the WinForms fixture and return its title as ``list_windows`` sees it.
+
+    Yields the title string read back from the native core for the fixture
+    window, so each test can assert on the round-tripped value.  Tears the
+    fixture process down afterwards.
+    """
+    if not _fixture_available():
+        pytest.skip("PowerShell/WinForms fixture unavailable on this host")
+
+    script = _FIXTURE_PS1.replace("__MARKER__", _MARKER)
+    script_dir = tempfile.mkdtemp(prefix="naturo_unicode_1159_")
+    script_path = os.path.join(script_dir, "fixture.ps1")
+    with open(script_path, "w", encoding="utf-8") as handle:
+        handle.write(script)
+
+    proc = subprocess.Popen(
+        ["powershell", "-NoProfile", "-STA", "-ExecutionPolicy", "Bypass", "-File", script_path],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        backend = get_backend()
+        title: Optional[str] = None
+        deadline = time.monotonic() + 30.0
+        while time.monotonic() < deadline:
+            for window in backend.list_windows():
+                if _MARKER in (window.title or ""):
+                    title = window.title
+                    break
+            if title is not None:
+                break
+            time.sleep(0.5)
+        else:
+            pytest.fail(
+                f"WinForms fixture window '{_MARKER}' never appeared in list_windows()"
+            )
+        yield title
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+        shutil.rmtree(script_dir, ignore_errors=True)
+
+
+@requires_fixture
+def test_bmp_emoji_preserved(fixture_title: str) -> None:
+    """A BMP emoji outside the ANSI codepage survives the core read path."""
+    assert _EMOJI_BMP in fixture_title
+
+
+@requires_fixture
+def test_cross_script_text_preserved(fixture_title: str) -> None:
+    """Japanese and Cyrillic characters round-trip losslessly."""
+    assert _JAPANESE in fixture_title
+    assert _CYRILLIC in fixture_title
+
+
+@requires_fixture
+def test_astral_emoji_preserved(fixture_title: str) -> None:
+    """An astral-plane emoji (4-byte UTF-8 / surrogate pair) round-trips."""
+    assert _EMOJI_ASTRAL in fixture_title
+
+
+@requires_fixture
+def test_no_replacement_or_question_mark(fixture_title: str) -> None:
+    """No character is lost to the ANSI ``'?'`` (or Unicode replacement) fallback.
+
+    The fixture title contains no literal ``'?'`` or U+FFFD, so either appearing
+    in the round-tripped title means a character was destroyed on the read path.
+    """
+    assert "?" not in fixture_title
+    assert "�" not in fixture_title


### PR DESCRIPTION
## What

`naturo list windows` (and `app list` / `app windows` / `app find`, which all
funnel through the same enumeration) silently corrupted any window title
containing a character outside the system's active ANSI codepage — emoji and
cross-script text — replacing it with `?` (U+003F). This is irreversible data
loss that happened in the native core's narrow (`...A`) Win32 read path, before
Python ever saw the bytes. Fixes #1159.

The mechanism (`GetWindowTextA`) encodes its result in the active ANSI codepage;
on a Chinese-locale (cp936) desktop that destroys emoji, kana outside the page,
Cyrillic on a Western page, etc. The #1150/#1157 work made *codepage-covered*
(e.g. Chinese) titles decode correctly, but the underlying narrow-API mechanism
is fundamentally lossy for anything outside the active page.

## How

`core/src/window.cpp`:
- Read titles via the wide `GetWindowTextW` and process paths via
  `QueryFullProcessImageNameW`, then convert to UTF-8 with a new
  `wide_to_utf8()` helper (`WideCharToMultiByte(CP_UTF8)`). The Python bridge
  already decodes core strings UTF-8-first (`_decode_native`, #1150), so the
  round-trip is now lossless with no Python-side change.
- `wide_to_utf8()` always NUL-terminates and, if the UTF-8 encoding overflows
  the fixed buffer, truncates on a UTF-8 character boundary (never mid
  multi-byte sequence) so the emitted JSON stays valid.
- The empty-title skip check also moved to `GetWindowTextW`.

All three narrow read sites in the file were converted in one sweep (no sibling
leak); a repo-wide grep confirms no other `...A` title/path read remains in
`core/src/`.

## How tested

- Reproduced the bug on a live cp936 desktop with the pre-fix DLL: a window
  titled `… ✳ …` (U+2733) came back as `… ? …`.
- Rebuilt the core (MSVC 14.44 + CMake) and confirmed the same window now
  returns `✳` (U+2733), Japanese, Cyrillic, and an astral-plane emoji (U+1F600,
  4-byte UTF-8) losslessly, with no `?` or U+FFFD.
- New desktop test `tests/test_window_title_unicode_1159.py` (4 cases): builds
  the title from explicit PowerShell code points (so the host PowerShell's
  no-BOM-script ANSI decoding can't itself mangle it — hermetic), launches a
  real WinForms window, and asserts lossless round-trip through
  `list_windows()`. **4/4 pass with the fix DLL; 3/4 (the emoji cases) FAIL on
  the pre-fix develop DLL** — proving the test is not tautological. (The
  cross-script case passes on both here only because cp936 happens to cover
  Japanese/Cyrillic on this host — the emoji cases are the discriminating ones.)
- Full non-desktop suite: 6770 passed, 171 skipped (the lone red is the
  pre-existing #1175 `test_total_time_recorded` host-clock flake — backend fully
  mocked, no `window.cpp` path; passes on CI).
- `ruff check` clean; new test collection-safe cross-platform (`--collect-only`).

## Public API

No public-API change — same JSON field, just correct bytes. Pure bug fix.

## Independent verification (Step 3.5 — fresh-context adversarial verifier)

**VERDICT: PASS.** A fresh sub-agent that did not write the code independently:
- Confirmed the host ACP is 936; U+2733 / U+1F600 are not representable in cp936.
- **Reproduced the original bug** on the pre-fix DLL: `… ✳ …` → `… ? …`, astral `😀` → `??`.
- **Rebuilt the fix DLL itself** (did not trust the deployed binary) and confirmed raw
  DLL bytes are strict UTF-8 (`\xe2\x9c\xb3`, `\xf0\x9f\x98\x80`); JSON parses with strict
  `json.loads`, no repair path needed. BMP, cross-script, astral, mixed-ASCII all lossless.
- **Anti-tautology:** same test → fix DLL `4 passed`, pre-fix DLL `3 failed, 1 passed`.
- **Truncation safety:** a 300×😀 (~1200-byte) title overflowing the 512-byte buffer cut on a
  clean 4-byte boundary (`utf8_byte_len 510`, ends `😀😀😀`), no U+FFFD, JSON still valid.
- **No sibling leak:** window.cpp is the only file reading titles; all three sites converted.
- **No regression:** Notepad + 92 ambient windows enumerate fine; CJK titles + process paths correct.
