### PR TITLE
fix(reliability): deselect real-desktop injecting tests by default (M4-3 safeguard)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,15 @@ naturo = ["bin/*.dll", "bin/*.so", "bin/*.dylib", "selectors_builtin/*.json"]
 testpaths = ["tests"]
 pythonpath = ["."]
 timeout = 120
+# Safety default: never run the real-desktop tests unless explicitly opted in.
+# The ``ui``/``integration``/``desktop`` suites drive real SendInput / native
+# UIA against whatever window has focus — an ad-hoc or looped ``pytest <file>``
+# would type into the user's active terminal (M4 criterion 3: "cmd/terminals
+# never touched"). CI already passes this exact ``-m`` filter; making it the
+# default aligns local runs with CI so injecting tests only run under an explicit
+# ``-m ui`` (or ``-m "ui or integration or desktop"``) opt-in, ideally scoped to
+# a throwaway window.
+addopts = "-m 'not ui and not integration and not desktop'"
 markers = [
     "ui: marks tests that need a desktop session (deselect with '-m \"not ui\"')",
     "windows: Windows-only test",

--- a/tests/test_pytest_safety_config.py
+++ b/tests/test_pytest_safety_config.py
@@ -1,0 +1,33 @@
+"""M4 criterion 3 — the default pytest config must keep injecting tests opt-in.
+
+The ``ui``/``integration``/``desktop`` suites drive real ``SendInput`` / native
+UIA against whatever window has focus. Without a default marker filter, an ad-hoc
+or looped ``pytest <file>`` runs them and types into the user's active terminal
+(this actually happened during M4 development). This guard asserts the default
+``addopts`` deselects those markers so injecting tests only run under an explicit
+``-m`` opt-in — enforcing the "cmd/terminals never touched" non-negotiable.
+
+Pure text parse of ``pyproject.toml`` — no naturo import, no DLL — Linux-collectable.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_PYPROJECT = Path(__file__).resolve().parent.parent / "pyproject.toml"
+
+
+def _addopts() -> str:
+    text = _PYPROJECT.read_text(encoding="utf-8")
+    match = re.search(r"^addopts\s*=\s*(.+)$", text, re.MULTILINE)
+    assert match, "pyproject.toml [tool.pytest.ini_options] must set a default addopts"
+    return match.group(1)
+
+
+def test_default_addopts_deselects_injecting_markers():
+    """A bare ``pytest`` must not run real-desktop input/UIA tests by default."""
+    addopts = _addopts()
+    for marker in ("not ui", "not integration", "not desktop"):
+        assert marker in addopts, (
+            f"default addopts must deselect injecting tests — missing {marker!r}: {addopts}"
+        )


### PR DESCRIPTION
Ad-hoc/looped `pytest <file>` ran the `@pytest.mark.ui` functional tests (real SendInput) and typed into the active terminal. CI already filters these; this makes the same `-m 'not ui and not integration and not desktop'` the DEFAULT addopts so injecting tests are opt-in only. Verified via --collect-only: default deselects 24 ui tests in test_input_keyboard.py; they appear only under -m ui. Guarded by tests/test_pytest_safety_config.py (Linux-collectable). Enforces the 'cmd/terminals never touched' non-negotiable (M4 criterion 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)