### PR TITLE
fix(input): IME-immune typing via ValuePattern + self-heal comtypes gen cache (#1219)

### DIFF
--- a/docs/AGENT_INTEGRATION.md
+++ b/docs/AGENT_INTEGRATION.md
@@ -95,6 +95,17 @@ A real Claude-Code agent runs exactly this sequence through the MCP tools with n
 naturo-specific code — see `tests/` for the contract the tools honor
 (`test_mcp_error_contract.py`, `test_mcp_inspect.py`).
 
+### Reliable text entry under IMEs
+
+`type_text` writes to the focused control through its UIA **ValuePattern** when
+one is available — text lands exactly, bypassing the keyboard and any active
+input method (e.g. a CJK Pinyin IME that would otherwise mangle injected
+keystrokes). The result reports `"method": "value_pattern"` or `"keystroke"`.
+Controls without a writable ValuePattern fall back to keystroke injection, which
+is best-effort under an active IME; pass `input_mode: "hardware"` to force
+scan-code keystrokes. For a guaranteed exact set on a known field, use
+`set_element_value` (also ValuePattern-based).
+
 ## Tool surface (summary)
 
 `capture_screen` · `capture_window` · `list_windows` · `list_apps` · `launch_app`

--- a/naturo/backends/base.py
+++ b/naturo/backends/base.py
@@ -317,6 +317,22 @@ class Backend(ABC):
         """
         return False
 
+    def set_focused_element_value(self, text: str, append: bool = True) -> bool:
+        """IME-immune text entry via the focused element's UIA ValuePattern.
+
+        Returns True if the text was set directly through accessibility
+        (bypassing keystroke injection and any active IME), False if
+        unavailable — in which case the caller should fall back to
+        :meth:`type_text`. The default returns False; Windows overrides it
+        to make ``type`` reliable on CJK/IME hosts (#1219).
+
+        Args:
+            text: Text to insert.
+            append: Append to the element's current value (keystroke-like) when
+                True, else replace the whole value.
+        """
+        return False
+
     @abstractmethod
     def type_text(self, text: str, delay_ms: int = 5, profile: str = "human",
                   wpm: int = 120, input_mode: str = "normal") -> None:

--- a/naturo/backends/windows/_input/_uia_interact.py
+++ b/naturo/backends/windows/_input/_uia_interact.py
@@ -243,10 +243,29 @@ class UIAInteractMixin:
         Ensures comtypes gen modules are generated before importing from them.
         Returns a tuple of (IUIAutomation instance, module reference).
 
+        On many deployed/enterprise hosts ``site-packages`` is read-only, so a
+        stale generated typelib in ``comtypes/gen`` cannot be regenerated in
+        place — comtypes raises ``PermissionError`` / a "Typelib different than
+        module" error and naturo's whole UIA layer (SetValue, ValuePattern
+        reads, …) silently dies (#1219). If the normal path fails for any
+        reason, redirect codegen to a writable per-user dir and retry once.
+
         Raises:
             ImportError: If comtypes is not available.
-            Exception: If UIA COM initialization fails.
+            Exception: If UIA COM initialization fails even after the retry.
         """
+        import comtypes.client  # type: ignore[import-untyped]  # noqa: F401
+        try:
+            return self._create_uia_via_comtypes()
+        except (ImportError, ModuleNotFoundError):
+            raise
+        except Exception:
+            self._redirect_comtypes_gen_dir()
+            return self._create_uia_via_comtypes()
+
+    @staticmethod
+    def _create_uia_via_comtypes():
+        """Build the IUIAutomation instance from the (possibly regenerated) gen."""
         import comtypes.client  # type: ignore[import-untyped]
         try:
             from comtypes.gen import UIAutomationClient as mod  # type: ignore[import-untyped]
@@ -259,6 +278,36 @@ class UIAInteractMixin:
             interface=mod.IUIAutomation,
         )
         return uia, mod
+
+    @staticmethod
+    def _redirect_comtypes_gen_dir():
+        """Point comtypes codegen at a writable per-user dir and drop stale gen.
+
+        Fixes the read-only-``site-packages`` + stale-cache deadlock (#1219): a
+        fresh writable ``gen_dir`` lets ``GetModule`` regenerate the typelib, and
+        restricting ``comtypes.gen.__path__`` to it prevents a stale read-only
+        cached module from shadowing the fresh one.
+        """
+        import os
+        import sys
+        import tempfile
+
+        import comtypes.client  # type: ignore[import-untyped]
+        import comtypes.gen  # type: ignore[import-untyped]
+
+        target = os.path.join(tempfile.gettempdir(), "naturo_comtypes_gen")
+        os.makedirs(target, exist_ok=True)
+        comtypes.client.gen_dir = target
+        comtypes.gen.__path__[:] = [target]
+        # Drop any already-imported (stale) gen submodules so the retry
+        # regenerates them into the writable dir instead of reusing the cache.
+        for name in [n for n in sys.modules if n.startswith("comtypes.gen.")]:
+            del sys.modules[name]
+        logger.warning(
+            "comtypes gen cache was unusable (stale/read-only); redirected "
+            "codegen to %s to keep the UIA ValuePattern path working (#1219)",
+            target,
+        )
 
     def _find_uia_element(self, uia, mod, hwnd: int = 0,
                           name: Optional[str] = None,
@@ -515,6 +564,53 @@ class UIAInteractMixin:
             return False
         except Exception as exc:
             logger.debug("SetValue unexpected error: %s", exc)
+            return False
+
+    def set_focused_element_value(self, text: str, append: bool = True) -> bool:
+        """IME-immune text entry: write to the focused element via ValuePattern.
+
+        Keystroke injection (SendInput) is intercepted by CJK/TSF IMEs and can
+        corrupt typed text (#1219: "naturo" -> "nature"). When the focused
+        control exposes a writable ValuePattern, set its value directly through
+        UIA — bypassing the keyboard and the IME entirely. Returns False (so the
+        caller falls back to keystrokes) when there is no focused element, no
+        ValuePattern, or the pattern is read-only.
+
+        Args:
+            text: Text to insert.
+            append: When True, append to the element's current value so a
+                ``type`` after existing text matches keystroke semantics; when
+                False, replace the whole value.
+
+        Returns:
+            True if the value was set via ValuePattern, False otherwise.
+        """
+        try:
+            uia, mod = self._init_comtypes_uia()
+        except (ImportError, Exception):
+            return False
+        try:
+            elem = uia.GetFocusedElement()
+            if elem is None:
+                return False
+            pat_unk = elem.GetCurrentPattern(mod.UIA_ValuePatternId)
+            if pat_unk is None:
+                return False
+            vp = pat_unk.QueryInterface(mod.IUIAutomationValuePattern)
+            if vp.CurrentIsReadOnly:
+                return False
+            new_value = ((vp.CurrentValue or "") + text) if append else text
+            vp.SetValue(new_value)
+            logger.info(
+                "type: set focused element via ValuePattern (IME-immune, len=%d)",
+                len(text),
+            )
+            return True
+        except (OSError, AttributeError) as exc:
+            logger.debug("set_focused_element_value failed: %s", exc)
+            return False
+        except Exception as exc:
+            logger.debug("set_focused_element_value unexpected error: %s", exc)
             return False
 
     def get_element_value_uia(

--- a/naturo/mcp/_input.py
+++ b/naturo/mcp/_input.py
@@ -105,8 +105,18 @@ def register_input_tools(server, _get_backend, _safe_tool):
                 },
             }
         backend = _get_backend()
-        backend.type_text(text=text, wpm=wpm, input_mode=input_mode)
-        return {"success": True}
+        # (#1219) Prefer IME-immune entry: keystroke injection (SendInput) is
+        # intercepted by CJK/TSF IMEs and can corrupt text ("naturo" ->
+        # "nature"). When the focused control exposes a writable ValuePattern,
+        # set its value directly through UIA — bypassing the keyboard and the
+        # IME. Fall back to keystrokes when there is no such control, or when
+        # the caller explicitly asked for keystroke-level "hardware" scan codes.
+        used_value_pattern = False
+        if input_mode == "normal":
+            used_value_pattern = bool(backend.set_focused_element_value(text, append=True))
+        if not used_value_pattern:
+            backend.type_text(text=text, wpm=wpm, input_mode=input_mode)
+        return {"success": True, "method": "value_pattern" if used_value_pattern else "keystroke"}
 
     @server.tool()
     @_safe_tool

--- a/tests/test_mcp_input.py
+++ b/tests/test_mcp_input.py
@@ -36,6 +36,10 @@ def _call_tool(server, tool_name: str, arguments: dict):
 @pytest.fixture
 def mock_backend():
     backend = MagicMock()
+    # Default: no focused ValuePattern control, so type_text falls back to
+    # keystroke injection (the path most tests assert). The IME-immune
+    # ValuePattern path (#1219) is covered explicitly in TestTypeText.
+    backend.set_focused_element_value.return_value = False
     return backend
 
 
@@ -155,6 +159,37 @@ class TestTypeText:
         assert data["success"] is True
         call_kwargs = mock_backend.type_text.call_args[1]
         assert call_kwargs["input_mode"] == "hardware"
+
+    def test_type_text_prefers_value_pattern_when_available(self, server, mock_backend):
+        """#1219: focused control with a writable ValuePattern → IME-immune
+        direct write, no keystroke injection."""
+        mock_backend.set_focused_element_value.return_value = True
+        result = _call_tool(server, "type_text", {"text": "naturo"})
+        data = json.loads(result[0].text)
+        assert data["success"] is True
+        assert data["method"] == "value_pattern"
+        mock_backend.set_focused_element_value.assert_called_once_with("naturo", append=True)
+        mock_backend.type_text.assert_not_called()
+
+    def test_type_text_falls_back_to_keystroke_without_value_pattern(self, server, mock_backend):
+        """No focused ValuePattern control (default) → keystroke injection."""
+        result = _call_tool(server, "type_text", {"text": "naturo"})
+        data = json.loads(result[0].text)
+        assert data["success"] is True
+        assert data["method"] == "keystroke"
+        mock_backend.set_focused_element_value.assert_called_once()
+        mock_backend.type_text.assert_called_once()
+
+    def test_type_text_hardware_mode_skips_value_pattern(self, server, mock_backend):
+        """Explicit 'hardware' scan-code mode is keystroke-only — ValuePattern
+        is not attempted."""
+        mock_backend.set_focused_element_value.return_value = True
+        result = _call_tool(server, "type_text", {"text": "hw", "input_mode": "hardware"})
+        data = json.loads(result[0].text)
+        assert data["success"] is True
+        assert data["method"] == "keystroke"
+        mock_backend.set_focused_element_value.assert_not_called()
+        mock_backend.type_text.assert_called_once()
 
 
 # ── Press Key ─────────────────────────────────────────────────────────

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -112,6 +112,10 @@ class TestToolFunctionsWithMockedBackend:
         """Create a comprehensive mock backend."""
         backend = MagicMock()
         # Setup return values for common methods
+        # No focused ValuePattern control by default → type_text uses keystroke
+        # injection (the asserted path); the IME-immune ValuePattern path (#1219)
+        # is covered in tests/test_mcp_input.py.
+        backend.set_focused_element_value.return_value = False
         backend.list_windows.return_value = []
         backend.list_apps.return_value = []
         backend.clipboard_get.return_value = "test"


### PR DESCRIPTION
## Problem (#1219)

`type_text` (keystroke injection via SendInput) is intercepted by CJK/TSF IMEs
and corrupts text — on a host with an active Chinese Pinyin IME, `naturo` typed
`naturo via from` and it landed as `nature via from` (independently reproduced).

## Fix

- **IME-immune typing via ValuePattern.** `type_text` now prefers writing to the
  focused control through its UIA `ValuePattern.SetValue` (append semantics),
  which never touches the keyboard and is inherently immune to the active input
  method. It falls back to keystroke injection when the focused control has no
  writable ValuePattern, or when the caller asks for `input_mode: "hardware"`.
  The tool result reports `"method": "value_pattern"` | `"keystroke"`.
- **Self-heal comtypes' generated typelib cache.** On read-only `site-packages`
  hosts (common in deployed/enterprise installs) a stale `comtypes/gen` module
  can't be regenerated in place — comtypes raises `PermissionError` /
  "Typelib different than module" and naturo's whole UIA layer (SetValue,
  ValuePattern reads) silently died. `_init_comtypes_uia` now redirects codegen
  to a writable per-user dir and retries, logging a WARNING instead of a silent
  fallback.

## Verification (real Chinese-locale host, active Pinyin IME HKL 0x08040804)

Independent QA driving the real MCP `type_text` tool:
- Writable-ValuePattern control (Run dialog Edit): returns `method: "value_pattern"`,
  read-back **character-exact** (`naturo`=`naturo`, `via`=`via`, `from`=`from`)
  — with the comtypes self-heal WARNING confirming the stale cache is present and
  the redirect is what keeps typing alive.
- Read-only-ValuePattern control: correctly returns `method: "keystroke"` (documented fallback).
- Unit tests: `test_mcp_input.py` (ValuePattern-preferred / keystroke-fallback /
  hardware-skips-VP), `test_mcp_server.py`, `test_uia_input.py` — all green; ruff clean.

Native `naturo_core.dll` unchanged — this is a Python-layer fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
