### PR TITLE
docs: correct `list windows --app` help to state it also matches the window title (fixes #1058)

### DIFF
--- a/naturo/cli/core/_list.py
+++ b/naturo/cli/core/_list.py
@@ -27,7 +27,7 @@ def apps(ctx, show_all, json_output) -> None:
 
 
 @list_cmd.command()
-@click.option("--app", help="Target application (name or partial match)")
+@click.option("--app", help="Target application: process name or window title (partial match)")
 @click.option("--process-name", "app", default=None, hidden=True, help="")
 @click.option("--window", "window_title", default=None,
               help="Window title pattern (substring match)")
@@ -44,9 +44,11 @@ def windows(app, window_title, hwnd, app_id, pid, json_output) -> None:
 
     Window-targeting filters (``--window``/``--hwnd``/``--app-id``) mirror the
     flag family used by ``see``/``capture``/``click`` so a window can be
-    narrowed the same way everywhere. ``--app`` matches the application name or
-    process name; ``--window`` matches the window title only. Filters combine
-    with AND.
+    narrowed the same way everywhere. ``--app`` is broad targeting: it matches
+    a window whose process name **or** window title contains the term — the
+    same rule ``see``/``capture``/``click`` use, so a window in a multi-window
+    process can be picked by title. ``--window`` narrows to the window title
+    only. Filters combine with AND.
     """
     if not _common._platform_supports_gui():
         msg = _common._platform_error_msg("Window listing")

--- a/tests/test_list_windows_app_help_1058.py
+++ b/tests/test_list_windows_app_help_1058.py
@@ -1,0 +1,135 @@
+"""Regression tests for #1058 — `list windows` help text must not lie about
+``--app``'s match scope.
+
+The ``list windows`` docstring (added by the #871 harmonization) claimed
+``--app`` matched the *application name or process name* and that ``--window``
+matched the *window title only*, describing the two filters as having disjoint
+scopes.  In reality ``--app <term>`` matches a window when ``<term>`` is a
+substring of the **window title** *or* the process basename — the deliberate,
+family-consistent broad-targeting rule shared by ``see``/``capture``/``click``
+(#671/#1084).  The defect was purely that the new docstring promised a narrower
+scope than the code (and the family) actually deliver.
+
+These tests pin the contract in both directions so it cannot silently drift
+back:
+
+1. the rendered ``list windows --help`` text documents that ``--app`` also
+   matches the window title (broad targeting), and no longer claims ``--app``
+   is process/app-name-only or that ``--window`` is the *only* way to match a
+   title; and
+2. the behavior the help now documents is real — ``--app`` matches by window
+   title as well as by process basename.
+
+All tests mock the backend and platform so they run on any CI host.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from naturo.cli.core._list import list_cmd
+
+
+def _make_window(**overrides):
+    w = MagicMock()
+    w.handle = overrides.get("handle", 12345)
+    w.title = overrides.get("title", "Untitled - Notepad")
+    w.process_name = overrides.get("process_name", "notepad.exe")
+    w.pid = overrides.get("pid", 5678)
+    w.x = overrides.get("x", 100)
+    w.y = overrides.get("y", 100)
+    w.width = overrides.get("width", 800)
+    w.height = overrides.get("height", 600)
+    w.is_visible = overrides.get("is_visible", True)
+    w.is_minimized = overrides.get("is_minimized", False)
+    return w
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def backend():
+    """Two windows whose titles do NOT contain their process basenames, so a
+    title match and a process match are unambiguously distinguishable."""
+    b = MagicMock()
+    b.list_windows.return_value = [
+        _make_window(handle=1001, title="Quarterly report - Notepad",
+                     process_name="notepad.exe", pid=100),
+        _make_window(handle=1002, title="Inbox - Mail",
+                     process_name="olk.exe", pid=200),
+    ]
+    return b
+
+
+def _patches(backend):
+    return [
+        patch("naturo.cli.core._common._platform_supports_gui", return_value=True),
+        patch("naturo.cli.core._common._get_backend", return_value=backend),
+        patch("naturo.cli.core._list.platform.system", return_value="Windows"),
+        patch("os.getpid", return_value=99999),
+        patch("os.getppid", return_value=99998),
+    ]
+
+
+def _run(runner, backend, args):
+    ctx = _patches(backend)
+    for p in ctx:
+        p.start()
+    try:
+        return runner.invoke(list_cmd, args, catch_exceptions=False)
+    finally:
+        for p in reversed(ctx):
+            p.stop()
+
+
+def test_help_documents_app_matches_window_title(runner):
+    """The rendered help must state that ``--app`` also matches the window
+    title — the broad-targeting behavior the code actually implements."""
+    result = runner.invoke(list_cmd, ["windows", "--help"], catch_exceptions=False)
+    assert result.exit_code == 0
+    help_text = result.output.lower()
+    # The honest contract: --app matches the process name OR the window title.
+    # Both halves of the broad-targeting rule must appear in the help so the
+    # docs describe what the code does (formatting markers between the words
+    # must not be assumed, so check the two terms independently).
+    assert "process name" in help_text
+    assert "window title" in help_text
+
+
+def test_help_does_not_describe_app_as_name_only(runner):
+    """The help must not reassert the old disjoint contract that described
+    ``--app`` as matching the ``application name or process name`` (with title
+    matching reserved to ``--window``) — that exact phrasing is what lied about
+    behavior in #1058, since ``--app`` also matches the title."""
+    result = runner.invoke(list_cmd, ["windows", "--help"], catch_exceptions=False)
+    assert result.exit_code == 0
+    normalized = " ".join(result.output.lower().split())
+    assert "application name or process name" not in normalized
+
+
+def test_app_filter_matches_by_window_title(runner, backend):
+    """Behavior the help now documents: ``--app <term>`` matches a window whose
+    *title* contains the term even when no process is named that."""
+    result = _run(runner, backend, ["windows", "--app", "Quarterly", "-j"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["success"] is True
+    assert data["count"] == 1
+    assert data["windows"][0]["handle"] == 1001
+
+
+def test_app_filter_matches_by_process_basename(runner, backend):
+    """``--app`` still matches by process basename (the other half of the
+    documented broad-targeting rule)."""
+    result = _run(runner, backend, ["windows", "--app", "olk", "-j"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["success"] is True
+    assert data["count"] == 1
+    assert data["windows"][0]["handle"] == 1002


### PR DESCRIPTION
## What

Fixes #1058 — the `list windows --help` text lied about `--app`'s match scope.

The docstring (added by the #871 harmonization) described `--app` and `--window` as having **disjoint** scopes:

> `--app` matches the application name or process name; `--window` matches the window title only.

In reality `--app <term>` matches a window when `<term>` is a substring of the **window title** *or* the process basename — the deliberate, family-consistent broad-targeting rule shared by `see`/`capture`/`click` (#671/#1084). The only defect was that the new docstring promised a narrower scope than the code (and the family) actually deliver.

This applies **option (A)** from the issue (the lower-risk resolution the reporter recommended): fix the docs to match the long-standing, intentional behavior, keeping `list windows --app` resolving identically to the rest of the window-targeting family. No behavior change.

### Changes
- `--app` option help: `Target application (name or partial match)` → `Target application: process name or window title (partial match)`.
- `windows` docstring: states `--app` is broad targeting (matches process name **or** window title, same rule as `see`/`capture`/`click`); `--window` narrows to the title only.

This is **doc/help-text only** — no new flag, no signature change, no previously-inert flag made functional.

## How tested
- `ruff check naturo/` → All checks passed.
- `mypy naturo/` → clean for changed code (the only error is a pre-existing third-party `mcp` lib parsed under mypy's `python_version=3.9` target — identical on clean develop, CI green).
- `python -m pytest tests/ -m "not desktop"` (full tree, UTF-8) → **6807 passed**, 171 skipped, 177 deselected; the lone local failure `test_agent::test_total_time_recorded` is a pre-existing timing flake (`total_time==0.0` on a fast box; passes in isolation), unrelated to this doc change.
- New regression test `tests/test_list_windows_app_help_1058.py` (4 tests) pins the contract **both directions**: help documents title matching + no longer asserts the old lying phrase; behavior matches by title and by process basename. Backend/platform mocked → runs on any CI host.

## Independent verification
A fresh-context adversarial sub-agent independently confirmed (verdict **PASS**):
- The original committed help did claim the disjoint/narrower scope (bug was real).
- The diff is doc-only (1 file, +6/-4): only the `--app` help string and docstring change; filter logic untouched.
- Rendered `list windows --help` now states the broad `process name OR window title` rule and no longer contains "application name or process name".
- Real-desktop proof of the documented behavior: `list windows --app test --json` → 10 Notepad windows matched **purely by title** (no "test" in the process name); `--app Notepad` → matched by process basename.
- Cross-command parity confirmed: `window_ops.py:430` uses the same `process_name OR title` rule as `see`/`capture`/`click`.
- Regression test: 4 passed.
- No public-API/contract change → no human sign-off gate triggered.
