### PR TITLE
fix: find emits reusable unified selector field matching see (fixes #1184)

### DIFF
--- a/naturo/cli/core/_find.py
+++ b/naturo/cli/core/_find.py
@@ -357,6 +357,36 @@ def find_cmd(query: str | None, query_opt: str | None, find_all: bool, role: str
         mgr.store_detection_result(snapshot_id, ui_map)
         mgr.store_ref_map(snapshot_id, ref_map)
 
+        # (#1184) Build the reusable unified ``app://…`` selector for each
+        # result so ``find`` output round-trips into ``selector save`` /
+        # ``find <selector>`` / ``click --selector`` without falling back to
+        # ``see``.  Uses the SAME SelectorBuilder + element-dict shape +
+        # app-default as ``see`` (_see.py), and the ancestor chain threaded
+        # through SearchResult, so ``find`` and ``see`` emit an identical
+        # selector for the same node.
+        import re as _re_mod
+
+        from naturo.selector import SelectorBuilder
+
+        _sel_builder = SelectorBuilder()
+        _selector_app = app or "*"
+
+        def _el_to_selector_dict(el: Any) -> dict[str, str]:
+            """Convert an ElementInfo to a dict for SelectorBuilder (#1184)."""
+            raw_id = str(el.id) if el.id else ""
+            aid = raw_id if raw_id and not _re_mod.fullmatch(r"e\d+", raw_id) else ""
+            return {
+                "role": el.role or "*",
+                "name": el.name or "",
+                "automationid": aid,
+            }
+
+        def _build_result_selector(r: Any) -> str:
+            """Build the unified selector for a SearchResult (#1184)."""
+            ancestors_dicts = [_el_to_selector_dict(a) for a in r.ancestors]
+            return _sel_builder.build_uri(
+                _el_to_selector_dict(r.element), ancestors_dicts, app=_selector_app)
+
         if json_output:
             data = [
                 {
@@ -369,6 +399,7 @@ def find_cmd(query: str | None, query_opt: str | None, find_all: bool, role: str
                     "y": r.element.y,
                     "width": r.element.width,
                     "height": r.element.height,
+                    "selector": _build_result_selector(r),
                     "breadcrumb": r.breadcrumb_str,
                     "keyboard_shortcut": r.element.keyboard_shortcut,
                 }
@@ -393,6 +424,9 @@ def find_cmd(query: str | None, query_opt: str | None, find_all: bool, role: str
                 shortcut = f" [{el.keyboard_shortcut}]" if el.keyboard_shortcut else ""
                 click.echo(f"  {ref}. [{el.role}]{name_str} {pos_str}{shortcut}")
                 click.echo(f"     {r.breadcrumb_str}")
+                # (#1184) Show the reusable unified selector so the human
+                # output is also discover-then-save friendly, not just JSON.
+                click.echo(f"     selector: {_build_result_selector(r)}")
 
             click.echo(f"\n{len(results)} element(s) found.")
             click.echo(f"Snapshot: {snapshot_id}")

--- a/naturo/search.py
+++ b/naturo/search.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import fnmatch
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import List, Optional
 
 from naturo.bridge import ElementInfo
@@ -22,11 +22,16 @@ class SearchResult:
         element: The matched ElementInfo.
         breadcrumb: List of (role, name) tuples from root to this element.
         breadcrumb_str: Human-readable breadcrumb string.
+        ancestors: List of ancestor ElementInfo objects from root to the
+            matched element's parent (root-first, excluding the element
+            itself). Threaded so callers can rebuild the unified ``app://``
+            selector with the same ancestor context ``see`` uses (#1184).
     """
 
     element: ElementInfo
     breadcrumb: List[tuple]
     breadcrumb_str: str = ""
+    ancestors: List[ElementInfo] = field(default_factory=list)
 
     def __post_init__(self):
         if not self.breadcrumb_str and self.breadcrumb:
@@ -72,7 +77,7 @@ def search_elements(
         parsed_role = role_filter
 
     results: List[SearchResult] = []
-    _search_recursive(root, parsed_role, parsed_name, actionable_only, [], results, max_results)
+    _search_recursive(root, parsed_role, parsed_name, actionable_only, [], [], results, max_results)
     return results
 
 
@@ -162,10 +167,16 @@ def _search_recursive(
     name_filter: Optional[str],
     actionable_only: bool,
     path: List[tuple],
+    ancestor_path: List[ElementInfo],
     results: List[SearchResult],
     max_results: int,
 ) -> None:
-    """Recursively search the element tree."""
+    """Recursively search the element tree.
+
+    ``ancestor_path`` is the chain of ElementInfo objects from the root down
+    to (but excluding) ``el``; it is recorded on each match so callers can
+    rebuild the unified selector with the same ancestor context (#1184).
+    """
     if len(results) >= max_results:
         return
 
@@ -193,7 +204,10 @@ def _search_recursive(
     if match_any and actionable_match:
         # For "match all" queries (no filters), skip if both name and role empty
         if role_filter or name_filter or (el.name or el.role):
-            results.append(SearchResult(element=el, breadcrumb=current_path))
+            results.append(SearchResult(
+                element=el, breadcrumb=current_path, ancestors=list(ancestor_path)))
 
+    child_ancestor_path = ancestor_path + [el]
     for child in el.children:
-        _search_recursive(child, role_filter, name_filter, actionable_only, current_path, results, max_results)
+        _search_recursive(child, role_filter, name_filter, actionable_only,
+                          current_path, child_ancestor_path, results, max_results)

--- a/tests/test_find_selector_field_1184.py
+++ b/tests/test_find_selector_field_1184.py
@@ -1,0 +1,161 @@
+"""Tests for #1184: ``find`` JSON/text results must emit the reusable unified
+``selector`` field that ``see`` emits for the same element.
+
+Before #1184, ``naturo find`` returned only an ephemeral snapshot-scoped
+``ref``/``id`` plus a human-readable ``breadcrumb`` — but not the machine
+resolvable ``app://…`` selector — which broke the natural discover-then-save
+workflow (``find`` an element → ``naturo selector save`` its selector). These
+tests pin that:
+
+1. Every ``find`` JSON element carries a non-empty ``app://`` ``selector``.
+2. ``find`` and ``see`` emit an *identical* selector for the same node
+   (the core parity contract).
+3. The selector survives the lateral payload-builder paths
+   (``--all`` / ``--role`` / ``--actionable``) and the human-readable output.
+
+The fixture is a small hermetic UIA-shaped tree; no real desktop is needed, so
+these run on headless CI (same backend ``ElementInfo`` consumed by both
+commands, mocked at ``_get_backend``).
+"""
+
+import json
+
+import pytest
+from unittest.mock import patch, MagicMock
+from click.testing import CliRunner
+
+from naturo.backends.base import ElementInfo
+from naturo.cli.core._find import find_cmd
+from naturo.cli.core._see import see
+
+
+def _node(role, name, children=None, el_id=""):
+    """Build a backend ElementInfo node for the fixture tree."""
+    return ElementInfo(
+        id=el_id,
+        role=role,
+        name=name,
+        value=None,
+        x=10,
+        y=20,
+        width=100,
+        height=40,
+        children=children or [],
+        properties={},
+    )
+
+
+@pytest.fixture
+def fixture_tree():
+    """A Notepad-shaped tree: Window > Pane > Document, plus a Save Button.
+
+    Mirrors the #1184 repro (a Document nested under a Pane under the Window),
+    so the threaded ancestor chain (Window, Pane) is exercised when the unified
+    selector is rebuilt for the Document.
+    """
+    document = _node("Document", "文本编辑器")
+    pane = _node("Pane", "", children=[document])
+    save_button = _node("Button", "Save", el_id="SaveBtn")
+    window = _node("Window", "无标题 - Notepad", children=[pane, save_button])
+    return window
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_backend(fixture_tree):
+    """Mock the backend so both find and see resolve the fixture tree."""
+    mock_be = MagicMock()
+    mock_be.get_element_tree.return_value = fixture_tree
+    # see builds a JSON dpi_context from these; keep them serializable so the
+    # only thing under test is the selector (not the mock's stand-in objects).
+    mock_be.get_dpi_scale.return_value = 1.0
+    mock_be.list_monitors.return_value = []
+    with patch("naturo.cli.core._common._platform_supports_gui", return_value=True), \
+         patch("naturo.cli.core._common._get_backend", return_value=mock_be):
+        yield mock_be
+
+
+def _find_json(runner, *args):
+    """Invoke find --json and return the parsed payload."""
+    result = runner.invoke(find_cmd, list(args) + ["--json"])
+    assert result.exit_code == 0, f"find failed: {result.output}"
+    return json.loads(result.output)
+
+
+def _walk(node):
+    """Yield every node in a see JSON tree (depth-first)."""
+    yield node
+    for child in node.get("children", []):
+        yield from _walk(child)
+
+
+class TestFindEmitsSelector:
+    """find JSON results must include the reusable unified selector (#1184)."""
+
+    def test_query_result_has_selector(self, runner, mock_backend):
+        """A query-search match carries a non-empty app:// selector."""
+        payload = _find_json(runner, "role:Document", "--hwnd", "12345")
+        assert payload["success"] is True
+        assert payload["count"] == 1
+        element = payload["elements"][0]
+        assert "selector" in element, "find element payload omits 'selector'"
+        assert element["selector"].startswith("app://"), element["selector"]
+        # The full ancestor chain (Window > Pane > Document) is encoded.
+        assert "Document" in element["selector"]
+        assert "Window" in element["selector"]
+
+    def test_selector_is_resolvable_not_breadcrumb_prose(self, runner, mock_backend):
+        """selector must be a machine-resolvable URI, distinct from breadcrumb."""
+        element = _find_json(runner, "role:Document", "--hwnd", "12345")["elements"][0]
+        # breadcrumb is human prose ("Window:… > Pane > Document:…");
+        # selector is an app:// URI — they must not be the same string.
+        assert element["selector"] != element["breadcrumb"]
+        assert " > " not in element["selector"]
+
+    @pytest.mark.parametrize("extra_args", [
+        ["--all"],
+        ["--role", "Button"],
+        ["--all", "--actionable"],
+    ])
+    def test_lateral_payload_paths_include_selector(self, runner, mock_backend, extra_args):
+        """--all / --role / --actionable share the payload builder — all must carry selector."""
+        payload = _find_json(runner, "--hwnd", "12345", *extra_args)
+        assert payload["count"] >= 1
+        for element in payload["elements"]:
+            assert element.get("selector", "").startswith("app://"), element
+
+    def test_human_output_shows_selector(self, runner, mock_backend):
+        """The non-JSON human output is also discover-then-save friendly."""
+        result = runner.invoke(find_cmd, ["role:Document", "--hwnd", "12345"])
+        assert result.exit_code == 0, result.output
+        assert "selector: app://" in result.output
+
+
+class TestFindSeeSelectorParity:
+    """find and see must emit an IDENTICAL selector for the same element (#1184)."""
+
+    def test_find_selector_matches_see_selector(self, runner, mock_backend):
+        """The Document's find selector equals its see selector, byte-for-byte."""
+        # find side
+        find_element = _find_json(runner, "role:Document", "--hwnd", "12345")["elements"][0]
+        find_selector = find_element["selector"]
+
+        # see side — same backend tree, same --hwnd targeting so both default
+        # the selector app to "*" and walk the identical ancestor chain.
+        see_result = runner.invoke(see, ["--hwnd", "12345", "--json", "--no-snapshot"])
+        assert see_result.exit_code == 0, see_result.output
+        see_tree = json.loads(see_result.output)
+        document_nodes = [
+            n for n in _walk(see_tree)
+            if n.get("role") == "Document" and n.get("name") == "文本编辑器"
+        ]
+        assert len(document_nodes) == 1, "see did not surface the Document node"
+        see_selector = document_nodes[0]["selector"]
+
+        assert find_selector == see_selector, (
+            f"find/see selector mismatch:\n  find={find_selector}\n  see ={see_selector}"
+        )


### PR DESCRIPTION
## What
`naturo find` (query-search path) now emits the reusable unified `app://…` **`selector`** field for every result — the same selector `naturo see` emits for the same `UIElement` — in both JSON and human output. This fixes #1184: previously `find` returned only an ephemeral snapshot-scoped `ref`/`id` plus a human-readable `breadcrumb`, so the natural **discover-then-save** workflow (`find` an element → `naturo selector save` / `find <selector>` / `click --selector`) was broken and users had to fall back to `see` and walk the tree by hand.

## How
- `naturo/search.py`: `SearchResult` now carries an `ancestors` field (root→parent `ElementInfo` chain, excluding self), threaded through `_search_recursive`. The flat `SearchResult` previously dropped the ancestor context the unified selector needs. Backward compatible (defaulted field; no external constructor changed).
- `naturo/cli/core/_find.py`: builds each result's selector with the **same** `SelectorBuilder` + element-dict shape (`role`/`name`/`automationid`) + `app`-default (`app or "*"`) that `see` uses, over the threaded ancestor chain. Adds `"selector"` to the JSON element payload and a `selector:` line to the human output (the lateral gap flagged in the issue — human output also lacked it). `ref`/`breadcrumb` are kept for backward compat.

The selector is identical to `see`'s, e.g. `app://*/Window[@name="无标题 - Notepad"]/Document[@name="文本编辑器"]`.

## How tested
- New `tests/test_find_selector_field_1184.py` (hermetic, no desktop; same backend `ElementInfo` mocked at `_get_backend`):
  - every `find` JSON element carries a non-empty `app://` selector;
  - selector is a resolvable URI, distinct from the `breadcrumb` prose;
  - the lateral payload-builder paths (`--all`/`--role`/`--actionable`) and the human output all include it;
  - **parity**: `find` and `see` emit a byte-for-byte identical selector for the same node — this also guards against future drift between the two selector code paths.
- `ruff check naturo/ tests/…` → clean; `mypy naturo/search.py naturo/cli/core/_find.py` → clean.
- Full non-desktop suite (`python -m pytest tests/ -m "not desktop"`): see gate report in the cycle log.

## Independent verification (Step 3.5, fresh-context adversarial sub-agent)
**VERDICT: PASS.** The verifier independently (a) `git stash`-confirmed the pre-fix `find -j` element had NO `selector` key, (b) restored the fix and confirmed `find`'s selector is byte-for-byte identical to `see`'s on its own fixture, (c) tried to break it across non-default paths — `--all`, `--role`, `--actionable`, human output, `--app foo` (app component → `foo`), 5-level deep nesting (full root-first chain), real-automationid vs `eN`-placeholder ids (placeholder correctly dropped), and a root-level match (empty ancestors) — all parity TRUE, none wrong/empty/malformed, and (d) checked EVOLUTION.md recurring classes: output-contract/cross-command parity satisfied + pinned, the new test is hermetic (mocks both `_platform_supports_gui` and `_get_backend`, pure in-memory fixture — passes under `-W error`), no platform-invariance/error-attribution concerns (pure additive output field). `tests/test_find_selector_field_1184.py` → 7 passed.

## Public-surface assessment
Additive, non-breaking output-field fix: brings `find`'s output into consistency with `see`'s **existing** `selector` contract. No new CLI flag, error code, exported symbol, or activated inert parameter. Same class as #886 (populate `keyboard_shortcut`) and #1141 (add `-j` success envelope) — both routine `fix` auto-merges — so auto-merge is enabled.
