### PR TITLE
fix: guard -j error envelope at source + route 6 CLI paths through canonical helper (fixes #1180)

### DIFF
--- a/naturo/cli/_app/diagnostics.py
+++ b/naturo/cli/_app/diagnostics.py
@@ -107,15 +107,11 @@ def app_inspect(ctx, name, app_name, pid, scan_all, quick, json_output) -> None:
                     f"Connect via RDP or Console to interact with desktop apps."
                 )
                 if json_output:
-                    click.echo(json_dumps({
-                        "success": False,
-                        "error": {
-                            "code": "NO_DESKTOP_SESSION",
-                            "message": msg,
-                            "pid": session0_proc.pid,
-                            "session": 0,
-                        },
-                    }, indent=2))
+                    click.echo(_json_error_str(
+                        "NO_DESKTOP_SESSION",
+                        msg,
+                        extra={"pid": session0_proc.pid, "session": 0},
+                    ))
                 else:
                     _safe_echo(f"Error: {msg}", err=True)
                 sys.exit(1)

--- a/naturo/cli/_app/lifecycle.py
+++ b/naturo/cli/_app/lifecycle.py
@@ -412,14 +412,9 @@ def app_find(ctx, name, pid, json_output) -> None:
             _safe_echo(f"Found: {proc.name} (PID: {proc.pid})")
     else:
         if json_output:
-            click.echo(json_dumps({
-                "success": False,
-                "process": None,
-                "error": {
-                    "code": "PROCESS_NOT_FOUND",
-                    "message": f"No process found matching '{name}'",
-                },
-            }, indent=2))
+            click.echo(_json_error_str(
+                "PROCESS_NOT_FOUND", f"No process found matching '{name}'"
+            ))
         else:
             _safe_echo(f"Not found: {name}")
         sys.exit(1)

--- a/naturo/cli/ai.py
+++ b/naturo/cli/ai.py
@@ -1,6 +1,7 @@
 """MCP command for AI agent integration."""
 import click
 from naturo.cli._jsonio import json_dumps
+from naturo.cli.error_helpers import emit_error
 import sys
 from naturo.cli.fuzzy_group import FuzzyGroup
 
@@ -34,11 +35,7 @@ def start(transport, host, port, json_output) -> None:
         from naturo.mcp_server import run_server
     except ImportError:
         msg = "MCP dependencies not installed. Run: pip install naturo[mcp]"
-        if json_output:
-            click.echo(json_dumps({"success": False, "error": {"code": "MISSING_DEPENDENCY", "message": msg}}))
-        else:
-            click.echo(f"Error: {msg}", err=True)
-        sys.exit(1)
+        emit_error("MISSING_DEPENDENCY", msg, json_output)
 
     try:
         # (#810) stdio transport uses stdout for JSON-RPC — any logging
@@ -57,17 +54,9 @@ def start(transport, host, port, json_output) -> None:
         msg = str(e)
         if "already in use" in msg.lower() or "address already in use" in msg.lower() or getattr(e, 'errno', 0) in (10048, 98):
             msg = f"Port {port} already in use"
-        if json_output:
-            click.echo(json_dumps({"success": False, "error": {"code": "SERVER_ERROR", "message": msg}}))
-        else:
-            click.echo(f"Error: {msg}", err=True)
-        sys.exit(1)
+        emit_error("SERVER_ERROR", msg, json_output)
     except Exception as e:
-        if json_output:
-            click.echo(json_dumps({"success": False, "error": {"code": "SERVER_ERROR", "message": str(e)}}))
-        else:
-            click.echo(f"Error: {e}", err=True)
-        sys.exit(1)
+        emit_error("SERVER_ERROR", str(e), json_output)
 
 
 @mcp.command()
@@ -94,17 +83,9 @@ def install(json_output) -> None:
                 click.echo("✅ MCP dependencies installed. Run 'naturo mcp start' to launch the server.")
         else:
             msg = result.stderr.strip() or result.stdout.strip() or "pip install failed"
