### PR TITLE
test(reliability): PID-scoped guaranteed teardown for bare-Popen launch sites (M4-3)

### DIFF
--- a/tests/_launch.py
+++ b/tests/_launch.py
@@ -1,0 +1,116 @@
+"""Guaranteed PID-scoped teardown for tests that launch real GUI apps (M4-3).
+
+Tests that did ``proc = subprocess.Popen(["calc.exe"]) ... proc.terminate()``
+leak on Windows 11: a UWP app's window-owner process (``CalculatorApp.exe``) is
+not the launcher PID, so terminating the launcher leaves the app running.
+
+``tracked_launch`` returns a Popen wrapper whose ``terminate()``/``kill()`` do a
+PID-scoped teardown of the app it actually started — the *new* watched-app PIDs
+that appeared since launch, plus the launcher — via ``taskkill /F /T /PID``.
+``/F`` force-closes so a Save/Don't-Save dialog cannot strand the process; ``/T``
+reaps the child tree. It never kills by image name, so pre-existing windows the
+user already had open are untouched. Callers keep their existing
+``finally: proc.terminate()`` — only the launch line changes.
+
+The PID-diff logic takes an injectable pid-lister, so it is unit-testable and
+Linux-collectable; the default lister uses ``tasklist``.
+"""
+from __future__ import annotations
+
+import subprocess
+import time
+from typing import Callable, Iterable
+
+# Image names to match when reaping a launched app (window-owner may differ from
+# the launcher, esp. for UWP apps hosted by a broker).
+NOTEPAD_IMAGES = ("Notepad.exe",)
+CALCULATOR_IMAGES = ("CalculatorApp.exe", "Calculator.exe")
+
+PidLister = Callable[[Iterable[str]], "set[int]"]
+
+
+def _tasklist_app_pids(image_names: Iterable[str]) -> "set[int]":
+    """PIDs of running processes whose image matches any of *image_names*."""
+    pids: "set[int]" = set()
+    for name in image_names:
+        try:
+            out = subprocess.run(
+                ["tasklist", "/FI", f"IMAGENAME eq {name}", "/FO", "CSV", "/NH"],
+                capture_output=True, text=True, timeout=5,
+            )
+        except Exception:
+            continue
+        for line in out.stdout.strip().splitlines():
+            parts = line.strip('"').split('","')
+            if len(parts) >= 2 and parts[0].lower() == name.lower():
+                try:
+                    pids.add(int(parts[1]))
+                except ValueError:
+                    continue
+    return pids
+
+
+def _pid_scoped_kill(pids: Iterable[int]) -> None:
+    for pid in pids:
+        try:
+            subprocess.run(
+                ["taskkill", "/F", "/T", "/PID", str(pid)],
+                capture_output=True, timeout=5,
+            )
+        except Exception:
+            pass
+
+
+class TrackedProc:
+    """Popen wrapper: ``terminate()``/``kill()`` PID-scoped-reap the launched app.
+
+    Proxies all other attributes (``pid``, ``poll``, ``wait``, …) to the real
+    Popen, so existing test code is unaffected.
+    """
+
+    def __init__(self, proc, image_names, baseline, pid_lister):
+        self._proc = proc
+        self._images = tuple(image_names)
+        self._baseline = set(baseline)
+        self._pid_lister = pid_lister
+        self._reaped = False
+
+    def __getattr__(self, name):
+        return getattr(self._proc, name)
+
+    def _reap(self) -> None:
+        if self._reaped:
+            return
+        self._reaped = True
+        launched = set(self._pid_lister(self._images)) - self._baseline
+        try:
+            launched.add(self._proc.pid)
+        except Exception:
+            pass
+        _pid_scoped_kill(launched)
+        try:
+            self._proc.terminate()  # reap the launcher handle itself
+        except Exception:
+            pass
+
+    def terminate(self) -> None:
+        self._reap()
+
+    def kill(self) -> None:
+        self._reap()
+
+
+def tracked_launch(cmd, image_names, settle: float = 0.0, pid_lister: PidLister = _tasklist_app_pids):
+    """Launch *cmd* and return a :class:`TrackedProc` for PID-scoped teardown.
+
+    Args:
+        cmd: Popen argument (list or string).
+        image_names: image names of the app's window-owner process(es).
+        settle: seconds to wait after launch (0 = caller handles timing).
+        pid_lister: ``(image_names) -> set[pid]`` (injectable for tests).
+    """
+    baseline = set(pid_lister(image_names))
+    proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    if settle:
+        time.sleep(settle)
+    return TrackedProc(proc, image_names, baseline, pid_lister)

