### PR TITLE
fix(reliability): generalize crash-recovery self-heal to the native core (M4-2)

### DIFF
--- a/naturo/backends/windows/_core.py
+++ b/naturo/backends/windows/_core.py
@@ -2,12 +2,61 @@
 
 from __future__ import annotations
 
+import functools
 import logging
 from typing import Optional
 
-from naturo.bridge import NaturoCore
+from naturo.bridge import NaturoCore, NaturoCoreError
 
 logger = logging.getLogger(__name__)
+
+# Native error codes for which re-initializing the core can plausibly recover —
+# a COM/system apartment that went bad mid-session. Op-level faults (invalid
+# argument, buffer-too-small, file I/O) are not core-state failures and are
+# never healed or retried, so a genuine bad request still surfaces immediately.
+_RECOVERABLE_CORE_CODES = frozenset({-2})  # -2 == System/COM error
+
+
+def heal_core_on_failure(*, retry: bool):
+    """Reset the native core after a recoverable COM/DLL failure so it self-heals.
+
+    Generalizes the comtypes gen-cache self-heal (#1220) to the native
+    recognition/input layers (M4-2): if the cached core/COM instance goes bad
+    mid-session, ``_ensure_core`` would otherwise keep handing back the broken
+    instance forever. On a :class:`NaturoCoreError` whose code marks a recoverable
+    core/COM failure, this drops the cached core (so the next ``_ensure_core``
+    re-initializes it) and logs a WARNING.
+
+    Args:
+        retry: When True the wrapped op — which MUST be idempotent (recognition)
+            — is retried once in place so the same call self-heals. When False
+            (side-effecting input) only the reset happens and the original error
+            propagates, so the *next* call re-inits with no risk of double-acting.
+    """
+
+    def deco(fn):
+        @functools.wraps(fn)
+        def wrapper(self, *args, **kwargs):
+            try:
+                return fn(self, *args, **kwargs)
+            except NaturoCoreError as exc:
+                if not self._is_recoverable_core_failure(exc):
+                    raise
+                logger.warning(
+                    "native core op %s failed with a recoverable COM/core error "
+                    "(code=%s); resetting core to self-heal %s (M4-2): %s",
+                    fn.__name__, exc.code,
+                    "and retrying now" if retry else "on the next call",
+                    exc,
+                )
+                self._reset_core()
+                if retry:
+                    return fn(self, *args, **kwargs)  # idempotent op → heal in place
+                raise
+
+        return wrapper
+
+    return deco
 
 
 class CoreMixin:
@@ -258,6 +307,21 @@ class CoreMixin:
             self._core.init()
             self._initialized = True
         return self._core
+
+    def _reset_core(self) -> None:
+        """Drop the cached native core so the next :meth:`_ensure_core` rebuilds it.
+
+        The self-heal escape hatch (M4-2) for a core/COM instance that went bad
+        mid-session. Cheap and safe: the core is re-created + re-initialized
+        lazily on the next demand.
+        """
+        self._core = None
+        self._initialized = False
+
+    @staticmethod
+    def _is_recoverable_core_failure(exc: NaturoCoreError) -> bool:
+        """Whether re-initializing the core could plausibly recover from *exc*."""
+        return getattr(exc, "code", None) in _RECOVERABLE_CORE_CODES
 
     @property
     def platform_name(self) -> str:

--- a/naturo/backends/windows/_element/_tree.py
+++ b/naturo/backends/windows/_element/_tree.py
@@ -15,6 +15,7 @@ import logging
 from typing import Optional
 
 from naturo.backends.base import ElementInfo as BaseElementInfo
+from naturo.backends.windows._core import heal_core_on_failure
 from naturo.bridge import populate_hierarchy
 from naturo.errors import NaturoError, StaleSnapshotCacheError
 
@@ -126,6 +127,7 @@ class ElementTreeMixin:
             return True
 
         return False
