### PR TITLE
fix: route find --ai errors through canonical six-key envelope (fixes #1179)

### DIFF
--- a/naturo/cli/core/_find.py
+++ b/naturo/cli/core/_find.py
@@ -1060,13 +1060,19 @@ def _find_with_ai(
         )
     except Exception as e:
         msg = str(e)
-        code = "AI_FIND_FAILED"
+        # Route through the canonical six-key error envelope (#884) so the
+        # category / context / suggested_action / recoverable keys are populated,
+        # not just code + message (#1179). Each branch uses a *registered* error
+        # code so its category and recovery hint resolve automatically — the
+        # generic branch uses AI_ANALYSIS_FAILED (category "ai") rather than the
+        # old unregistered "AI_FIND_FAILED", which would degrade to "unknown".
+        code = "AI_ANALYSIS_FAILED"
         if "unavailable" in msg.lower() or "api key" in msg.lower():
             code = "AI_PROVIDER_UNAVAILABLE"
         elif "capture" in msg.lower():
             code = "CAPTURE_FAILED"
         if json_output:
-            click.echo(json_dumps({"success": False, "error": {"code": code, "message": msg}}))
+            click.echo(_common._json_error_str(code, msg))
         else:
             click.echo(f"Error: {msg}", err=True)
         raise SystemExit(1)

--- a/tests/test_find_ai_error_envelope_1179.py
+++ b/tests/test_find_ai_error_envelope_1179.py
@@ -1,0 +1,99 @@
+"""``find --ai`` error JSON must carry the full six-key #884 envelope (#1179).
+
+The ``_find_with_ai`` exception handler (``naturo/cli/core/_find.py``) used to
+hand-roll its ``-j`` error as a two-key ``{"code", "message"}`` object, dropping
+the four other canonical keys (``category``, ``context``, ``suggested_action``,
+``recoverable``) that every other command's error path carries via
+:func:`naturo.cli.error_helpers.json_error`. As a side effect the actionable
+guidance registered for ``AI_PROVIDER_UNAVAILABLE`` ("set an API key …") never
+reached the user. It also emitted an off-taxonomy, unregistered ``AI_FIND_FAILED``
+code for the generic-failure branch, which would resolve to category ``unknown``
+with no recovery hint.
+
+These tests pin the contract for all three codes the handler assigns
+(``AI_ANALYSIS_FAILED`` generic / ``AI_PROVIDER_UNAVAILABLE`` / ``CAPTURE_FAILED``):
+the emitted JSON is the canonical six-key envelope, ``error.code`` resolves to a
+registered code with the matching category, and ``suggested_action`` is non-empty.
+They assert BEHAVIOR (the populated keys), so they fail on the old two-key shape.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from naturo.cli.core._find import find_cmd
+
+# The exact six keys the #884 error envelope must carry, in any order.
+_SIX_KEYS = {"code", "message", "category", "context", "suggested_action", "recoverable"}
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def _invoke_ai_failure(runner, exc):
+    """Drive ``find --ai --json`` with ``ai_find_element`` raising ``exc``."""
+    with pytest.MonkeyPatch().context() as mp:
+        def _boom(*args, **kwargs):
+            raise exc
+
+        mp.setattr("naturo.ai_find.ai_find_element", _boom)
+        result = runner.invoke(find_cmd, ["the save button", "--ai", "--json"])
+    return result
+
+
+def _parse_error(result):
+    """Assert non-zero exit and a well-formed error envelope, return the error obj."""
+    assert result.exit_code != 0, result.output
+    payload = json.loads(result.output)
+    assert payload["success"] is False
+    error = payload["error"]
+    assert set(error.keys()) == _SIX_KEYS, (
+        f"error envelope must carry exactly the six #884 keys, got {sorted(error)}"
+    )
+    return error
+
+
+class TestFindAiErrorEnvelopeContract1179:
+    """Every ``find --ai`` failure code emits the full six-key envelope."""
+
+    def test_generic_failure_uses_registered_ai_analysis_failed(self, runner):
+        """A generic detector crash yields the registered ``AI_ANALYSIS_FAILED``.
+
+        The old code emitted an unregistered ``AI_FIND_FAILED`` string that would
+        degrade to category ``unknown`` with no hint; the fix uses the canonical
+        registered code so category resolves to ``ai`` and a recovery hint is set.
+        """
+        result = _invoke_ai_failure(runner, RuntimeError("detector crashed"))
+        error = _parse_error(result)
+        assert error["code"] == "AI_ANALYSIS_FAILED"
+        assert error["category"] == "ai"
+        assert error["suggested_action"]  # non-empty actionable guidance
+        assert isinstance(error["recoverable"], bool)
+        assert "detector crashed" in error["message"]
+
+    def test_provider_unavailable_carries_set_api_key_guidance(self, runner):
+        """``AI_PROVIDER_UNAVAILABLE`` must reach the user with its API-key hint."""
+        result = _invoke_ai_failure(
+            runner, RuntimeError("AI provider unavailable: auto")
+        )
+        error = _parse_error(result)
+        assert error["code"] == "AI_PROVIDER_UNAVAILABLE"
+        assert error["category"] == "ai"
+        # The registered guidance (error_helpers.py) tells the user to set a key.
+        assert "API key" in error["suggested_action"]
+        assert error["recoverable"] is False
+
+    def test_capture_failure_uses_registered_capture_failed(self, runner):
+        """A capture-related message maps to the registered ``CAPTURE_FAILED``."""
+        result = _invoke_ai_failure(
+            runner, RuntimeError("screen capture failed: no display")
+        )
+        error = _parse_error(result)
+        assert error["code"] == "CAPTURE_FAILED"
+        assert error["category"] == "automation"
+        assert error["suggested_action"]
+        assert isinstance(error["recoverable"], bool)

--- a/tests/test_json_unicode_894.py
+++ b/tests/test_json_unicode_894.py
@@ -229,11 +229,12 @@ class TestElementTreeSurfacesKeepCjkLiteral:
     """The element-tree ``-j`` surfaces #1025 called out echo CJK literally."""
 
     def test_find_ai_error_envelope_keeps_cjk_literal(self, runner):
-        """``find --ai`` JSON error envelope (``_find.py:294``) stays literal.
+        """``find --ai`` JSON error envelope stays literal.
 
-        This callsite — one of the raw ``json_module.dumps`` sites #1025
-        flagged — echoes the underlying failure message; a CJK message must
-        survive without ``\\uXXXX`` escaping.
+        This callsite echoes the underlying failure message; a CJK message must
+        survive without ``\\uXXXX`` escaping. The generic-failure branch now emits
+        the registered ``AI_ANALYSIS_FAILED`` code via the canonical six-key
+        envelope (#1179), replacing the old unregistered ``AI_FIND_FAILED``.
         """
         with patch("naturo.ai_find.ai_find_element",
                    side_effect=RuntimeError(f"detector crashed: {_CJK}")):
@@ -243,6 +244,6 @@ class TestElementTreeSurfacesKeepCjkLiteral:
             )
 
         assert result.exit_code != 0
-        assert "AI_FIND_FAILED" in result.output
+        assert "AI_ANALYSIS_FAILED" in result.output
         assert _CJK in result.output
         assert "\\u" not in result.output


### PR DESCRIPTION
## What
`find --ai` failures emitted a truncated two-key JSON error envelope
(`{"code", "message"}`), dropping the four other canonical keys
(`category`, `context`, `suggested_action`, `recoverable`) that every other
command's `-j` error path carries via the #884 six-key contract. As a side
effect the registered `AI_PROVIDER_UNAVAILABLE` guidance ("Set an API key:
ANTHROPIC_API_KEY, …") never reached the user, and the generic branch emitted
an **unregistered** `AI_FIND_FAILED` string that would degrade to category
`unknown` with no recovery hint.

This routes the `_find_with_ai` exception handler through the canonical
`_common._json_error_str` helper (already used by the sibling
MISSING_DEPENDENCY / FILE_NOT_FOUND paths in the same function) and swaps the
generic code to the registered `AI_ANALYSIS_FAILED`. All three assigned codes
now resolve their category + recovery hint automatically:

| message matches | code | category | recoverable | hint |
|---|---|---|---|---|
| "unavailable"/"api key" | `AI_PROVIDER_UNAVAILABLE` | ai | false | set an API key |
| "capture" | `CAPTURE_FAILED` | automation | true | window not minimized |
| (generic) | `AI_ANALYSIS_FAILED` | ai | true | try another provider |

No new CLI flag, symbol, or signature — this restores the existing #884
contract for an error path (same output-contract-fidelity class as #1172 /
#1173 / #886 / #1159).

## How tested
- New `tests/test_find_ai_error_envelope_1179.py`: drives all three branches
  through the real `find_cmd` CLI and asserts the error object carries
  **exactly** the six keys, the registered code, the matching category, a
  non-empty `suggested_action`, and a bool `recoverable`. Asserts behaviour
  (populated keys), so it fails on the old two-key shape.
- Updated `tests/test_json_unicode_894.py` for the new generic code.
- `ruff check` clean; changed file mypy-clean in isolation (full-tree mypy is
  blocked by a pre-existing env quirk: `python_version=3.9` target vs the
  `mcp` site-package's 3.10 `match` syntax — reproduces on unchanged files).
- Full suite: `python -m pytest tests/ -m "not desktop"` → **6765 passed**,
  171 skipped. The only red (test_agent timing race + test_cost_guardrails
  GBK-locale UnicodeDecodeError) reproduces on pristine develop with my change
  stashed — pre-existing/environmental, green on Linux CI.

## Independent verification (Step 3.5, fresh-context adversarial sub-agent)
**VERDICT: PASS.** Independently stashed to confirm the original 2-key bug was
real (`OLD keys: ['code','message']`, `OLD code: AI_FIND_FAILED`), then drove
all three branches through the real CLI:
```
generic     exit 1  code: AI_ANALYSIS_FAILED      cat: ai          recov: True   keys==6: True
unavailable exit 1  code: AI_PROVIDER_UNAVAILABLE cat: ai          recov: False  keys==6: True
capture     exit 1  code: CAPTURE_FAILED          cat: automation  recov: True   keys==6: True
```
Confirmed all three codes registered (enum + category + recovery hint), no
live `AI_FIND_FAILED` emission remains, path is OS-invariant (no platform gate
between the call and its `except`; pure lowercase substring match), test is
hermetic. Targeted suite: 40 passed, 1 skipped.
