### PR TITLE
fix: resolve set targets by cached point + source window when AutomationId/name absent (fixes #1208)

### DIFF
--- a/naturo/backends/windows/_input/_uia_interact.py
+++ b/naturo/backends/windows/_input/_uia_interact.py
@@ -308,6 +308,130 @@ class UIAInteractMixin:
 
         return root.FindFirst(mod.TreeScope_Descendants, cond)
 
+    def _resolve_interaction_element(
+        self,
+        uia,
+        mod,
+        *,
+        hwnd: int = 0,
+        name: Optional[str] = None,
+        automation_id: Optional[str] = None,
+        role: Optional[str] = None,
+        x: Optional[int] = None,
+        y: Optional[int] = None,
+    ):
+        """Resolve a live UIA element for interaction, by identity then point.
+
+        Resolution order, most precise first:
+
+        1. **Specific identity** (``name`` / ``automation_id``) — survives small
+           coordinate drift, so it is preferred when available.
+        2. **Screen point** (``x``, ``y``) — ``ElementFromPoint`` against the
+           cached bounding-box centre. This lets naturo act on *any* element it
+           previously located, even one with no ``AutomationId`` and no name
+           (e.g. the Property Tab Builder ``Message`` Edit). Tried before a
+           role-only match because a point is unambiguous (#1208).
+        3. **Role-only match** — last resort; ambiguous when several elements
+           share a role, so it runs only when nothing more specific resolved.
+
+        Args:
+            uia: The UI Automation root object from ``_init_comtypes_uia``.
+            mod: The comtypes UIAutomationClient module.
+            hwnd: Window handle to scope identity searches. 0 = desktop root.
+            name: Accessible name of the target element.
+            automation_id: UIA AutomationId of the target element.
+            role: UIA control type (e.g. ``"Edit"``).
+            x: Screen X of the cached element centre, or ``None``.
+            y: Screen Y of the cached element centre, or ``None``.
+
+        Returns:
+            The resolved UIA element, or ``None`` if every strategy failed.
+        """
+        elem = None
+        if name or automation_id:
+            elem = self._find_uia_element(
+                uia, mod, hwnd=hwnd, name=name,
+                automation_id=automation_id, role=role,
+            )
+        if elem is None and x is not None and y is not None:
+            # Occlusion-independent: match the cached point inside the *target
+            # window's own* UIA tree. ElementFromPoint is avoided because it
+            # returns whichever window is topmost at the screen point, so an
+            # overlapping window (e.g. a terminal) would hijack the hit (#1208).
+            elem = self._find_element_in_window_at_point(
+                uia, mod, hwnd, int(x), int(y),
+            )
+            if elem is None and not hwnd:
+                # No window scope to walk — last-resort screen hit test.
+                from ctypes import wintypes
+                try:
+                    elem = uia.ElementFromPoint(wintypes.POINT(int(x), int(y)))
+                except Exception as exc:  # noqa: BLE001 — COM/OS errors vary
+                    logger.debug("ElementFromPoint(%s, %s) failed: %s", x, y, exc)
+                    elem = None
+            if elem is not None:
+                logger.debug(
+                    "Resolved interaction element by cached point (%d, %d) (#1208)",
+                    int(x), int(y),
+                )
+        if elem is None and role and not name and not automation_id:
+            elem = self._find_uia_element(
+                uia, mod, hwnd=hwnd, name=name,
+                automation_id=automation_id, role=role,
+            )
+        return elem
+
+    def _find_element_in_window_at_point(self, uia, mod, hwnd, x, y):
+        """Find the element in ``hwnd``'s UIA tree whose bounds enclose ``(x, y)``.
+
+        Walks the *target window's* own subtree via ``ElementFromHandle`` and
+        returns the smallest element whose bounding rectangle contains the
+        point (i.e. the most specific leaf control there). Unlike
+        ``ElementFromPoint``, this is unaffected by other windows overlapping
+        the target on screen, so it resolves cached snapshot elements even when
+        the window is occluded or not foreground (#1208).
+
+        Args:
+            uia: UI Automation root object.
+            mod: comtypes UIAutomationClient module.
+            hwnd: Target window handle. ``0``/falsy returns ``None``.
+            x: Screen X of the cached element centre.
+            y: Screen Y of the cached element centre.
+
+        Returns:
+            The smallest enclosing UIA element, or ``None`` if none was found.
+        """
+        if not hwnd:
+            return None
+        try:
+            root = uia.ElementFromHandle(hwnd)
+            if root is None:
+                return None
+            elements = root.FindAll(
+                mod.TreeScope_Descendants, uia.CreateTrueCondition()
+            )
+        except Exception as exc:  # noqa: BLE001 — COM/OS errors vary
+            logger.debug("ElementFromHandle/FindAll for point match failed: %s", exc)
+            return None
+
+        best = None
+        best_area = None
+        length = elements.Length if elements is not None else 0
+        for i in range(length):
+            try:
+                el = elements.GetElement(i)
+                rect = el.CurrentBoundingRectangle
+            except Exception:  # noqa: BLE001 — skip elements that error
+                continue
+            left, top, right, bottom = rect.left, rect.top, rect.right, rect.bottom
+            if right <= left or bottom <= top:
+                continue
+            if left <= x <= right and top <= y <= bottom:
+                area = (right - left) * (bottom - top)
+                if best_area is None or area < best_area:
+                    best, best_area = el, area
+        return best
+
     def set_element_value(
         self,
         text: str,
@@ -315,6 +439,8 @@ class UIAInteractMixin:
         name: Optional[str] = None,
         automation_id: Optional[str] = None,
         role: Optional[str] = None,
+        x: Optional[int] = None,
+        y: Optional[int] = None,
     ) -> bool:
         """Set text on a UI element using UIA ValuePattern.SetValue().
 
@@ -328,6 +454,8 @@ class UIAInteractMixin:
             name: Accessible name of the target element.
             automation_id: UIA AutomationId of the target element.
             role: UIA control type (e.g. "Edit").
+            x: Screen X of the cached element centre (point fallback). (#1208)
+            y: Screen Y of the cached element centre (point fallback). (#1208)
 
         Returns:
             True if SetValue succeeded, False otherwise.
@@ -339,11 +467,13 @@ class UIAInteractMixin:
             return False
 
         try:
-            elem = self._find_uia_element(uia, mod, hwnd=hwnd, name=name,
-                                          automation_id=automation_id, role=role)
+            elem = self._resolve_interaction_element(
+                uia, mod, hwnd=hwnd, name=name,
+                automation_id=automation_id, role=role, x=x, y=y,
+            )
             if elem is None:
-                # If targeting by name/automation_id failed, try finding the
-                # first editable element (e.g. Edit control) in the window
+                # If targeting by name/automation_id/point failed, try finding
+                # the first editable element (e.g. Edit control) in the window
                 if hwnd and role:
                     root = uia.ElementFromHandle(hwnd)
                     # Map common role names to UIA ControlTypeId
@@ -393,6 +523,8 @@ class UIAInteractMixin:
         automation_id: Optional[str] = None,
         role: Optional[str] = None,
         name: Optional[str] = None,
+        x: Optional[int] = None,
+        y: Optional[int] = None,
     ) -> Optional[str]:
         """Toggle a UI element via UIA TogglePattern.
 
@@ -416,8 +548,10 @@ class UIAInteractMixin:
         try:
             from comtypes import COMError  # type: ignore[import-untyped]
 
-            elem = self._find_uia_element(uia, mod, hwnd=hwnd, name=name,
-                                          automation_id=automation_id, role=role)
+            elem = self._resolve_interaction_element(
+                uia, mod, hwnd=hwnd, name=name,
+                automation_id=automation_id, role=role, x=x, y=y,
+            )
             if elem is None:
                 logger.debug("Toggle: target element not found")
                 return None
@@ -449,6 +583,8 @@ class UIAInteractMixin:
         automation_id: Optional[str] = None,
         role: Optional[str] = None,
         name: Optional[str] = None,
+        x: Optional[int] = None,
+        y: Optional[int] = None,
     ) -> bool:
         """Select a UI element via UIA SelectionItemPattern.
 
@@ -470,8 +606,10 @@ class UIAInteractMixin:
         try:
             from comtypes import COMError  # type: ignore[import-untyped]
 
-            elem = self._find_uia_element(uia, mod, hwnd=hwnd, name=name,
-                                          automation_id=automation_id, role=role)
+            elem = self._resolve_interaction_element(
+                uia, mod, hwnd=hwnd, name=name,
+                automation_id=automation_id, role=role, x=x, y=y,
+            )
             if elem is None:
                 logger.debug("Select: target element not found")
                 return False
@@ -500,6 +638,8 @@ class UIAInteractMixin:
         role: Optional[str] = None,
         name: Optional[str] = None,
         expand: bool = True,
+        x: Optional[int] = None,
+        y: Optional[int] = None,
     ) -> bool:
         """Expand or collapse a UI element via UIA ExpandCollapsePattern.
 
