### PR TITLE
fix: emit clean saved-selector not-found message without KeyError quotes (fixes #1172)

### DIFF
--- a/naturo/cli/selector_cmd.py
+++ b/naturo/cli/selector_cmd.py
@@ -24,6 +24,24 @@ SELECTORS_DIR = Path.home() / ".naturo" / "selectors"
 BUILTIN_DIR = Path(__file__).parent.parent / "selectors_builtin"
 
 
+class SelectorNotFoundError(KeyError):
+    """Raised when an ``@app/name`` selector reference cannot be resolved.
+
+    Subclasses :class:`KeyError` so existing callers that catch ``KeyError`` to
+    distinguish the not-found case from a malformed reference (a ``ValueError``)
+    keep working unchanged. It overrides ``__str__`` because ``KeyError`` is the
+    one builtin whose ``__str__`` wraps its argument in ``repr`` quotes
+    (``str(KeyError("msg")) == "'msg'"``): consumers that build a user-facing
+    error message via ``str(exc)`` — ``find``/``click``/``type`` — would
+    otherwise leak stray single quotes into the JSON envelope's ``message``
+    (#1172), inconsistent with the clean ``ValueError`` malformed-format path.
+    """
+
+    def __str__(self) -> str:
+        """Return the message verbatim, without ``KeyError``'s repr quoting."""
+        return self.args[0] if self.args else super().__str__()
+
+
 def _ensure_dir(d: Path) -> Path:
     d.mkdir(parents=True, exist_ok=True)
     return d
@@ -96,7 +114,10 @@ def resolve_named_selector(reference: str) -> str:
         The selector string stored under that name.
 
     Raises:
-        KeyError: If the reference cannot be found in user or built-in selectors.
+        SelectorNotFoundError: If the reference cannot be found in user or
+            built-in selectors. This is a :class:`KeyError` subclass with a
+            clean ``__str__`` (no repr quotes), so ``except KeyError`` callers
+            are unaffected while ``str(exc)`` yields a clean message (#1172).
         ValueError: If the reference format is invalid.
     """
     ref = reference.lstrip("@")
@@ -121,7 +142,7 @@ def resolve_named_selector(reference: str) -> str:
         info = builtin_sels[name]
         return info.get("selector", info) if isinstance(info, dict) else info
 
-    raise KeyError(f"Selector not found: @{app_name}/{name}")
+    raise SelectorNotFoundError(f"Selector not found: @{app_name}/{name}")
 
 
 @click.group("selector", cls=FuzzyGroup)

--- a/tests/test_selector_cmd.py
+++ b/tests/test_selector_cmd.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
@@ -171,6 +171,65 @@ class TestResolveNamedSelector:
     def test_resolve_empty_parts_raises_value_error(self, tmp_selectors):
         with pytest.raises(ValueError, match="must be non-empty"):
             selector_cmd.resolve_named_selector("@/name")
+
+
+# ── #1172: not-found message must not leak KeyError repr quotes ──────────────
+
+
+class TestSelectorNotFoundMessageNoQuoteLeak1172:
+    """#1172: a saved-selector not-found failure must report a clean message.
+
+    ``resolve_named_selector`` raised a bare ``KeyError`` for the not-found case,
+    and ``str(KeyError("msg"))`` returns ``"'msg'"`` — ``KeyError`` is the one
+    builtin whose ``__str__`` wraps its argument in ``repr`` quotes. Every
+    consumer that built a user-facing message via ``str(exc)`` — ``find``,
+    ``click``, and ``type`` — therefore leaked stray single quotes into the JSON
+    envelope's ``message`` (``"'Selector not found: @app/name'"``). The sibling
+    malformed-format failure (a ``ValueError``) was already clean, so the two
+    paths reported the same error code with inconsistent message formatting.
+    """
+
+    def test_resolve_message_has_no_repr_quotes(self, tmp_selectors):
+        """The raised exception's ``str()`` is the clean message, unquoted."""
+        with pytest.raises(KeyError) as excinfo:
+            selector_cmd.resolve_named_selector("@noapp/nosel")
+        assert str(excinfo.value) == "Selector not found: @noapp/nosel"
+
+    def test_find_at_ref_not_found_message_is_clean(self, runner, tmp_selectors):
+        """``find @app/name`` (selector strategy) emits an unquoted message."""
+        from naturo.cli.core._find import find_cmd
+
+        result = runner.invoke(find_cmd, ["@noapp/nobtn", "-j"])
+        payload = json.loads(result.output)
+        assert payload["success"] is False
+        assert payload["error"]["code"] == "SELECTOR_REF_ERROR"
+        assert payload["error"]["message"] == "Selector not found: @noapp/nobtn"
+
+    def test_click_type_resolver_at_ref_not_found_message_is_clean(
+        self, tmp_selectors, capsys
+    ):
+        """The click/type family's resolver emits the same unquoted message.
+
+        ``_resolve_selector_target`` dereferences the ``@app/name`` ref before it
+        touches the backend, so a ``MagicMock`` backend is never used — the path
+        fails fast at resolution, exactly as ``click``/``type`` do at runtime.
+        """
+        from naturo.cli.interaction import _common
+
+        with pytest.raises(SystemExit):
+            _common._resolve_selector_target(
+                "@noapp/nobtn",
+                MagicMock(),
+                app=None,
+                window_title=None,
+                hwnd=None,
+                pid=None,
+                json_output=True,
+            )
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["success"] is False
+        assert payload["error"]["code"] == "SELECTOR_REF_ERROR"
+        assert payload["error"]["message"] == "Selector not found: @noapp/nobtn"
 
 
 # ── @app/name resolution in interaction commands ────────────────────────────


### PR DESCRIPTION
## What
`find`/`click`/`type` against a non-existent saved selector (`@app/name`) leaked
`KeyError`'s repr quotes into the JSON envelope's `message`
(`"'Selector not found: @app/name'"`) instead of the clean
`"Selector not found: @app/name"`. `KeyError` is the one builtin whose
`__str__` wraps its argument in `repr` quotes, and `resolve_named_selector`
raised a bare `KeyError` for the not-found case. Every consumer that builds a
user-facing message via `str(exc)` therefore leaked stray single quotes — while
the sibling malformed-format failure (a `ValueError`) was already clean, so the
two paths emitted the same `SELECTOR_REF_ERROR` code with inconsistent message
formatting. (Fixes #1172.)

## How
- Introduce `SelectorNotFoundError`, a `KeyError` subclass with a `__str__` that
  returns the message verbatim (no repr quoting). Subclassing `KeyError` keeps
  every existing `except KeyError` caller working unchanged (the two consumers
  `_find.py` and `interaction/_common.py` catch `(KeyError, ValueError)` and
  build the message via `str(exc)`), so the only behavioral change is the clean
  message text.
- Raise `SelectorNotFoundError` (was bare `KeyError`) in `resolve_named_selector`
  for the not-found case; the error CODE (`SELECTOR_REF_ERROR`), category, and
  full six-key #884 envelope are unchanged.

Minimal, message-only fix — no signature, flag, or contract change.

## How tested
- `ruff check naturo/` → All checks passed
- `mypy naturo/cli/selector_cmd.py` → Success: no issues found
- `python -m pytest tests/test_selector_cmd.py -q` → 48 passed (new
  `TestSelectorNotFoundMessageNoQuoteLeak1172`: resolver `str()` unquoted +
  `find @app/name -j` and the click/type resolver both emit clean
  `SELECTOR_REF_ERROR` messages)
- Full non-desktop suite: `python -m pytest tests/ -m "not desktop"` →
  **6774 passed, 171 skipped** (the 11 `test_cost_guardrails` errors under the
  Windows `gbk` locale vanish under `PYTHONUTF8=1`; CI runs UTF-8 on Linux)

## Independent verification
A fresh-context adversarial sub-agent (did not write the code) returned **PASS**:
- Reproduced the original bug: `str(KeyError("…")) == "'…'"` (quote leak is real).
- Confirmed the fix raises an `isinstance(..., KeyError)` whose `str()` is the
  clean unquoted message (backward compat: `except KeyError` still catches it).
- Walked both consumer paths end-to-end: `find @noapp/nobtn -j` and
  `_resolve_selector_target(...)` both emit `success:false`,
  `code:"SELECTOR_REF_ERROR"`, clean unquoted `message`, full six-key envelope.
- Malformed ref (`@app/`) on both paths still emits the SAME code with a clean
  ValueError message — the two paths are now consistent and the already-clean
  path was not regressed.
- Verified the new tests would FAIL pre-fix (real guards, not tautologies) and
  that empty-args `SelectorNotFoundError()` does not crash (`str()` → `""`).
- Confirmed no error-CODE/category change (only message text), consistent with
  the #884 six-key contract and error-attribution bug classes in EVOLUTION.md.
