### PR TITLE
fix: surface JAB element states through the bridge + backend pipeline (part of #1200)

### DIFF
--- a/naturo/backends/windows/_element/_tree.py
+++ b/naturo/backends/windows/_element/_tree.py
@@ -332,7 +332,10 @@ class ElementTreeMixin:
                     # (#1200) Accessibility states (e.g. a JAB checkbox's
                     # checked/unchecked) are emitted by the native layer and must
                     # survive the bridge→backend conversion to reach consumers.
-                    "states": el.states,
+                    # getattr: backends that don't emit states (image/OCR/UWP
+                    # fallback, test fixtures) leave the attribute absent → None,
+                    # matching the dataclass default rather than crashing.
+                    "states": getattr(el, "states", None),
                 }.items() if v is not None
             }
 

--- a/naturo/backends/windows/_element/_tree.py
+++ b/naturo/backends/windows/_element/_tree.py
@@ -329,6 +329,10 @@ class ElementTreeMixin:
                 k: v for k, v in {
                     "parent_id": el.parent_id,
                     "keyboard_shortcut": el.keyboard_shortcut,
+                    # (#1200) Accessibility states (e.g. a JAB checkbox's
+                    # checked/unchecked) are emitted by the native layer and must
+                    # survive the bridge→backend conversion to reach consumers.
+                    "states": el.states,
                 }.items() if v is not None
             }
 

--- a/naturo/bridge/_models.py
+++ b/naturo/bridge/_models.py
@@ -137,6 +137,10 @@ class ElementInfo:
         parent_id: Parent element's id (filled by Python-layer traversal).
         keyboard_shortcut: Keyboard shortcut string (e.g., "Ctrl+S").
         hwnd: Win32 window handle (Windows only, for hybrid mode and direct messaging).
