### PR TITLE
fix: report the window a coordinate click actually hit; fail loudly on wrong-process target (fixes #1207)

### DIFF
--- a/naturo/cli/interaction/_click.py
+++ b/naturo/cli/interaction/_click.py
@@ -34,6 +34,65 @@ def _get_screen_bound() -> int:
     return 65535
 
 
+def _window_root_at_point(x: int, y: int):
+    """Return the top-level window actually under screen point ``(x, y)``.
+
+    Lets the click command report which window a coordinate click really
+    landed on, so naturo never claims success when an overlapping window — or
+    a failed foreground switch — silently received the click instead (#1207).
+
+    Args:
+        x: Screen X coordinate.
+        y: Screen Y coordinate.
+
+    Returns:
+        ``(root_hwnd, title, pid)`` for the top-level window at the point, or
+        ``None`` if it cannot be determined (e.g. non-Windows or no window).
+    """
+    import sys
+    if sys.platform != "win32":
+        return None
+    try:
+        import ctypes
+        from ctypes import wintypes
+        user32 = ctypes.windll.user32
+        user32.WindowFromPoint.restype = wintypes.HWND
+        user32.WindowFromPoint.argtypes = [wintypes.POINT]
+        user32.GetAncestor.restype = wintypes.HWND
+        user32.GetAncestor.argtypes = [wintypes.HWND, wintypes.UINT]
+        hwnd = user32.WindowFromPoint(wintypes.POINT(int(x), int(y)))
+        if not hwnd:
+            return None
+        root = user32.GetAncestor(hwnd, 2) or hwnd  # GA_ROOT = 2
+        length = user32.GetWindowTextLengthW(root)
+        buf = ctypes.create_unicode_buffer(length + 1)
+        user32.GetWindowTextW(root, buf, length + 1)
+        pid = wintypes.DWORD()
+        user32.GetWindowThreadProcessId(root, ctypes.byref(pid))
+        return int(root), buf.value, int(pid.value)
+    except Exception as exc:  # noqa: BLE001 — ctypes/OS errors vary
+        logger.debug("WindowFromPoint(%s, %s) failed: %s", x, y, exc)
+        return None
+
+
+def _window_pid(hwnd: int):
+    """Return the process ID owning ``hwnd``, or ``None`` if undeterminable."""
+    import sys
+    if sys.platform != "win32" or not hwnd:
+        return None
+    try:
+        import ctypes
+        from ctypes import wintypes
+        pid = wintypes.DWORD()
+        ctypes.windll.user32.GetWindowThreadProcessId(
+            wintypes.HWND(int(hwnd)), ctypes.byref(pid)
+        )
+        return int(pid.value) or None
+    except Exception as exc:  # noqa: BLE001 — ctypes/OS errors vary
+        logger.debug("GetWindowThreadProcessId(%s) failed: %s", hwnd, exc)
+        return None
+
+
 @click.command("click")
 @click.argument("query", required=False)
 @click.option("--on", "on_text", help="Target element (eN ref or text label)")
@@ -454,12 +513,42 @@ def click_cmd(query: str | None, on_text: str | None, ref_alias: str | None,
         "x": x, "y": y, "button": button, "double_click": double,
     })
 
+    # (#1207) Honesty check: confirm the click actually reached its target.
+    # For coordinate-based clicks, find the top-level window now under the
+    # point.  When a specific target window was known (--app/--hwnd/--pid or a
+    # cached snapshot) and the click landed on a *different process'* window,
+    # the target was occluded or never came to the foreground — fail loudly
+    # instead of reporting a success that did not happen.
+    _hit = None
+    if x is not None and y is not None:
+        _hit = _window_root_at_point(x, y)
+    if _hit and _focus_hwnd:
+        _target_pid = _window_pid(_focus_hwnd)
+        if _target_pid and _hit[2] and _hit[2] != _target_pid:
+            _common._json_err(
+                f"Click at ({x}, {y}) landed on window {_hit[1]!r} "
+                f"(hwnd {_hit[0]}, pid {_hit[2]}), not the target window "
+                f"(hwnd {_focus_hwnd}, pid {_target_pid}). The target is "
+                f"occluded or failed to come to the foreground; the click did "
+                f"not reach it.",
+                json_output,
+                code="CLICK_WRONG_WINDOW",
+            )
+            return
+
     action = "double-clicked" if double else "clicked"
     if _zero_bounds_element is not None:
         loc = f"{_zero_bounds_element.title or _zero_bounds_element.role} (via UIA Invoke)"
     else:
         loc = f"({x}, {y})" if coords else (target_id or "element")
     result_data: dict[str, Any] = {"action": action, "target": str(loc), "button": button}
+    # (#1207) Disclose which window actually received a coordinate click, so a
+    # caller can see when a raw --coords click hit something other than what
+    # they intended (naturo cannot know intent for bare coordinates).
+    if _hit:
+        result_data["hit_window"] = {
+            "hwnd": _hit[0], "title": _hit[1], "pid": _hit[2],
+        }
     if _image_match_info is not None:
         result_data["image_match"] = _image_match_info
     if _clipboard_action:

