### PR TITLE
test(reliability): process-snapshot orphan harness + PID-scoped teardown (M4-3)

### DIFF
--- a/tests/_process_snapshot.py
+++ b/tests/_process_snapshot.py
@@ -1,0 +1,88 @@
+"""Process-snapshot harness — detect test-launched processes that leaked (M4-3).
+
+A before/after snapshot of GUI *app* processes lets the desktop/browser suite
+assert it left **zero orphaned** processes. The snapshot/diff logic is pure and
+takes an injectable process lister, so it is unit-testable and Linux-collectable;
+the real lister uses ``tasklist``. The opt-in session fixture that runs it over
+the real suite lives in ``tests/integration/conftest.py``.
+
+Only GUI app processes the suite launches are watched (notepad, calculator,
+chrome, msedge, excel, …). Shells, terminals, the Python test runner, and system
+processes are **never** watched — the "cmd/terminals never touched" non-negotiable
+means the harness must not so much as flag them, even if one appears mid-run.
+"""
+from __future__ import annotations
+
+from typing import Callable, Iterable
+
+# App image names the desktop/browser suite launches and must clean up.
+WATCHED_APP_NAMES = frozenset({
+    "notepad.exe",
+    "calculatorapp.exe", "calculator.exe",
+    "chrome.exe", "msedge.exe", "chromium.exe",
+    "excel.exe", "winword.exe",
+    "mspaint.exe", "wordpad.exe",
+})
+
+# Never watched / never touched: shells, terminals, the test runner, the shell.
+# A process whose image is here is ignored unconditionally — the harness will
+# never report it as an orphan and nothing may ever kill it.
+NEVER_WATCH = frozenset({
+    "cmd.exe", "conhost.exe", "powershell.exe", "pwsh.exe",
+    "windowsterminal.exe", "openconsole.exe", "bash.exe", "sh.exe",
+    "python.exe", "pythonw.exe", "pytest.exe", "py.exe",
+    "explorer.exe", "ssh.exe", "sshd.exe", "code.exe",
+})
+
+# A process lister returns ``(image_name, pid)`` pairs; image name case-insensitive.
+ProcList = Callable[[], Iterable["tuple[str, int]"]]
+
+
+def snapshot(lister: ProcList, watch: "frozenset[str]" = WATCHED_APP_NAMES) -> "dict[str, set[int]]":
+    """Return ``{app_name: {pids}}`` for watched apps only.
+
+    Anything in :data:`NEVER_WATCH` is skipped unconditionally; anything not in
+    *watch* is ignored (we only track apps the suite is responsible for).
+    """
+    result: "dict[str, set[int]]" = {}
+    for name, pid in lister():
+        n = name.lower()
+        if n in NEVER_WATCH:
+            continue
+        if n in watch:
+            result.setdefault(n, set()).add(pid)
+    return result
+
+
+def find_orphans(
+    before: "dict[str, set[int]]", after: "dict[str, set[int]]",
+) -> "dict[str, set[int]]":
+    """Return watched PIDs present in *after* but not *before* — leaked processes."""
+    orphans: "dict[str, set[int]]" = {}
+    for name, pids in after.items():
+        leaked = pids - before.get(name, set())
+        if leaked:
+            orphans[name] = leaked
+    return orphans
+
+
+def tasklist_lister() -> "list[tuple[str, int]]":
+    """Real process lister via ``tasklist`` CSV. Windows-only; empty elsewhere."""
+    import subprocess
+
+    try:
+        out = subprocess.run(
+            ["tasklist", "/FO", "CSV", "/NH"],
+            capture_output=True, text=True, timeout=10,
+        )
+    except Exception:
+        return []
+    procs: "list[tuple[str, int]]" = []
+    for line in out.stdout.splitlines():
+        parts = [p.strip('"') for p in line.split('","')]
+        if len(parts) >= 2:
+            try:
+                procs.append((parts[0].lower(), int(parts[1])))
+            except ValueError:
+                continue
+    return procs

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -197,6 +197,38 @@ def _forbid_unsafe_live_input():
             strategy_cls.type_text = original  # type: ignore[method-assign]
 
 
