### PR TITLE
fix: get reads any element naturo found, resolving unnamed elements by cached point + window (fixes #1208)

### DIFF
--- a/naturo/backends/windows/_element/_tree.py
+++ b/naturo/backends/windows/_element/_tree.py
@@ -392,6 +392,8 @@ class ElementTreeMixin:
         resolved_role = role
         resolved_name = name
         target_hwnd = hwnd or 0
+        coords = None
+        snap_hwnd = None
 
         if ref and not resolved_aid:
             from naturo.snapshot import get_snapshot_manager
@@ -409,10 +411,24 @@ class ElementTreeMixin:
                     resolved_role = elem.role
                     resolved_name = elem.label
                 else:
-                    raise NaturoError(
-                        f"Element {ref} has no AutomationId, role, or name "
-                        f"for value lookup"
-                    )
+                    # (#1208) No identifier/name: capture the cached point and
+                    # source window so the value can be read live from the
+                    # element inside its own window's UIA tree (handled below),
+                    # instead of refusing for an element naturo already found.
+                    frame = getattr(elem, "frame", None)
+                    if frame and (frame[2] > 0 or frame[3] > 0):
+                        coords = (frame[0] + frame[2] // 2,
+                                  frame[1] + frame[3] // 2)
+                    try:
+                        _snap = mgr.get_snapshot(_snap_id)
+                        snap_hwnd = getattr(_snap, "window_handle", None)
+                    except Exception:
+                        snap_hwnd = None
+                    if coords is None:
+                        raise NaturoError(
+                            f"Element {ref} has no AutomationId, name, or "
+                            f"location for value lookup"
+                        )
             else:
                 raise StaleSnapshotCacheError(ref)
 
@@ -426,6 +442,24 @@ class ElementTreeMixin:
         # (the CLI analog of the MCP #957 ``require_hwnd`` contract).
         if (app or window_title) and not target_hwnd:
             target_hwnd = self._resolve_hwnd(app=app, window_title=window_title)
+
+        # (#1208) Cached-point value read for an element with no AutomationId
+        # and no name: resolve it live inside its source window's UIA tree and
+        # read the value via ValuePattern/TextPattern. Mirrors the set-value
+        # resolution so naturo can READ anything it already located.
+        # NOTE: this is a Python/comtypes fallback layered on top of the C++
+        # core reader below; consolidating the two onto one layer is tracked
+        # as tech debt.
+        if coords is not None and not resolved_aid and not (
+                resolved_role and resolved_name):
+            if not target_hwnd and snap_hwnd:
+                target_hwnd = snap_hwnd
+            if hasattr(self, "get_element_value_uia"):
+                _uia_val = self.get_element_value_uia(
+                    hwnd=target_hwnd or 0, x=coords[0], y=coords[1],
+                )
+                if _uia_val is not None:
+                    return _uia_val
 
         if not resolved_aid and not resolved_role and not resolved_name:
             # (#242) Fallback: when no element identifiers are provided but

--- a/naturo/backends/windows/_input/_uia_interact.py
+++ b/naturo/backends/windows/_input/_uia_interact.py
@@ -517,6 +517,123 @@ class UIAInteractMixin:
             logger.debug("SetValue unexpected error: %s", exc)
             return False
 
+    def get_element_value_uia(
+        self,
+        hwnd: int = 0,
+        name: Optional[str] = None,
+        automation_id: Optional[str] = None,
+        role: Optional[str] = None,
+        x: Optional[int] = None,
+        y: Optional[int] = None,
+    ) -> Optional[dict]:
+        """Read an element's current value via UIA patterns (Python/comtypes).
+
+        Mirrors :meth:`set_element_value`'s resolution so naturo can READ the
+        value of an element it already located even when that element has no
+        AutomationId and no name — resolving it inside its source window's own
+        UIA tree at the cached point (occlusion-independent) and querying
+        ValuePattern, then TextPattern, TogglePattern, and finally the Name
+        property. (#1208)
+
+        Args:
+            hwnd: Window handle to scope identity/tree search. 0 = desktop root.
+            name: Accessible name of the target element.
+            automation_id: UIA AutomationId of the target element.
+            role: UIA control type (e.g. ``"Edit"``).
+            x: Screen X of the cached element centre (point fallback).
+            y: Screen Y of the cached element centre (point fallback).
+
+        Returns:
+            A dict with ``value``, ``pattern``, ``role``, ``name`` and
+            ``automation_id``, or ``None`` if no element or value was found.
+        """
+        try:
+            uia, mod = self._init_comtypes_uia()
+        except (ImportError, Exception):
+            logger.debug("comtypes not available — cannot read value via UIA")
+            return None
+
+        _CTRL_TYPE_TO_ROLE = {
+            50000: "Button", 50002: "CheckBox", 50003: "ComboBox",
+            50004: "Edit", 50007: "ListItem", 50008: "List",
+            50020: "Text", 50026: "Group", 50030: "Document",
+        }
+        try:
+            from comtypes import COMError  # type: ignore[import-untyped]
+
+            elem = self._resolve_interaction_element(
+                uia, mod, hwnd=hwnd, name=name,
+                automation_id=automation_id, role=role, x=x, y=y,
+            )
+            if elem is None:
+                return None
+
+            try:
+                _role = _CTRL_TYPE_TO_ROLE.get(elem.CurrentControlType)
+            except (COMError, AttributeError):
+                _role = None
+            try:
+                _name = elem.CurrentName or ""
+            except (COMError, AttributeError):
+                _name = ""
+            try:
+                _aid = elem.CurrentAutomationId or ""
+            except (COMError, AttributeError):
+                _aid = ""
+
+            value = None
+            pattern = None
+            try:
+                pat = elem.GetCurrentPattern(mod.UIA_ValuePatternId)
+                if pat is not None:
+                    value = pat.QueryInterface(
+                        mod.IUIAutomationValuePattern).CurrentValue
+                    pattern = "ValuePattern"
+            except (COMError, AttributeError):
+                pass
+            # Multiline WinForms edits often expose an empty ValuePattern but
+            # carry the real text in TextPattern — so fall through on an empty
+            # (not just None) value. (#1208)
+            if not value:
+                try:
+                    pat = elem.GetCurrentPattern(mod.UIA_TextPatternId)
+                    if pat is not None:
+                        rng = pat.QueryInterface(
+                            mod.IUIAutomationTextPattern).DocumentRange
+                        _text = rng.GetText(-1)
+                        if _text:
+                            value = _text
+                            pattern = "TextPattern"
+                except (COMError, AttributeError):
+                    pass
+            if not value:
+                try:
+                    pat = elem.GetCurrentPattern(mod.UIA_TogglePatternId)
+                    if pat is not None:
+                        state = pat.QueryInterface(
+                            mod.IUIAutomationTogglePattern).CurrentToggleState
+                        value = {0: "Off", 1: "On", 2: "Indeterminate"}.get(
+                            state, "Unknown")
+                        pattern = "TogglePattern"
+                except (COMError, AttributeError):
+                    pass
+            if not value and _name:
+                value = _name
+                pattern = "Name"
+            if value is None:
+                return None
+
+            return {
+                "value": value,
+                "pattern": pattern,
+                "role": _role,
+                "name": _name,
+                "automation_id": _aid,
+            }
+        except Exception as exc:  # noqa: BLE001 — COM/OS errors vary
+            logger.debug("get_element_value_uia failed: %s", exc)
+            return None
+
     def toggle_element(
         self,
         hwnd: int = 0,

--- a/tests/test_get_value_fallback_1208.py
+++ b/tests/test_get_value_fallback_1208.py
@@ -1,0 +1,80 @@
+"""Regression tests for #1208 (read side) — get must read any element naturo found.
+
+``get_element_value`` previously refused an element that had no AutomationId and
+no name ("Element eN has no AutomationId, role, or name for value lookup"), even
+though naturo had captured its bounding box and source window. It now captures
+the cached point + window handle and reads the value live from the element
+inside its own window's UIA tree (``get_element_value_uia``).
+
+These tests instantiate the mixin and mock the snapshot manager, the C++ core,
+and the UIA reader, so they are desktop-independent and send no input.
+"""
+
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from naturo.backends.windows._element._tree import ElementTreeMixin
+from naturo.errors import NaturoError
+
+
+class _Stub(ElementTreeMixin):
+    """Concrete carrier of the mixin for isolated method testing."""
+
+
+def _unnamed_element(frame):
+    """A resolved snapshot element with no AutomationId / title / label."""
+    return types.SimpleNamespace(
+        identifier=None, role="Edit", title=None, label=None, frame=frame,
+    )
+
+
+def _make_backend(reader_result):
+    backend = _Stub()
+    backend._ensure_core = MagicMock(return_value=MagicMock())
+    backend._resolve_hwnd = MagicMock(return_value=0)
+    backend.get_element_value_uia = MagicMock(return_value=reader_result)
+    return backend
+
+
+@patch("naturo.snapshot.get_snapshot_manager")
+def test_unnamed_element_read_via_cached_point(mock_get_mgr):
+    """An unnamed Edit is read via the cached point inside its source window."""
+    mgr = MagicMock()
+    mgr.resolve_ref_element.return_value = (
+        _unnamed_element((2249, 423, 419, 150)), "snap1",
+    )
+    mgr.get_snapshot.return_value = types.SimpleNamespace(window_handle=727448)
+    mock_get_mgr.return_value = mgr
+
+    backend = _make_backend(
+        {"value": "hello", "pattern": "TextPattern", "role": "Edit",
+         "name": "", "automation_id": ""},
+    )
+
+    result = backend.get_element_value(ref="e55")
+
+    assert result["value"] == "hello"
+    backend.get_element_value_uia.assert_called_once()
+    _, kwargs = backend.get_element_value_uia.call_args
+    assert kwargs["x"] == 2249 + 419 // 2
+    assert kwargs["y"] == 423 + 150 // 2
+    assert kwargs["hwnd"] == 727448
+
+
+@patch("naturo.snapshot.get_snapshot_manager")
+def test_unnamed_element_without_geometry_raises(mock_get_mgr):
+    """No identity AND no usable bounding box → loud failure, no false success."""
+    mgr = MagicMock()
+    mgr.resolve_ref_element.return_value = (
+        _unnamed_element((0, 0, 0, 0)), "snap1",
+    )
+    mgr.get_snapshot.return_value = types.SimpleNamespace(window_handle=None)
+    mock_get_mgr.return_value = mgr
+
+    backend = _make_backend(None)
+
+    with pytest.raises(NaturoError):
+        backend.get_element_value(ref="e55")
+    backend.get_element_value_uia.assert_not_called()


### PR DESCRIPTION
## What
The **read side** of #1208 (the write side landed in #1209). `get_element_value` refused an element with no AutomationId and no name — `Element eN has no AutomationId, role, or name for value lookup` — even though naturo had captured the element's bounding box and source window.

It now captures the cached point + source-window handle and reads the value live from the element **inside its own window's UIA tree** via a new `get_element_value_uia` (occlusion-independent, reusing #1209's resolution): `ValuePattern → TextPattern → TogglePattern → Name`. Multiline edits often expose an **empty** `ValuePattern` while their text lives in `TextPattern`, so an empty (not just `None`) value falls through to `TextPattern`.

## How tested
- New desktop-independent unit tests `tests/test_get_value_fallback_1208.py`: an unnamed Edit is read via the cached point inside its source window (asserts coords + hwnd passed to the reader); no-identity + no-geometry still raises (no false success).
- `ruff` clean; `mypy` clean on changed files; `test_get_cmd.py` + new tests = 43 passed locally.
- Live (read-only) on this desktop: `get <ref>` on an unnamed element no longer errors and routes to the UIA reader.

## Known limitation (separate, pre-existing)
SolidWorks **Property Tab Builder**'s multiline *Caption* box exposes only a `ScrollViewer` in the UIA control view, whose text is readable by **neither** the C++ core reader **nor** comtypes (ValuePattern/TextPattern return null/empty). This affects both readers and is not introduced here — filing separately.

## Tech debt
`get` value-reading goes through the C++ core while `set`/`click`/`toggle` go through Python comtypes; this PR layers a Python reader on top of the C++ one. Consolidating read/write onto one UIA layer is being filed as a tech-debt issue.