### PR TITLE
fix: round-trip emitted app://* wildcard-host selector across all windows (fixes #1190)

### DIFF
--- a/naturo/cli/core/_find.py
+++ b/naturo/cli/core/_find.py
@@ -949,27 +949,44 @@ def _find_with_selector(
 
     backend = _common._get_backend(json_output)
 
-    try:
-        tree = backend.get_element_tree(
-            app=app, window_title=window_title, hwnd=hwnd, pid=pid,
-            depth=depth, backend=method,
-        )
-    except _common.WindowNotFoundError as exc:
-        _emit_error("WINDOW_NOT_FOUND", str(exc))
-    except Exception as exc:
-        _emit_error("TREE_ERROR", f"Failed to get UI tree for selector resolution: {exc}")
-
-    if tree is None:
-        _emit_error(
-            "WINDOW_NOT_FOUND",
-            "No window found for selector resolution. Check that the target "
-            "application is running and visible.",
+    # An emitted wildcard-host selector (app://*/Window[@name="…"]/…) with no
+    # explicit window target resolves across all top-level windows so the
+    # selector see/find emit round-trips straight back into find --selector
+    # (#1190) — the same behavior the click family uses, kept in lock-step via
+    # the shared _common helper, which returns None for every other selector
+    # shape so the normal single-window path (below) is unchanged.
+    forest = None
+    if (ast.app == "*" and app is None and window_title is None
+            and hwnd is None and pid is None):
+        from naturo.cli.interaction._common import _resolve_wildcard_host_forest
+        forest = _resolve_wildcard_host_forest(
+            backend, ast, depth=depth, method=method,
         )
 
-    # Reuse the click family's ElementInfo→dict conversion so both commands feed
-    # the resolver an identically-shaped tree (no semantic drift).
-    from naturo.cli.interaction._common import _elementinfo_to_dict
-    tree_dict = [_elementinfo_to_dict(tree)]
+    if forest is not None:
+        tree_dict = forest
+    else:
+        try:
+            tree = backend.get_element_tree(
+                app=app, window_title=window_title, hwnd=hwnd, pid=pid,
+                depth=depth, backend=method,
+            )
+        except _common.WindowNotFoundError as exc:
+            _emit_error("WINDOW_NOT_FOUND", str(exc))
+        except Exception as exc:
+            _emit_error("TREE_ERROR", f"Failed to get UI tree for selector resolution: {exc}")
+
+        if tree is None:
+            _emit_error(
+                "WINDOW_NOT_FOUND",
+                "No window found for selector resolution. Check that the target "
+                "application is running and visible.",
+            )
+
+        # Reuse the click family's ElementInfo→dict conversion so both commands
+        # feed the resolver an identically-shaped tree (no semantic drift).
+        from naturo.cli.interaction._common import _elementinfo_to_dict
+        tree_dict = [_elementinfo_to_dict(tree)]
 
     resolver = SelectorResolver()
     if find_all:

--- a/naturo/cli/interaction/_common.py
+++ b/naturo/cli/interaction/_common.py
@@ -490,6 +490,80 @@ def _elementinfo_to_dict(el) -> dict:
     return result
 
 
+def _resolve_wildcard_host_forest(
+    backend,
+    ast,
+    depth: int,
+    method: Optional[str] = None,
+) -> Optional[list[dict]]:
+    """Build a window-tree forest for an emitted wildcard-host selector (#1190).
+
+    A selector that ``see``/``find`` emit leads with a concrete
+    ``Window[@name="…"]`` segment under the portable wildcard host ``app://*``
+    (e.g. ``app://*/Window[@name="无标题 - Notepad"]/Document[@name="…"]``). For
+    that emitted selector to round-trip without an extra ``--hwnd``/``--app``
+    flag, the named window must be located across ALL top-level windows — not
+    just the foreground window ``get_element_tree`` returns when no target is
+    given (which is usually NOT the window the selector names, hence the
+    ``SELECTOR_NOT_FOUND`` reported in #1190).
+
+    The leading ``Window`` title narrows the search via ``_resolve_hwnds`` so
+    only the matching window's tree is fetched. The function deliberately acts
+    ONLY on this concrete-leading-window shape: it returns ``None`` for any other
+    selector (a bare ``//Role`` short-form, a wildcard/empty leading title, a
+    non-wildcard host), leaving the caller's normal single-window resolution path
+    — and its existing behavior — entirely untouched.
+
+    Args:
+        backend: Platform backend exposing ``_resolve_hwnds`` and
+            ``get_element_tree``.
+        ast: Parsed selector AST.
+        depth: Maximum tree depth to fetch per window.
+        method: Accessibility backend to forward to ``get_element_tree``
+            (``None`` lets the backend pick its default).
+
+    Returns:
+        A list of window element dicts (a forest the resolver can walk), or
+        ``None`` when this narrow shape does not apply or no window matched.
+    """
+    if ast.app != "*" or not ast.nodes:
+        return None
+    leading = ast.nodes[0]
+    if leading.role.lower() != "window":
+        return None
+    title = leading.name
+    if not title or "*" in title or "?" in title:
+        return None
+    if not (hasattr(backend, "_resolve_hwnds")
+            and hasattr(backend, "get_element_tree")):
+        return None
+
+    try:
+        hwnds = backend._resolve_hwnds(window_title=title)
+    except Exception:
+        # A window-enumeration fault must not escape uncaught — fall through to
+        # the caller's normal single-window path, which attributes its own tree
+        # faults to TREE_ERROR (error-attribution discipline, #1047/#1067).
+        return None
+    if not hwnds:
+        return None
+
+    tree_kwargs: dict = {"depth": depth}
+    if method is not None:
+        tree_kwargs["backend"] = method
+
+    forest: list[dict] = []
+    for hwnd in hwnds:
+        try:
+            subtree = backend.get_element_tree(hwnd=hwnd, **tree_kwargs)
+        except Exception:
+            # A single unreadable window must not abort the whole search.
+            continue
+        if subtree is not None:
+            forest.append(_elementinfo_to_dict(subtree))
+    return forest or None
+
+
 def _resolve_selector_target(
     selector_str: str,
     backend,
@@ -556,30 +630,43 @@ def _resolve_selector_target(
         )
         return None
 
-    try:
-        tree = backend.get_element_tree(
-            app=app, window_title=window_title, hwnd=hwnd, pid=pid,
-            depth=20,
-        )
-    except Exception as exc:
-        _json_err(
-            f"Failed to get UI tree for selector resolution: {exc}",
-            json_output,
-            code="TREE_ERROR",
-        )
-        return None
+    # An emitted wildcard-host selector (app://*/Window[@name="…"]/…) with no
+    # explicit window target resolves across all top-level windows so it
+    # round-trips straight back from see/find (#1190); the helper returns None
+    # for every other selector shape, leaving the normal single-window path
+    # (and its behavior) unchanged.
+    forest = None
+    if (ast.app == "*" and app is None and window_title is None
+            and hwnd is None and pid is None):
+        forest = _resolve_wildcard_host_forest(backend, ast, depth=20)
 
-    if tree is None:
-        _json_err(
-            "No window found for selector resolution. "
-            "Check that the target application is running and visible.",
-            json_output,
-            code="WINDOW_NOT_FOUND",
-        )
-        return None
+    if forest is not None:
+        tree_dict = forest
+    else:
+        try:
+            tree = backend.get_element_tree(
+                app=app, window_title=window_title, hwnd=hwnd, pid=pid,
+                depth=20,
+            )
+        except Exception as exc:
+            _json_err(
+                f"Failed to get UI tree for selector resolution: {exc}",
+                json_output,
+                code="TREE_ERROR",
+            )
+            return None
 
-    # Convert ElementInfo tree to dict tree for the resolver
-    tree_dict = [_elementinfo_to_dict(tree)]
+        if tree is None:
+            _json_err(
+                "No window found for selector resolution. "
+                "Check that the target application is running and visible.",
+                json_output,
+                code="WINDOW_NOT_FOUND",
+            )
+            return None
+
+        # Convert ElementInfo tree to dict tree for the resolver
+        tree_dict = [_elementinfo_to_dict(tree)]
 
     # Resolve
     resolver = SelectorResolver()

--- a/tests/test_selector_wildcard_host_roundtrip_1190.py
+++ b/tests/test_selector_wildcard_host_roundtrip_1190.py
@@ -1,0 +1,196 @@
+"""Tests for #1190: a wildcard-host (``app://*``) selector must round-trip.
+
+``see`` and ``find`` emit their reusable locator with the portable wildcard host
+``app://*`` (e.g. ``app://*/Window[@name="无标题 - Notepad"]/Document[@name="…"]``).
+Before this fix, pasting that exact string back into ``find --selector`` /
+``click --selector`` *without* an extra ``--hwnd``/``--app`` flag failed with
+``SELECTOR_NOT_FOUND``: the resolver fetched only the single default (foreground)
+window's tree, so the window the selector actually names was never searched.
+
+The fix resolves a target-less wildcard host across ALL top-level windows. These
+tests pin both directions:
+
+* **Round-trip** — emit a selector via ``find`` (over a concrete ``--hwnd``),
+  feed it straight back into ``find --selector`` with no target flag, assert it
+  resolves to the same element.
+* **Click family** — the shared ``_resolve_selector_target`` (used by
+  ``click``/``type``/``press``/mouse) resolves the same wildcard host to the
+  named element's coordinates.
+
+The fixture is **discriminating**: the foreground window that the default
+``get_element_tree()`` path returns is a *different* app that does NOT contain
+the target element, so a passing test proves the across-windows search — not the
+ambient desktop — is what makes the selector resolve (negative control included).
+
+Hermetic: a small UIA-shaped tree behind a mocked backend; no real desktop, so
+this runs on headless CI.
+"""
+
+import json
+
+import pytest
+from unittest.mock import patch, MagicMock
+from click.testing import CliRunner
+
+from naturo.backends.base import ElementInfo, WindowInfo
+from naturo.cli.core._find import find_cmd
+
+NOTEPAD_HWND = 111
+OTHER_HWND = 222
+NOTEPAD_TITLE = "无标题 - Notepad"
+DOCUMENT_NAME = "文本编辑器"
+
+
+def _node(role, name, children=None, el_id=""):
+    """Build a backend ElementInfo node for the fixture tree."""
+    return ElementInfo(
+        id=el_id,
+        role=role,
+        name=name,
+        value=None,
+        x=10,
+        y=20,
+        width=100,
+        height=40,
+        children=children or [],
+        properties={},
+    )
+
+
+@pytest.fixture
+def notepad_tree():
+    """A Notepad-shaped tree: Window > Pane > Document (the #1190 repro shape)."""
+    document = _node("Document", DOCUMENT_NAME)
+    pane = _node("Pane", "", children=[document])
+    return _node("Window", NOTEPAD_TITLE, children=[pane])
+
+
+@pytest.fixture
+def other_tree():
+    """A different foreground window WITHOUT the target Document (negative control)."""
+    return _node("Window", "Some Other App", children=[_node("Button", "OK")])
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_backend(notepad_tree, other_tree):
+    """Backend where the Notepad window is NOT the default/foreground window.
+
+    * ``get_element_tree(hwnd=NOTEPAD_HWND)`` → the Notepad tree.
+    * ``get_element_tree(hwnd=OTHER_HWND)``   → the other app's tree.
+    * ``get_element_tree()`` with no hwnd (the old single-window path) → the
+      *other* window, which lacks the target — so the only way to resolve the
+      Notepad selector is the across-windows search.
+    * ``_resolve_hwnds(window_title=NOTEPAD_TITLE)`` → ``[NOTEPAD_HWND]``.
+    * ``list_windows()`` → both windows.
+    """
+    def _get_tree(*args, **kwargs):
+        hwnd = kwargs.get("hwnd")
+        if hwnd == NOTEPAD_HWND:
+            return notepad_tree
+        if hwnd == OTHER_HWND:
+            return other_tree
+        # No explicit hwnd → emulate "foreground window" = the other app.
+        return other_tree
+
+    def _resolve_hwnds(app=None, window_title=None):
+        if window_title and window_title in NOTEPAD_TITLE:
+            return [NOTEPAD_HWND]
+        return []
+
+    mock_be = MagicMock()
+    mock_be.get_element_tree.side_effect = _get_tree
+    mock_be._resolve_hwnds.side_effect = _resolve_hwnds
+    mock_be.list_windows.return_value = [
+        WindowInfo(handle=OTHER_HWND, title="Some Other App",
+                   process_name="other.exe", pid=2, x=0, y=0,
+                   width=100, height=100, is_visible=True, is_minimized=False),
+        WindowInfo(handle=NOTEPAD_HWND, title=NOTEPAD_TITLE,
+                   process_name="notepad.exe", pid=1, x=0, y=0,
+                   width=100, height=100, is_visible=True, is_minimized=False),
+    ]
+    with patch("naturo.cli.core._common._platform_supports_gui", return_value=True), \
+         patch("naturo.cli.core._common._get_backend", return_value=mock_be):
+        yield mock_be
+
+
+class TestFindSelectorWildcardRoundTrip:
+    """The emitted app://* selector must resolve back through find --selector."""
+
+    def test_emitted_selector_round_trips_without_target_flag(self, runner, mock_backend):
+        """Emit via find --hwnd, paste back into find --selector with no target."""
+        # 1) Emit: a concrete --hwnd query yields the reusable selector field.
+        emit = runner.invoke(
+            find_cmd, ["role:Document", "--hwnd", str(NOTEPAD_HWND), "--json"]
+        )
+        assert emit.exit_code == 0, emit.output
+        emitted = json.loads(emit.output)["elements"][0]["selector"]
+        # The emitted locator uses the portable wildcard host.
+        assert emitted.startswith("app://*/"), emitted
+
+        # 2) Round-trip: feed that exact string back with NO --hwnd/--app.
+        back = runner.invoke(find_cmd, ["--selector", emitted, "--json"])
+        assert back.exit_code == 0, (
+            f"emitted selector did not round-trip: {emitted}\n{back.output}"
+        )
+        payload = json.loads(back.output)
+        assert payload["success"] is True, payload
+        assert payload["count"] == 1, payload
+        assert payload["elements"][0]["name"] == DOCUMENT_NAME, payload
+
+    def test_explicit_wildcard_selector_resolves_across_windows(self, runner, mock_backend):
+        """A hand-written app://* selector resolves even though it is not the foreground window."""
+        selector = (
+            f'app://*/Window[@name="{NOTEPAD_TITLE}"]/Document[@name="{DOCUMENT_NAME}"]'
+        )
+        result = runner.invoke(find_cmd, ["--selector", selector, "--json"])
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["success"] is True and payload["count"] == 1, payload
+
+    def test_unknown_wildcard_selector_still_reports_not_found(self, runner, mock_backend):
+        """A wildcard host naming a non-existent element fails honestly (no false match)."""
+        selector = 'app://*/Window[@name="无标题 - Notepad"]/Document[@name="does-not-exist"]'
+        result = runner.invoke(find_cmd, ["--selector", selector, "--json"])
+        assert result.exit_code != 0, result.output
+        payload = json.loads(result.output)
+        assert payload["success"] is False
+        assert payload["error"]["code"] == "SELECTOR_NOT_FOUND", payload
+
+
+class TestClickFamilyWildcardResolution:
+    """The shared click/type/press resolver honors a target-less wildcard host."""
+
+    def test_resolve_selector_target_finds_named_window(self, mock_backend):
+        from naturo.cli.interaction._common import _resolve_selector_target
+
+        selector = (
+            f'app://*/Window[@name="{NOTEPAD_TITLE}"]/Document[@name="{DOCUMENT_NAME}"]'
+        )
+        coords = _resolve_selector_target(
+            selector, mock_backend, app=None, window_title=None,
+            hwnd=None, pid=None, json_output=True,
+        )
+        # The Document sits at x=10,y=20,w=100,h=40 → center (60, 40).
+        assert coords == (60, 40), coords
+
+    def test_resolve_selector_target_negative_control(self, mock_backend):
+        """A wildcard host naming a missing element fails honestly (no false match).
+
+        ``_resolve_selector_target`` reports the failure via ``_json_err``, which
+        exits non-zero rather than returning — so the across-windows search never
+        fabricates a match for an element that is in no window.
+        """
+        from naturo.cli.interaction._common import _resolve_selector_target
+
+        selector = 'app://*/Window[@name="无标题 - Notepad"]/Document[@name="missing"]'
+        with pytest.raises(SystemExit) as exc_info:
+            _resolve_selector_target(
+                selector, mock_backend, app=None, window_title=None,
+                hwnd=None, pid=None, json_output=True,
+            )
+        assert exc_info.value.code != 0


### PR DESCRIPTION
## What

Fixes #1190 — the reusable selector that `see` and `find` emit
(`app://*/Window[@name="…"]/Document[@name="…"]`) now **round-trips**: pasting
that exact string back into `find --selector` / `click --selector` /
`type --selector` (and the rest of the click family) with **no** extra
`--hwnd`/`--app` target flag resolves the named element, instead of failing with
`SELECTOR_NOT_FOUND`.

## Root cause

A target-less selector fetched only the single default (foreground) window's
tree via `get_element_tree()`. The emitted selector uses the portable wildcard
host `app://*` and leads with the concrete `Window[@name="<title>"]` of a
*different* window, so that window was never searched → `SELECTOR_NOT_FOUND`.
This broke the advertised `see → copy selector → click` workflow and undercut
the #1184/#1188 reusable-selector promise.

## How

A new shared helper `_resolve_wildcard_host_forest` (in
`cli/interaction/_common.py`, used by **both** the click family's
`_resolve_selector_target` and `find --selector` so they stay in lock-step)
locates the window named in the leading `Window[@name="…"]` segment via
`_resolve_hwnds(window_title=…)` and resolves the path across the matching
window(s).

The change is deliberately **surgical**: the helper engages **only** for the
emitted shape — `app://*` host **and** a literal (wildcard-free)
`Window[@name="…"]` leading segment **and** no explicit window target. For every
other selector (`//Role` short-form, bare-role wildcard like `app://*/Button[…]`,
concrete host `app://Notepad/…`, or any selector with an explicit
`--hwnd`/`--app`) it returns `None` and the existing single-window resolution
path — and its behavior — is unchanged. No new CLI flag, parameter, error code,
or exported symbol is added; existing `SELECTOR_NOT_FOUND`/`WINDOW_NOT_FOUND`/
`TREE_ERROR` codes are reused, so a non-existent element still fails honestly.

## How tested

- **New regression test** `tests/test_selector_wildcard_host_roundtrip_1190.py`
  (hermetic, mocked backend; runs on headless CI). Emits a selector via `find`,
  feeds it straight back into `find --selector` with no target flag, asserts it
  resolves; plus an explicit wildcard-resolution case, a click-family
  `_resolve_selector_target` case, and two negative controls (non-existent
  element → `SELECTOR_NOT_FOUND`). The fixture is **discriminating**: the
  foreground window the default path returns is a *different* app, so a green
  test proves the across-windows search — not the ambient desktop — does the
  work. Verified it FAILS on the pre-fix code (reproduces the exact
  `SELECTOR_NOT_FOUND` symptom) and passes with the fix.
- `python -m ruff check naturo/` → **All checks passed**.
- `mypy`: **0 new errors** from this change (a pre-existing, unrelated
  environment artifact — the third-party `mcp` package uses Python-3.10 `match`
  syntax while the repo pins `mypy python_version = "3.9"` — halts mypy on
  clean `develop` too; verified identical 1-error output with the change stashed).
- Full non-desktop suite: `python -m pytest tests/ -m "not desktop"` →
  **6805 passed**, 171 skipped (incl. the 5 new #1190 tests). The 1 failure
  (`test_agent::test_total_time_recorded`, flaky timing/`no display`) and 11
  errors (`test_cost_guardrails`, Windows `gbk`-codec `UnicodeDecodeError`
  reading a YAML file) are **pre-existing environment artifacts** reproduced on
  clean `develop` with the change stashed — neither touches the selector/find
  path and neither occurs on UTF-8 Linux CI.
- Existing selector suites (594 selector/find-selector/resolve-selector tests)
  all green — confirming no behavior change for non-emitted selector shapes.

## Independent verification

An independent fresh-context adversarial verifier (separate sub-agent that did
not write the code) returned **PASS** after a hermetic adversarial review:
- Reproduced the discrimination guarantee — patched `_resolve_wildcard_host_forest`
  to return `None` and confirmed the *exact emitted selector* then fails with
  `SELECTOR_NOT_FOUND` (the mock's no-hwnd path returns a *different* foreground
  window), proving a green gate reflects the across-windows search, not the
  ambient desktop. The test cannot pass for the wrong reason.
- 12 throwaway adversarial probes (`.work/`): no-match honesty (never-lie) for
  both `find` and the click family; title-collision (3 windows share the leading
  title, resolver picks the right one, does not bail on the first); shape
  discrimination (bare `//Role`, concrete host `app://notepad.exe/…`,
  wildcard/empty leading title, non-`Window` leading role all fall through to
  the unchanged single-window path); error attribution (a `_resolve_hwnds` fault
  and a single unreadable window are swallowed/`continue`d without aborting the
  search or mis-attributing a code — the #1047/#1067 class); `hasattr` guards
  against a missing-method backend. All 12 passed.
- Cross-command parity (#1058/#1065 class): `find --selector` and the
  click/type/press resolver use the **identical guard** and the **same shared
  helper**, kept in lock-step; the only divergence is `find` forwarding
  `depth`/`method` (#1169) vs click's pre-existing `depth=20` — not a regression.
- Verdict was hermetic (mocked backend, no live UI) — appropriate for this
  headless run; cross-platform behavior is gated separately by CI.

## Auto-merge OFF — needs Ace sign-off

No new flag/parameter/error-code/exported symbol is added, but this **activates
the round-trip resolution semantics of the emitted `app://*` selector** — a
target-less wildcard-host selector that previously always failed now resolves
across all windows. Under the public-surface guardrail ("honoring an
already-documented contract is a *trigger*, not an exemption" — the #1134
lesson), a behavior-activation of a public selector form is a human-only
sign-off. Opening **without** `--auto`; leaving #1190 `status:in-progress` for
Ace's review + merge.
