### PR TITLE
test(reliability): assert soak action genuinely fires (M4-4 follow-up)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,7 @@ markers = [
     "linux: Linux-only test",
     "slow: takes >5s to run",
     "stress: stress/stability test (>30s)",
+    "soak: long-running soak/reliability cycles (M4-4; desktop QA only, opt-in)",
     "e2e: end-to-end workflow test",
     "acceptance: role-based acceptance test",
     "performance: performance benchmark",

--- a/tests/_soak.py
+++ b/tests/_soak.py
@@ -1,0 +1,153 @@
+"""Soak harness — run many recognition+action cycles and detect instability (M4-4).
+
+``run_soak`` drives ``cycle_fn`` N times, sampling per-cycle wall time plus a
+resource sample (process RSS MB + watched-app process count) via an injectable
+``sampler``. It reports whether the run was stable: **zero failures, zero process
+leak, zero memory leak, no timing degradation**.
+
+All timing/resource inputs are injectable (``sampler``, ``clock``), so the
+analysis is deterministic and unit-testable with no real processes — the module
+is Linux-collectable. The real ≥100-cycle run against real apps lives in a
+desktop-gated test and is driven by isolated QA.
+"""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Callable
+
+# Timing is "degraded" if the last quarter of cycles averages more than this
+# multiple of the first quarter — a runaway slowdown, not normal jitter.
+DEGRADE_TIME_FACTOR = 3.0
+# Memory "leaks" if RSS grows by more than this from first to last sample.
+LEAK_MEM_GROWTH_MB = 50.0
+
+
+@dataclass
+class ResourceSample:
+    rss_mb: float
+    proc_count: int
+
+
+@dataclass
+class SoakResult:
+    cycles: int
+    failures: "list[tuple[int, str]]" = field(default_factory=list)
+    durations_ms: "list[float]" = field(default_factory=list)
+    samples: "list[ResourceSample]" = field(default_factory=list)
+
+    @property
+    def failed(self) -> bool:
+        return len(self.failures) > 0
+
+    @property
+    def process_leaked(self) -> bool:
+        if len(self.samples) < 2:
+            return False
+        return self.samples[-1].proc_count > self.samples[0].proc_count
+
+    @property
+    def memory_leaked(self) -> bool:
+        if len(self.samples) < 2:
+            return False
+        return (self.samples[-1].rss_mb - self.samples[0].rss_mb) > LEAK_MEM_GROWTH_MB
+
+    @property
+    def time_degraded(self) -> bool:
+        n = len(self.durations_ms)
+        if n < 8:
+            return False
+        q = max(1, n // 4)
+        first = sum(self.durations_ms[:q]) / q
+        last = sum(self.durations_ms[-q:]) / q
+        if first <= 0:
+            return False
+        return last > first * DEGRADE_TIME_FACTOR
+
+    @property
+    def ok(self) -> bool:
+        return not (self.failed or self.process_leaked or self.memory_leaked or self.time_degraded)
+
+    def summary(self) -> str:
+        return (
+            f"soak: {self.cycles} cycles, {len(self.failures)} failures, "
+            f"proc {self.samples[0].proc_count if self.samples else '?'}"
+            f"->{self.samples[-1].proc_count if self.samples else '?'}, "
+            f"rss {self.samples[0].rss_mb if self.samples else '?'}"
+            f"->{self.samples[-1].rss_mb if self.samples else '?'}MB, "
+            f"degraded={self.time_degraded}, ok={self.ok}"
+        )
+
+
+def run_soak(
+    cycle_fn: "Callable[[int], None]",
+    cycles: int,
+    *,
+    sampler: "Callable[[], ResourceSample]",
+    clock: "Callable[[], float]" = time.perf_counter,
+    on_progress: "Callable[[int, SoakResult], None] | None" = None,
+) -> SoakResult:
+    """Run *cycles* recognition+action cycles and return a :class:`SoakResult`.
+
+    A cycle that raises is recorded as a failure (index + message) and the soak
+    continues — one flaky cycle must not abort the run, and the final verdict
+    still fails. ``sampler`` is called once per cycle for the resource sample.
+    """
+    result = SoakResult(cycles=cycles)
+    for i in range(cycles):
+        t0 = clock()
+        try:
+            cycle_fn(i)
+        except Exception as exc:  # noqa: BLE001 — record any cycle failure, keep going
+            result.failures.append((i, f"{type(exc).__name__}: {exc}"))
+        result.durations_ms.append((clock() - t0) * 1000.0)
+        try:
+            result.samples.append(sampler())
+        except Exception:  # noqa: BLE001 — a sampler hiccup must not abort the soak
+            pass
+        if on_progress is not None:
+            on_progress(i, result)
+    return result
+
+
+def _current_rss_mb() -> float:
+    """Working-set (RSS) of the current process in MB, via psapi. 0.0 on failure."""
+    try:
+        import ctypes
+        from ctypes import wintypes
+
+        class _PMC(ctypes.Structure):
+            _fields_ = [
+                ("cb", wintypes.DWORD),
+                ("PageFaultCount", wintypes.DWORD),
+                ("PeakWorkingSetSize", ctypes.c_size_t),
+                ("WorkingSetSize", ctypes.c_size_t),
+                ("QuotaPeakPagedPoolUsage", ctypes.c_size_t),
+                ("QuotaPagedPoolUsage", ctypes.c_size_t),
+                ("QuotaPeakNonPagedPoolUsage", ctypes.c_size_t),
+                ("QuotaNonPagedPoolUsage", ctypes.c_size_t),
+                ("PagefileUsage", ctypes.c_size_t),
+                ("PeakPagefileUsage", ctypes.c_size_t),
+            ]
+
+        counters = _PMC()
+        counters.cb = ctypes.sizeof(_PMC)
+        handle = ctypes.windll.kernel32.GetCurrentProcess()
+        if ctypes.windll.psapi.GetProcessMemoryInfo(handle, ctypes.byref(counters), counters.cb):
+            return counters.WorkingSetSize / (1024.0 * 1024.0)
+    except Exception:
+        pass
+    return 0.0
+
+
+def _watched_proc_count() -> int:
+    """Total count of watched GUI-app processes currently running (leak signal)."""
+    from tests._process_snapshot import snapshot, tasklist_lister
+
+    snap = snapshot(tasklist_lister)
+    return sum(len(pids) for pids in snap.values())
+
+
+def real_sampler() -> ResourceSample:
+    """Live sampler for the real desktop soak: naturo RSS + watched-app count."""
+    return ResourceSample(rss_mb=_current_rss_mb(), proc_count=_watched_proc_count())

--- a/tests/integration/test_soak_desktop.py
+++ b/tests/integration/test_soak_desktop.py
@@ -22,6 +22,8 @@ def test_soak_notepad_and_calculator_100_cycles(notepad_app, calculator_app):
 
     backend = WindowsBackend()
     pids = [notepad_app, calculator_app]  # window-owner PIDs from the fixtures
+    cycles = 100
+    actions_fired = {"n": 0}
 
     def _hwnd_for(pid: int):
         for w in backend.list_windows():
@@ -35,12 +37,21 @@ def test_soak_notepad_and_calculator_100_cycles(notepad_app, calculator_app):
         tree = backend.get_element_tree(pid=pid, depth=3)
         assert tree is not None, f"cycle {i}: no element tree for pid {pid}"
         # Action: re-focus the app's window (benign, idempotent, targets the
-        # launched app by hwnd — never the terminal).
+        # launched app by hwnd — never the terminal). Count firings so a run
+        # where the window can't be resolved can't masquerade as a clean soak;
+        # a rare transient miss is tolerated by the 95% floor asserted below.
         hwnd = _hwnd_for(pid)
-        if hwnd:
+        if hwnd is not None:
             backend.focus_window(hwnd=hwnd)
+            actions_fired["n"] += 1
 
-    result = run_soak(cycle, 100, sampler=real_sampler)
+    result = run_soak(cycle, cycles, sampler=real_sampler)
     assert result.ok, (
         result.summary() + f" | first failures: {result.failures[:5]}"
+    )
+    # Guard against a recognition-only pass: the action must genuinely fire for
+    # (nearly) every cycle, else "0 failures" would mask "action never ran".
+    assert actions_fired["n"] >= cycles * 0.95, (
+        f"action fired only {actions_fired['n']}/{cycles} cycles — not a full "
+        "recognition+action soak"
     )

--- a/tests/integration/test_soak_desktop.py
+++ b/tests/integration/test_soak_desktop.py
@@ -1,0 +1,46 @@
+"""M4 criterion 4 — real desktop soak: >=100 recognition+action cycles, >=2 apps.
+
+Gated ``@pytest.mark.desktop`` + ``@pytest.mark.soak`` so it is opt-in and never
+runs on Linux CI or by default (``pytest`` defaults to ``-m "not ... desktop"``).
+Isolated QA runs it with ``-m "desktop and soak"``. It launches Notepad and
+Calculator via the PID-scoped guaranteed-teardown fixtures, then alternates
+recognition (``get_element_tree``) + a benign action (``focus_window``) for 100
+cycles, asserting the soak verdict: zero failures, zero process leak, zero memory
+leak, no timing degradation.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.desktop
+@pytest.mark.soak
+def test_soak_notepad_and_calculator_100_cycles(notepad_app, calculator_app):
+    from naturo.backends.windows import WindowsBackend
+
+    from tests._soak import real_sampler, run_soak
+
+    backend = WindowsBackend()
+    pids = [notepad_app, calculator_app]  # window-owner PIDs from the fixtures
+
+    def _hwnd_for(pid: int):
+        for w in backend.list_windows():
+            if getattr(w, "pid", None) == pid and getattr(w, "is_visible", False):
+                return w.handle
+        return None
+
+    def cycle(i: int) -> None:
+        pid = pids[i % len(pids)]
+        # Recognition: fuse the app's element tree (deterministic UIA path).
+        tree = backend.get_element_tree(pid=pid, depth=3)
+        assert tree is not None, f"cycle {i}: no element tree for pid {pid}"
+        # Action: re-focus the app's window (benign, idempotent, targets the
+        # launched app by hwnd — never the terminal).
+        hwnd = _hwnd_for(pid)
+        if hwnd:
+            backend.focus_window(hwnd=hwnd)
+
+    result = run_soak(cycle, 100, sampler=real_sampler)
+    assert result.ok, (
+        result.summary() + f" | first failures: {result.failures[:5]}"
+    )

--- a/tests/test_soak.py
+++ b/tests/test_soak.py
@@ -1,0 +1,104 @@
+"""M4 criterion 4 — unit tests for the soak harness verdict logic.
+
+Deterministic injected clock + sampler + cycle_fn — no real processes, apps, or
+timing, so the module is Linux-collectable. Proves the harness flags failures,
+process leaks, memory leaks, and timing degradation, and stays green on a stable
+run.
+"""
+from __future__ import annotations
+
+from tests._soak import LEAK_MEM_GROWTH_MB, ResourceSample, run_soak
+
+
+class _Clock:
+    """Fake monotonic clock yielding t0,t1 pairs so each cycle has *durations[i]* seconds."""
+
+    def __init__(self, durations_s):
+        self._vals = []
+        t = 0.0
+        for d in durations_s:
+            self._vals.append(t)          # t0
+            self._vals.append(t + d)      # t1
+            t += d + 1.0
+        self._i = 0
+
+    def __call__(self):
+        v = self._vals[self._i]
+        self._i += 1
+        return v
+
+
+def _sampler(samples):
+    it = iter(samples)
+    return lambda: next(it)
+
+
+def _stable_samples(n, rss=100.0, proc=2):
+    return [ResourceSample(rss_mb=rss, proc_count=proc) for _ in range(n)]
+
+
+def test_stable_run_is_ok():
+    n = 12
+    res = run_soak(
+        lambda i: None, n,
+        sampler=_sampler(_stable_samples(n)),
+        clock=_Clock([0.001] * n),
+    )
+    assert not res.failed and not res.process_leaked
+    assert not res.memory_leaked and not res.time_degraded
+    assert res.ok is True
+    assert len(res.durations_ms) == n and len(res.samples) == n
+
+
+def test_failure_is_recorded_and_soak_continues():
+    n = 10
+
+    def cycle(i):
+        if i == 3:
+            raise RuntimeError("boom")
+
+    res = run_soak(cycle, n, sampler=_sampler(_stable_samples(n)), clock=_Clock([0.001] * n))
+    assert res.failed and len(res.failures) == 1
+    assert res.failures[0][0] == 3 and "boom" in res.failures[0][1]
+    assert len(res.durations_ms) == n  # continued through all cycles
+    assert res.ok is False
+
+
+def test_process_leak_detected():
+    n = 10
+    samples = [ResourceSample(100.0, 2) for _ in range(n - 1)] + [ResourceSample(100.0, 5)]
+    res = run_soak(lambda i: None, n, sampler=_sampler(samples), clock=_Clock([0.001] * n))
+    assert res.process_leaked is True
+    assert res.ok is False
+
+
+def test_memory_leak_detected():
+    n = 10
+    samples = [ResourceSample(100.0, 2) for _ in range(n - 1)] + [
+        ResourceSample(100.0 + LEAK_MEM_GROWTH_MB + 10, 2)
+    ]
+    res = run_soak(lambda i: None, n, sampler=_sampler(samples), clock=_Clock([0.001] * n))
+    assert res.memory_leaked is True
+    assert res.ok is False
+
+
+def test_time_degradation_detected():
+    n = 20
+    durations = [0.001] * 15 + [0.01] * 5  # last quarter ~10x the first quarter
+    res = run_soak(lambda i: None, n, sampler=_sampler(_stable_samples(n)), clock=_Clock(durations))
+    assert res.time_degraded is True
+    assert res.ok is False
+
+
+def test_no_degradation_flag_with_too_few_cycles():
+    n = 4
+    res = run_soak(lambda i: None, n, sampler=_sampler(_stable_samples(n)),
+                   clock=_Clock([0.001, 0.001, 0.001, 1.0]))
+    assert res.time_degraded is False  # not enough data to judge a trend
+
+
+def test_summary_is_descriptive():
+    n = 10
+    res = run_soak(lambda i: None, n, sampler=_sampler(_stable_samples(n)), clock=_Clock([0.001] * n))
+    s = res.summary()
+    assert "cycles" in s and "ok=True" in s


### PR DESCRIPTION
Follow-up to #1227 addressing the verifier's MEDIUM gap: if window resolution returns None the focus action was silently skipped, so '0 failures' could mask a recognition-only run. Now counts action firings and asserts >=95% of cycles (tolerating a rare transient UWP visibility miss) so the soak proves a full recognition+action cycle. Collect-clean, ruff-clean. Generated with Claude Code