### PR TITLE
fix: register find --selector error codes for complete envelope (fixes #1182, fixes #1183)

### DIFF
--- a/naturo/cli/error_helpers.py
+++ b/naturo/cli/error_helpers.py
@@ -138,6 +138,28 @@ _RECOVERY_HINTS: dict[str, tuple[str, bool]] = {
         "or 'naturo selector list --builtin' for built-in templates.",
         False,
     ),
+    # find/click/type --selector resolution faults (#1182/#1183). SELECTOR_REF_ERROR
+    # reaches parity with SELECTOR_NOT_FOUND's guidance (same condition, different
+    # entry point); INVALID_SELECTOR points at the selector grammar; TREE_ERROR is a
+    # transient automation fault worth retrying once the window is confirmed present.
+    "SELECTOR_REF_ERROR": (
+        "The saved selector reference (@app/name) could not be resolved. Use "
+        "'naturo selector list' to see saved selectors, or 'naturo selector list "
+        "--builtin' for built-in templates.",
+        False,
+    ),
+    "INVALID_SELECTOR": (
+        "The selector string is malformed. Check the selector syntax — e.g. "
+        "'Role:Name', '//Button[@name=\"OK\"]', or '@app/saved-name'. Use --help "
+        "for the supported selector formats.",
+        False,
+    ),
+    "TREE_ERROR": (
+        "Failed to read the UI tree while resolving the selector. Ensure the target "
+        "window is open and responsive (use 'naturo list windows' to verify), then "
+        "retry.",
+        True,
+    ),
     "BASELINE_NOT_FOUND": (
         "Visual baseline not found. Use 'naturo visual list' to see saved baselines, "
         "or 'naturo visual baseline <name> --from <image>' to create one.",

--- a/naturo/errors.py
+++ b/naturo/errors.py
@@ -51,6 +51,11 @@ class ErrorCode:
     MISSING_DEPENDENCY = "MISSING_DEPENDENCY"
     PLATFORM_ERROR = "PLATFORM_ERROR"
 
+    # Selector-resolution errors (naturo find/click/type --selector, #1182/#1183)
+    SELECTOR_REF_ERROR = "SELECTOR_REF_ERROR"
+    INVALID_SELECTOR = "INVALID_SELECTOR"
+    TREE_ERROR = "TREE_ERROR"
+
     # Dialog errors
     DIALOG_NOT_FOUND = "DIALOG_NOT_FOUND"
 
@@ -144,6 +149,15 @@ _ERROR_CATEGORIES: dict[str, str] = {
     ErrorCode.INVALID_SCREENSHOT: ErrorCategory.VALIDATION,
     ErrorCode.MISSING_DEPENDENCY: ErrorCategory.CONFIGURATION,
     ErrorCode.PLATFORM_ERROR: ErrorCategory.ENVIRONMENT,
+    # Selector-resolution codes on the find/click/type --selector moat path
+    # (#1182/#1183): a saved ``@app/name`` reference that does not resolve is a
+    # named session artifact, like SELECTOR_NOT_FOUND (session); a malformed
+    # selector string is a validation fault, like INVALID_INPUT (validation); a
+    # tree-fetch failure during resolution is an automation operation fault, like
+    # CAPTURE_FAILED (automation).
+    ErrorCode.SELECTOR_REF_ERROR: ErrorCategory.SESSION,
+    ErrorCode.INVALID_SELECTOR: ErrorCategory.VALIDATION,
+    ErrorCode.TREE_ERROR: ErrorCategory.AUTOMATION,
     ErrorCode.DIALOG_NOT_FOUND: ErrorCategory.AUTOMATION,
     ErrorCode.DEPENDENCY_MISSING: ErrorCategory.CONFIGURATION,
     ErrorCode.NO_DESKTOP_SESSION: ErrorCategory.ENVIRONMENT,

--- a/tests/test_find_selector_error_codes_1182_1183.py
+++ b/tests/test_find_selector_error_codes_1182_1183.py
@@ -1,0 +1,137 @@
+"""Find-engine selector error codes carry a complete envelope — #1182 + #1183.
+
+Background
+----------
+The ``find``/``click``/``type --selector`` resolver (the v0.3.2 recognition-moat
+surface) emits three error codes that were **raw string literals**, registered in
+neither :data:`naturo.errors._ERROR_CATEGORIES` nor
+:data:`naturo.cli.error_helpers._RECOVERY_HINTS`:
+
+- ``SELECTOR_REF_ERROR`` — a saved ``@app/name`` reference that does not resolve
+  (#1182). The sibling ``selector load``/``test``/``show`` subcommands use the
+  registered ``SELECTOR_NOT_FOUND`` for the identical condition, so the moat path
+  gave a *less* actionable error (``category:"unknown"`` + ``suggested_action:null``).
+- ``INVALID_SELECTOR`` — a malformed selector string (validation fault, #1183).
+- ``TREE_ERROR`` — a UI-tree-fetch failure during selector resolution
+  (automation fault, #1183).
+
+Because they bypassed the :class:`~naturo.errors.ErrorCode` enum, the #1101 drift
+guard (``test_error_category_completeness_1101.py``) never covered them, so they
+silently degraded to ``category:"unknown"`` with no recovery hint — defeating the
+six-key #884 envelope contract on the moat surface. The fix promotes all three to
+real ``ErrorCode`` members and registers their category + recovery hint, so the
+#1101 guard now protects them permanently.
+
+These tests are pure-Python (no DLL, no desktop) and run on every CI lane.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from click.testing import CliRunner
+from unittest.mock import patch
+
+from naturo.cli.core import find_cmd
+from naturo.cli.error_helpers import json_error
+from naturo.errors import ErrorCategory, ErrorCode, category_for_code
+
+# The three codes this issue pair registers, with the categories chosen to match
+# their already-mapped peers: a saved-selector reference is a named, session-scoped
+# artifact like SELECTOR_NOT_FOUND (session); a malformed selector is a validation
+# fault like INVALID_INPUT (validation); a tree-fetch fault during resolution is an
+# automation operation failure like CAPTURE_FAILED (automation).
+_EXPECTED = {
+    "SELECTOR_REF_ERROR": (ErrorCategory.SESSION, False),
+    "INVALID_SELECTOR": (ErrorCategory.VALIDATION, False),
+    "TREE_ERROR": (ErrorCategory.AUTOMATION, True),
+}
+
+
+# ── 1. Each code is a first-class ErrorCode member (so #1101 guard covers it) ──
+
+
+@pytest.mark.parametrize("code", sorted(_EXPECTED))
+def test_code_is_a_registered_error_code(code: str) -> None:
+    """The code is promoted out of a bare string into the ``ErrorCode`` enum."""
+    assert getattr(ErrorCode, code) == code
+
+
+# ── 2. category_for_code resolves the finalized, non-unknown category ─────────
+
+
+@pytest.mark.parametrize("code,expected", sorted(_EXPECTED.items()))
+def test_category_is_concrete(code: str, expected: tuple) -> None:
+    assert category_for_code(code) == expected[0]
+    assert category_for_code(code) != ErrorCategory.UNKNOWN
+
+
+# ── 3. The full six-key envelope: category + non-null suggested_action ────────
+
+
+@pytest.mark.parametrize("code", sorted(_EXPECTED))
+def test_json_error_envelope_is_complete(code: str) -> None:
+    """``json_error`` — the path these callsites use — emits all six keys filled.
+
+    The bug was ``suggested_action:null`` + ``category:"unknown"``; pin that both
+    are now populated (behavior, not shape).
+    """
+    expected_category, expected_recoverable = _EXPECTED[code]
+    payload = json.loads(json_error(code, "selector resolution failed"))
+    error = payload["error"]
+    assert payload["success"] is False
+    assert error["code"] == code
+    assert error["category"] == expected_category
+    assert error["suggested_action"] is not None
+    assert error["suggested_action"].strip() != ""
+    assert error["recoverable"] is expected_recoverable
+    # The canonical six keys are all present (#884 contract).
+    assert set(error) >= {
+        "code", "message", "category", "context",
+        "suggested_action", "recoverable",
+    }
+
+
+def test_selector_ref_error_points_at_selector_list() -> None:
+    """#1182: the not-found hint reaches parity with ``SELECTOR_NOT_FOUND``.
+
+    A user hitting "@app/name not found" via the find/click/type moat path now
+    gets the same actionable pointer the ``selector`` subcommands already give.
+    """
+    payload = json.loads(json_error("SELECTOR_REF_ERROR", "Selector not found: @noapp/nobtn"))
+    assert "selector list" in payload["error"]["suggested_action"]
+
+
+# ── 4. End-to-end through the real ``find`` CLI (platform-invariant paths) ────
+#
+# INVALID_SELECTOR and SELECTOR_REF_ERROR are emitted BEFORE the GUI-platform gate
+# and any backend call, so these drive the real command on every OS without a DLL.
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def test_find_invalid_selector_envelope_end_to_end(runner) -> None:
+    result = runner.invoke(find_cmd, ["--selector", "app://", "--json"])
+    assert result.exit_code == 1
+    error = json.loads(result.output)["error"]
+    assert error["code"] == "INVALID_SELECTOR"
+    assert error["category"] == ErrorCategory.VALIDATION
+    assert error["suggested_action"] is not None
+
+
+def test_find_selector_ref_error_envelope_end_to_end(runner) -> None:
+    with patch(
+        "naturo.cli.selector_cmd.resolve_named_selector",
+        side_effect=KeyError("Selector not found: @ghost/btn"),
+    ):
+        result = runner.invoke(find_cmd, ["--selector", "@ghost/btn", "--json"])
+    assert result.exit_code == 1
+    error = json.loads(result.output)["error"]
+    assert error["code"] == "SELECTOR_REF_ERROR"
+    assert error["category"] == ErrorCategory.SESSION
+    assert error["suggested_action"] is not None
+    assert "selector list" in error["suggested_action"]


### PR DESCRIPTION
## What
The `find`/`click`/`type --selector` resolver (the v0.3.2 recognition-moat surface) emitted three error codes as **bare string literals** — registered in neither `naturo/errors.py::_ERROR_CATEGORIES` nor `naturo/cli/error_helpers.py::_RECOVERY_HINTS`:

| code | before | after |
|------|--------|-------|
| `SELECTOR_REF_ERROR` (#1182) | `category:"unknown"`, `suggested_action:null` | `category:"session"` + "use `naturo selector list`" hint |
| `INVALID_SELECTOR` (#1183) | `category:"unknown"`, `suggested_action:null` | `category:"validation"` + selector-syntax hint |
| `TREE_ERROR` (#1183) | `category:"unknown"`, `suggested_action:null` | `category:"automation"`, `recoverable:true` + retry hint |

This broke the #884 six-key envelope contract on the moat path: a user hitting "selector not found" via `find` got a *less* actionable error than via the `selector load`/`test`/`show` subcommands (which already use the registered `SELECTOR_NOT_FOUND`).

The fix promotes all three to real `ErrorCode` members and registers their category + recovery hint, at parity with their already-registered peers (`SELECTOR_NOT_FOUND`=session, `INVALID_INPUT`=validation, `CAPTURE_FAILED`=automation). Because they are now `ErrorCode` members, the #1101 completeness guard covers them permanently.

**Why both issues in one PR:** #1183 is the explicit sibling QA filed alongside #1182 ("filing these two together so the find-engine error surface is registered as a complete set"). They touch the identical two maps; fixing only one would leave the others leaking `category:"unknown"` — the partial-fix anti-pattern (#1004→#1086). Same defect class as #1101.

## Public-API note
Not a public-surface addition (no `--auto` guardrail trip): the three `code` *strings* were already emitted in the public JSON output as raw literals; this only corrects their always-promised `category`/`suggested_action`/`recoverable` metadata to honor the existing #884 contract — exactly the #1101 bug-fix class. No new CLI flag, parameter, or behavior; no change to which `code` values users see.

## How tested
- `ruff check naturo/` — all checks passed.
- New test `tests/test_find_selector_error_codes_1182_1183.py` — 12 passed: each code is a registered `ErrorCode`, `category_for_code` is concrete (non-unknown), full six-key `json_error` envelope with non-null `suggested_action`, and end-to-end through the real `find` CLI for `INVALID_SELECTOR`/`SELECTOR_REF_ERROR` (both emitted **before** the GUI-platform gate → Linux-CI-safe per #1072).
- Targeted: `pytest test_find_selector_error_codes_1182_1183.py test_error_category_completeness_1101.py test_error_envelope_884.py` → **88 passed**.
- Full non-desktop suite: **6783 passed** (the only non-passes are two pre-existing local-env flakes unrelated to this diff: a GBK-codec `UnicodeDecodeError` in `test_cost_guardrails.py` and a `total_time>0` timing flake in `test_agent.py` — both green on Linux CI).

## Independent verification (Step 3.5 — fresh-context adversarial sub-agent)
**VERDICT: PASS.** A separate agent that did not write the code independently:
- Reproduced the degraded envelope (`json_error('FAKE_CODE')` → unknown/null) and confirmed the three `_find.py` emit sites (L892/L897/L915) were raw strings.
- Confirmed the fixed CLI envelopes live: `find --selector "app://" -j` → INVALID_SELECTOR/validation/non-null hint; unit path for SELECTOR_REF_ERROR (session) and TREE_ERROR (automation, recoverable=true).
- Verified categories match siblings, the #1101 guard now covers all three (88 passed), and the e2e tests run before the platform gate.
- **Grep of the whole `naturo/` tree found exactly two emit-site groups** (`_find.py` and `_common.py` click/type family); both route through the same `json_error` registry, so the fix covers both — **no partial-fix gap.**