--- a/tests/test_app_control.py
+++ b/tests/test_app_control.py
@@ -487,7 +487,8 @@ class TestAppLifecycleE2EWindows:
         from naturo.backends.windows import WindowsBackend
         backend = WindowsBackend()
 
-        proc = subprocess.Popen(["notepad.exe"])
+        from tests._launch import NOTEPAD_IMAGES, tracked_launch
+        proc = tracked_launch(["notepad.exe"], NOTEPAD_IMAGES)
         try:
             notepad_wins = self._poll_for_notepad(backend, self._is_notepad_window)
             assert len(notepad_wins) >= 1, "Notepad not found in window list after launch"
@@ -526,7 +527,8 @@ class TestAppLifecycleE2EWindows:
         from naturo.backends.windows import WindowsBackend
         backend = WindowsBackend()
 
-        proc = subprocess.Popen(["notepad.exe"])
+        from tests._launch import NOTEPAD_IMAGES, tracked_launch
+        proc = tracked_launch(["notepad.exe"], NOTEPAD_IMAGES)
         try:
             notepad_wins = self._poll_for_notepad(backend, self._is_notepad_window)
             notepad = notepad_wins[0] if notepad_wins else None

--- a/tests/test_cli_phase2.py
+++ b/tests/test_cli_phase2.py
@@ -538,7 +538,8 @@ class TestNotepadAutomation:
         import subprocess
         import time
 
-        proc = subprocess.Popen(["notepad.exe"])
+        from tests._launch import NOTEPAD_IMAGES, tracked_launch
+        proc = tracked_launch(["notepad.exe"], NOTEPAD_IMAGES)
         try:
             # Find Notepad window (UWP/WinUI3 Notepad on Win11 may be
             # hosted by ApplicationFrameHost.exe, so check title too #534)

--- a/tests/test_e2e_notepad.py
+++ b/tests/test_e2e_notepad.py
@@ -43,7 +43,8 @@ def core():
 
 def _launch_notepad():
     """Launch notepad and return the process."""