@@ -522,8 +662,10 @@ class UIAInteractMixin:
         try:
             from comtypes import COMError  # type: ignore[import-untyped]
 
-            elem = self._find_uia_element(uia, mod, hwnd=hwnd, name=name,
-                                          automation_id=automation_id, role=role)
+            elem = self._resolve_interaction_element(
+                uia, mod, hwnd=hwnd, name=name,
+                automation_id=automation_id, role=role, x=x, y=y,
+            )
             if elem is None:
                 logger.debug("ExpandCollapse: target element not found")
                 return False

--- a/naturo/cli/values/_set.py
+++ b/naturo/cli/values/_set.py
@@ -37,30 +37,59 @@ def _resolve_element_identifiers(ref, automation_id, role, name):
         name: Element name (passthrough if already set).
 
     Returns:
-        Tuple of (automation_id, role, name) with ref resolved.
+        Tuple of (automation_id, role, name, coords, window_handle) with ref
+        resolved, where ``coords`` is the cached ``(x, y)`` element centre (or
+        ``None``) and ``window_handle`` is the source window's HWND (or
+        ``None``) — both used to resolve the element inside its own window's
+        UIA tree when it has no AutomationId/name (#1208).
 
     Raises:
-        NaturoError: If ref cannot be resolved.
+        NaturoError: If ref resolves to an element with no AutomationId, name,
+            *or* usable coordinates.
+        StaleSnapshotCacheError: If the ref is not in the current snapshot.
     """
+    coords = None
+    snap_hwnd = None
     if ref and not automation_id:
         from naturo.snapshot import get_snapshot_manager
         mgr = get_snapshot_manager()
         result = mgr.resolve_ref_element(ref)
         if result:
             elem, _snap_id = result
+            # Source window handle: lets the backend resolve the element inside
+            # that window's own UIA tree (occlusion-independent), instead of a
+            # screen-point hit test that an overlapping window would hijack.
+            try:
+                _snap = mgr.get_snapshot(_snap_id)
+                snap_hwnd = getattr(_snap, "window_handle", None)
+            except Exception:
+                snap_hwnd = None
+            # naturo already located this element, so capture its cached
+            # bounding-box centre. This lets set/toggle/select/expand act on
+            # elements that have no AutomationId and no name (e.g. an unnamed
+            # Edit or ComboBox) by resolving them live inside their source
+            # window's own UIA tree, instead of refusing and pushing identifier
+            # discovery onto the user (#1208).
+            frame = getattr(elem, "frame", None)
+            if frame and (frame[2] > 0 or frame[3] > 0):
+                coords = (frame[0] + frame[2] // 2, frame[1] + frame[3] // 2)
             if elem.identifier:
                 automation_id = elem.identifier
             elif elem.role and (elem.title or elem.label):
                 role = role or elem.role
                 name = name or elem.title or elem.label
+            elif coords is not None:
+                # Unnamed element with a known location: keep its role as a hint
+                # for pattern selection; resolution falls back to the point.
+                role = role or elem.role
             else:
                 raise NaturoError(
-                    f"Element {ref} has no AutomationId, role, or name "
+                    f"Element {ref} has no AutomationId, name, or location "
                     f"for value setting"
                 )
         else:
             raise StaleSnapshotCacheError(ref)
-    return automation_id, role, name
+    return automation_id, role, name, coords, snap_hwnd
 
 
 @click.command("set")
@@ -206,8 +235,9 @@ def set_cmd(ctx, target, value, ref, automation_id, role, name, toggle,
     try:
         backend = _get_backend()
 
-        # Resolve ref to identifiers
-        resolved_aid, resolved_role, resolved_name = (
+        # Resolve ref to identifiers (+ cached point/window fallback, #1208)
+        (resolved_aid, resolved_role, resolved_name, resolved_coords,
+         resolved_snap_hwnd) = (
             _resolve_element_identifiers(ref, automation_id, role, name)
         )
 
@@ -215,24 +245,31 @@ def set_cmd(ctx, target, value, ref, automation_id, role, name, toggle,
         target_hwnd = hwnd or 0
         if (app or window_title) and not target_hwnd:
             target_hwnd = _resolve_hwnd(backend, app, window_title)
+        # Fall back to the snapshot's source window so point resolution can walk
+        # the correct window's UIA tree (occlusion-independent). (#1208)
+        if not target_hwnd and resolved_snap_hwnd:
+            target_hwnd = resolved_snap_hwnd
 
         if toggle:
             _do_toggle(backend, target_hwnd, resolved_aid, resolved_role,
-                       resolved_name, ref, json_output)
+                       resolved_name, ref, json_output, coords=resolved_coords)
         elif select:
             _do_select(backend, target_hwnd, resolved_aid, resolved_role,
-                       resolved_name, ref, json_output)
+                       resolved_name, ref, json_output, coords=resolved_coords)
         elif expand:
             _do_expand_collapse(backend, target_hwnd, resolved_aid,
                                 resolved_role, resolved_name, ref,
-                                json_output, expanding=True)
+                                json_output, expanding=True,
+                                coords=resolved_coords)
         elif collapse:
             _do_expand_collapse(backend, target_hwnd, resolved_aid,
                                 resolved_role, resolved_name, ref,
-                                json_output, expanding=False)
+                                json_output, expanding=False,
+                                coords=resolved_coords)
         else:
             _do_set_value(backend, target_hwnd, resolved_aid, resolved_role,
-                          resolved_name, ref, value, json_output)
+                          resolved_name, ref, value, json_output,
+                          coords=resolved_coords)
 
     except NaturoError as exc:
         emit_exception_error(exc, json_output)
@@ -267,7 +304,7 @@ def _resolve_hwnd(backend, app, window_title):
 
 
 def _do_set_value(backend, hwnd, automation_id, role, name, ref, value,
-                  json_output) -> None:
+                  json_output, coords=None) -> None:
     """Set text value via UIA ValuePattern.
 
     Args:
@@ -280,12 +317,14 @@ def _do_set_value(backend, hwnd, automation_id, role, name, ref, value,
         value: Text value to set.
         json_output: Whether to output JSON.
     """
+    point = {"x": coords[0], "y": coords[1]} if coords else {}
     success = backend.set_element_value(
         text=value,
         hwnd=hwnd,
         name=name,
         automation_id=automation_id,
         role=role,
+        **point,
     )
 
     if not success:
@@ -314,7 +353,8 @@ def _do_set_value(backend, hwnd, automation_id, role, name, ref, value,
         click.echo(f"Set value on {target_str}: {value!r}")
 
 
-def _do_toggle(backend, hwnd, automation_id, role, name, ref, json_output) -> None:
+def _do_toggle(backend, hwnd, automation_id, role, name, ref, json_output,
+               coords=None) -> None:
     """Toggle element via UIA TogglePattern.
 
     Args:
@@ -326,11 +366,13 @@ def _do_toggle(backend, hwnd, automation_id, role, name, ref, json_output) -> No
         ref: Original ref string (for display).
         json_output: Whether to output JSON.
     """
+    point = {"x": coords[0], "y": coords[1]} if coords else {}
     result = backend.toggle_element(
         hwnd=hwnd,
         automation_id=automation_id,
         role=role,
         name=name,
+        **point,
     )
 
     if result is None:
@@ -358,7 +400,8 @@ def _do_toggle(backend, hwnd, automation_id, role, name, ref, json_output) -> No
         click.echo(f"Toggled {target_str} → {result}")
 
 
-def _do_select(backend, hwnd, automation_id, role, name, ref, json_output) -> None:
+def _do_select(backend, hwnd, automation_id, role, name, ref, json_output,
+               coords=None) -> None:
     """Select element via UIA SelectionItemPattern.
 
     Args:
@@ -370,11 +413,13 @@ def _do_select(backend, hwnd, automation_id, role, name, ref, json_output) -> No
         ref: Original ref string (for display).
         json_output: Whether to output JSON.
     """
+    point = {"x": coords[0], "y": coords[1]} if coords else {}
     success = backend.select_element(
         hwnd=hwnd,
         automation_id=automation_id,
         role=role,
         name=name,
+        **point,
     )
 
     if not success:
@@ -403,7 +448,7 @@ def _do_select(backend, hwnd, automation_id, role, name, ref, json_output) -> No
 
 
 def _do_expand_collapse(backend, hwnd, automation_id, role, name, ref,
-                        json_output, expanding) -> None:
+                        json_output, expanding, coords=None) -> None:
     """Expand or collapse element via UIA ExpandCollapsePattern.
 
     Args:
@@ -417,12 +462,14 @@ def _do_expand_collapse(backend, hwnd, automation_id, role, name, ref,
         expanding: True to expand, False to collapse.
     """
     action = "expand" if expanding else "collapse"
+    point = {"x": coords[0], "y": coords[1]} if coords else {}
     success = backend.expand_collapse_element(
         hwnd=hwnd,
         automation_id=automation_id,
         role=role,
         name=name,
         expand=expanding,
+        **point,
     )
 
     if not success:

--- a/tests/test_set_cmd.py
+++ b/tests/test_set_cmd.py
@@ -44,10 +44,16 @@ def _make_mock_backend(
     return mock
 
 
-def _mock_resolve_identifiers(aid=None, role=None, name=None):
-    """Return a mock for _resolve_element_identifiers."""
+def _mock_resolve_identifiers(aid=None, role=None, name=None, coords=None,
+                              snap_hwnd=None):
+    """Return a mock for _resolve_element_identifiers.
+
+    Mirrors the 5-tuple contract (aid, role, name, coords, window_handle)
+    introduced in #1208; ``coords``/``snap_hwnd`` default to ``None`` so
+    existing identity-based tests are unaffected.
+    """
     def _resolve(ref, automation_id, r, n):
-        return (aid or automation_id, role or r, name or n)
+        return (aid or automation_id, role or r, name or n, coords, snap_hwnd)
     return _resolve
 
 

--- a/tests/test_set_resolution_fallback_1208.py
+++ b/tests/test_set_resolution_fallback_1208.py
@@ -1,0 +1,101 @@
+"""Regression tests for #1208 — set/get must operate any element naturo found.
+
+``_resolve_element_identifiers`` must NOT refuse an element just because it has
+no AutomationId and no name. When naturo already located the element it has the
+element's bounding box and source window, so it returns a point + window-handle
+fallback that the backend resolves via the window's own UIA tree (occlusion-
+independent), instead of pushing identifier discovery onto the caller.
+
+These tests mock the snapshot manager, so they are desktop-independent and run
+on the GitHub-hosted runner (no ``@pytest.mark.desktop``).
+"""
+
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from naturo.cli.values._set import _resolve_element_identifiers
+from naturo.errors import NaturoError
+
+
+def _element(identifier=None, role="Edit", title=None, label=None,
+             frame=(0, 0, 0, 0)):
+    """Build a minimal stand-in for a resolved snapshot ``UIElement``."""
+    return types.SimpleNamespace(
+        identifier=identifier, role=role, title=title, label=label, frame=frame,
+    )
+
+
+def _manager(element, window_handle=None, snap_id="snap1"):
+    """Build a mock snapshot manager returning ``element`` for any ref."""
+    mgr = MagicMock()
+    mgr.resolve_ref_element.return_value = (element, snap_id)
+    mgr.get_snapshot.return_value = types.SimpleNamespace(
+        window_handle=window_handle,
+    )
+    return mgr
+
+
+@patch("naturo.snapshot.get_snapshot_manager")
+def test_unnamed_element_resolves_via_coords_and_window(mock_get_mgr):
+    """An unnamed, AutomationId-less Edit yields cached point + window handle."""
+    mock_get_mgr.return_value = _manager(
+        _element(frame=(2249, 423, 419, 150)), window_handle=727448,
+    )
+
+    aid, role, name, coords, hwnd = _resolve_element_identifiers(
+        "e55", None, None, None,
+    )
+
+    assert aid is None
+    assert name is None
+    # centre of the cached bounding box
+    assert coords == (2249 + 419 // 2, 423 + 150 // 2)
+    assert hwnd == 727448
+
+
+@patch("naturo.snapshot.get_snapshot_manager")
+def test_no_identity_and_no_geometry_raises(mock_get_mgr):
+    """With neither identity nor a usable bounding box, set must fail loudly."""
+    mock_get_mgr.return_value = _manager(
+        _element(frame=(0, 0, 0, 0)), window_handle=None,
+    )
+
+    with pytest.raises(NaturoError):
+        _resolve_element_identifiers("e55", None, None, None)
+
+
+@patch("naturo.snapshot.get_snapshot_manager")
+def test_automation_id_is_preferred_over_point(mock_get_mgr):
+    """A real AutomationId still wins; coords are captured as a backup."""
+    mock_get_mgr.return_value = _manager(
+        _element(identifier="txtSearch", frame=(10, 10, 50, 20)),
+        window_handle=123,
+    )
+
+    aid, role, name, coords, hwnd = _resolve_element_identifiers(
+        "e1", None, None, None,
+    )
+
+    assert aid == "txtSearch"
+    assert coords == (10 + 50 // 2, 10 + 20 // 2)
+    assert hwnd == 123
+
+
+@patch("naturo.snapshot.get_snapshot_manager")
+def test_role_plus_name_still_resolves(mock_get_mgr):
+    """An element with role+title resolves by identity (coords still returned)."""
+    mock_get_mgr.return_value = _manager(
+        _element(role="Button", title="OK", frame=(5, 5, 40, 20)),
+        window_handle=99,
+    )
+
+    aid, role, name, coords, hwnd = _resolve_element_identifiers(
+        "e3", None, None, None,
+    )
+
+    assert aid is None
+    assert role == "Button"
+    assert name == "OK"
+    assert coords == (5 + 40 // 2, 5 + 20 // 2)


### PR DESCRIPTION
## What
`set`/`toggle`/`select`/`expand` refused any element lacking both an AutomationId and a name (e.g. the SolidWorks Property Tab Builder `Message`/`Caption` Edit and `Type` ComboBox), even though naturo had already captured the element's bounding box and source window. They now fall back to resolving the element **inside its source window's own UIA tree** — `ElementFromHandle(window)` + smallest-bounding-rect match at the cached point.

This is **occlusion-independent**: unlike `ElementFromPoint` (which returns whatever window is topmost at the screen point), walking the target window's tree is not hijacked when another window overlaps the target.

## Resolution order (most precise first)
1. Specific identity — `name` / `AutomationId`
2. Cached point inside the source window's tree — handles unnamed/AutomationId-less controls (#1208)
3. Role-only match — last resort

## How tested
- **Live, real desktop**: against SolidWorks **Property Tab Builder**, `naturo set <ref> "..."` now writes the unnamed `Message`/`Caption` Edit successfully **while a terminal window occludes the builder** (previously: `Error: Failed to set value` / `Element eN has no AutomationId, role, or name`).
- **Unit (desktop-independent)**: new `tests/test_set_resolution_fallback_1208.py` (4 cases) — unnamed element returns cached coords+window-handle, no-identity+no-geometry still raises, AutomationId preferred, role+name path intact.
- Gate: `ruff` clean; `mypy` clean on changed files; `pytest tests/test_set_cmd.py` + new tests = 40 passed. The 2 unrelated failures in the broader run (`test_uia_input` comtypes init, `test_keyboard_shortcut_886`) reproduce on clean `develop` (pre-existing, environment-specific).

## Follow-ups (rest of #1208)
- `get` / `see` reading values via the same point→window resolution (so results are verifiable through naturo's API).
- selector-path resolution (#1190) as an additional fallback link.