-            if json_output:
-                click.echo(json_dumps({"success": False, "error": {"code": "INSTALL_FAILED", "message": msg}}))
-            else:
-                click.echo(f"Error: {msg}", err=True)
-            sys.exit(1)
+            emit_error("INSTALL_FAILED", msg, json_output)
     except Exception as e:
-        if json_output:
-            click.echo(json_dumps({"success": False, "error": {"code": "INSTALL_FAILED", "message": str(e)}}))
-        else:
-            click.echo(f"Error: {e}", err=True)
-        sys.exit(1)
+        emit_error("INSTALL_FAILED", str(e), json_output)
 
 
 @mcp.command()
@@ -133,8 +114,4 @@ def tools(json_output) -> None:
                 click.echo(f"  {t['name']:20s}  {desc}")
     except ImportError:
         msg = "MCP dependencies not installed. Run: pip install naturo[mcp]"
-        if json_output:
-            click.echo(json_dumps({"success": False, "error": {"code": "MISSING_DEPENDENCY", "message": msg}}))
-        else:
-            click.echo(f"Error: {msg}", err=True)
-        sys.exit(1)
+        emit_error("MISSING_DEPENDENCY", msg, json_output)

--- a/naturo/cli/config_cmd.py
+++ b/naturo/cli/config_cmd.py
@@ -15,6 +15,7 @@ Commands
 from __future__ import annotations
 
 from naturo.cli._jsonio import json_dumps
+from naturo.cli.error_helpers import emit_error, json_error
 import os
 from typing import Optional
 
