### PR TITLE
test: prove naturo click actuates a JAB-recognized Swing control (part of #932)

### DIFF
--- a/benchmarks/recognition/fixtures/java/SwingControlsFixture.java
+++ b/benchmarks/recognition/fixtures/java/SwingControlsFixture.java
@@ -40,7 +40,32 @@ public final class SwingControlsFixture {
     /** Stable window title used by the recognition harness to find this window. */
     public static final String WINDOW_TITLE = "Naturo Swing Recognition Fixture";
 
+    /** Initial status-label text (and accessible name) before any action. */
+    public static final String STATUS_PENDING = "Order Status: Pending";
+    /** Status after the Submit Order button is actuated — the success-action proof. */
+    public static final String STATUS_SUBMITTED = "Order Status: Submitted";
+    /** Status after the Cancel Order button is actuated. */
+    public static final String STATUS_CANCELLED = "Order Status: Cancelled";
+
     private SwingControlsFixture() {
+    }
+
+    /**
+     * Update a status label's text and keep its accessible name in lock-step.
+     *
+     * <p>Swing does not propagate {@link javax.swing.JLabel#setText} to the
+     * label's accessible name automatically, and the Java Access Bridge reports
+     * a control's accessible name — so a test that re-reads the label through
+     * JAB after a click only observes the change if the accessible name is
+     * updated alongside the visible text. Updating both keeps the on-screen UI
+     * and the JAB-visible accessibility tree honest and consistent.
+     *
+     * @param label  the status label to update.
+     * @param status the new status text (also set as the accessible name).
+     */
+    private static void setStatus(JLabel label, String status) {
+        label.setText(status);
+        label.getAccessibleContext().setAccessibleName(status);
     }
 
     /**
@@ -54,12 +79,23 @@ public final class SwingControlsFixture {
 
         JPanel controls = new JPanel(new GridLayout(0, 1, 4, 4));
 
+        // Created first so the button action listeners below can mutate it; it
+        // is still added to the panel in its original visual position.
+        JLabel statusLabel = new JLabel(STATUS_PENDING);
+        statusLabel.getAccessibleContext().setAccessibleName(STATUS_PENDING);
+
         JButton submitButton = new JButton("Submit Order");
         submitButton.getAccessibleContext().setAccessibleName("Submit Order");
+        // Actuating the button changes a JAB-observable property (the status
+        // label's accessible name), so a test can prove naturo's click reached
+        // the real Swing control — verify-after-action through Java Access
+        // Bridge, not just recognition.
+        submitButton.addActionListener(event -> setStatus(statusLabel, STATUS_SUBMITTED));
         controls.add(submitButton);
 
         JButton cancelButton = new JButton("Cancel Order");
         cancelButton.getAccessibleContext().setAccessibleName("Cancel Order");
+        cancelButton.addActionListener(event -> setStatus(statusLabel, STATUS_CANCELLED));
         controls.add(cancelButton);
 
         JTextField customerField = new JTextField("Ada Lovelace");
@@ -70,8 +106,6 @@ public final class SwingControlsFixture {
         expressCheck.getAccessibleContext().setAccessibleName("Express Shipping");
         controls.add(expressCheck);
 
-        JLabel statusLabel = new JLabel("Order Status: Pending");
-        statusLabel.getAccessibleContext().setAccessibleName("Order Status: Pending");
         controls.add(statusLabel);
 
         DefaultTableModel tableModel = new DefaultTableModel(

--- a/tests/test_jab_action_932.py
+++ b/tests/test_jab_action_932.py
@@ -1,0 +1,195 @@
+"""Live Java Access Bridge *action* assertions against the owned Swing fixture (#932).
+
+The recognition tests (``test_jab_recognition_932.py``) prove naturo *sees* Java
+controls through the Java Access Bridge (JAB) where a UIA-only baseline is blind.
+These tests close the remaining #932 slice: they prove naturo can *act* on a
+JAB-recognized Swing control and that the action genuinely takes effect — the
+"naturo click ... via JAB" half of the acceptance criteria.
+
+The proof is honest end-to-end and avoids self-confirmation:
+
+1. naturo recognizes a button through JAB (its screen rectangle comes from the
+   JAB tree — UIA cannot see it, as the recognition tests establish).
+2. naturo clicks the button's center via real ``SendInput`` injection.
+3. naturo re-reads the window through JAB and observes that the button's action
+   listener changed a *different* control's accessible name. The state that
+   changes is read back through the same JAB provider, so the assertion proves
+   the click reached the live Swing control — verify-after-action, not a
+   recognition tautology.
+
+A discriminating second action (Cancel → a different status) rules out the
+"any click flips to one fixed string" false positive.
+
+These are ``@pytest.mark.desktop`` because they launch a real JVM window, inject
+real input, and call the native DLL, so they run on an interactive Windows
+desktop with a JDK and JAB enabled — not on the headless CI runners. When that
+environment is absent the whole module is skipped.
+"""
+from __future__ import annotations
+
+import platform
+import time
+
+import pytest
+
+from benchmarks.recognition.harness import JavaSwingFixtureApp
+from naturo.backends.base import get_backend
+
+pytestmark = pytest.mark.desktop
+
+#: Status-label accessible-name states defined by ``SwingControlsFixture.java``.
+STATUS_PENDING = "Order Status: Pending"
+STATUS_SUBMITTED = "Order Status: Submitted"
+STATUS_CANCELLED = "Order Status: Cancelled"
+
+#: Bounded wait for the Swing event-dispatch thread to apply a click's action
+#: and for the JAB tree to reflect the new accessible name.
+_ACTION_SETTLE_SECONDS = 0.7
+_ACTION_POLL_TIMEOUT = 5.0
+
+
+def _fixture_available() -> bool:
+    """Whether this host can build and run the Java Swing fixture."""
+    return platform.system() == "Windows" and JavaSwingFixtureApp().available
+
+
+requires_fixture = pytest.mark.skipif(
+    not _fixture_available(),
+    reason="requires an interactive Windows desktop with a JDK (JAVA_HOME)",
+)
+
+
+def _find(node, predicate):
+    """Return the first element in ``node``'s subtree matching ``predicate``.
+
+    Args:
+        node: Root :class:`~naturo.backends.base.ElementInfo`, or ``None``.
+        predicate: Callable taking an element and returning ``True`` on a match.
+
+    Returns:
+        The first matching element, or ``None`` if none matches.
+    """
+    stack = [node]
+    while stack:
+        current = stack.pop()
+        if current is None:
+            continue
+        if predicate(current):
+            return current
+        stack.extend(current.children or [])
+    return None
+
+
+def _status_name(tree) -> str | None:
+    """Read the fixture's status-label accessible name from a JAB tree.
+
+    Args:
+        tree: Root JAB element tree for the fixture window.
+
+    Returns:
+        The status label's accessible name (e.g. ``"Order Status: Pending"``),
+        or ``None`` if the label is not present in the tree.
+    """
+    label = _find(tree, lambda element: (element.name or "").startswith("Order Status"))
+    return label.name if label is not None else None
+
+
+@pytest.fixture
+def swing_app():
+    """Launch a fresh Swing fixture per test so the initial status is known."""
+    if not _fixture_available():
+        pytest.skip("Java Swing fixture unavailable on this host")
+    app = JavaSwingFixtureApp()
+    with app:
+        window = app.find_window()
+        assert window is not None, "fixture window did not appear"
+        yield app, window
+
+
+def _jab_tree(backend, hwnd):
+    """Read the JAB element tree for ``hwnd`` (focused first for a stable read)."""
+    tree = backend.get_element_tree(hwnd=hwnd, depth=15, backend="jab")
+    assert tree is not None, "JAB returned no tree for the live Swing window"
+    return tree
+
+
+def _click_control_via_jab(backend, hwnd, control_name: str) -> None:
+    """Recognize a control through JAB and click its center via real input.
+
+    Args:
+        backend: The active naturo backend.
+        hwnd: The fixture window handle.
+        control_name: Accessible name of the control to click.
+
+    Raises:
+        AssertionError: If JAB does not recognize ``control_name``.
+    """
+    tree = _jab_tree(backend, hwnd)
+    control = _find(tree, lambda element: element.name == control_name)
+    assert control is not None, f"JAB did not recognize control {control_name!r}"
+    center_x = control.x + control.width // 2
+    center_y = control.y + control.height // 2
+    # Foreground the fixture so the injected click lands on it, then click the
+    # JAB-recognized coordinates through naturo's real input path.
+    backend.focus_window(hwnd=hwnd)
+    time.sleep(0.3)
+    backend.click(x=center_x, y=center_y)
+
+
+def _wait_for_status(backend, hwnd, expected: str) -> str:
+    """Poll the JAB tree until the status label reads ``expected`` (bounded).
+
+    Args:
+        backend: The active naturo backend.
+        hwnd: The fixture window handle.
+        expected: The accessible name the status label should reach.
+
+    Returns:
+        The status label's accessible name once it equals ``expected``, or its
+        last observed value if the timeout elapses (so the caller's assertion
+        reports the real divergence).
+    """
+    deadline = time.monotonic() + _ACTION_POLL_TIMEOUT
+    last = None
+    time.sleep(_ACTION_SETTLE_SECONDS)
+    while time.monotonic() < deadline:
+        last = _status_name(_jab_tree(backend, hwnd))
+        if last == expected:
+            return last
+        time.sleep(0.25)
+    return last
+
+
+@requires_fixture
+def test_naturo_click_actuates_jab_recognized_button(swing_app):
+    """naturo clicks a JAB-recognized Swing button and the action takes effect.
+
+    Causation chain, all observed through JAB:
+    * the status label starts at ``Pending``;
+    * clicking the JAB-recognized ``Submit Order`` button drives it to
+      ``Submitted``;
+    * clicking the JAB-recognized ``Cancel Order`` button then drives it to
+      ``Cancelled`` — a *different* result for a *different* button, ruling out
+      a fixed-string false positive.
+    """
+    _app, window = swing_app
+    backend = get_backend()
+
+    initial = _status_name(_jab_tree(backend, window.hwnd))
+    assert initial == STATUS_PENDING, (
+        f"fixture should start at {STATUS_PENDING!r}, got {initial!r}"
+    )
+
+    _click_control_via_jab(backend, window.hwnd, "Submit Order")
+    after_submit = _wait_for_status(backend, window.hwnd, STATUS_SUBMITTED)
+    assert after_submit == STATUS_SUBMITTED, (
+        "clicking the JAB-recognized 'Submit Order' button did not take effect: "
+        f"status is {after_submit!r}, expected {STATUS_SUBMITTED!r}"
+    )
+
+    _click_control_via_jab(backend, window.hwnd, "Cancel Order")
+    after_cancel = _wait_for_status(backend, window.hwnd, STATUS_CANCELLED)
+    assert after_cancel == STATUS_CANCELLED, (
+        "clicking the JAB-recognized 'Cancel Order' button did not take effect: "
+        f"status is {after_cancel!r}, expected {STATUS_CANCELLED!r}"
+    )


### PR DESCRIPTION
## What

Closes the **click-via-JAB action-assertion** slice of #932: prove naturo can not
only *recognize* but *act* on a Java/Swing control through the Java Access Bridge.

Until now #932 had proven recognition (`test_jab_recognition_932.py`: JAB recovers
every Swing control UIA is blind to) but the "naturo click … via JAB" half of the
acceptance criteria was unverified — it was blocked on input injection (#863), which
is no longer blocked in a console session.

- **`benchmarks/recognition/fixtures/java/SwingControlsFixture.java`** — the owned
  Swing fixture's `Submit Order` / `Cancel Order` buttons now carry `ActionListener`s
  that drive a status `JLabel` to `Order Status: Submitted` / `Order Status: Cancelled`.
  The listener updates both the visible text **and** the accessible name (Swing does
  not propagate `setText` to the accessible name, and JAB reports the accessible name),
  so the post-click state is observable through the same JAB provider that recognized
  the button. Recognition counts are unchanged (the named controls are identical), so
  the `docs/RECOGNITION.md` +40 row and `test_jab_recognition_932.py` still hold.
- **`tests/test_jab_action_932.py`** — a `@pytest.mark.desktop` test that:
  1. recognizes a button **through JAB** (its screen rectangle comes from the JAB tree,
     which UIA cannot see);
  2. clicks the button center via naturo's real `SendInput` path;
  3. re-reads the window through JAB and asserts the status label's accessible name
     changed — **verify-after-action through JAB**, not a recognition tautology.

  A discriminating second action (`Cancel Order` → a *different* status) rules out the
  "any click flips to one fixed string" false positive, and the fixture is relaunched
  per test so the initial `Pending` state is deterministic.

This is a test/fixture-only change — **no `naturo/` production code and no public API**.

### Scope note (follow-up filed)
naturo's JAB provider currently exposes element **`name`** but not `value` (JTextField
text) or checkbox toggle **state** (verified empirically: every JAB element's `value`
is empty and `properties` carries no state). So *type-via-JAB with verification* cannot
be asserted honestly yet — it needs the JAB value/state exposure, a native-core slice
filed separately. This PR delivers the click slice that is fully verifiable today.

## How tested

- `python -m pytest tests/test_jab_action_932.py -v` → **1 passed** (live, real desktop,
  real click): `Order Status: Pending` → click Submit (JAB coords) → `Submitted` →
  click Cancel (JAB coords) → `Cancelled`.
- `python -m pytest tests/test_jab_recognition_932.py tests/test_jab_action_932.py` →
  **5 passed** (recognition unaffected by the fixture change).
- `python -m pytest tests/test_jab_action_932.py --collect-only -q` → collects cleanly
  (module is `desktop`-marked, so CI deselects/skips it — cross-platform safe).
- `ruff check` clean on the changed files. Full non-desktop suite
  (`pytest tests/ -m "not desktop" --basetemp=<isolated>`): **6811 passed**; the only
  reds are the pre-existing, already-tracked in-progress flakes (#1175: `test_cost_guardrails`
  locale-encoding errors + `test_agent::test_total_time_recorded`) — none introduced by
  this change, which adds no production code.

## Independent verification

An independent fresh-context adversarial verifier (it did not write the code) **PASSED** this slice on the real desktop:

- **Premise reproduced:** `test_jab_recognition_932.py` → 4 passed (UIA blind to Swing controls; JAB attaches + recognizes all 5). Confirmed JAB exposes the status label's accessible `name` but `value=''` and no checkbox state — so the accessible-name channel is the honest one to assert on.
- **Fix runs live:** `pytest tests/test_jab_action_932.py` → 1 passed; an independent probe reproduced `Pending → Submit@(960,330) → Submitted → Cancel → Cancelled`.
- **Break-it checks survived:** reading status twice with **no click** stays `Pending` (not a tautology); Submit vs Cancel give **different** results (not a fixed string); clicking a **non-button** at the status-label coords leaves `Pending` (the JAB-recognized button coords are load-bearing); fresh fixture per test → deterministic initial state across 3 reruns.
- **CI-safe:** collect-only succeeds; `-m "not desktop"` deselects it (desktop marker registered); ruff clean; `git diff --name-only` shows the only tracked change is the fixture `.java` — no `naturo/` production code, so it cannot redden the cross-platform suite.
- **EVOLUTION:** the inverse of the green-CI/red-desktop non-hermetic class — mocks nothing, asserts real observed state, satisfies never-lie / verify-after-action.

Verdict: **PASS**, no blocking weaknesses.