+@pytest.fixture(autouse=True, scope="session")
+def _assert_no_orphaned_processes():
+    """Fail the session if the desktop/browser suite leaks a test-launched app (M4-3).
+
+    A before/after process snapshot of watched GUI apps (notepad, calculator,
+    chrome, msedge, excel, …) asserts **zero orphaned** PIDs remain after the
+    whole suite — every launching test must guarantee PID-scoped teardown. Shells,
+    terminals and the test runner are **never** watched, so the harness cannot
+    touch (or even flag) a ``cmd``/terminal.
+
+    Opt-in: only active when ``NATURO_ASSERT_NO_ORPHANS=1`` (the desktop-QA lane),
+    so it is inert on Linux CI and on a developer's live desktop by default.
+    """
+    import os
+
+    if os.environ.get("NATURO_ASSERT_NO_ORPHANS") != "1":
+        yield
+        return
+
+    from tests._process_snapshot import find_orphans, snapshot, tasklist_lister
+
+    before = snapshot(tasklist_lister)
+    yield
+    after = snapshot(tasklist_lister)
+    orphans = find_orphans(before, after)
+    assert not orphans, (
+        f"Orphaned test-launched processes leaked (M4-3): {orphans}. "
+        "Every launching test must guarantee PID-scoped teardown "
+        "(kill by PID, dismiss Save/Don't-Save dialogs)."
+    )
+
+
 def cli_stdout(result):
     """Extract stdout-only text from a Click CliRunner result.
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -259,15 +259,19 @@ def notepad_app(has_desktop) -> Generator[int, None, None]:
 
     yield actual_pid
 
-    # Teardown: kill Notepad (by image name for UWP, fallback to proc handle)
-    try:
-        subprocess.run(
-            ["taskkill", "/F", "/IM", "Notepad.exe"],
-            capture_output=True,
-            timeout=5,
-        )
-    except Exception:
-        pass
+    # Teardown: PID-scoped kill of the tracked window owner + launcher (M4-3).
+    # Never kill by image name — that would also take out pre-existing Notepad
+    # windows the user opened. ``/T`` reaps child processes; ``/F`` force-closes
+    # so a "Save changes?" dialog cannot strand the process.
+    for pid in {actual_pid, proc.pid}:
+        try:
+            subprocess.run(
+                ["taskkill", "/F", "/T", "/PID", str(pid)],
+                capture_output=True,
+                timeout=5,
+            )
+        except Exception:
+            pass
     try:
         proc.terminate()
     except Exception:
@@ -297,15 +301,17 @@ def calculator_app(has_desktop) -> Generator[int, None, None]:
 
     yield actual_pid
 
-    # Teardown: kill Calculator
-    try:
-        subprocess.run(
-            ["taskkill", "/F", "/IM", "CalculatorApp.exe"],
-            capture_output=True,
-            timeout=5,
-        )
-    except Exception:
-        pass
+    # Teardown: PID-scoped kill of the tracked app + launcher (M4-3) — never by
+    # image name, which would kill a Calculator the user already had open.
+    for pid in {actual_pid, proc.pid}:
+        try:
+            subprocess.run(
+                ["taskkill", "/F", "/T", "/PID", str(pid)],
+                capture_output=True,
+                timeout=5,
+            )
+        except Exception:
+            pass
     try:
         proc.terminate()
     except Exception:

--- a/tests/test_process_snapshot.py
+++ b/tests/test_process_snapshot.py
@@ -1,0 +1,79 @@
+"""M4 criterion 3 — unit tests for the process-snapshot orphan harness.
+
+Pure snapshot/diff logic driven by a fake process lister — no real processes,
+Linux-collectable. Proves the harness detects leaked test-launched apps, ignores
+pre-existing ones, and NEVER flags shells/terminals/the runner (enforcing
+"cmd/terminals never touched").
+"""
+from __future__ import annotations
+
+from tests._process_snapshot import (
+    NEVER_WATCH,
+    WATCHED_APP_NAMES,
+    find_orphans,
+    snapshot,
+)
+
+
+def _lister(pairs):
+    return lambda: list(pairs)
+
+
+def test_detects_leaked_app():
+    before = snapshot(_lister([]))
+    after = snapshot(_lister([("Notepad.exe", 100)]))
+    assert find_orphans(before, after) == {"notepad.exe": {100}}
+
+
+def test_ignores_preexisting_process():
+    """A process present both before and after was not launched by the suite."""
+    before = snapshot(_lister([("notepad.exe", 100)]))
+    after = snapshot(_lister([("notepad.exe", 100)]))
+    assert find_orphans(before, after) == {}
+
+
+def test_partial_leak_same_app_new_pid():
+    before = snapshot(_lister([("notepad.exe", 100)]))
+    after = snapshot(_lister([("notepad.exe", 100), ("notepad.exe", 200)]))
+    assert find_orphans(before, after) == {"notepad.exe": {200}}
+
+
+def test_cmd_and_terminals_are_never_flagged():
+    """The core safety property: shells/terminals/the runner are NEVER watched,
+    even when they appear only in the 'after' snapshot."""
+    before = snapshot(_lister([]))
+    after = snapshot(_lister([
+        ("cmd.exe", 11), ("conhost.exe", 12), ("powershell.exe", 13),
+        ("pwsh.exe", 14), ("windowsterminal.exe", 15), ("python.exe", 16),
+        ("pytest.exe", 17), ("bash.exe", 18), ("ssh.exe", 19), ("explorer.exe", 20),
+    ]))
+    assert after == {}
+    assert find_orphans(before, after) == {}
+
+
+def test_only_watched_app_names_tracked():
+    """A random unwatched process is neither snapshotted nor flagged."""
+    after = snapshot(_lister([("some_random_service.exe", 500)]))
+    assert after == {}
+
+
+def test_case_insensitive_image_names():
+    after = snapshot(_lister([("CHROME.EXE", 700), ("MsEdge.exe", 701)]))
+    assert after == {"chrome.exe": {700}, "msedge.exe": {701}}
+
+
+def test_multiple_apps_mixed_leak_and_preexisting():
+    before = snapshot(_lister([("chrome.exe", 1), ("excel.exe", 2)]))
+    after = snapshot(_lister([
+        ("chrome.exe", 1),           # pre-existing
+        ("chrome.exe", 3),           # leaked
+        ("excel.exe", 2),            # pre-existing
+        ("notepad.exe", 4),          # leaked (new app)
+        ("cmd.exe", 99),             # never watched
+    ]))
+    assert find_orphans(before, after) == {"chrome.exe": {3}, "notepad.exe": {4}}
+
+
+def test_watch_and_never_watch_are_disjoint():
+    """No image name may be both watched and never-watched (would be ambiguous)."""
+    assert WATCHED_APP_NAMES.isdisjoint(NEVER_WATCH)


### PR DESCRIPTION
M4 criterion 3: a before/after process snapshot asserts the desktop/browser suite leaves ZERO orphaned test-launched PIDs. Shells/terminals/the runner are never watched (cmd never touched). Pure diff logic is Linux-collectable + unit-tested (8, incl. an explicit cmd/terminal-never-flagged test); the session assertion fixture is opt-in via NATURO_ASSERT_NO_ORPHANS=1 (inert on CI + dev desktop). Also tightened notepad/calculator teardown from kill-by-image-name to PID-scoped taskkill /PID /T /F so teardown never kills pre-existing user windows. The real-suite zero-orphan run is a desktop-QA step (isolated session). Generated with Claude Code