@@ -82,7 +83,7 @@ def setup_anthropic(mode: Optional[str], token: Optional[str], json_output: bool
     if token is None:
         if json_output:
             msg = "Token required when using --json. Pass --token <value>."
-            click.echo(json_dumps({"success": False, "error": {"code": "INVALID_INPUT", "message": msg}}))
+            click.echo(json_error("INVALID_INPUT", msg))
             raise SystemExit(1)
 
         if mode == "api_key":
@@ -98,11 +99,7 @@ def setup_anthropic(mode: Optional[str], token: Optional[str], json_output: bool
     token = token.strip()
     if not token:
         msg = "Token cannot be empty."
-        if json_output:
-            click.echo(json_dumps({"success": False, "error": {"code": "INVALID_INPUT", "message": msg}}))
-        else:
-            click.echo(f"Error: {msg}", err=True)
-        raise SystemExit(1)
+        emit_error("INVALID_INPUT", msg, json_output)
 
     # Persist
     creds = load_credentials()

--- a/naturo/cli/snapshot.py
+++ b/naturo/cli/snapshot.py
@@ -15,6 +15,7 @@ Commands
 from __future__ import annotations
 
 from naturo.cli._jsonio import json_dumps
+from naturo.cli.error_helpers import emit_error
 
 import click
 
@@ -137,19 +138,11 @@ def snapshot_clean(session: str | None, days: int | None, clean_all: bool, yes: 
     """
     if not clean_all and days is None:
         msg = "Specify --days N or --all.  Run with --help for usage."
-        if json_output:
-            click.echo(json_dumps({"success": False, "error": {"code": "INVALID_INPUT", "message": msg}}))
-        else:
-            click.echo(f"Error: {msg}", err=True)
-        raise SystemExit(1)
+        emit_error("INVALID_INPUT", msg, json_output)
 
     if days is not None and days < 0:
         msg = f"--days must be >= 0, got {days}"
-        if json_output:
-            click.echo(json_dumps({"success": False, "error": {"code": "INVALID_INPUT", "message": msg}}))
-        else:
-            click.echo(f"Error: {msg}", err=True)
-        raise SystemExit(1)
+        emit_error("INVALID_INPUT", msg, json_output)
 
     # Determine which sessions to clean
     if session == "all":

--- a/naturo/cli/system/_clipboard.py
+++ b/naturo/cli/system/_clipboard.py
@@ -18,7 +18,7 @@ import sys
 
 import click
 
-from naturo.cli.error_helpers import emit_error, emit_exception_error
+from naturo.cli.error_helpers import emit_error, emit_exception_error, json_error
 from naturo.cli.fuzzy_group import FuzzyGroup
 
 logger = logging.getLogger(__name__)
@@ -31,11 +31,7 @@ def _get_backend(json_output: bool = False):
         return get_backend()
     except Exception as exc:
         if json_output:
-            click.echo(json_dumps({
-                "success": False,
-                "error": "BACKEND_ERROR",
-                "message": str(exc),
-            }))
+            click.echo(json_error("BACKEND_ERROR", str(exc)))
             sys.exit(1)
         raise click.UsageError(str(exc))
 

--- a/tests/test_clipboard_cmd.py
+++ b/tests/test_clipboard_cmd.py
@@ -334,9 +334,24 @@ class TestClipboardBackendError:
     def test_get_backend_error_json(self, runner):
         with patch("naturo.backends.base.get_backend", side_effect=RuntimeError("no backend")):
             result = runner.invoke(clipboard, ["get", "--json"])
+        assert result.exit_code != 0
         data = json.loads(result.output)
         assert data["success"] is False
-        assert data["error"] == "BACKEND_ERROR"
+        # Canonical six-key error envelope (#884/#1180): ``error`` is an object,
+        # not a bare string. The prior flat shape (``error == "BACKEND_ERROR"``)
+        # silently dropped category/context/suggested_action/recoverable; the
+        # backend-error path now routes through ``json_error`` like every other
+        # ``-j`` error path.
+        assert data["error"]["code"] == "BACKEND_ERROR"
+        assert set(data["error"]) == {
+            "code",
+            "message",
+            "category",
+            "context",
+            "suggested_action",
+            "recoverable",
+        }
+        assert isinstance(data["error"]["recoverable"], bool)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_error_envelope_source_guard_1180.py
+++ b/tests/test_error_envelope_source_guard_1180.py
@@ -1,0 +1,131 @@
+"""Source-level guard against hand-rolled ``-j`` error envelopes (issue #1180).
+
+Background
+----------
+The six-key JSON **error** envelope (``code``, ``message``, ``category``,
+``context``, ``suggested_action``, ``recoverable``) was unified by #884 and is
+guarded *positively* by :mod:`test_error_envelope_contract_1001`, which walks the
+Click tree and asserts the emitted shape. That contract proves the paths it can
+*reach*: parse-stage usage errors across the full tree, plus a hand-curated
+sample of runtime failures. But a command body that hand-builds
+``json_dumps({"success": False, "error": {...}})`` instead of routing through the
+canonical :func:`naturo.cli.error_helpers.json_error` /
+:func:`~naturo.cli.error_helpers.emit_error` silently emits a truncated envelope
+on a path the curated sample never triggers — which is exactly how #1179
+(``find --ai`` emitted a 2-key error) and a cluster of sibling drifts
+(``mcp``/``config``/``snapshot``/``clipboard``/``app`` paths) reached users.
+
+This module closes the hole **at the source**, the role #1180 calls out: a
+lightweight AST guard that scans the CLI package and fails CI if any module other
+than the canonical error builders constructs a ``{"success": False, ...}`` error
+envelope as a literal. A new command physically cannot hand-roll an error
+envelope and pass CI — it must call the helper, which guarantees all six keys.
+
+Scope
+-----
+The guard covers ``naturo/cli/**`` — the ``-j`` CLI contract surface #884 fixed.
+The MCP-tool error surface (``isError`` flag, #882) is a separate contract and is
+out of scope here. The canonical builders in ``error_helpers.py`` are the single
+allowed home for the literal (``json_error`` wraps the six-key object in it), so
+that module is the lone allowlist entry.
+
+The test is pure static analysis — it parses source files, runs no command, and
+needs no DLL or desktop, so it executes on every CI lane.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import naturo.cli
+
+# The CLI package whose ``-j`` error paths must funnel through the canonical
+# helpers rather than hand-building the envelope.
+_CLI_ROOT = Path(naturo.cli.__file__).parent
+
+# The single module allowed to construct the ``{"success": False, "error": ...}``
+# literal: it *is* the canonical builder every other path must call. Relative to
+# ``_CLI_ROOT`` so the allowlist is stable regardless of checkout location.
+_ALLOWED = {"error_helpers.py"}
+
+
+def _has_success_false_key(node: ast.Dict) -> bool:
+    """Return whether *node* is a dict literal with a ``"success": False`` entry.
+
+    That key/value pair is the fingerprint of a hand-rolled error envelope: the
+    canonical :func:`success_envelope` only ever sets ``success`` to ``True``, and
+    the error builders live in the allowlisted module, so a literal ``False`` here
+    anywhere else is a command body bypassing :func:`json_error`/:func:`emit_error`.
+    """
+    for key, value in zip(node.keys, node.values):
+        if (
+            isinstance(key, ast.Constant)
+            and key.value == "success"
+            and isinstance(value, ast.Constant)
+            and value.value is False
+        ):
+            return True
+    return False
+
+
+def _find_handrolled_error_envelopes(source: str) -> list[int]:
+    """Return the line numbers of hand-rolled error-envelope literals in *source*."""
+    tree = ast.parse(source)
+    return [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Dict) and _has_success_false_key(node)
+    ]
+
+
+def _scan_cli_package() -> dict[str, list[int]]:
+    """Map each offending CLI module (relative path) to its violation line numbers."""
+    violations: dict[str, list[int]] = {}
+    for path in sorted(_CLI_ROOT.rglob("*.py")):
+        relative = path.relative_to(_CLI_ROOT).as_posix()
+        if path.name in _ALLOWED:
+            continue
+        lines = _find_handrolled_error_envelopes(path.read_text(encoding="utf-8"))
+        if lines:
+            violations[relative] = lines
+    return violations
+
+
+def test_no_handrolled_error_envelopes_in_cli() -> None:
+    """No CLI module outside the canonical builder hand-rolls an error envelope.
+
+    A ``{"success": False, "error": ...}`` literal anywhere but ``error_helpers``
+    means a ``-j`` error path skipped :func:`json_error`/:func:`emit_error` and so
+    risks emitting fewer than the six #884 keys. Route the error through the helper
+    instead — it guarantees the full canonical envelope.
+    """
+    violations = _scan_cli_package()
+    assert not violations, (
+        "Hand-rolled error envelopes found — route these through "
+        "naturo.cli.error_helpers.json_error()/emit_error() so the full six-key "
+        "#884 envelope (code, message, category, context, suggested_action, "
+        "recoverable) is emitted, not a truncated subset:\n"
+        + "\n".join(
+            f"  {module}: line(s) {', '.join(map(str, lines))}"
+            for module, lines in violations.items()
+        )
+    )
+
+
+def test_guard_detects_a_synthetic_handrolled_envelope() -> None:
+    """The detector fires on the exact anti-pattern it is meant to catch.
+
+    Pins the guard itself: a future refactor that weakens ``_has_success_false_key``
+    (so it silently matches nothing) would make ``test_no_handrolled_error_...``
+    vacuously pass. This positive control keeps the guard honest.
+    """
+    handrolled = (
+        'click.echo(json_dumps({"success": False, '
+        '"error": {"code": "BOOM", "message": "boom"}}))'
+    )
+    assert _find_handrolled_error_envelopes(handrolled) == [1]
+
+    # The canonical success envelope (success=True) must NOT trip the guard.
+    canonical_success = 'json_dumps({"success": True, "windows": [], "count": 0})'
+    assert _find_handrolled_error_envelopes(canonical_success) == []


### PR DESCRIPTION
## What

Closes the `#884 → #1172 → #1179` ERROR-envelope regression class **at the source** (#1180).

#884 unified the six-key `-j` error envelope (`code, message, category, context,
suggested_action, recoverable`) by hand, command-by-command, with no self-maintaining
guard. `test_error_envelope_contract_1001` already walks the live Click tree for the
*runtime* paths it can reach, but a command body that hand-builds
`json.dumps({"success": False, "error": {...}})` on a path the curated sample never
triggers silently ships a truncated envelope — exactly how #1179 (`find --ai`, a 2-key
error) and a cluster of siblings (`mcp` / `config` / `snapshot` / `clipboard` / `app`)
drifted.

This PR adds the missing **source-level AST guard** (#1180 approach step 2) and fixes the
violations it surfaces:

- **`tests/test_error_envelope_source_guard_1180.py`** — a pure static-analysis test that
  parses every `naturo/cli/**` module and fails CI if any module other than the canonical
  builder (`error_helpers.py`) constructs a `{"success": False, ...}` error literal. A new
  command physically cannot hand-roll an error envelope and pass CI — it must call
  `json_error()` / `emit_error()`, which guarantees all six keys. Ships with a
  positive-control test so a future weakening of the detector cannot make the guard
  vacuously pass.
- **6 CLI modules** routed through the canonical helper: `ai.py` (mcp start/install/tools),
  `snapshot.py` (clean), `config_cmd.py` (anthropic setup), `system/_clipboard.py`,
  `_app/diagnostics.py` (inspect — `pid`/`session` preserved via `extra=`),
  `_app/lifecycle.py` (find). `_clipboard.py`'s old literal was in fact **broken**
  (`"error": "BACKEND_ERROR"` as a bare string + a stray top-level `message`) — now a
  correct six-key envelope.
- **`tests/test_clipboard_cmd.py`** updated to assert the corrected canonical envelope (it
  had been pinning the old broken bare-string shape).

No public-API / CLI surface change — error *codes* and *messages* are unchanged; only the
emission mechanism is normalized so every `-j` error path emits the full six-key schema.

## How tested

- `python -m ruff check naturo/` → All checks passed
- `python -m mypy naturo/` → clean for changed files (only pre-existing site-packages `mcp`
  3.9-syntax noise, identical on a pristine develop checkout)
- Guard + runtime contract + clipboard:
  `python -m pytest tests/test_error_envelope_source_guard_1180.py tests/test_error_envelope_contract_1001.py tests/test_clipboard_cmd.py -q` → **248 passed**
- Full non-desktop suite with an isolated temp base (to avoid a concurrent QA run's shared
  `pytest-of-Naturobot` lock):
  `python -m pytest tests/ -m "not desktop" --basetemp=<private>` →
  **6786 passed, 0 failed**, 171 skipped. The only 11 errors are all in
  `tests/test_cost_guardrails.py` (`UnicodeDecodeError: 'gbk' codec` — a host-locale YAML
  encoding issue, already tracked by **#1175**, green on the UTF-8 Linux CI); none touch a
  module changed here.

## Independent verification

An independent fresh-context sub-agent reproduced and adversarially reviewed the uncommitted
change — verdict **PASS**:

- Guard test passes, ruff clean, related suites green
  (`test_error_envelope_contract_1001` + `test_find_ai_error_envelope_1179` +
  `test_error_envelope_884` → 235 passed; `test_app_cmd` + `test_error_helpers` → 146 passed).
- **Guard has teeth (proved by stash):** stashing the 6 CLI fixes made the guard FAIL,
  flagging all 6 files at the exact hand-rolled literal lines; restoring made it pass again.
  Reverting even one fix re-introduces a flagged literal, so the guard fails CI on regression.
- **Per-file equivalence (live-exercised, all exit 1, all six keys):** `emit_error` calls
  `sys.exit(1)` so the removed trailing `sys.exit(1)` loses nothing; `diagnostics.py`'s
  `pid`/`session` preserved via `extra=`; `_clipboard.py`'s old literal was in fact broken
  (`"error": "BACKEND_ERROR"` bare string) → now a correct canonical envelope; `lifecycle.py`'s
  vestigial top-level `process: None` dropped (no test asserted it).
- No new mis-attribution (EVOLUTION.md class): the refactor changes only the *emission
  mechanism*, not any `try`/`except`, code, or message; categories resolve unchanged.

CI (Linux/macOS) gates cross-platform separately.
