### PR TITLE
refactor(M2): align adaptation-degree vocabulary to GOAL (full-tree/partial/vision-only/none)

### DIFF
--- a/benchmarks/recognition/harness.py
+++ b/benchmarks/recognition/harness.py
@@ -161,10 +161,13 @@ def adaptation_degree(result: "CoverageResult") -> str:
     See docs/design/software-adaptation-degree.md §2. This is a coarse class,
     never a false-precision score:
 
-    * ``full``           -- a deterministic non-UIA framework (cdp/jab/com/ia2/
-      msaa) adds net elements (``delta > 0``). The moat case.
-    * ``uncertain-only`` -- the only non-UIA contribution is image/OCR/AI.
-    * ``uia-only``       -- only UIA adds value (a UIA-only rival would tie).
+    * ``full-tree``   -- a deterministic non-UIA framework (cdp/jab/com/ia2/
+      msaa) adds net elements (``delta > 0``): the fused tree recovers content
+      UIA collapses. The moat case.
+    * ``vision-only`` -- the only non-UIA contribution is image/OCR/AI (uncertain).
+    * ``partial``     -- only UIA adds value (a UIA-only rival would tie); UIA
+      typically sees just the accessible subset, not the framework's content.
+    * ``none``        -- nothing recognized (empty tree).
 
     ``blocked: needs env`` is decided at collection time (a framework that
     cannot be exercised on the host), not here.
@@ -175,11 +178,13 @@ def adaptation_degree(result: "CoverageResult") -> str:
         if technique_class(t) == DETERMINISTIC and t != "uia"
     ]
     uncertain = [t for t in techniques if technique_class(t) != DETERMINISTIC]
+    if not techniques and result.cascade_count == 0:
+        return "none"
     if deterministic_non_uia and result.delta > 0:
-        return "full"
+        return "full-tree"
     if uncertain and not deterministic_non_uia and result.delta > 0:
