### PR TITLE
feat(recognition): Unified Auto Element Tree — correctness-tagged fusion (M1)

### DIFF
--- a/docs/RECOGNITION_TREE.md
+++ b/docs/RECOGNITION_TREE.md
@@ -1,0 +1,169 @@
+# Unified Auto Element Tree — Node Schema & Fusion Rules (ADR)
+
+Status: **accepted** · Milestone: **M1** · Supersedes the single `source` tag
+emitted by `naturo see` today.
+
+This document is the schema-of-record for naturo's moat: **one app in → one fused,
+correctness-tagged element tree out, automatically.** Every later slice (the
+fusion tagger, the `--json` contract, `tests/test_unified_tree.py`, real-app QA)
+conforms to what is defined here. It complements `RECOGNITION.md` (which covers
+*coverage* vs rivals); this doc defines the *node contract*.
+
+---
+
+## 1. Why
+
+Commercial RPA's first law is **correctness — enterprises need 100%**. naturo
+already runs a cascade that fuses several recognition frameworks
+(`naturo/cascade/`): UIA → MSAA/IA2 → Java Access Bridge → Electron/CDP →
+AI vision. But each node today carries only a single opaque `properties["source"]`
+string. That is not enough to *reason about correctness*:
+
+- An agent cannot tell whether a node is a **guaranteed** accessibility hit or a
+  **best-guess** AI/image detection.
+- When the same on-screen element is seen by two techniques, there is no record
+  that both saw it, and no rule for which one to trust for an action.
+- The CLI cannot warn a human/agent that it is about to act on an *uncertain* node.
+
+The Unified Auto Element Tree fixes this by tagging **every node** with the set of
+techniques that recognized it, a confidence, and an explicit **correctness class**.
+
+## 2. Recognition techniques
+
+A *technique* is a single recognition method. The canonical technique ids (already
+used as `source` tags in `naturo/cascade/`) and their correctness class:
+
+| technique | class           | notes                                              |
+| --------- | --------------- | -------------------------------------------------- |
+| `uia`     | `deterministic` | Windows UI Automation                              |
+| `msaa`    | `deterministic` | MSAA / IAccessible                                 |
+| `ia2`     | `deterministic` | IAccessible2                                       |
+| `jab`     | `deterministic` | Java Access Bridge (Swing/AWT/SWT)                 |
+| `cdp`     | `deterministic` | Chrome DevTools Protocol (Electron/CEF/Chromium)   |
+| `com`     | `deterministic` | App COM/scripting (e.g. Excel, SAP GUI Scripting)  |
+| `image`   | `uncertain`     | Template/image matching                            |
+| `vision`  | `uncertain`     | AI vision model detection                          |
+
+**Correctness classes** are exactly two:
+
+- **`deterministic`** — the element and its bounds come from a structured,
+  reproducible source (an accessibility API, DevTools, or app COM). Guaranteed:
+  same window state → same node. Safe to act/read without a warning.
+- **`uncertain`** — the element comes from image matching or an AI vision model.
+  Bounds are *estimated* and may shift run to run. **The CLI must WARN** before an
+  agent relies on such a node.
+
+The class of a *technique* is fixed (the table above). The class of a *node* is
+derived by fusion (§4): a node is `deterministic` if **any** of its techniques is
+deterministic, else `uncertain`.
+
+## 3. Node schema
+
+Every node in the fused tree carries these fields (added to the existing
+`naturo see --json` node object; existing fields such as `id`, `role`, `name`,
+`value`, `selector`, `x/y/width/height`, `children` are unchanged):
+
+```jsonc
+{
+  "id": "e12",
+  "role": "Button",
+  "name": "Save",
+  // ... existing fields (selector, bounds, children, ...) ...
+
+  "techniques": ["uia"],          // string[]  — every technique that recognized
+                                  //   this node, deterministic-first order.
+                                  //   Never empty for a real node.
+  "correctness": "deterministic", // "deterministic" | "uncertain" (derived, §4)
+  "confidence": 1.0               // float 0.0–1.0 (see §3.1)
+}
+```
+
+Backward compatibility: the legacy `"source"` field is **retained** and set to
+`techniques[0]` (the preferred technique, §4) so existing consumers keep working.
+
+### 3.1 Confidence
+
+`confidence` is a float in `[0.0, 1.0]`:
+
+- **Deterministic techniques** report `1.0` — an accessibility/DevTools/COM hit is
+  not probabilistic. (A future adapter may lower this to flag a known-flaky
+  control; the default is `1.0`.)
+- **`vision`** carries the model's self-reported confidence when available
+  (already threaded through `properties["confidence"]`, default `0.5`).
+- **`image`** carries the template-match score (0.0–1.0).
+- For a **fused** node seen by several techniques, confidence is the **max** across
+  its techniques (a deterministic hit dominates).
+
+## 4. Fusion rules
+
+Fusion is deterministic and bounded. Given the per-technique element sets the
+cascade already produces:
+
+1. **Same element, several techniques → one node, all marked.** When two
+   techniques recognize the same on-screen element (matched by the existing
+   IoU + text/proximity dedup in `naturo/cascade/_merge.py`), they collapse to a
+   **single** node whose `techniques[]` lists **all** contributing techniques.
+2. **Deterministic-first ordering.** `techniques[]` is ordered deterministic
+   techniques first (in cascade order `uia, msaa, ia2, jab, cdp, com`), then
+   uncertain (`image, vision`). `techniques[0]` is the **preferred** technique —
+   the one used for actions, reads, and the legacy `source` field.
+3. **Node correctness is the strongest class.** `correctness = "deterministic"` if
+   any technique in `techniques[]` is deterministic, else `"uncertain"`. Thus a
+   button seen by both `uia` and `vision` is `deterministic` and preferred via
+   `uia`; the AI detection only *corroborates*, it never downgrades a guaranteed
+   node.
+4. **Uncertain-only nodes survive but are flagged.** An element that *only* AI or
+   image matching found (no deterministic technique covered that region) stays in
+   the tree — that is the coverage moat — but is `correctness: "uncertain"` and
+   triggers the CLI warning (§5).
+5. **No fabricated fusion.** Techniques are only merged when the existing dedup
+   matches them. Two genuinely distinct elements are never collapsed to inflate a
+   node's correctness.
+
+## 5. CLI contract (`naturo see`)
+
+`naturo see … --json` emits **one** fused tree per app/window where **every node**
+carries `techniques[]`, `correctness`, and `confidence`.
+
+- **Deterministic preferred:** where the same element is seen by several
+  techniques, the deterministic one is `techniques[0]` and drives actions/reads.
+- **AI/image warning (required):** when the tree contains **any** node whose only
+  source is `image`/`vision` (`correctness == "uncertain"`), the CLI prints a
+  single clear warning to **stderr** (never polluting `--json` stdout), e.g.:
+
+  ```
+  warning: 3 element(s) were recognized only by AI/image (uncertain); their
+  bounds are estimated and may shift. Deterministic sources are preferred for
+  actions. Run with --no-vision to exclude them.
+  ```
+
+  In `--json` mode the same fact is also exposed structurally as a top-level
+  `recognition_summary` object (counts per technique + `uncertain_nodes`) so an
+  agent can branch on it without parsing stderr.
+- **stdout purity:** the warning goes to stderr; `--json` stdout stays a single
+  valid JSON document (honoring the existing stdout-purity contract).
+
+## 6. Self-heal (bounded, deterministic)
+
+When a stored selector breaks, naturo re-anchors to the **same** element via
+multi-attribute anchors (role + name + AutomationId + relative position among
+siblings) drawn from the deterministic tree. Self-heal **never** introduces an
+uncertain technique to "heal" a deterministic node — healing that crosses into
+`uncertain` must surface as a warning, not a silent substitution. (Implementation
+tracked as a later M1/M4 slice; this ADR fixes the invariant.)
+
+## 7. Extensible adapter architecture
+
+Recognition is augmented by pluggable, per-app/version **adapters**. An adapter
+may (a) contribute a new technique for a node, (b) refine bounds/roles for a known
+app, or (c) raise/lower a node's confidence. Adapters MUST declare their technique
+id and its correctness class (§2) and MUST NOT relabel an `uncertain` technique as
+`deterministic`. The fusion rules (§4) apply uniformly to adapter-contributed
+techniques. (Adapter API is a later milestone; this ADR reserves the contract so
+adapters compose with the schema.)
+
+## 8. Non-goals for M1
+
+- Cross-window graph fusion (M1 is per app/window).
+- SAP/Qt/terminal/OCR technique coverage (M2).
+- The self-heal and adapter *implementations* (contracts fixed here; code later).

