### PR TITLE
fix(reliability): robust Calculator fixture + taskkill-independent teardown (M4-3/4)

### DIFF
--- a/tests/_launch.py
+++ b/tests/_launch.py
@@ -50,15 +50,41 @@ def _tasklist_app_pids(image_names: Iterable[str]) -> "set[int]":
     return pids
 
 
+def kill_pid(pid: int) -> bool:
+    """Force-terminate *pid*, robust to a broken/blocked ``taskkill`` CLI.
+
+    Some hosts return "ERROR: Critical error" from ``taskkill`` — so a teardown
+    that shells out to it silently leaks. This prefers Win32 ``TerminateProcess``
+    (works regardless of the CLI) and *also* runs ``taskkill /F /T /PID`` to reap
+    the child tree (e.g. a UWP broker's children). Returns True if
+    ``TerminateProcess`` reported success.
+    """
+    killed = False
+    try:
+        import ctypes
+
+        PROCESS_TERMINATE = 0x0001
+        handle = ctypes.windll.kernel32.OpenProcess(PROCESS_TERMINATE, False, int(pid))
+        if handle:
+            try:
+                killed = bool(ctypes.windll.kernel32.TerminateProcess(handle, 1))
+            finally:
+                ctypes.windll.kernel32.CloseHandle(handle)
+    except Exception:
+        pass
+    try:
+        subprocess.run(
+            ["taskkill", "/F", "/T", "/PID", str(pid)],
+            capture_output=True, timeout=5,
+        )
+    except Exception:
+        pass
+    return killed
+
+
 def _pid_scoped_kill(pids: Iterable[int]) -> None:
     for pid in pids:
-        try:
-            subprocess.run(
-                ["taskkill", "/F", "/T", "/PID", str(pid)],
-                capture_output=True, timeout=5,
-            )
-        except Exception:
-            pass
+        kill_pid(pid)
 
 
 class TrackedProc:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -259,59 +259,105 @@ def notepad_app(has_desktop) -> Generator[int, None, None]:
 
     yield actual_pid
 
-    # Teardown: PID-scoped kill of the tracked window owner + launcher (M4-3).
-    # Never kill by image name — that would also take out pre-existing Notepad
-    # windows the user opened. ``/T`` reaps child processes; ``/F`` force-closes
-    # so a "Save changes?" dialog cannot strand the process.
+    # Teardown: PID-scoped kill of the tracked window owner + launcher (M4-3),
+    # robust to a broken ``taskkill`` CLI (Win32 TerminateProcess). Never by image
+    # name — pre-existing Notepad windows the user opened stay untouched. Force
+    # kill so a "Save changes?" dialog cannot strand the process.
+    from tests._launch import kill_pid
     for pid in {actual_pid, proc.pid}:
-        try:
-            subprocess.run(
-                ["taskkill", "/F", "/T", "/PID", str(pid)],
-                capture_output=True,
-                timeout=5,
-            )
-        except Exception:
-            pass
+        kill_pid(pid)
     try:
         proc.terminate()
     except Exception:
         pass
 
 
+def _find_calculator_window_pid() -> Optional[int]:
+    """PID of the process owning a visible Calculator window (mirrors the Notepad
+    finder, #534). ``calc.exe`` is a launcher stub that exits immediately and the
+    UWP ``CalculatorApp.exe`` hosts the window via a broker; the ``tasklist``
+    IMAGENAME filter is also broken on some hosts — so enumerate windows and match
+    the Calculator title/owner instead.
+    """
+    try:
+        import ctypes
+        from ctypes import wintypes
+
+        user32 = ctypes.WinDLL("user32", use_last_error=True)
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        psapi = ctypes.WinDLL("psapi", use_last_error=True)
+        PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+        found_pid = ctypes.c_ulong(0)
+
+        @ctypes.WINFUNCTYPE(wintypes.BOOL, wintypes.HWND, wintypes.LPARAM)
+        def enum_callback(hwnd, lparam):
+            if not user32.IsWindowVisible(hwnd):
+                return True
+            buf = ctypes.create_unicode_buffer(256)
+            user32.GetWindowTextW(hwnd, buf, 256)
+            title = buf.value.strip()
+            # English "Calculator" or Chinese "计算器"
+            if title and ("calculator" in title.lower() or "计算器" in title):
+                window_pid = wintypes.DWORD()
+                user32.GetWindowThreadProcessId(hwnd, ctypes.byref(window_pid))
+                h_proc = kernel32.OpenProcess(
+                    PROCESS_QUERY_LIMITED_INFORMATION, False, window_pid.value,
+                )
+                if h_proc:
+                    try:
+                        name_buf = ctypes.create_unicode_buffer(260)
+                        if psapi.GetProcessImageFileNameW(h_proc, name_buf, 260):
+                            import os
+                            if "calculator" in os.path.basename(name_buf.value).lower():
+                                found_pid.value = window_pid.value
+                                return False
+                    finally:
+                        kernel32.CloseHandle(h_proc)
+                if not found_pid.value:  # Calculator-titled visible window is enough
+                    found_pid.value = window_pid.value
+                    return False
+            return True
+
+        user32.EnumWindows(enum_callback, 0)
+        return found_pid.value or None
+    except Exception:
+        return None
+
+
 @pytest.fixture(scope="module")
 def calculator_app(has_desktop) -> Generator[int, None, None]:
