### PR TITLE
fix(cli): set -j uses consistent {success:true} envelope (#1054)

### DIFF
--- a/naturo/cli/values/_set.py
+++ b/naturo/cli/values/_set.py
@@ -342,7 +342,7 @@ def _do_set_value(backend, hwnd, automation_id, role, name, ref, value,
 
     if json_output:
         click.echo(json_dumps({
-            "status": "ok",
+            "success": True,
             "action": "set_value",
             "ref": ref,
             "value": value,
@@ -389,7 +389,7 @@ def _do_toggle(backend, hwnd, automation_id, role, name, ref, json_output,
 
     if json_output:
         click.echo(json_dumps({
-            "status": "ok",
+            "success": True,
             "action": "toggle",
             "ref": ref,
             "new_state": result,
@@ -437,7 +437,7 @@ def _do_select(backend, hwnd, automation_id, role, name, ref, json_output,
 
     if json_output:
         click.echo(json_dumps({
-            "status": "ok",
+            "success": True,
             "action": "select",
             "ref": ref,
             "pattern": "SelectionItemPattern",
@@ -487,7 +487,7 @@ def _do_expand_collapse(backend, hwnd, automation_id, role, name, ref,
 
     if json_output:
         click.echo(json_dumps({
-            "status": "ok",
+            "success": True,
             "action": action,
             "ref": ref,
             "pattern": "ExpandCollapsePattern",

--- a/tests/test_set_cmd.py
+++ b/tests/test_set_cmd.py
@@ -109,7 +109,7 @@ class TestSetValue:
 
         assert result.exit_code == 0
         data = json.loads(result.output)
-        assert data["status"] == "ok"
+        assert data["success"] is True
         assert data["action"] == "set_value"
         assert data["value"] == "test"
         assert data["pattern"] == "ValuePattern"
@@ -286,7 +286,7 @@ class TestSetToggle:
 
         assert result.exit_code == 0
         data = json.loads(result.output)
-        assert data["status"] == "ok"
+        assert data["success"] is True
         assert data["action"] == "toggle"
         assert data["new_state"] == "Off"
         assert data["pattern"] == "TogglePattern"
@@ -368,7 +368,7 @@ class TestSetSelect:
 
         assert result.exit_code == 0
         data = json.loads(result.output)
-        assert data["status"] == "ok"
+        assert data["success"] is True
         assert data["action"] == "select"
         assert data["pattern"] == "SelectionItemPattern"
 
@@ -450,7 +450,7 @@ class TestSetExpandCollapse:
 
         assert result.exit_code == 0
         data = json.loads(result.output)
-        assert data["status"] == "ok"
+        assert data["success"] is True
         assert data["action"] == "expand"
         assert data["pattern"] == "ExpandCollapsePattern"
 


### PR DESCRIPTION
`set -j` returned `{"status": "ok"}` in all 4 paths (`naturo/cli/values/_set.py`), inconsistent with the `{"success": true, ...}` envelope every other command uses — agents branching on `resp["success"]` hit a `KeyError`. Now returns `"success": True`; the 4 test assertions updated. 36 set tests pass.

Fixes the **set** half of #1054.

**Credit: @muhamedfazalps**, who reported this and opened #1055. Their patch targeted the pre-refactor `set_cmd.py` (since moved to `naturo/cli/values/_set.py` and carrying CRLF churn, hence unmergeable), so this is a clean reimplementation on the current tree — closing #1055 in favour of this.

The **get** half of #1054 (bare list/object → envelope) is a larger output-contract change and is left for a separate PR.

**[Orc]**