### PR TITLE
docs(M2): publish SOFTWARE_ADAPTATION.md + Excel COM/OCR harness fixtures

### DIFF
--- a/benchmarks/recognition/harness.py
+++ b/benchmarks/recognition/harness.py
@@ -191,6 +191,7 @@ def measure_window(
     window_title: Optional[str] = None,
     depth: int = 15,
     notes: str = "",
+    run_ocr: bool = False,
 ) -> CoverageResult:
     """Measure UIA-only vs full-cascade recognition on one open window.
 
@@ -226,7 +227,7 @@ def measure_window(
     )
     full = run_cascade(
         backend, hwnd=hwnd, pid=pid, window_title=window_title,
-        depth=depth, backend_name="auto",
+        depth=depth, backend_name="auto", run_ocr=run_ocr,
     )
 
     full_counts = _provider_counts(full.stats)
@@ -930,6 +931,124 @@ class JavaSwingFixtureApp:
             self._process = None
 
     def __enter__(self) -> "JavaSwingFixtureApp":
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        self.stop()
+
+
+class ExcelComFixtureApp:
+    """Launch and control an owned Excel workbook for COM-provider measurement.
+
+    Excel collapses its cell grid into a single opaque UIA node; only the COM
+    provider (binding the running Excel instance, cells projected via
+    ``PointsToScreenPixels``) recovers the cells. This fixture writes a small
+    known workbook, opens it in Excel, and measures the uia-only vs full-cascade
+    delta — the literal spreadsheet case.
+    """
+
+    #: Excel window titles look like ``<file> - Excel``.
+    WINDOW_TITLE_SUBSTRING = " - Excel"
+    _STEM = "naturo_adaptation_cells"
+    _CELLS = "Product,Qty\nWidget,42\nGadget,7\nSprocket,13\n"
+
+    def __init__(self, *, excel_path: Optional[str] = None) -> None:
+        import os
+
+        self.excel_path = excel_path or os.path.join(
+            os.environ.get("ProgramFiles", r"C:\Program Files"),
+            "Microsoft Office", "root", "Office16", "EXCEL.EXE",
+        )
+        self._process: Optional[subprocess.Popen] = None
+        self._win_pid: Optional[int] = None
+        self._workdir: Optional[str] = None
+
+    @property
+    def available(self) -> bool:
+        import importlib.util
+
+        return (
+            Path(self.excel_path).is_file()
+            and importlib.util.find_spec("win32com") is not None
+        )
+
+    def start(self, ready_timeout: float = 45.0) -> None:
+        import os
+        import tempfile
+
+        if not self.available:
+            raise RuntimeError(
+                f"Excel COM fixture unavailable: excel={self.excel_path!r}; "
+                "Excel + pywin32 required."
+            )
+        self._workdir = tempfile.mkdtemp(prefix="naturo_excel_fix_")
+        csv_path = os.path.join(self._workdir, f"{self._STEM}.csv")
+        with open(csv_path, "w", encoding="utf-8") as fh:
+            fh.write(self._CELLS)
+        logger.info("Launching Excel COM fixture: %s", csv_path)
+        self._process = subprocess.Popen([self.excel_path, csv_path])
+
+        deadline = time.monotonic() + ready_timeout
+        while time.monotonic() < deadline:
+            window = self.find_window()
+            if window is not None:
+                self._win_pid = window.pid  # the process actually hosting the grid
+                time.sleep(2.5)  # settle render + Excel COM/ROT registration
+                return
+            time.sleep(0.5)
+        self.stop()
+        raise RuntimeError(
+            f"Excel window did not appear within {ready_timeout:.0f}s."
+        )
+
+    def find_window(self):
+        backend = get_backend()
+        for window in backend.list_windows():
+            title = window.title or ""
+            if self.WINDOW_TITLE_SUBSTRING in title and self._STEM in title.lower():
+                return window
+        return None
+
+    def measure(self, depth: int = 15) -> CoverageResult:
+        window = self.find_window()
+        if window is None:
+            raise RuntimeError("Could not locate the Excel fixture window.")
+        return measure_window(
+            app="Owned Excel workbook (real Excel via COM)",
+            framework="Excel COM",
+            hwnd=window.hwnd,
+            pid=window.pid,
+            depth=depth,
+            notes=(
+                "A real Excel window: the cell grid is one opaque UIA node; only "
+                "the COM provider (running-instance binding, cells projected via "
+                "PointsToScreenPixels) recovers the cells."
+            ),
+        )
+
+    def stop(self) -> None:
+        # Kill Excel PID-scoped (the window's host process), then the launcher;
+        # terminate — never a UI close — so no Save/Don't-Save dialog is raised.
+        for pid in (self._win_pid, self._process.pid if self._process else None):
+            if pid is None:
+                continue
+            try:
+                subprocess.run(
+                    ["taskkill", "/F", "/PID", str(pid)],
+                    capture_output=True,
+                )
+            except OSError:
+                pass
+        self._process = None
+        self._win_pid = None
+        if self._workdir is not None:
+            import shutil
+
+            shutil.rmtree(self._workdir, ignore_errors=True)
+            self._workdir = None
+
+    def __enter__(self) -> "ExcelComFixtureApp":
         self.start()
         return self
 

--- a/benchmarks/recognition/run_benchmark.py
+++ b/benchmarks/recognition/run_benchmark.py
@@ -35,6 +35,7 @@ from benchmarks.recognition.harness import (
     ChromiumFixtureApp,
     CoverageResult,
     ElectronFixtureApp,
+    ExcelComFixtureApp,
     JavaSwingFixtureApp,
     measure_running_app,
 )
@@ -105,7 +106,18 @@ def collect_results() -> tuple[List[CoverageResult], List[str]]:
             "JAVA_HOME) and enable Java Access Bridge (`jabswitch -enable`)."
         )
 
-    # 4. Optional real desktop apps (included only when actually open).
+    # 4. Owned Excel workbook (the literal spreadsheet / COM case).
+    excel = ExcelComFixtureApp()
+    if excel.available:
+        with excel:
+            results.append(excel.measure())
+    else:
+        gaps.append(
+            "Excel COM fixture skipped: Microsoft Excel or pywin32 not "
+            "available on this machine."
+        )
+
+    # 5. Optional real desktop apps (included only when actually open).
     for spec in OPTIONAL_APPS:
         result = measure_running_app(
             app=spec["app"],

--- a/docs/SOFTWARE_ADAPTATION.md
+++ b/docs/SOFTWARE_ADAPTATION.md
@@ -1,0 +1,88 @@
+# Software Adaptation Degree
+
+How well does naturo recognize a given piece of Windows software, and with what
+correctness guarantee? This table is measured **live on the host that runs it** —
+nothing is hand-authored. Frameworks that cannot be exercised on the measuring
+host are marked **blocked / candidate** and are **not counted** as coverage
+(no fabrication). Schema & scoring: [`docs/design/software-adaptation-degree.md`](design/software-adaptation-degree.md).
+
+## What is measured
+
+For one app, on the **same window in the same state**, we run naturo twice:
+
+- **UIA-only** — `run_cascade(backend_name="uia")`: exactly the tree a UIA-only
+  rival (Windows-MCP / Terminator / UFO²) would walk.
+- **Cascade** — `run_cascade(backend_name="auto")`: naturo's full multi-framework
+  cascade (UIA → CDP → JAB → COM, plus opt-in local OCR).
+
+`Delta` is the elements the multi-framework cascade recovers that UIA-only cannot.
+Every fused node carries `techniques[]` + `correctness` (`deterministic` for
+uia/msaa/ia2/jab/cdp/com vs `uncertain` for image/ocr/vision) — see
+[`docs/RECOGNITION_TREE.md`](RECOGNITION_TREE.md). The **adaptation degree** is an
+honest coarse class, never a false-precision score:
+
+| degree           | meaning                                                                       |
+| ---------------- | ----------------------------------------------------------------------------- |
+| `full`           | a **deterministic** non-UIA framework (cdp/jab/com/…) recovers net elements.   |
+| `uncertain-only` | the only non-UIA contribution is image/OCR (recovered, but **warned**).        |
+| `uia-only`       | only UIA adds value (a UIA-only rival would tie).                              |
+| `blocked / candidate` | the framework is not exercisable / not wired on this host — **not counted**. |
+
+## Measured coverage (host: this dev machine, 2026-07-01)
+
+| Software | Framework | UIA-only | Cascade | Delta | Correctness | Degree | Source (re-runnable) |
+| --- | --- | ---: | ---: | ---: | --- | --- | --- |
+| Chrome (local web app) | Electron/CDP (`cdp`) | 51 | 88 | **+37** | deterministic | `full` | `run_benchmark` (ChromiumFixtureApp) |
+| Owned Java Swing app | Java Access Bridge (`jab`) | 6 | 46 | **+40** | deterministic | `full` | `run_benchmark` (JavaSwingFixtureApp) |
+| Microsoft Excel workbook | Excel COM (`com`) | 596 | 604 | **+8** | deterministic | `full` | `naturo see --cascade --json` on a running Excel window † |
+| Text baked into an image | Local OCR (`ocr`) | 20 | 25 | **+5** | uncertain (warned) | `uncertain-only` | `naturo see --cascade --ocr --json` ‡ |
+
+- **cdp** contributes +34 web-content elements (New/Open/Save/Inbox/… inside the
+  Chromium content layer UIA collapses to one node).
+- **jab** contributes +40 Swing controls (Submit Order, Cancel Order, Customer
+  Name, Express Shipping, the order table & catalog tree) below a `SunAwtFrame`
+  UIA renders as opaque chrome. Requires the JAB-enabled JVM
+  (`jabswitch -enable`) and a current `naturo_core.dll`.
+- **com** recovers spreadsheet cells (Widget/Gadget/Sprocket/42/7/13) that Excel
+  renders as one opaque UIA grid node; cells are projected to screen coordinates
+  via Excel's `PointsToScreenPixels`.
+- **ocr** recovers text baked into images/canvas (e.g. `NaturoOCR` @0.999,
+  `Amount 98765` @0.986) that no accessibility API exposes; **uncertain** by
+  construction, so the CLI warns and deterministic sources stay preferred.
+
+† The automated `ExcelComFixtureApp` measured **+0 on this host** because Office
+runs unactivated and pops a modal "Microsoft Excel" activation/nag dialog that
+blocks the COM running-instance binding. The COM moat itself is verified by the
+command above (which targets the workbook window directly). Re-run the fixture on
+an **activated Office** (or with the nag pre-dismissed) to reproduce the delta
+in-harness. Tracked as a fixture follow-up.
+
+‡ OCR is **opt-in** (`--ocr`) and requires the `ocr` extra
+(`pip install naturo[ocr]`, a local engine — no cloud key). Without `--ocr` the
+tree contains no `ocr` nodes and no uncertain warning.
+
+## Blocked / candidate frameworks (not counted)
+
+| Framework | Technique | Status on this host | Reason |
+| --- | --- | --- | --- |
+| Firefox / IA2 | `ia2` | **candidate** | Firefox is installed, but the IA2 additive path is not yet wired into the cascade. |
+| Legacy MSAA | `msaa` | **candidate** | Native path exists but is not run additively; no pure-MSAA app measured here. |
+| SAP GUI | `com`/scripting | **blocked: needs env** | SAP GUI is not installed on this host. |
+| Electron (npm fixture) | `cdp` | skipped | The owned Electron fixture needs `npm install`; the Chromium fixture already covers the CDP case. |
+
+## Reproduce
+
+```powershell
+# UIA-vs-cascade coverage table (Chromium=cdp, Java Swing=jab; Excel needs activated Office):
+python -m benchmarks.recognition.run_benchmark --markdown
+
+# COM (Excel) — open a workbook with data, then target its window:
+naturo see --hwnd <XLMAIN_hwnd> --cascade --backend auto --json
+
+# OCR — a window showing text baked into an image:
+naturo see --hwnd <hwnd> --cascade --ocr --json
+```
+
+All numbers above come from these commands on a real desktop. Frameworks not
+exercisable here are listed as blocked/candidate and excluded from any
+"N frameworks supported" count.

--- a/docs/design/software-adaptation-degree.md
+++ b/docs/design/software-adaptation-degree.md
@@ -68,11 +68,20 @@ correctness_counts: dict = {}        # {"deterministic": N, "uncertain": M}
 
 Recorded from live probes; re-derive per host. Only ✓ rows count toward coverage.
 
+> **Update (2026-07-01, after provisioning):** several rows below were an initial
+> snapshot and are now superseded — `jab` is **reproducible** (the source handshake
+> #1174 was already correct; only the *local dev DLL* was stale — rebuilt with the
+> VS2022 Build Tools that ARE installed; the earlier "MSVC absent / #1213" note was
+> wrong, #1213 is an unrelated issue and #1096 is the real, already-fixed handshake
+> bug); `ocr` is **reproducible** (`rapidocr_onnxruntime` installed — local, no cloud
+> key); `ia2` is a **candidate** (Firefox now installed, additive path not yet wired).
+> The authoritative current per-software matrix is `docs/SOFTWARE_ADAPTATION.md`.
+
 | framework | technique | status on this host | evidence |
 | --------- | --------- | ------------------- | -------- |
 | Win32/UWP/WPF | `uia` | ✓ reproducible | M1 QA: Notepad 46 nodes deterministic |
 | Electron/Chromium | `cdp` | ✓ reproducible | M1 QA: Chrome uia+cdp fusion |
-| Java Swing/AWT | `jab` | ✗ blocked: needs env | native `naturo_core.dll` handshake defect (#1213); MSVC absent → cannot rebuild here |
+| Java Swing/AWT | `jab` | ✗ blocked: needs env | native `naturo_core.dll` handshake defect (#1096); MSVC absent → cannot rebuild here |
 | Firefox/IA2 | `ia2` | ✗ blocked: needs env | no Firefox/Thunderbird/LibreOffice installed |
 | Office COM | `com` | ⚑ candidate (unwired) | Excel + Word installed; not yet a cascade provider |
 | Legacy MSAA | `msaa` | ⚑ candidate (suppressed) | in primary loop but first-non-empty (uia) wins; no additive path yet |


### PR DESCRIPTION
## What (M2: publish the software-adaptation-degree table)

Completes M2 criteria 2/3: a **public, per-software adaptation-degree table**
(`docs/SOFTWARE_ADAPTATION.md`) built from **real recognition runs** on this host,
with non-reproducible frameworks marked blocked/candidate and **not counted**.

## Contents

- **`docs/SOFTWARE_ADAPTATION.md`** — measured coverage: Chrome/**cdp** (+37),
  Java Swing/**jab** (+40), Excel/**com** (+8), text-image/**ocr** (+5, uncertain,
  warned); blocked/candidate rows (ia2 candidate — Firefox installed but not wired;
  msaa candidate; SAP blocked). Every number has a re-runnable command.
- **`benchmarks/recognition/harness.py`** — `ExcelComFixtureApp` (owned Excel
  workbook, COM measurement, PID-scoped teardown by terminate — no Save dialog) +
  `run_ocr` on `measure_window`. Modules stay Linux-collectable (win32com/rapidocr
  imported lazily).
- **`benchmarks/recognition/run_benchmark.py`** — runs the Excel fixture (gap when
  Excel/pywin32 absent).
- **`docs/design/software-adaptation-degree.md`** — host-matrix correction: the
  earlier "MSVC absent / jab blocked / #1213" note was wrong (VS2022 Build Tools
  ARE installed; the JAB source handshake #1174 was already correct — only the
  local dev DLL was stale; #1213 is unrelated, #1096 is the real handshake bug).

## Real-run evidence

`python -m benchmarks.recognition.run_benchmark` on a real desktop:
`cdp` +37 (degree full), `jab` +40 (degree full) — both deterministic, zero
uncertain. Independent QA earlier confirmed `com` (+8, deterministic) and `ocr`
(uncertain, warned) via `naturo see --cascade [--ocr]`, all with zero orphaned
processes and PID-scoped teardown.

## Honest caveat

The automated Excel fixture measured +0 **on this host** because Office runs
unactivated and shows a modal activation nag that blocks the COM binding; the COM
moat is verified by the documented `see --cascade` command. Re-run on an activated
Office to reproduce the com delta in-harness (fixture follow-up noted in the doc).

## Tests

Existing benchmark unit tests unchanged (16 pass, Linux-collectable). `ruff check
naturo/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
