### PR TITLE
fix: conftest uses os.name not platform.system() — stop headless pytest hang (fixes #1204)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import platform
 from typing import Optional
 from unittest.mock import MagicMock
 
@@ -16,7 +15,7 @@ import pytest
 # we monkeypatch the constructors to auto-skip on CI Windows.
 
 _ON_CI = os.environ.get("CI") == "true"
-_IS_WINDOWS = platform.system() == "Windows"
+_IS_WINDOWS = os.name == "nt"
 _CI_WINDOWS = _ON_CI and _IS_WINDOWS
 
 if _CI_WINDOWS:
@@ -73,7 +72,7 @@ def _has_desktop_session() -> bool:
 
     Always returns False on non-Windows platforms.
     """
-    if platform.system() != "Windows":
+    if os.name != "nt":
         return False
     try:
         import ctypes
@@ -210,10 +209,10 @@ def cli_stdout(result):
 
 @pytest.fixture
 def is_windows():
-    return platform.system() == "Windows"
+    return os.name == "nt"
 
 
 @pytest.fixture
 def skip_if_not_windows():
-    if platform.system() != "Windows":
+    if os.name != "nt":
         pytest.skip("Windows-only test")

--- a/tests/test_conftest_no_platform_spawn_1204.py
+++ b/tests/test_conftest_no_platform_spawn_1204.py
@@ -1,0 +1,49 @@
+"""Regression guard for #1204: the test harness must not call ``platform.system()``.
+
+`platform.system()` (via `platform.uname()` → `_syscmd_ver()`) shells out to
+``cmd /c ver`` on Windows. In a headless / no-console session that subprocess can
+**never return**, so any module-level `platform.system()` in `conftest.py` hangs
+pytest at collection time — which silently degrades the local test gate (a Dev
+cycle then can't run the full suite, so blast-radius misses ship Windows-green /
+CI-red, e.g. #1203). Use the cheap constant ``os.name == "nt"`` instead.
+
+This test fails if `conftest.py` ever reintroduces a `platform.system()` *call*,
+keeping the harness hang-free. (Source/AST scan, not a runtime spawn — itself safe.)
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+CONFTEST = Path(__file__).parent / "conftest.py"
+
+
+def _platform_system_calls(source: str) -> list[int]:
+    """Line numbers of any `platform.system(...)` call expression in *source*."""
+    tree = ast.parse(source)
+    hits: list[int] = []
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "system"
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "platform"
+        ):
+            hits.append(node.lineno)
+    return hits
+
+
+def test_conftest_does_not_call_platform_system() -> None:
+    hits = _platform_system_calls(CONFTEST.read_text(encoding="utf-8"))
+    assert not hits, (
+        "tests/conftest.py calls platform.system() at line(s) "
+        f"{hits} — this spawns `cmd /c ver` and HANGS pytest in a headless "
+        "session (#1204). Use `os.name == 'nt'` instead."
+    )
+
+
+def test_guard_detects_a_real_platform_system_call() -> None:
+    """Positive control: the AST scanner actually catches the bad pattern."""
+    bad = "import platform\nflag = platform.system() == 'Windows'\n"
+    assert _platform_system_calls(bad) == [2]


### PR DESCRIPTION
## What
`tests/conftest.py` called `platform.system()` at module level. On Windows that shells out to `cmd /c ver` (via `platform.uname()` → `_syscmd_ver()`), which **never returns in a headless / no-console session** → pytest hangs at collection. This degraded the local test gate: a Dev cycle couldn't run the full suite, so blast-radius misses shipped Windows-green / CI-red (e.g. #1203 `test_uwp_fallback` AttributeError caught only by CI).

Swapped the 4 Windows checks to the cheap constant `os.name == "nt"` (no subprocess), removed the now-unused `import platform`.

## How tested
- Reproduced: `timeout 3 python -c "import platform; platform.system()"` **hangs** in this session.
- After fix: `pytest tests/test_bridge_errors.py --co` collects in **0.32s** (was hanging).
- Added `tests/test_conftest_no_platform_spawn_1204.py` — an AST source-guard (with positive control) that fails if `conftest.py` ever reintroduces a `platform.system()` call. `2 passed in 0.45s`.

Fixes #1204. **[Orc-Mycelium]** (fixed directly per Ace's "fix-before-continue" — this is the root cause behind the #1203 CI red.)