-    """Launch Calculator and yield its PID. Clean up on teardown.
+    """Launch Calculator and yield the PID owning its window. Clean up on teardown.
 
-    Windows Calculator is a UWP/WinUI3 app — tests modern UI framework detection.
-    Note: UWP apps launch via a broker, so the PID from Popen may differ
-    from the actual Calculator process.
+    Windows Calculator is a UWP/WinUI3 app launched via a broker: ``calc.exe``
+    exits immediately and ``CalculatorApp.exe`` hosts the window.  Resolve the
+    window owner via ``EnumWindows`` (robust to the launcher stub exiting and to a
+    broken ``tasklist`` IMAGENAME filter), polling because UWP launch is slow.
     """
-    proc = _launch_app("calc.exe", wait_seconds=3.0)
-    if proc is None:
-        pytest.skip("Could not launch Calculator")
+    proc = subprocess.Popen(
+        "calc.exe", stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
 
-    # UWP apps: the actual process is CalculatorApp.exe, not calc.exe
-    time.sleep(1)
-    actual_pid = _find_process_by_name("CalculatorApp.exe")
+    actual_pid = None
+    deadline = time.monotonic() + 15.0
+    while actual_pid is None and time.monotonic() < deadline:
+        actual_pid = _find_calculator_window_pid()
+        if actual_pid is None:
+            time.sleep(1.0)
     if actual_pid is None:
-        # Fallback: try the broker PID
-        actual_pid = _find_process_by_name("Calculator.exe")
-    if actual_pid is None:
-        actual_pid = proc.pid
+        try:
+            proc.terminate()
+        except Exception:
+            pass
+        pytest.skip("Could not launch Calculator (no window resolved)")
 
     yield actual_pid
 
-    # Teardown: PID-scoped kill of the tracked app + launcher (M4-3) — never by
-    # image name, which would kill a Calculator the user already had open.
+    # Teardown: PID-scoped kill of the resolved window owner + launcher (M4-3),
+    # robust to a broken ``taskkill`` CLI (Win32 TerminateProcess). Never by image
+    # name — a Calculator the user already had open stays untouched.
+    from tests._launch import kill_pid
     for pid in {actual_pid, proc.pid}:
-        try:
-            subprocess.run(
-                ["taskkill", "/F", "/T", "/PID", str(pid)],
-                capture_output=True,
-                timeout=5,
-            )
-        except Exception:
-            pass
+        kill_pid(pid)
     try:
         proc.terminate()
     except Exception:

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -1,9 +1,10 @@
 """M4 criterion 3 — unit tests for PID-scoped guaranteed app teardown.
 
-Drives ``TrackedProc`` with a fake process + injected pid-lister and a mocked
-``subprocess.run`` — no real processes, Linux-collectable. Proves teardown kills
-only the PIDs the launch introduced (launcher + new window-owner), never
-pre-existing ones, and is idempotent.
+Drives ``TrackedProc`` with a fake process + injected pid-lister and a patched
+``kill_pid`` — no real processes are ever opened or terminated, so this is safe
+to run on Windows and Linux-collectable. Proves teardown targets only the PIDs
+the launch introduced (launcher + new window-owner), never pre-existing ones, and
+is idempotent.
 """
 from __future__ import annotations
 
@@ -24,23 +25,18 @@ class _FakeProc:
         return None
 
 
-def _killed_pids(mock_run):
-    killed = set()
-    for call in mock_run.call_args_list:
-        args = call.args[0] if call.args else call.kwargs.get("args", [])
-        if args and args[0] == "taskkill" and "/PID" in args:
-            killed.add(int(args[args.index("/PID") + 1]))
-    return killed
+def _killed(kill_mock):
+    return {c.args[0] for c in kill_mock.call_args_list}
 
 
 def test_terminate_kills_only_launched_pids_not_preexisting():
     """UWP case: launcher pid 3, pre-existing app pid 1, launched window-owner