+        states: Accessibility state string emitted by the native layer, if any
+            (e.g., "enabled,focusable,visible,checked"). Currently populated by the
+            Java Access Bridge backend, which exposes a control's checked/selected
+            state; ``None`` for backends that do not emit states. (#1200)
     """
     id: str
     role: str
@@ -150,6 +154,7 @@ class ElementInfo:
     parent_id: Optional[str] = None
     keyboard_shortcut: Optional[str] = None
     hwnd: Optional[int] = None
+    states: Optional[str] = None
 
 
 def _parse_element(data: dict) -> ElementInfo:
@@ -174,6 +179,7 @@ def _parse_element(data: dict) -> ElementInfo:
         children=children,
         parent_id=data.get("parent_id"),
         keyboard_shortcut=data.get("keyboard_shortcut"),
+        states=data.get("states"),
     )
 
 

--- a/tests/test_bridge_models.py
+++ b/tests/test_bridge_models.py
@@ -305,6 +305,23 @@ class TestElementInfo:
         )
         assert e.hwnd == 65540
 
+    def test_states_default_none(self):
+        """states defaults to None for elements without accessibility states."""
+        e = ElementInfo(
+            id="e1", role="Edit", name="Input", value=None,
+            x=0, y=0, width=200, height=25,
+        )
+        assert e.states is None
+
+    def test_with_states(self):
+        """A checkbox-like element can carry its JAB accessibility states (#1200)."""
+        e = ElementInfo(
+            id="chk1", role="CheckBox", name="Express Shipping", value=None,
+            x=0, y=0, width=120, height=24,
+            states="enabled,focusable,visible,checked",
+        )
+        assert e.states == "enabled,focusable,visible,checked"
+
     def test_children_are_independent_lists(self):
         """Each ElementInfo should have its own children list."""
         e1 = ElementInfo(id="a", role="A", name="A", value=None, x=0, y=0, width=0, height=0)
@@ -358,6 +375,42 @@ class TestParseElement:
         assert elem.width == 80
         assert elem.height == 30
         assert elem.keyboard_shortcut == "Enter"
+
+    def test_states_absent_defaults_none(self):
+        """A native element JSON without a ``states`` key yields ``states=None``."""
+        elem = _parse_element({"id": "x", "role": "Button", "name": "OK"})
+        assert elem.states is None
+
+    def test_reads_states(self):
+        """``_parse_element`` surfaces the native ``states`` field (#1200).
+
+        The Java Access Bridge layer (``core/src/jab.cpp``) writes a ``states``
+        string into the per-element JSON, but the parser previously discarded it,
+        so a Swing ``JCheckBox``'s checked/unchecked state never reached any
+        Python consumer. Surfacing it unblocks honest verify-after-action for
+        JAB-driven checkbox/toggle automation (#932).
+        """
+        data = {
+            "id": "chk1",
+            "role": "CheckBox",
+            "name": "Express Shipping",
+            "x": 758, "y": 407, "width": 404, "height": 26,
+            "states": "enabled,focusable,visible,showing,checked",
+        }
+        elem = _parse_element(data)
+        assert elem.states == "enabled,focusable,visible,showing,checked"
+
+    def test_states_propagate_to_children(self):
+        """Each parsed child independently carries its own ``states``."""
+        data = {
+            "id": "panel", "role": "Pane", "name": "Form",
+            "children": [
+                {"id": "c1", "role": "CheckBox", "name": "A", "states": "checked"},
+                {"id": "c2", "role": "CheckBox", "name": "B", "states": "unchecked"},
+            ],
+        }
+        elem = _parse_element(data)
+        assert [c.states for c in elem.children] == ["checked", "unchecked"]
 
     def test_with_children(self):
         data = {

--- a/tests/test_jab_recognition_932.py
+++ b/tests/test_jab_recognition_932.py
@@ -138,6 +138,51 @@ def test_jab_recognizes_swing_controls(swing_app):
     assert not missing, f"JAB did not recognize controls: {sorted(missing)}"
 
 
+def _find_by_name(tree, name: str):
+    """Return the first element in ``tree`` whose name matches ``name``.
+
+    Args:
+        tree: Root :class:`~naturo.backends.base.ElementInfo`, or ``None``.
+        name: Exact (stripped) accessible name to look for.
+
+    Returns:
+        The matching :class:`ElementInfo`, or ``None`` if not found.
+    """
+    stack = [tree]
+    while stack:
+        node = stack.pop()
+        if node is None:
+            continue
+        if node.name and node.name.strip() == name:
+            return node
+        stack.extend(node.children or [])
+    return None
+
+
+@requires_fixture
+def test_jab_exposes_control_states(swing_app):
+    """The JAB backend surfaces accessibility ``states`` to the Python layer (#1200).
+
+    ``core/src/jab.cpp`` computes a ``states`` string for every element, but the
+    Python parser used to discard it, so a Swing ``JCheckBox``'s checked/unchecked
+    state never reached any consumer — blocking honest verify-after-action for
+    JAB-driven checkbox/toggle automation. This proves the field now round-trips
+    natively: the fixture's checkbox exposes a non-empty states string.
+    """
+    _app, window = swing_app
+    backend = get_backend()
+    tree = backend.get_element_tree(hwnd=window.hwnd, depth=15, backend="jab")
+    assert tree is not None, "JAB returned no tree for a live Swing window"
+
+    checkbox = _find_by_name(tree, "Express Shipping")
+    assert checkbox is not None, "JAB did not recognize the 'Express Shipping' checkbox"
+    states = checkbox.properties.get("states")
+    assert states is not None and states.strip(), (
+        "JAB checkbox exposed no accessibility states — the native 'states' field "
+        f"was dropped before reaching the backend element (got {states!r})"
+    )
+
+
 @requires_fixture
 def test_cascade_shows_positive_jab_delta(swing_app):
     """The full cascade recognizes more than UIA alone, with JAB as the source."""

--- a/tests/test_jab_states_convert_1200.py
+++ b/tests/test_jab_states_convert_1200.py
@@ -18,16 +18,19 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-from naturo.backends.windows._element._tree import ElementTreeMixin
 from naturo.bridge._models import ElementInfo
 
 
-def _make_backend(tree: ElementInfo) -> ElementTreeMixin:
+def _make_backend(tree: ElementInfo):
     """Build a minimal backend whose JAB tree fetch returns ``tree``.
 
     Mirrors the real Windows backend's resolution path while stubbing the native
-    core and the coordinate fixup (which needs a live window handle).
+    core and the coordinate fixup (which needs a live window handle). The Windows
+    backend mixin is imported inside this function (not at module top) so the test
+    module still collects on non-Windows CI, matching ``test_find_element_window_scoping_963``.
     """
+    from naturo.backends.windows._element._tree import ElementTreeMixin
+
     class _Harness(ElementTreeMixin):
         def __init__(self) -> None:
             self._core = MagicMock()

--- a/tests/test_jab_states_convert_1200.py
+++ b/tests/test_jab_states_convert_1200.py
@@ -1,0 +1,80 @@
+"""`states` survives the bridge→backend conversion in ``get_element_tree`` (#1200).
+
+The Java Access Bridge native layer emits a per-element ``states`` string, the
+bridge parser surfaces it on ``ElementInfo.states`` (the ``_models`` model), and
+the Windows backend's ``get_element_tree`` must carry it into the returned
+element's ``properties`` so a consumer — e.g. the #932 checkbox-via-JAB
+verify-after-action proof — can read a control's checked/unchecked state.
+
+Before #1200 the bridge ``ElementInfo`` dropped ``states`` in its parser, and the
+backend ``convert()`` step (bridge ``ElementInfo`` → ``backends.base.ElementInfo``)
+never copied it — so a JAB control's state never reached any consumer. These
+tests pin both halves of that path.
+
+Cross-platform / hermetic: the core and resolver are mocked, so no DLL or
+interactive desktop is needed and they run on CI.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from naturo.backends.windows._element._tree import ElementTreeMixin
+from naturo.bridge._models import ElementInfo
+
+
+def _make_backend(tree: ElementInfo) -> ElementTreeMixin:
+    """Build a minimal backend whose JAB tree fetch returns ``tree``.
+
+    Mirrors the real Windows backend's resolution path while stubbing the native
+    core and the coordinate fixup (which needs a live window handle).
+    """
+    class _Harness(ElementTreeMixin):
+        def __init__(self) -> None:
+            self._core = MagicMock()
+            self._core.jab_get_element_tree.return_value = tree
+
+        def _ensure_core(self):
+            return self._core
+
+        def _resolve_hwnd(self, app=None, window_title=None, hwnd=None, pid=None):
+            return hwnd or 1
+
+        def _fixup_element_coords(self, result, handle):
+            return result
+
+    return _Harness()
+
+
+def _element(**overrides) -> ElementInfo:
+    """A bridge ``ElementInfo`` with sensible defaults for these tests."""
+    fields = dict(
+        id="", role="CheckBox", name="Express Shipping", value=None,
+        x=0, y=0, width=10, height=10,
+    )
+    fields.update(overrides)
+    return ElementInfo(**fields)
+
+
+def test_jab_states_reach_backend_element_properties():
+    """A JAB element's ``states`` reaches the backend element's ``properties`` (#1200)."""
+    root = _element(role="Panel", name="Form", children=[
+        _element(states="enabled,focusable,visible,checked"),
+    ])
+    backend = _make_backend(root)
+
+    result = backend.get_element_tree(hwnd=42, backend="jab")
+
+    assert result is not None
+    checkbox = result.children[0]
+    assert checkbox.properties.get("states") == "enabled,focusable,visible,checked"
+
+
+def test_element_without_states_omits_property_key():
+    """A UIA-style element with no ``states`` gets no spurious ``states`` key."""
+    root = _element(role="Panel", name="Form", children=[_element(states=None)])
+    backend = _make_backend(root)
+
+    result = backend.get_element_tree(hwnd=42, backend="jab")
+
+    assert result is not None
+    assert "states" not in result.children[0].properties


### PR DESCRIPTION
## What

The Java Access Bridge native layer (`core/src/jab.cpp`) computes a per-element
`states` string (e.g. a `JCheckBox`'s `checked`/`unchecked`) and writes it into the element
JSON, but it never reached any Python consumer — so honest verify-after-action for
JAB-driven `type`/checkbox automation was impossible. It was dropped at **two** layers:

1. **The bridge parser** `_parse_element` (`naturo/bridge/_models.py`) never read `"states"`,
   so the bridge `ElementInfo` discarded it.
2. **The backend conversion** `convert()` in `naturo/backends/windows/_element/_tree.py`
   (bridge `ElementInfo` → `backends.base.ElementInfo`, the object `get_element_tree` actually
   returns) copied `parent_id`/`keyboard_shortcut`/value-preview into `properties` but **not
   `states`** — so even after fixing layer 1, the field died before reaching `see`/`find`/the
   #932 desktop tests.

This PR plumbs `states` through **both** layers — **Gap 1 of #1200** (the pure-Python,
no-native-rebuild gap):

- `ElementInfo` (bridge) gains `states: Optional[str] = None`; `_parse_element` reads
  `data.get("states")`.
- `convert()` carries `el.states` into the backend element's `properties["states"]` when present
  (same mechanism as `keyboard_shortcut`). `states` is JAB-specific, so `properties` — explicitly
  "backend-specific properties" — is the idiomatic carrier.

`states` is populated by the JAB backend today (UIA/MSAA/IA2 do not emit a `states` field
natively at HEAD — verified); it is simply absent from `properties` for elements that have none.
The change is additive and does **not** alter the public `UIElement`/CLI/MCP output schema.

## Why

Unblocks the remaining **#932** Java-recognition action slice that PR #1199 (click-via-JAB)
could not cover — **checkbox/toggle-via-JAB with verify-after-action**, which reads a control's
`states` back after a toggle. It is the direct dependency the #1200 follow-up identified.

## Scope / what remains on #1200

- **Gap 2** (JAB `value` sourced from the accessible *description* rather than
  `AccessibleText`/`getCurrentAccessibleValue`) needs a native C++ change + rebuild and is **not**
  in this PR — #1200 stays open for it.
- Surfacing `states` into the public `see`/`find`/MCP output schema (`UIElement`) is a separate,
  deliberately-scoped follow-up (it would expand the public element envelope).

## How tested

- `ruff check naturo/` clean; `mypy` clean on both changed modules.
- New hermetic unit tests (CI-runnable, no DLL/desktop):
  - `tests/test_bridge_models.py` — `_parse_element` reads `states`, defaults `None`, propagates per-child.
  - `tests/test_jab_states_convert_1200.py` — pins the **conversion layer**: a JAB element's `states`
    reaches the backend element's `properties`, and elements without states get no spurious key.
- New live `@pytest.mark.desktop` test `tests/test_jab_recognition_932.py::test_jab_exposes_control_states`
  — on the owned OpenJDK-21 Swing fixture, `get_backend().get_element_tree(..., backend="jab")` now
  exposes the `Express Shipping` checkbox's `states` via `properties` (empty/absent before this fix).
- Full non-desktop `tests/` summary in the cycle gate report.

## Independent verification

A fresh-context adversarial verifier initially returned **FAIL**, correctly catching that the
first revision fixed only the bridge parser while `convert()` still dropped `states` at the
bridge→backend boundary (the live @desktop test hit `AttributeError: 'ElementInfo' object has no
attribute 'states'` on the real Swing fixture). This PR adds the `convert()` fix + a CI-runnable
test pinning that layer, then was re-verified.
