### PR TITLE
fix: reject empty/whitespace find query instead of silent match-all (fixes #1193)

### DIFF
--- a/naturo/cli/core/_find.py
+++ b/naturo/cli/core/_find.py
@@ -242,6 +242,20 @@ def find_cmd(query: str | None, query_opt: str | None, find_all: bool, role: str
         )
         return
 
+    # (#1193) Treat an empty / whitespace-only query the same as a missing one.
+    # Left as-is, "" / "   " falls through to the search layer, which normalizes
+    # it to the "*" wildcard and matches *every* element with success:true — the
+    # silent-wrong class QA guards against (an unpopulated `naturo find "$VAR"`
+    # would dump the whole tree as a "success"). Selector- and image-mode already
+    # reject empty input (INVALID_SELECTOR / FILE_NOT_FOUND); this aligns the
+    # default text path with them and with the argument-omitted path. Callers
+    # that want every element opt in explicitly via --all (or narrow with
+    # --role/--actionable, which keep the match-all intent below).
+    if query is not None and not query.strip():
+        query = None
+    if query_opt is not None and not query_opt.strip():
+        query_opt = None
+
     # Resolve query: --all flag → wildcard, --query option → override positional
     if find_all:
         query = "*"
@@ -250,11 +264,14 @@ def find_cmd(query: str | None, query_opt: str | None, find_all: bool, role: str
     # else: query is the positional arg (may be None)
 
     if query is None:
-        # When --actionable or --role is set, treat missing query as wildcard
+        # When --actionable or --role is set, treat a missing or empty query as a
+        # wildcard — the explicit filter already narrows the match-all intent.
         if actionable or role:
             query = "*"
         else:
-            msg = "Missing argument 'QUERY'. Provide as positional arg or --query/-q option."
+            msg = ("Missing or empty argument 'QUERY'. Provide a non-empty query "
+                   "as a positional arg or --query/-q option, or use --all to "
+                   "match every element.")
             if json_output:
                 click.echo(_common._json_error_str("INVALID_INPUT", msg))
             else:

--- a/tests/test_find_empty_query_1193.py
+++ b/tests/test_find_empty_query_1193.py
@@ -1,0 +1,93 @@
+"""Tests for `find` rejecting an empty/whitespace-only query (fixes #1193).
+
+`naturo find ""` and `naturo find "   "` previously normalized to the ``*``
+wildcard and matched **every** element with ``success: true`` — identical to
+``--all`` — while ``naturo find`` (argument omitted) correctly errored with
+``INVALID_INPUT``. An empty string is, from the caller's perspective, the same
+"no query given" situation (a typo / an unpopulated ``naturo find "$VAR"``), so
+a silent match-all dump masquerading as success is exactly the silent-wrong
+class QA guards against. The default text path now agrees with the
+selector/image modes (which already reject empty input) and with the
+argument-omitted path: empty/whitespace → ``INVALID_INPUT``. Callers that want
+every element opt in explicitly via ``--all`` (or narrow with
+``--role``/``--actionable``).
+"""
+
+import json
+
+import pytest
+from unittest.mock import patch, MagicMock
+from click.testing import CliRunner
+
+from naturo.cli.core import find_cmd
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_backend():
+    """Mock the backend so find_cmd doesn't need a real GUI session."""
+    mock_be = MagicMock()
+    mock_be.get_element_tree.return_value = None
+    with patch("naturo.cli.core._common._platform_supports_gui", return_value=True), \
+         patch("naturo.cli.core._common._get_backend", return_value=mock_be):
+        yield mock_be
+
+
+class TestFindEmptyQueryRejected:
+    """An empty / whitespace-only query must error, never silently match-all."""
+
+    @pytest.mark.parametrize("args", [
+        ["", "--json"],
+        ["   ", "--json"],
+        ["-q", "", "--json"],
+        ["-q", "   ", "--json"],
+    ])
+    def test_empty_query_json_errors_invalid_input(self, runner, args):
+        """Empty/whitespace query returns an INVALID_INPUT envelope, not success."""
+        result = runner.invoke(find_cmd, args)
+        assert result.exit_code != 0, result.output
+        data = json.loads(result.output)
+        assert data["success"] is False
+        assert data["error"]["code"] == "INVALID_INPUT"
+        # It must NOT have fallen through to a match-all element dump.
+        assert "elements" not in data
+
+    def test_empty_query_does_not_reach_backend(self, runner, mock_backend):
+        """The empty-query guard fires before any backend tree fetch."""
+        result = runner.invoke(find_cmd, ["", "--json"])
+        assert result.exit_code != 0
+        mock_backend.get_element_tree.assert_not_called()
+
+    @pytest.mark.parametrize("args", [[""], ["   "]])
+    def test_empty_query_plain_text_errors(self, runner, args):
+        """Without --json the empty query shows a plain-text error and exits 1."""
+        result = runner.invoke(find_cmd, args)
+        assert result.exit_code != 0
+        assert "Error" in (result.output or "")
+
+
+class TestFindEmptyQueryWithExplicitMatchAll:
+    """--all / --role / --actionable keep the explicit match-all intent."""
+
+    def test_empty_query_with_all_flag_passes_gate(self, runner, mock_backend):
+        """`find "" --all` opts into match-all, so it reaches the backend."""
+        result = runner.invoke(find_cmd, ["", "--all", "--json"])
+        # Mock tree is None → WINDOW_NOT_FOUND, but the empty-query gate is passed.
+        assert "INVALID_INPUT" not in (result.output or "")
+        mock_backend.get_element_tree.assert_called()
+
+    def test_empty_query_with_actionable_passes_gate(self, runner, mock_backend):
+        """`find "" --actionable` keeps the wildcard intent (#124 parity)."""
+        result = runner.invoke(find_cmd, ["", "--actionable", "--json"])
+        assert "INVALID_INPUT" not in (result.output or "")
+        mock_backend.get_element_tree.assert_called()
+
+    def test_empty_query_with_role_passes_gate(self, runner, mock_backend):
+        """`find "" --role Button` keeps the wildcard intent (#124 parity)."""
+        result = runner.invoke(find_cmd, ["", "--role", "Button", "--json"])
+        assert "INVALID_INPUT" not in (result.output or "")
+        mock_backend.get_element_tree.assert_called()


### PR DESCRIPTION
## What

`naturo find "   "` (whitespace-only) and `naturo find -q ""` / `-q "   "` previously normalized to the `*` wildcard and matched **every** element with `success: true` — identical to `--all` — while `naturo find` with the argument omitted correctly errored with `INVALID_INPUT`. An empty/whitespace query is, from the caller's perspective, the same "no query given" situation (a typo, an unpopulated `naturo find "$VAR"`), so a silent match-all dump masquerading as success is exactly the silent-wrong class we guard against (Never Lie). This aligns the default text path with the argument-omitted path and with selector/image modes (which already reject empty input).

Fixes #1193.

## How

In `find_cmd`, before query resolution, treat an empty/whitespace-only positional `query` or `--query/-q` value as a missing query (set to `None`). The existing `query is None` branch then:
- returns a registered `INVALID_INPUT` error (category `validation`) when no explicit filter is set, with updated guidance pointing to `--all`;
- still resolves to the `*` wildcard when `--all`/`--role`/`--actionable` opt into match-all.

The guard runs **before** the `_platform_supports_gui()` gate, so the bad-input → `INVALID_INPUT` contract is platform-invariant (Linux/macOS CI gets the same code as the Windows desktop).

Scope: `naturo/cli/core/_find.py` (+19/-2) plus a new test module. No new flag, symbol, error code, or parameter — a behavioral bug fix.

## How tested

- `ruff check naturo/` → clean.
- Full suite: `python -m pytest tests/ -q -m "not desktop"` → **6810 passed**, 171 skipped (1 pre-existing failure + 11 errors in `test_cost_guardrails.py`/`test_agent.py` are local-env artifacts — proven identical on clean develop, unrelated to find, and develop CI is green).
- New test `tests/test_find_empty_query_1193.py` → 10 passed; collects with no desktop/optional deps.
- Real-desktop E2E: `find ""`/`find "   "`/`find -q ""` → `INVALID_INPUT`/`success:false`; `find "" --all`/`--role`/`--actionable` → reach backend, `success:true`; `find "*"` and real text queries unaffected.

## Independent verification

A fresh-context adversarial sub-agent (did not write the code) independently **confirmed the original bug** (fix stashed: `find "   " -j` → `success:true, count:44`; `-q "   "` same), then could not break the fix on any error / non-default / opt-in path (tab-only and newline-only queries → `INVALID_INPUT`; `--all`/`--role`/`--actionable` opt-ins → `success:true`; `*` and real queries unaffected). Confirmed `INVALID_INPUT` is a registered `ErrorCode` (category `validation`, full envelope), validation precedes the GUI gate (platform-invariant, pinned by `test_empty_query_does_not_reach_backend`), and the change satisfies the EVOLUTION.md silent-wrong / platform-invariant-order / error-code-registration / option-coverage classes. Targeted tests 10 passed. **Verdict: PASS.** (Minor, non-blocking, pre-existing: `find "" --image foo.png` returns `INVALID_INPUT` with the image-conflict message rather than an empty-query message — still no silent match-all.)