-    pid 2 → kill {2, 3}, never the pre-existing 1."""
+    pid 2 → reap {2, 3}, never the pre-existing 1."""
     proc = _FakeProc(pid=3)
     tp = TrackedProc(proc, CALCULATOR_IMAGES, baseline={1}, pid_lister=lambda imgs: {1, 2})
-    with patch("tests._launch.subprocess.run") as run:
+    with patch("tests._launch.kill_pid") as kp:
         tp.terminate()
-    killed = _killed_pids(run)
+    killed = _killed(kp)
     assert killed == {2, 3}
     assert 1 not in killed          # pre-existing user window untouched
     assert proc.terminated          # launcher handle reaped
@@ -49,30 +45,29 @@ def test_terminate_kills_only_launched_pids_not_preexisting():
 def test_kill_is_pid_scoped_alias():
     proc = _FakeProc(pid=9)
     tp = TrackedProc(proc, NOTEPAD_IMAGES, baseline={7}, pid_lister=lambda imgs: {7, 8})
-    with patch("tests._launch.subprocess.run") as run:
+    with patch("tests._launch.kill_pid") as kp:
         tp.kill()
-    assert _killed_pids(run) == {8, 9}
+    assert _killed(kp) == {8, 9}
 
 
 def test_reap_is_idempotent():
     """A second terminate()/kill() must not issue more kills."""
     proc = _FakeProc(pid=3)
     tp = TrackedProc(proc, NOTEPAD_IMAGES, baseline=set(), pid_lister=lambda imgs: {5})
-    with patch("tests._launch.subprocess.run") as run:
+    with patch("tests._launch.kill_pid") as kp:
         tp.terminate()
-        first = run.call_count
+        first = kp.call_count
         tp.kill()
-        assert run.call_count == first
+        assert kp.call_count == first
 
 
 def test_no_launched_pids_still_reaps_launcher():
-    """If nothing new appears (classic app where launcher owns the window), the
-    launcher pid is still killed."""
+    """Classic app where the launcher owns the window: the launcher pid is killed."""
     proc = _FakeProc(pid=42)
     tp = TrackedProc(proc, NOTEPAD_IMAGES, baseline={42}, pid_lister=lambda imgs: {42})
-    with patch("tests._launch.subprocess.run") as run:
+    with patch("tests._launch.kill_pid") as kp:
         tp.terminate()
-    assert _killed_pids(run) == {42}
+    assert _killed(kp) == {42}
 
 
 def test_proxies_attributes_to_real_popen():
@@ -80,3 +75,15 @@ def test_proxies_attributes_to_real_popen():
     tp = TrackedProc(proc, NOTEPAD_IMAGES, baseline=set(), pid_lister=lambda imgs: set())
     assert tp.pid == 42             # proxied
     assert tp.poll() is None        # proxied
+
+
+def test_kill_pid_never_raises_and_attempts_taskkill_fallback():
+    """kill_pid on a definitely-invalid PID must not raise and must still attempt
+    the taskkill fallback (Win32 TerminateProcess can't open an invalid PID)."""
+    from tests._launch import kill_pid
+
+    with patch("tests._launch.subprocess.run") as run:
+        result = kill_pid(4294967295)  # invalid PID -> OpenProcess NULL, no terminate
+    args = run.call_args[0][0] if run.call_args else []
+    assert "taskkill" in args and "/PID" in args and "4294967295" in args
+    assert result in (True, False)  # never raises


### PR DESCRIPTION
Real-machine QA found criterion-4 soak SKIPPED ('Could not launch Calculator') + leaked orphaned CalculatorApp: calc.exe is a stub that exits immediately and this host's tasklist/taskkill return 'Critical error'. Fix: calculator_app resolves the CalculatorApp window via EnumWindows (like the notepad fixture, robust to the stub + broken tasklist); kill_pid() force-terminates via Win32 TerminateProcess (works when taskkill is broken) so guaranteed teardown is CLI-independent; notepad/calc fixtures + tracked_launch use it. test_launch.py patches kill_pid (never touches a real PID); 6 pass, integration collects, ruff clean. Unblocks the real soak + zero-orphan runs. Generated with Claude Code