+    @heal_core_on_failure(retry=True)
     def get_element_tree(self, window_title: Optional[str] = None,
                          depth: int = 3,
                          app: Optional[str] = None,

--- a/naturo/backends/windows/_input/_keyboard.py
+++ b/naturo/backends/windows/_input/_keyboard.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+from naturo.backends.windows._core import heal_core_on_failure
 from naturo.backends.windows._strategies import get_input_strategy
 
 
 class KeyboardMixin:
     """Keyboard interaction: text typing, key presses, and hotkey combinations."""
 
+    @heal_core_on_failure(retry=False)
     def type_text(self, text: str = "", delay_ms: int = 5, profile: str = "linear",
                   wpm: int = 120, input_mode: str = "normal") -> None:
         """Type text using SendInput.

--- a/naturo/backends/windows/_input/_mouse.py
+++ b/naturo/backends/windows/_input/_mouse.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 from typing import Optional
 
+from naturo.backends.windows._core import heal_core_on_failure
 from naturo.backends.windows._strategies import get_input_strategy
 
 
 class MouseMixin:
     """Mouse interaction: click, scroll, drag, and cursor movement."""
 
+    @heal_core_on_failure(retry=False)
     def click(self, x: Optional[int] = None, y: Optional[int] = None,
               element_id: Optional[str] = None, button: str = "left",
               double: bool = False, input_mode: str = "normal",

--- a/tests/test_crash_recovery.py
+++ b/tests/test_crash_recovery.py
@@ -1,0 +1,124 @@
+"""M4 criterion 2 — generalized crash-recovery / self-heal for the native core.
+
+The comtypes gen-cache self-heal (#1220) recovered a broken UIA codegen cache on
+the next call. This generalizes the same idea to the native recognition/input
+layers: if the cached ``NaturoCore``/COM instance goes bad mid-session,
+``heal_core_on_failure`` resets it so the next call re-initializes rather than
+staying broken forever, logging a WARNING.
+
+These tests exercise the decorator + ``CoreMixin`` reset logic directly on a fake
+core — no ``WindowsBackend`` instantiation (that needs Win32), so the module is
+Linux-collectable.
+"""
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from naturo.backends.windows._core import CoreMixin, heal_core_on_failure
+from naturo.bridge import NaturoCoreError
+
+
+class _FakeCore:
+    """Stand-in for the native core: raises a COM error (-2) when ``broken``."""
+
+    def __init__(self, broken: bool):
+        self.broken = broken
+        self.op_calls = 0
+
+    def do_op(self, value):
+        self.op_calls += 1
+        if self.broken:
+            raise NaturoCoreError(-2, "do_op")  # -2 == System/COM error (recoverable)
+        return f"ok:{value}"
+
+    def do_op_fatal(self, value):
+        raise NaturoCoreError(-1, "do_op")  # -1 == invalid argument (NOT recoverable)
+
+
+class _FakeBackend:
+    """Minimal object with the CoreMixin self-heal surface + a lazy fake core.
+
+    The first core built is ``broken`` (raises -2); every core built after a
+    reset is healthy — modelling a COM instance that went bad then re-initialized.
+    """
+
+    _reset_core = CoreMixin._reset_core
+    _is_recoverable_core_failure = staticmethod(CoreMixin._is_recoverable_core_failure)
+
+    def __init__(self):
+        self._core = None
+        self._initialized = False
+        self.core_builds = 0
+
+    def _ensure_core(self) -> _FakeCore:
+        if self._core is None:
+            self.core_builds += 1
+            self._core = _FakeCore(broken=(self.core_builds == 1))
+            self._initialized = True
+        return self._core
+
+    @heal_core_on_failure(retry=True)
+    def recognize(self, value):
+        """Idempotent (recognition-like) — self-heals within the same call."""
+        return self._ensure_core().do_op(value)
+
+    @heal_core_on_failure(retry=False)
+    def act(self, value):
+        """Side-effecting (input-like) — resets on failure, heals on next call."""
+        return self._ensure_core().do_op(value)
+
+    @heal_core_on_failure(retry=True)
+    def recognize_fatal(self, value):
+        return self._ensure_core().do_op_fatal(value)
+
+
+def test_idempotent_op_self_heals_in_place(caplog):
+    """retry=True: a broken core is reset + re-initialized and the SAME call
+    succeeds — the generalized #1220 self-heal (M4-2)."""
+    be = _FakeBackend()
+    with caplog.at_level(logging.WARNING):
+        result = be.recognize("x")
+    assert result == "ok:x"            # the call succeeded despite the first core failing
+    assert be.core_builds == 2         # core was rebuilt (re-initialized) once
+    assert any("self-heal" in r.message and "recognize" in r.message for r in caplog.records), \
+        "expected a WARNING documenting the self-heal"
+
+
+def test_side_effecting_op_resets_then_next_call_succeeds(caplog):
+    """retry=False: the failing input call propagates (no double-act), the core
+    is reset, and the NEXT call re-initializes and succeeds."""
+    be = _FakeBackend()
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(NaturoCoreError):
+            be.act("a")                # first call fails (broken core) ...
+        assert be._core is None        # ... but the core was reset (will re-init)
+        result = be.act("b")           # the NEXT call self-heals
+    assert result == "ok:b"
+    assert be.core_builds == 2
+    assert any("self-heal" in r.message for r in caplog.records)
+
+
+def test_non_recoverable_error_is_not_healed_or_retried(caplog):
+    """A non-COM op fault (code -1) must NOT reset/retry the core — a genuine bad
+    request surfaces immediately, no infinite-heal, core untouched."""
+    be = _FakeBackend()
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(NaturoCoreError) as ei:
+            be.recognize_fatal("x")
+    assert ei.value.code == -1
+    assert be.core_builds == 1                      # core was NOT rebuilt
+    assert be._core is not None                     # core was NOT reset
+    assert not any("self-heal" in r.message for r in caplog.records)
+
+
+def test_reset_core_clears_cached_instance():
+    """_reset_core drops the cached core so _ensure_core rebuilds it."""
+    be = _FakeBackend()
+    first = be._ensure_core()
+    assert be._core is first and be._initialized is True
+    be._reset_core()
+    assert be._core is None and be._initialized is False
+    second = be._ensure_core()
+    assert second is not first                       # a fresh core after reset


### PR DESCRIPTION
M4 criterion 2: generalizes the comtypes self-heal (#1220) to the native recognition/input layers. heal_core_on_failure decorator + CoreMixin._reset_core: on a recoverable COM/core failure (NaturoCoreError code -2) reset the cached core so the next _ensure_core re-inits + WARNING. retry=True (get_element_tree) heals in place; retry=False (type_text, click) resets + heals next call, no double-act; non-recoverable -1/-3/-4 surface immediately. tests/test_crash_recovery.py (4, fake core, Linux-collectable) proves force-failure -> next-call-succeeds + WARNING both modes. Independent verifier PASS.

Generated with Claude Code