--- a/naturo/cascade/__init__.py
+++ b/naturo/cascade/__init__.py
@@ -63,6 +63,18 @@ from naturo.cascade._coverage import (
     _is_shallow_tree,
 )
 from naturo.cascade._providers import _fetch_ai_elements, _fetch_cdp_elements
+from naturo.cascade._correctness import (
+    DETERMINISTIC,
+    DETERMINISTIC_TECHNIQUES,
+    UNCERTAIN,
+    UNCERTAIN_TECHNIQUES,
+    annotate,
+    node_correctness,
+    node_techniques,
+    recognition_summary,
+    technique_class,
+    uncertain_warning,
+)
 
 __all__ = [
     # Types
@@ -103,4 +115,15 @@ __all__ = [
     # Providers
     "_fetch_ai_elements",
     "_fetch_cdp_elements",
+    # Correctness / fusion tagging (M1 Unified Auto Element Tree)
+    "DETERMINISTIC",
+    "DETERMINISTIC_TECHNIQUES",
+    "UNCERTAIN",
+    "UNCERTAIN_TECHNIQUES",
+    "annotate",
+    "node_correctness",
+    "node_techniques",
+    "recognition_summary",
+    "technique_class",
+    "uncertain_warning",
 ]

--- a/naturo/cascade/_correctness.py
+++ b/naturo/cascade/_correctness.py
@@ -88,7 +88,12 @@ def node_correctness(techniques: list[str]) -> str:
 
 
 def node_confidence(props: dict, techniques: list[str]) -> float:
-    """Max confidence across a node's techniques (deterministic ⇒ 1.0)."""
+    """Max confidence across a node's techniques (deterministic ⇒ 1.0).
+
+    Clamped to ``[0.0, 1.0]`` (ADR §3.1): a vision model's self-reported score
+    is passed through untrusted (see ``_providers.py``), so an out-of-range
+    value must never leak into ``see --json`` and contradict the schema.
+    """
     best = 0.0
     for t in techniques:
         if technique_class(t) == DETERMINISTIC:
@@ -100,7 +105,7 @@ def node_confidence(props: dict, techniques: list[str]) -> float:
             except (TypeError, ValueError):
                 score = _DEFAULT_UNCERTAIN_CONFIDENCE
             best = max(best, score)
-    return best
+    return max(0.0, min(1.0, best))
 
 
 def annotate(props: dict) -> Optional[dict]:

--- a/naturo/cascade/_correctness.py
+++ b/naturo/cascade/_correctness.py
@@ -1,0 +1,165 @@
+"""Correctness tagging & fusion for the Unified Auto Element Tree.
+
+Schema of record: ``docs/RECOGNITION_TREE.md``.
+
+Every node in a fused cascade tree is tagged with:
+
+* ``techniques`` — every recognition technique that saw the node,
+  deterministic-first (the first entry is the *preferred* technique used for
+  actions/reads and the legacy ``source`` field).
+* ``correctness`` — ``"deterministic"`` if any technique is deterministic, else
+  ``"uncertain"``.
+* ``confidence`` — float in ``[0.0, 1.0]``; ``1.0`` for deterministic techniques,
+  the model/match score for uncertain ones, ``max`` across a fused node.
+
+This module is pure Python (no platform imports) so the fusion, tagging, and
+AI-warning logic is unit-testable on any OS.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from naturo.backends.base import ElementInfo
+
+#: Techniques whose hits are structured and reproducible (guaranteed).
+DETERMINISTIC_TECHNIQUES = ("uia", "msaa", "ia2", "jab", "cdp", "com")
+#: Techniques whose hits are estimated (image match / AI vision).
+UNCERTAIN_TECHNIQUES = ("image", "vision", "ai")
+
+#: Canonical ordering: deterministic first (cascade order), then uncertain.
+_TECHNIQUE_ORDER = [
+    "uia", "msaa", "ia2", "jab", "cdp", "com",  # deterministic
+    "image", "vision", "ai",                    # uncertain
+]
+
+DETERMINISTIC = "deterministic"
+UNCERTAIN = "uncertain"
+
+#: Default confidence for an uncertain hit that reports no score.
+_DEFAULT_UNCERTAIN_CONFIDENCE = 0.5
+
+
+def technique_class(technique: str) -> str:
+    """Return the correctness class of a single technique.
+
+    Unknown techniques are treated as ``uncertain`` — a fail-safe: naturo never
+    claims correctness it cannot justify.
+    """
+    return DETERMINISTIC if technique in DETERMINISTIC_TECHNIQUES else UNCERTAIN
+
+
+def _order_key(technique: str) -> int:
+    try:
+        return _TECHNIQUE_ORDER.index(technique)
+    except ValueError:
+        return len(_TECHNIQUE_ORDER)
+
+
+def node_techniques(props: dict) -> list[str]:
+    """Collect every technique that recognized a node, deterministic-first.
+
+    Reads, in order of authority, ``properties``:
+
+    * ``source`` — the primary technique that produced the node.
+    * ``corroborated_by`` — techniques whose duplicate hit was fused into this
+      node during merge (§4 of the ADR).
+    * ``techniques`` — an explicit pre-set list (e.g. from an adapter).
+
+    Duplicates are removed and the result is sorted deterministic-first.
+    """
+    collected: list[str] = []
+    source = props.get("source")
+    if source:
+        collected.append(source)
+    for extra in props.get("corroborated_by") or []:
+        collected.append(extra)
+    for extra in props.get("techniques") or []:
+        collected.append(extra)
+    # Stable de-dup, then deterministic-first ordering.
+    deduped = list(dict.fromkeys(collected))
+    return sorted(deduped, key=_order_key)
+
+
+def node_correctness(techniques: list[str]) -> str:
+    """A node is deterministic if *any* of its techniques is deterministic."""
+    if any(technique_class(t) == DETERMINISTIC for t in techniques):
+        return DETERMINISTIC
+    return UNCERTAIN
+
+
+def node_confidence(props: dict, techniques: list[str]) -> float:
+    """Max confidence across a node's techniques (deterministic ⇒ 1.0)."""
+    best = 0.0
+    for t in techniques:
+        if technique_class(t) == DETERMINISTIC:
+            best = max(best, 1.0)
+        else:
+            raw = props.get("confidence")
+            try:
+                score = float(raw) if raw is not None else _DEFAULT_UNCERTAIN_CONFIDENCE
+            except (TypeError, ValueError):
+                score = _DEFAULT_UNCERTAIN_CONFIDENCE
+            best = max(best, score)
+    return best
+
+
+def annotate(props: dict) -> Optional[dict]:
+    """Return the fusion tags for a node, or ``None`` if it carries no technique.
+
+    ``None`` means the node was not produced by the cascade (e.g. a plain
+    ``get_element_tree`` walk); callers leave such nodes untagged so non-cascade
+    output is unchanged and never falsely warned as uncertain.
+    """
+    techniques = node_techniques(props)
+    if not techniques:
+        return None
+    return {
+        "techniques": techniques,
+        "correctness": node_correctness(techniques),
+        "confidence": round(node_confidence(props, techniques), 3),
+        "preferred": techniques[0],
+    }
+
+
+def recognition_summary(root: ElementInfo) -> dict:
+    """Aggregate technique/correctness counts over a fused tree.
+
+    Nodes with no technique tag (non-cascade nodes) are ignored so the summary
+    reflects only what the cascade actually recognized.
+    """
+    from naturo.cascade._coverage import _flatten
+
+    by_technique: dict[str, int] = {}
+    total = 0
+    uncertain = 0
+    for el in _flatten(root):
+        props = getattr(el, "properties", {}) or {}
+        techniques = node_techniques(props)
+        if not techniques:
+            continue
+        total += 1
+        for t in techniques:
+            by_technique[t] = by_technique.get(t, 0) + 1
+        if node_correctness(techniques) == UNCERTAIN:
+            uncertain += 1
+    return {
+        "total_nodes": total,
+        "by_technique": by_technique,
+        "uncertain_nodes": uncertain,
+        "has_uncertain": uncertain > 0,
+    }
+
+
+def uncertain_warning(summary: dict) -> Optional[str]:
+    """Human-readable warning when a tree contains AI/image-only nodes.
+
+    Returns ``None`` when every recognized node is deterministic.
+    """
+    n = summary.get("uncertain_nodes", 0)
+    if n <= 0:
+        return None
+    return (
+        f"warning: {n} element(s) were recognized only by AI/image "
+        "(uncertain); their bounds are estimated and may shift. Deterministic "
+        "sources are preferred for actions."
+    )

--- a/naturo/cascade/_merge.py
+++ b/naturo/cascade/_merge.py
@@ -76,6 +76,25 @@ def _text_proximity_match(
     return None
 
 
+def _record_corroboration(node: ElementInfo, ai_el: ElementInfo) -> None:
+    """Record that an uncertain hit corroborated a deterministic node (M1).
+
+    The duplicate AI/image element is *not* added to the tree, but the technique
+    that saw it is appended to the matched node's ``corroborated_by`` list so the
+    fused node reports every technique that recognized it
+    (``docs/RECOGNITION_TREE.md`` §4).  Deterministic ordering/preference is
+    applied later by :mod:`naturo.cascade._correctness`.
+    """
+    ai_props = getattr(ai_el, "properties", {}) or {}
+    technique = ai_props.get("source", "vision")
+    node_props = node.properties
+    if not isinstance(node_props, dict):
+        return
+    corroborated = node_props.setdefault("corroborated_by", [])
+    if technique not in corroborated:
+        corroborated.append(technique)
+
+
 def _merge_ai_into_tree(
     root: ElementInfo,
     ai_elements: List[ElementInfo],
@@ -147,6 +166,8 @@ def _merge_ai_into_tree(
                 break
 
         if is_duplicate:
+            if best_match is not None:
+                _record_corroboration(best_match, ai_el)
             skipped += 1
             logger.debug(
                 "AI merge: skip '%s' (%d,%d %dx%d) IoU=%.2f with UIA '%s'",
@@ -158,6 +179,7 @@ def _merge_ai_into_tree(
         # --- Pass 2: text + proximity dedup (#702) ---
         text_match = _text_proximity_match(ai_el, uia_visible, proximity_px)
         if text_match is not None:
+            _record_corroboration(text_match, ai_el)
             skipped += 1
             logger.debug(
                 "AI merge: skip '%s' (%d,%d %dx%d) text+proximity match "

--- a/naturo/cascade/_run.py
+++ b/naturo/cascade/_run.py
@@ -353,9 +353,15 @@ def run_cascade(
 
             elapsed = (time.monotonic() - t0) * 1000
             if cdp_elements:
-                # Tag and add CDP elements as children of root
+                # Tag and graft CDP elements onto the tree as children of the
+                # root, mirroring the JAB branch below.  Appending only to
+                # ``merged_elements`` (coverage math) dropped them from the
+                # fused tree, so ``see --cascade --json`` recognized web DOM
+                # content but never emitted a cdp-tagged node (no uia+cdp
+                # fusion).  Same graft as ``_run_cdp_only``.
                 for el in cdp_elements:
                     tagged_el = _tag_source(el, "cdp")
+                    root_tree.children.append(tagged_el)
                     merged_elements.append(tagged_el)
 
                 stats.providers.append(ProviderStat(

--- a/naturo/cli/core/_see.py
+++ b/naturo/cli/core/_see.py
@@ -142,7 +142,7 @@ def see(app: str | None, window_title: str | None, hwnd: int | None, pid: int | 
 
         # ── Cascade mode: progressive multi-provider recognition (issue #140) ──
         cascade_stats = None
-        if cascade or backend == "auto" or backend == "hybrid":
+        if cascade or backend in ("auto", "hybrid", "cdp"):
             # (#275) Auto-capture screenshot for cascade mode so AI vision
             # fallback can trigger when UIA tree is too shallow.
             # (#694) Use capture_window with resolved hwnd so the screenshot

--- a/naturo/cli/core/_see.py
+++ b/naturo/cli/core/_see.py
@@ -349,6 +349,17 @@ def see(app: str | None, window_title: str | None, hwnd: int | None, pid: int | 
             el_dict = _el_to_selector_dict(el)
             return _sel_builder.build_uri(el_dict, ancestors_dicts, app=_selector_app)
 
+        # (M1) Unified Auto Element Tree: fusion tags + AI/image warning.
+        # recognition_summary only counts cascade-tagged nodes, so a plain
+        # (non-cascade) tree yields an empty summary and no false warning.
+        from naturo.cascade._correctness import (
+            annotate as _fusion_annotate,
+            recognition_summary as _fusion_summary,
+            uncertain_warning as _fusion_warning,
+        )
+        _recognition = _fusion_summary(tree)
+        _recognition_warning = _fusion_warning(_recognition)
+
         if json_output:
             # (#237) Use a sequential counter matching _flatten() DFS order
             # to assign unique display IDs.  The previous reverse-map approach
@@ -438,6 +449,13 @@ def see(app: str | None, window_title: str | None, hwnd: int | None, pid: int | 
                     d["keyboard_shortcut"] = props["keyboard_shortcut"]
                 if props.get("source"):
                     d["source"] = props["source"]
+                # (M1) Correctness-tagged fusion: every cascade node carries
+                # techniques[] + correctness + confidence; deterministic first.
+                _fusion = _fusion_annotate(props)
+                if _fusion is not None:
+                    d["techniques"] = _fusion["techniques"]
+                    d["correctness"] = _fusion["correctness"]
+                    d["confidence"] = _fusion["confidence"]
                 return d
             out = to_dict(tree)
             assert out is not None, "Root element should never be filtered"
@@ -445,6 +463,10 @@ def see(app: str | None, window_title: str | None, hwnd: int | None, pid: int | 
                 out["snapshot_id"] = snapshot_id
             if cascade_stats:
                 out["cascade_stats"] = cascade_stats.to_dict()
+            # (M1) Structured recognition summary so agents can branch on
+            # correctness without parsing the stderr warning.
+            if _recognition["total_nodes"] > 0:
+                out["recognition_summary"] = _recognition
 
             # Add DPI context so AI agents know coordinate scaling
             try:
@@ -462,6 +484,9 @@ def see(app: str | None, window_title: str | None, hwnd: int | None, pid: int | 
 
 
             click.echo(json_dumps(out, indent=2))
+            # (M1) Correctness warning to stderr keeps --json stdout pure.
+            if _recognition_warning:
+                click.echo(_recognition_warning, err=True)
         else:
             # BUG-071: include short element IDs (e1, e2, ...) that can be
             # passed to ``naturo click e3`` for quick interaction.
@@ -520,6 +545,9 @@ def see(app: str | None, window_title: str | None, hwnd: int | None, pid: int | 
                     print_tree(child, indent + 1, child_ancestors)
 
             print_tree(tree)
+            # (M1) Warn (stderr) when any node is AI/image-only (uncertain).
+            if _recognition_warning:
+                click.echo(_recognition_warning, err=True)
             if snapshot_id:
                 click.echo(f"\nSnapshot: {snapshot_id}")
                 if show_selectors:

--- a/tests/test_cascade.py
+++ b/tests/test_cascade.py
@@ -282,6 +282,37 @@ class TestRunCascade:
         # CDP path was entered (no exception)
         assert result.tree is not None
 
+    def test_cdp_elements_grafted_onto_tree(self):
+        """Auto-cascade CDP elements must be attached to the fused tree, not
+        merely counted for coverage.
+
+        Regression: the auto CDP branch appended fetched elements only to the
+        internal coverage list and dropped the ``root_tree.children.append``
+        step the JAB branch performs, so ``see --cascade --json`` recognized
+        web DOM content (cdp: ok/N in stats) but never emitted a cdp-tagged
+        node — no uia+cdp fusion ever reached the tree.
+        """
+        tree = _make_el(id="root", w=1000, h=600)
+        be = _make_backend(tree)
+        cdp_el = _make_el(id="cdp_1", role="Button", name="Save Order",
+                          x=10, y=10, w=80, h=30, props={"source": "cdp"})
+
+        with patch("naturo.cascade._fetch_cdp_elements", return_value=[cdp_el]), \
+             patch("naturo.cascade.find_cdp_port", return_value=9222):
+            result = run_cascade(be, backend_name="auto", pid=1234)
+
+        from naturo.cascade import _flatten, recognition_summary
+        ids = [e.id for e in _flatten(result.tree)]
+        assert "cdp_1" in ids, "CDP node was discarded instead of grafted onto the tree"
+        summary = recognition_summary(result.tree)
+        assert summary["by_technique"].get("cdp") == 1
+        # cdp is deterministic — the fused node must be preferred deterministically.
+        cdp_node = next(e for e in _flatten(result.tree) if e.id == "cdp_1")
+        from naturo.cascade import annotate
+        fusion = annotate(cdp_node.properties)
+        assert fusion["correctness"] == "deterministic"
+        assert fusion["techniques"] == ["cdp"]
+
     def test_ai_fill_gaps_skipped_without_screenshot(self):
         """AI vision not attempted when no screenshot_path provided."""
         tree = _make_el(id="root")

--- a/tests/test_unified_tree.py
+++ b/tests/test_unified_tree.py
@@ -72,6 +72,15 @@ def test_node_confidence_rules():
     assert C.node_confidence({"confidence": 0.8}, ["uia", "vision"]) == 1.0
 
 
+def test_node_confidence_clamped_to_unit_range():
+    # ADR §3.1: confidence is [0.0, 1.0]. A vision model's score is untrusted
+    # (passed through from provider JSON) and must never leak out of range.
+    assert C.node_confidence({"confidence": 95}, ["vision"]) == 1.0
+    assert C.node_confidence({"confidence": -0.3}, ["vision"]) == 0.0
+    fusion = C.annotate({"source": "vision", "confidence": 1.5})
+    assert fusion["confidence"] == 1.0
+
+
 def test_annotate_tagged_node():
     fusion = C.annotate({"source": "uia"})
     assert fusion == {

--- a/tests/test_unified_tree.py
+++ b/tests/test_unified_tree.py
@@ -1,0 +1,238 @@
+"""Unified Auto Element Tree — fusion, correctness tagging, AI-warning (M1).
+
+Schema of record: ``docs/RECOGNITION_TREE.md``.
+
+These tests are **Linux-collectable**: the module top imports only pure helpers
+(no Windows-only backend). CLI end-to-end imports live inside their test bodies
+and the backend/platform guard are monkeypatched, so the fused ``see --json``
+contract is exercised on any OS.
+"""
+from __future__ import annotations
+
+import json
+
+from naturo.backends.base import ElementInfo
+from naturo.cascade import _correctness as C
+from naturo.cascade._merge import _merge_ai_into_tree, _record_corroboration
+
+
+def _el(role="Button", name="", source=None, x=0, y=0, w=10, h=10,
+        confidence=None, children=None):
+    props: dict = {}
+    if source is not None:
+        props["source"] = source
+    if confidence is not None:
+        props["confidence"] = confidence
+    return ElementInfo(
+        id=f"{role}-{name}", role=role, name=name, value=None,
+        x=x, y=y, width=w, height=h,
+        children=children or [], properties=props,
+    )
+
+
+# ── technique classification ──────────────────────────────────────────────
+
+def test_deterministic_techniques_classified():
+    for t in ("uia", "msaa", "ia2", "jab", "cdp", "com"):
+        assert C.technique_class(t) == C.DETERMINISTIC
+
+
+def test_uncertain_techniques_classified():
+    for t in ("image", "vision", "ai"):
+        assert C.technique_class(t) == C.UNCERTAIN
+
+
+def test_unknown_technique_is_uncertain_failsafe():
+    # naturo never claims correctness it cannot justify.
+    assert C.technique_class("mystery-adapter") == C.UNCERTAIN
+
+
+# ── node techniques / correctness / confidence ────────────────────────────
+
+def test_node_techniques_deterministic_first_and_deduped():
+    props = {"source": "vision", "corroborated_by": ["uia", "uia"],
+             "techniques": ["cdp"]}
+    # deterministic (uia, cdp in cascade order) before uncertain (vision)
+    assert C.node_techniques(props) == ["uia", "cdp", "vision"]
+
+
+def test_node_correctness_prefers_deterministic():
+    assert C.node_correctness(["uia", "vision"]) == C.DETERMINISTIC
+    assert C.node_correctness(["vision"]) == C.UNCERTAIN
+    assert C.node_correctness([]) == C.UNCERTAIN
+
+
+def test_node_confidence_rules():
+    assert C.node_confidence({}, ["uia"]) == 1.0
+    # vision default when no score reported
+    assert C.node_confidence({}, ["vision"]) == 0.5
+    # explicit vision score honored
+    assert C.node_confidence({"confidence": 0.8}, ["vision"]) == 0.8
+    # fused node: deterministic dominates
+    assert C.node_confidence({"confidence": 0.8}, ["uia", "vision"]) == 1.0
+
+
+def test_annotate_tagged_node():
+    fusion = C.annotate({"source": "uia"})
+    assert fusion == {
+        "techniques": ["uia"],
+        "correctness": "deterministic",
+        "confidence": 1.0,
+        "preferred": "uia",
+    }
+
+
+def test_annotate_untagged_node_returns_none():
+    # A plain (non-cascade) node carries no technique — must stay untagged so
+    # non-cascade output is never falsely flagged as uncertain.
+    assert C.annotate({}) is None
+
+
+def test_annotate_vision_only_is_uncertain():
+    fusion = C.annotate({"source": "vision", "confidence": 0.6})
+    assert fusion["correctness"] == "uncertain"
+    assert fusion["preferred"] == "vision"
+    assert fusion["confidence"] == 0.6
+
+
+# ── recognition summary + warning ─────────────────────────────────────────
+
+def test_recognition_summary_counts_and_uncertain():
+    root = _el("Window", "App", source="uia", w=200, h=200, children=[
+        _el("Button", "Save", source="uia", x=0, y=0, w=100, h=50),
+        _el("Icon", "Avatar", source="vision", x=120, y=0, w=40, h=40,
+            confidence=0.6),
+    ])
+    summary = C.recognition_summary(root)
+    assert summary["total_nodes"] == 3
+    assert summary["by_technique"] == {"uia": 2, "vision": 1}
+    assert summary["uncertain_nodes"] == 1
+    assert summary["has_uncertain"] is True
+
+
+def test_recognition_summary_ignores_untagged_tree():
+    # Non-cascade tree (no source tags) → empty summary, no warning.
+    root = _el("Window", "App", w=200, h=200, children=[_el("Button", "Ok")])
+    summary = C.recognition_summary(root)
+    assert summary["total_nodes"] == 0
+    assert summary["has_uncertain"] is False
+    assert C.uncertain_warning(summary) is None
+
+
+def test_uncertain_warning_present_when_ai_only_nodes():
+    warning = C.uncertain_warning({"uncertain_nodes": 2, "has_uncertain": True})
+    assert warning is not None
+    assert "uncertain" in warning.lower()
+    assert "2" in warning
+
+
+# ── fusion: same element seen by several techniques → mark all ─────────────
+
+def test_merge_records_corroboration_prefers_deterministic():
+    button = _el("Button", "Save", source="uia", x=0, y=0, w=100, h=50)
+    root = _el("Window", "App", source="uia", w=200, h=200, children=[button])
+    # An AI vision hit overlapping the same button (IoU well above threshold).
+    ai = _el("Button", "Save", source="vision", x=5, y=5, w=90, h=40,
+             confidence=0.7)
+
+    added, added_count, skipped = _merge_ai_into_tree(root, [ai])
+
+    # The duplicate AI element is not added as a new node...
+    assert added_count == 0
+    assert skipped == 1
+    # ...but the deterministic node now records the corroborating technique.
+    assert button.properties.get("corroborated_by") == ["vision"]
+
+    fusion = C.annotate(button.properties)
+    assert fusion["techniques"] == ["uia", "vision"]   # deterministic first
+    assert fusion["correctness"] == "deterministic"
+    assert fusion["preferred"] == "uia"                # deterministic preferred
+    assert fusion["confidence"] == 1.0
+
+
+def test_merge_keeps_ai_only_novel_node_as_uncertain():
+    root = _el("Window", "App", source="uia", w=400, h=400, children=[
+        _el("Button", "Save", source="uia", x=0, y=0, w=50, h=20),
+    ])
+    # An AI hit in an empty region — no deterministic node covers it.
+    ai = _el("Icon", "Avatar", source="vision", x=300, y=300, w=30, h=30,
+             confidence=0.4)
+
+    added, added_count, skipped = _merge_ai_into_tree(root, [ai])
+    assert added_count == 1
+    novel = added[0]
+    fusion = C.annotate(novel.properties)
+    assert fusion["correctness"] == "uncertain"
+    assert fusion["preferred"] == "vision"
+
+
+def test_record_corroboration_dedupes_technique():
+    node = _el("Button", "Save", source="uia")
+    ai = _el("Button", "Save", source="vision")
+    _record_corroboration(node, ai)
+    _record_corroboration(node, ai)
+    assert node.properties["corroborated_by"] == ["vision"]
+
+
+# ── CLI contract: `naturo see --cascade --json` (criterion 2) ──────────────
+
+def test_see_json_emits_fused_correctness_tree(monkeypatch):
+    from click.testing import CliRunner
+    import naturo.cli.core._common as common
+    import naturo.cascade as cascade_pkg
+    from naturo.cli.core._see import see
+    from naturo.cascade._types import CascadeResult, CascadeStats
+
+    root = _el("Window", "App", source="uia", w=200, h=200, children=[
+        _el("Button", "Save", source="uia", x=0, y=0, w=100, h=50),
+        _el("Icon", "Avatar", source="vision", x=120, y=0, w=40, h=40,
+            confidence=0.6),
+    ])
+    result = CascadeResult(tree=root, stats=CascadeStats(),
+                           primary_provider="uia")
+
+    monkeypatch.setattr(common, "_platform_supports_gui", lambda: True)
+
+    class FakeBackend:
+        def _resolve_hwnd(self, **kw):
+            return 123
+
+        def capture_window(self, **kw):
+            raise RuntimeError("no gui in CI")
+
+        def capture_screen(self, **kw):
+            raise RuntimeError("no gui in CI")
+
+        def get_dpi_scale(self, i):
+            return 1.0
+
+        def list_monitors(self):
+            return []
+
+    monkeypatch.setattr(common, "_get_backend", lambda jo: FakeBackend())
+    monkeypatch.setattr(cascade_pkg, "run_cascade", lambda *a, **k: result)
+
+    try:
+        # click <8.2 mixes stderr into stdout unless disabled; >=8.2 always
+        # separates them and dropped the kwarg.
+        runner = CliRunner(mix_stderr=False)
+    except TypeError:
+        runner = CliRunner()
+    res = runner.invoke(
+        see, ["--app", "x", "--cascade", "--json", "--no-snapshot"],
+    )
+    assert res.exit_code == 0, (res.output, res.exception)
+
+    data = json.loads(res.stdout)
+    # Every fused node carries techniques[] + correctness.
+    assert data["techniques"] == ["uia"]
+    assert data["correctness"] == "deterministic"
+    child_techs = {tuple(c["techniques"]) for c in data["children"]}
+    assert ("uia",) in child_techs and ("vision",) in child_techs
+    # Structured summary present and flags the AI-only node.
+    assert data["recognition_summary"]["has_uncertain"] is True
+    assert data["recognition_summary"]["uncertain_nodes"] == 1
+    # Warning goes to stderr (keeps --json stdout pure).
+    assert "uncertain" in res.stderr.lower()
+    # stdout is a single valid JSON document (purity).
+    assert res.stdout.strip().startswith("{")


### PR DESCRIPTION
## What & why

Milestone **M1**: promote the recognition cascade's single per-node `source` tag into the **Unified Auto Element Tree** contract — the correctness-first moat. Every fused node now carries `techniques[]` (which methods recognized it), `correctness` (`deterministic` for uia/msaa/ia2/jab/cdp/com vs `uncertain` for image/vision), and `confidence`; deterministic sources are preferred; the CLI warns when a node is AI/image-only.

## Changes

- **`docs/RECOGNITION_TREE.md`** — schema-of-record ADR: technique→class table, node schema, fusion rules (same element seen by several techniques → one node, all marked, deterministic preferred), the CLI warning contract, and the self-heal / adapter invariants.
- **`naturo/cascade/_correctness.py`** (new, pure/OS-agnostic) — technique classification, deterministic-first ordering, max-confidence fusion (clamped to [0,1]), `recognition_summary`, and the AI/image-only warning.
- **`naturo/cascade/_merge.py`** — record a corroborating AI/image hit onto the matched deterministic node (`corroborated_by`) instead of dropping it, so a node seen by uia+vision reports both and stays deterministic-preferred.
- **`naturo/cascade/_run.py`** — graft auto-cascade **CDP** elements onto the fused tree (they were computed for coverage then discarded, so uia+cdp fusion never reached the tree).
- **`naturo/cli/core/_see.py`** — `see --cascade --json` emits per-node `techniques`/`correctness`/`confidence` + a top-level `recognition_summary`, warns on stderr for AI/image-only nodes (keeps `--json` stdout pure), and routes `--backend cdp` through the fusion path.
- **Tests** — `tests/test_unified_tree.py` (17, Linux-collectable) + a cascade regression test for the CDP graft.

## Verification (independent, fresh-context sub-agents)

- **Code review:** spec conformance, Linux-collectable (import chain has zero Windows-only imports), ruff/mypy clean. Found & fixed a confidence-clamp contract gap.
- **Real-app QA on 2 frameworks, zero orphaned processes (PID-scoped teardown):**
  - **UIA / Notepad** — 46 nodes all `[uia]/deterministic/1.0`; negative AI-warning check passed.
  - **Electron / CDP (Chrome)** — one tree fuses `uia` chrome + `cdp` DOM controls (`by_technique {uia, cdp}`), all deterministic; found & fixed the CDP-graft bug, then re-verified PASS.
- **Local gates:** `test_unified_tree.py` 17/17; cascade 85; see-CLI/json-purity 251; `ruff check naturo/` clean.

## Notes / follow-ups

- **Java/JAB** could not be recovered end-to-end on a healthy JAB host — root-caused to a pre-existing native defect (missing `Windows_run()` + message-pump handshake), tracked in **#1213** (needs a native `naturo_core.dll` rebuild). Not introduced by this change; the fusion schema tags `jab` nodes correctly once the provider returns them (unit-covered).
- The AI-only **positive** warning is unit-tested (no AI provider on the QA host); the negative "don't cry wolf" case is verified on real apps.
- Chrome 149 needs `--remote-allow-origins=*` for CDP — naturo launch docs to be updated separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