-    return subprocess.Popen(["notepad.exe"])
+    from tests._launch import NOTEPAD_IMAGES, tracked_launch
+    return tracked_launch(["notepad.exe"], NOTEPAD_IMAGES)
 
 
 def _is_notepad_window(w) -> bool:

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -1,0 +1,82 @@
+"""M4 criterion 3 — unit tests for PID-scoped guaranteed app teardown.
+
+Drives ``TrackedProc`` with a fake process + injected pid-lister and a mocked
+``subprocess.run`` — no real processes, Linux-collectable. Proves teardown kills
+only the PIDs the launch introduced (launcher + new window-owner), never
+pre-existing ones, and is idempotent.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from tests._launch import CALCULATOR_IMAGES, NOTEPAD_IMAGES, TrackedProc
+
+
+class _FakeProc:
+    def __init__(self, pid):
+        self.pid = pid
+        self.terminated = False
+
+    def terminate(self):
+        self.terminated = True
+
+    def poll(self):
+        return None
+
+
+def _killed_pids(mock_run):
+    killed = set()
+    for call in mock_run.call_args_list:
+        args = call.args[0] if call.args else call.kwargs.get("args", [])
+        if args and args[0] == "taskkill" and "/PID" in args:
+            killed.add(int(args[args.index("/PID") + 1]))
+    return killed
+
+
+def test_terminate_kills_only_launched_pids_not_preexisting():
+    """UWP case: launcher pid 3, pre-existing app pid 1, launched window-owner
+    pid 2 → kill {2, 3}, never the pre-existing 1."""
+    proc = _FakeProc(pid=3)
+    tp = TrackedProc(proc, CALCULATOR_IMAGES, baseline={1}, pid_lister=lambda imgs: {1, 2})
+    with patch("tests._launch.subprocess.run") as run:
+        tp.terminate()
+    killed = _killed_pids(run)
+    assert killed == {2, 3}
+    assert 1 not in killed          # pre-existing user window untouched
+    assert proc.terminated          # launcher handle reaped
+
+
+def test_kill_is_pid_scoped_alias():
+    proc = _FakeProc(pid=9)
+    tp = TrackedProc(proc, NOTEPAD_IMAGES, baseline={7}, pid_lister=lambda imgs: {7, 8})
+    with patch("tests._launch.subprocess.run") as run:
+        tp.kill()
+    assert _killed_pids(run) == {8, 9}
+
+
+def test_reap_is_idempotent():
+    """A second terminate()/kill() must not issue more kills."""
+    proc = _FakeProc(pid=3)
+    tp = TrackedProc(proc, NOTEPAD_IMAGES, baseline=set(), pid_lister=lambda imgs: {5})
+    with patch("tests._launch.subprocess.run") as run:
+        tp.terminate()
+        first = run.call_count
+        tp.kill()
+        assert run.call_count == first
+
+
+def test_no_launched_pids_still_reaps_launcher():
+    """If nothing new appears (classic app where launcher owns the window), the
+    launcher pid is still killed."""
+    proc = _FakeProc(pid=42)
+    tp = TrackedProc(proc, NOTEPAD_IMAGES, baseline={42}, pid_lister=lambda imgs: {42})
+    with patch("tests._launch.subprocess.run") as run:
+        tp.terminate()
+    assert _killed_pids(run) == {42}
+
+
+def test_proxies_attributes_to_real_popen():
+    proc = _FakeProc(pid=42)
+    tp = TrackedProc(proc, NOTEPAD_IMAGES, baseline=set(), pid_lister=lambda imgs: set())
+    assert tp.pid == 42             # proxied
+    assert tp.poll() is None        # proxied

--- a/tests/test_phase2_comprehensive.py
+++ b/tests/test_phase2_comprehensive.py
@@ -800,7 +800,8 @@ class TestE2EWorkflows:
             if "notepad" in w.process_name.lower()
         }
 
-        proc = subprocess.Popen(["notepad.exe"])
+        from tests._launch import NOTEPAD_IMAGES, tracked_launch
+        proc = tracked_launch(["notepad.exe"], NOTEPAD_IMAGES)
         try:
             # (#472) Poll for the window to appear instead of a fixed sleep.
             # On busy CI runners, 1.5s is sometimes not enough.  Also handle

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -213,7 +213,8 @@ class TestSelectorE2EWindows:
         from naturo.backends.windows import WindowsBackend
         backend = WindowsBackend()
 
-        proc = subprocess.Popen(["calc.exe"])
+        from tests._launch import CALCULATOR_IMAGES, tracked_launch
+        proc = tracked_launch(["calc.exe"], CALCULATOR_IMAGES)
         try:
             time.sleep(2.0)
 
@@ -244,7 +245,8 @@ class TestSelectorE2EWindows:
         from naturo.backends.windows import WindowsBackend
         backend = WindowsBackend()
 
-        proc = subprocess.Popen(["notepad.exe"])
+        from tests._launch import NOTEPAD_IMAGES, tracked_launch
+        proc = tracked_launch(["notepad.exe"], NOTEPAD_IMAGES)
         try:
             time.sleep(1.5)
 


### PR DESCRIPTION
Completes criterion 3's 'guaranteed-teardown covers EVERY launching test'. Tests that did Popen(['calc.exe']) + proc.terminate() leaked UWP apps (window-owner PID != launcher). tracked_launch() wraps Popen so terminate()/kill() PID-scoped-reap the launched app (new watched-app PIDs + launcher) via taskkill /F /T /PID, never by image name (pre-existing user windows untouched). All 7 bare-Popen sites migrated; only the launch line changed. Helper unit-tested (5, Linux-collectable); the 5 migrated files collect clean. Generated with Claude Code