-        return "uncertain-only"
-    return "uia-only"
+        return "vision-only"
+    return "partial"
 
 
 def measure_window(

--- a/docs/SOFTWARE_ADAPTATION.md
+++ b/docs/SOFTWARE_ADAPTATION.md
@@ -23,19 +23,20 @@ honest coarse class, never a false-precision score:
 
 | degree           | meaning                                                                       |
 | ---------------- | ----------------------------------------------------------------------------- |
-| `full`           | a **deterministic** non-UIA framework (cdp/jab/com/…) recovers net elements.   |
-| `uncertain-only` | the only non-UIA contribution is image/OCR (recovered, but **warned**).        |
-| `uia-only`       | only UIA adds value (a UIA-only rival would tie).                              |
+| `full-tree`           | a **deterministic** non-UIA framework (cdp/jab/com/…) recovers net elements.   |
+| `vision-only` | the only non-UIA contribution is image/OCR (recovered, but **warned**).        |
+| `partial`       | only UIA adds value (a UIA-only rival would tie).                              |
+| `none`          | nothing recognized; the cascade returns an empty tree for this window. |
 | `blocked / candidate` | the framework is not exercisable / not wired on this host — **not counted**. |
 
 ## Measured coverage (host: this dev machine, 2026-07-01)
 
 | Software | Framework | UIA-only | Cascade | Delta | Correctness | Degree | Source (re-runnable) |
 | --- | --- | ---: | ---: | ---: | --- | --- | --- |
-| Chrome (local web app) | Electron/CDP (`cdp`) | 51 | 88 | **+37** | deterministic | `full` | `run_benchmark` (ChromiumFixtureApp) |
-| Owned Java Swing app | Java Access Bridge (`jab`) | 6 | 46 | **+40** | deterministic | `full` | `run_benchmark` (JavaSwingFixtureApp) |
-| Microsoft Excel workbook | Excel COM (`com`) | 596 | 604 | **+8** | deterministic | `full` | `naturo see --cascade --json` on a running Excel window † |
-| Text baked into an image | Local OCR (`ocr`) | 20 | 25 | **+5** | uncertain (warned) | `uncertain-only` | `naturo see --cascade --ocr --json` ‡ |
+| Chrome (local web app) | Electron/CDP (`cdp`) | 51 | 88 | **+37** | deterministic | `full-tree` | `run_benchmark` (ChromiumFixtureApp) |
+| Owned Java Swing app | Java Access Bridge (`jab`) | 6 | 46 | **+40** | deterministic | `full-tree` | `run_benchmark` (JavaSwingFixtureApp) |
+| Microsoft Excel workbook | Excel COM (`com`) | 596 | 604 | **+8** | deterministic | `full-tree` | `naturo see --cascade --json` on a running Excel window † |
+| Text baked into an image | Local OCR (`ocr`) | 20 | 25 | **+5** | uncertain (warned) | `vision-only` | `naturo see --cascade --ocr --json` ‡ |
 
 - **cdp** contributes +34 web-content elements (New/Open/Save/Inbox/… inside the
   Chromium content layer UIA collapses to one node).

--- a/docs/design/software-adaptation-degree.md
+++ b/docs/design/software-adaptation-degree.md
@@ -35,9 +35,10 @@ we cannot justify. The degree is one of four honest classes:
 
 | degree            | meaning                                                                 |
 | ----------------- | ----------------------------------------------------------------------- |
-| `full`            | cascade recovers substantially more than UIA-only (`delta > 0`) via a **deterministic** non-UIA framework (cdp/jab/com/ia2/msaa). The moat case. |
-| `uia-only`        | only UIA fires; no non-UIA framework adds elements. naturo works but so would a UIA-only rival. |
-| `uncertain-only`  | the only non-UIA contribution is image/OCR/AI (uncertain). Recognized, but **warned** — bounds estimated. |
+| `full-tree`            | cascade recovers substantially more than UIA-only (`delta > 0`) via a **deterministic** non-UIA framework (cdp/jab/com/ia2/msaa). The moat case. |
+| `partial`         | only UIA fires; no non-UIA framework adds elements — UIA typically sees just the accessible subset, and a UIA-only rival would tie. |
+| `none`            | nothing recognized; the cascade returns an empty tree for the window. |
+| `vision-only`  | the only non-UIA contribution is image/OCR/AI (uncertain). Recognized, but **warned** — bounds estimated. |
 | `blocked: needs env` | the framework naturo *would* use is not exercisable on this host (missing app, missing engine, or a known defect). **Not counted** as coverage. |
 
 `delta`, counts and the fired frameworks are always shown as the underlying

--- a/tests/test_adaptation_degree.py
+++ b/tests/test_adaptation_degree.py
@@ -24,30 +24,35 @@ def _result(uia, cascade, techniques):
 
 def test_degree_full_when_deterministic_non_uia_adds_elements():
     # cdp is deterministic + non-UIA + positive delta -> the moat case.
-    assert adaptation_degree(_result(20, 34, ["uia", "cdp"])) == "full"
+    assert adaptation_degree(_result(20, 34, ["uia", "cdp"])) == "full-tree"
 
 
 def test_degree_uia_only_when_only_uia():
-    assert adaptation_degree(_result(20, 20, ["uia"])) == "uia-only"
+    assert adaptation_degree(_result(20, 20, ["uia"])) == "partial"
 
 
 def test_degree_uncertain_only_when_non_uia_is_ai_or_image():
     # vision adds elements but it is uncertain, not deterministic.
-    assert adaptation_degree(_result(20, 26, ["uia", "vision"])) == "uncertain-only"
+    assert adaptation_degree(_result(20, 26, ["uia", "vision"])) == "vision-only"
 
 
 def test_degree_uia_only_when_non_uia_framework_adds_no_net_elements():
     # cdp fired but delta == 0 (all corroborating) -> no measured advantage.
-    assert adaptation_degree(_result(20, 20, ["uia", "cdp"])) == "uia-only"
+    assert adaptation_degree(_result(20, 20, ["uia", "cdp"])) == "partial"
 
 
 def test_degree_full_prefers_deterministic_over_present_uncertain():
     # Both a deterministic non-UIA (jab) and an uncertain (vision) fired,
     # with a positive delta -> deterministic wins the classification.
-    assert adaptation_degree(_result(10, 30, ["uia", "jab", "vision"])) == "full"
+    assert adaptation_degree(_result(10, 30, ["uia", "jab", "vision"])) == "full-tree"
 
 
 # ── _degree_fields_from_summary (derives table fields from M1 summary) ─────
+
+def test_degree_none_when_nothing_recognized():
+    # empty tree (no techniques, zero elements) -> nothing recognized.
+    assert adaptation_degree(_result(0, 0, [])) == "none"
+
 
 def test_degree_fields_orders_deterministic_first_and_counts_correctness():
     summary = {
@@ -82,6 +87,6 @@ def test_coverage_result_to_dict_carries_new_fields():
     d = r.to_dict()
     assert d["techniques"] == ["uia", "cdp"]
     assert d["correctness_counts"] == {"deterministic": 34, "uncertain": 0}
-    assert d["degree"] == "full"
+    assert d["degree"] == "full-tree"
     # existing fields still present
     assert d["delta"] == 14


### PR DESCRIPTION
Aligns the adaptation-degree labels to agents/GOAL.md M2 criterion 2 (full-tree / partial / vision-only / none), replacing the ad-hoc full / uia-only / uncertain-only. Adds a `none` degree (empty tree). Updates `adaptation_degree()`, the unit tests (17 pass, +none test), the ADR and the published SOFTWARE_ADAPTATION.md. `blocked: needs env` unchanged. Pure vocabulary alignment; no measurement logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)