--- a/tests/test_click_wrong_window_1207.py
+++ b/tests/test_click_wrong_window_1207.py
@@ -1,0 +1,93 @@
+"""Tests for click landing-window honesty (#1207).
+
+A coordinate click must never be reported as a success when it actually landed
+on a different window — e.g. the target was occluded or never came to the
+foreground, so the synthetic click reached whatever window was on top instead.
+
+When a target window is known (--app/--hwnd/--pid or a cached snapshot) and the
+window under the click point belongs to a *different process*, the command must
+fail loudly (CLICK_WRONG_WINDOW). For bare --coords with no known target, it
+discloses which window received the click via ``hit_window``.
+
+These tests patch the window-hit-test helpers, so they are desktop-independent
+and send no real input.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from naturo.cli._jsonio import json_dumps  # noqa: F401 — ensures module import
+from naturo.cli.interaction import click_cmd
+
+
+def _invoke(args, *, hit, target_pid):
+    """Invoke click_cmd with the window hit-test helpers patched.
+
+    Args:
+        args: CLI args (without -j; added here).
+        hit: tuple returned by _window_root_at_point, or None.
+        target_pid: value returned by _window_pid for the target hwnd.
+    """
+    backend = MagicMock()
+    backend._resolve_hwnd.return_value = 349525
+    # Avoid the UWP/WinUI UIA-click branch so the normal backend.click() runs.
+    backend._is_afh_window.return_value = False
+    backend._is_winui_window.return_value = False
+    with patch("naturo.cli.interaction._common._get_backend",
+               return_value=backend), \
+         patch("naturo.cli.interaction._common._auto_route", return_value={}), \
+         patch("naturo.cli.interaction._click._window_root_at_point",
+               return_value=hit), \
+         patch("naturo.cli.interaction._click._window_pid",
+               return_value=target_pid):
+        runner = CliRunner()
+        return runner.invoke(click_cmd, args + ["--no-verify", "-j"]), backend
+
+
+def test_targeted_click_on_other_process_window_fails_loudly():
+    """--hwnd target occluded by another process → CLICK_WRONG_WINDOW, exit!=0."""
+    result, backend = _invoke(
+        ["--coords", "500", "300", "--hwnd", "349525"],
+        hit=(777, "WindowsTerminal", 999),  # different pid
+        target_pid=111,
+    )
+    assert result.exit_code != 0
+    assert "CLICK_WRONG_WINDOW" in result.output
+
+
+def test_targeted_click_same_process_succeeds():
+    """Click landing on the target's own process is reported as success."""
+    result, backend = _invoke(
+        ["--coords", "500", "300", "--hwnd", "349525"],
+        hit=(349525, "Target App", 111),  # same pid as target
+        target_pid=111,
+    )
+    assert result.exit_code == 0
+    assert "hit_window" in result.output
+    backend.click.assert_called_once()
+
+
+def test_bare_coords_discloses_hit_window():
+    """Bare --coords (no target) cannot fail, but discloses the hit window."""
+    result, backend = _invoke(
+        ["--coords", "500", "300"],
+        hit=(777, "WindowsTerminal", 999),
+        target_pid=None,
+    )
+    assert result.exit_code == 0
+    assert "hit_window" in result.output
+    assert "999" in result.output  # the pid actually clicked
+
+
+def test_no_hit_info_behaves_as_before():
+    """When the hit window is undeterminable, output omits hit_window."""
+    result, backend = _invoke(
+        ["--coords", "500", "300"],
+        hit=None,
+        target_pid=None,
+    )
+    assert result.exit_code == 0
+    assert "hit_window" not in result.output
+    backend.click.assert_called_once()


### PR DESCRIPTION
## What
A coordinate click was reported as `clicked` even when it landed on a **different window** — the target was occluded or never came to the foreground, so the synthetic `SendInput` reached whatever window was topmost at the point. That is a false success — a violation of naturo's never-lie contract (#226 / #231).

`click` now hit-tests the top-level window under the click point (`WindowFromPoint` + `GA_ROOT`):
- **Targeted click** (`--app`/`--hwnd`/`--pid` or a cached snapshot) landing on a **different process'** window → fails loudly with `CLICK_WRONG_WINDOW` instead of reporting success.
- **Bare `--coords`** (intent unknowable) → discloses the window actually clicked via a `hit_window` field, so the caller can see it hit e.g. a terminal rather than the intended app.

Cross-*process* comparison (not exact-hwnd) avoids false positives from an app's own owned/child windows.

## Why
Observed live on this desktop: `naturo click --coords <pt-on-occluded-SolidWorks>` printed `action: clicked` with **zero pixel change** in SolidWorks — the click had gone to the overlapping terminal. naturo must not report that as success.

## How tested
- New desktop-independent tests `tests/test_click_wrong_window_1207.py` (CliRunner + patched hit-test helpers): wrong-process target → `CLICK_WRONG_WINDOW` + non-zero exit; same-process → success + `hit_window`; bare coords → `hit_window` disclosed; no hit info → unchanged behavior.
- `ruff` clean; `mypy` clean on the changed file; full `-k click` suite green locally before push (319 passed).

## Note
The honesty check is best-effort and Windows-only (`WindowFromPoint`); on non-Windows it is a no-op. Foreground activation itself (#608) is unchanged — this PR makes the *outcome* truthful when activation/visibility fails.