### PR TITLE
fix(mcp): reliable agent typing (paste) + verified window focus

### DIFF
--- a/naturo/backends/windows/_window.py
+++ b/naturo/backends/windows/_window.py
@@ -152,31 +152,50 @@ class WindowMixin:
         if self._is_iconic(handle):
             ctypes.windll.user32.ShowWindow(handle, SW_RESTORE)
 
-        # SetForegroundWindow fails silently when caller is not the foreground
-        # process. Use AttachThreadInput trick to work around this Windows
-        # restriction: attach to the target window's thread, set foreground,
-        # then detach.
-        foreground_hwnd = ctypes.windll.user32.GetForegroundWindow()
+        # SetForegroundWindow is silently ignored when the caller is a
+        # background process (the MCP server never holds the foreground): the
+        # old single-shot attempt returned while the window did NOT come
+        # forward, so subsequent keystroke/paste landed in the WRONG window.
+        # Harden it: clear the foreground-lock timeout, then retry
+        # AttachThreadInput + foreground + activate + focus, VERIFYING
+        # GetForegroundWindow each round until the switch actually sticks.
+        import time
+        u = ctypes.windll.user32
         current_tid = ctypes.windll.kernel32.GetCurrentThreadId()
-        target_tid = ctypes.windll.user32.GetWindowThreadProcessId(handle, None)
-        fg_tid = ctypes.windll.user32.GetWindowThreadProcessId(foreground_hwnd, None)
-
-        attached_target = False
-        attached_fg = False
+        target_tid = u.GetWindowThreadProcessId(handle, None)
+        # Clear SPI_SETFOREGROUNDLOCKTIMEOUT (0x2000) so a background process is
+        # allowed to steal the foreground; SPIF_SENDCHANGE (0x2) broadcasts it.
         try:
-            if current_tid != target_tid:
-                attached_target = bool(ctypes.windll.user32.AttachThreadInput(current_tid, target_tid, True))
-            if current_tid != fg_tid and fg_tid != target_tid:
-                attached_fg = bool(ctypes.windll.user32.AttachThreadInput(current_tid, fg_tid, True))
+            u.SystemParametersInfoW(0x2000, 0, 0, 0x2)
+        except Exception:
+            pass
+        for _attempt in range(6):
+            if u.GetForegroundWindow() == handle:
+                return
+            foreground_hwnd = u.GetForegroundWindow()
+            fg_tid = u.GetWindowThreadProcessId(foreground_hwnd, None)
+            attached_target = False
+            attached_fg = False
+            try:
+                if current_tid != target_tid:
+                    attached_target = bool(u.AttachThreadInput(current_tid, target_tid, True))
+                if current_tid != fg_tid and fg_tid != target_tid:
+                    attached_fg = bool(u.AttachThreadInput(current_tid, fg_tid, True))
 
-            ctypes.windll.user32.ShowWindow(handle, SW_SHOW)
-            ctypes.windll.user32.BringWindowToTop(handle)
-            ctypes.windll.user32.SetForegroundWindow(handle)
-        finally:
-            if attached_target:
-                ctypes.windll.user32.AttachThreadInput(current_tid, target_tid, False)
-            if attached_fg:
-                ctypes.windll.user32.AttachThreadInput(current_tid, fg_tid, False)
+                u.ShowWindow(handle, SW_SHOW)
+                u.BringWindowToTop(handle)
+                u.SetForegroundWindow(handle)
+                u.SetActiveWindow(handle)
+                u.SetFocus(handle)
+            finally:
+                if attached_target:
+                    u.AttachThreadInput(current_tid, target_tid, False)
+                if attached_fg:
+                    u.AttachThreadInput(current_tid, fg_tid, False)
+
+            if u.GetForegroundWindow() == handle:
+                return
+            time.sleep(0.04)
 
     def close_window(self, title: Optional[str] = None, hwnd: Optional[int] = None,
                      force: bool = False) -> None:

--- a/naturo/mcp/_input.py
+++ b/naturo/mcp/_input.py
@@ -10,6 +10,38 @@ logger = logging.getLogger(__name__)
 _EN_REF_RE = re.compile(r"e\d+")
 
 
+def _paste_text(backend, text: str) -> bool:
+    """Insert ``text`` via clipboard paste — atomic, fast, and IME-immune.
+
+    A fast per-character SendInput drops characters on heavy controls (Win11
+    Notepad's RichEdit under the modern TSF input host): "hello from naturo"
+    lands as "hello      turo". Pasting inserts the whole string in one shot,
+    so there is no per-key race and no IME composition to corrupt it. The
+    caller's clipboard is saved and restored so it is not clobbered.
+
+    Returns True if the paste was delivered (clipboard set + Ctrl+V sent).
+    """
+    import time
+    try:
+        saved = backend.clipboard_get()
+    except Exception:
+        saved = None
+    delivered = False
+    try:
+        backend.clipboard_set(text)
+        backend.hotkey("ctrl", "v")
+        time.sleep(0.06)  # let the target consume the clipboard before restoring it
+        delivered = True
+    except Exception:
+        delivered = False
+    if saved is not None:
+        try:
+            backend.clipboard_set(saved)
+        except Exception:
+            pass
+    return delivered
+
+
 def register_input_tools(server, _get_backend, _safe_tool):
     """Register input action MCP tools."""
 
@@ -111,12 +143,26 @@ def register_input_tools(server, _get_backend, _safe_tool):
         # set its value directly through UIA — bypassing the keyboard and the
         # IME. Fall back to keystrokes when there is no such control, or when
         # the caller explicitly asked for keystroke-level "hardware" scan codes.
-        used_value_pattern = False
+        # Reliability ladder (each rung is exact; fall to the next only if it can't apply):
+        #   1. writable ValuePattern → set the value directly (instant, IME-immune);
+        #   2. clipboard paste → insert atomically (fast, IME-immune, no per-key race) —
+        #      this is what heavy controls like Win11 Notepad need, where fast keystroke
+        #      SendInput drops chars ("hello from naturo" -> "hello      turo");
+        #   3. keystroke at the requested wpm — now with profile="human" so wpm is
+        #      actually honored (the old call left profile="linear", so wpm was ignored
+        #      and it typed at 5 ms/char, which is the drop cause).
+        method = "keystroke"
+        used = False
         if input_mode == "normal":
-            used_value_pattern = bool(backend.set_focused_element_value(text, append=True))
-        if not used_value_pattern:
-            backend.type_text(text=text, wpm=wpm, input_mode=input_mode)
-        return {"success": True, "method": "value_pattern" if used_value_pattern else "keystroke"}
+            used = bool(backend.set_focused_element_value(text, append=True))
+            if used:
+                method = "value_pattern"
+        if not used and input_mode == "normal" and _paste_text(backend, text):
+            used = True
+            method = "clipboard_paste"
+        if not used:
+            backend.type_text(text=text, wpm=wpm, input_mode=input_mode, profile="human")
+        return {"success": True, "method": method}
 
     @server.tool()
     @_safe_tool

--- a/tests/test_mcp_input.py
+++ b/tests/test_mcp_input.py
@@ -128,11 +128,14 @@ class TestTypeText:
         result = _call_tool(server, "type_text", {"text": "hello world"})
         data = json.loads(result[0].text)
         assert data["success"] is True
-        mock_backend.type_text.assert_called_once_with(
-            text="hello world", wpm=120, input_mode="normal",
-        )
+        # Normal mode with no writable ValuePattern → atomic clipboard paste.
+        assert data["method"] == "clipboard_paste"
+        mock_backend.clipboard_set.assert_any_call("hello world")
 
     def test_type_text_custom_wpm(self, server, mock_backend):
+        # wpm only applies to the keystroke fallback; force it by making paste
+        # unavailable, then confirm wpm reaches the backend.
+        mock_backend.clipboard_set.side_effect = RuntimeError("no clipboard")
         result = _call_tool(server, "type_text", {"text": "fast", "wpm": 300})
         data = json.loads(result[0].text)
         assert data["success"] is True
@@ -150,8 +153,7 @@ class TestTypeText:
         result = _call_tool(server, "type_text", {"text": "日本語テスト 🎉"})
         data = json.loads(result[0].text)
         assert data["success"] is True
-        call_kwargs = mock_backend.type_text.call_args[1]
-        assert call_kwargs["text"] == "日本語テスト 🎉"
+        mock_backend.clipboard_set.assert_any_call("日本語テスト 🎉")
 
     def test_type_text_hardware_mode(self, server, mock_backend):
         result = _call_tool(server, "type_text", {"text": "hw", "input_mode": "hardware"})
@@ -171,13 +173,25 @@ class TestTypeText:
         mock_backend.set_focused_element_value.assert_called_once_with("naturo", append=True)
         mock_backend.type_text.assert_not_called()
 
-    def test_type_text_falls_back_to_keystroke_without_value_pattern(self, server, mock_backend):
-        """No focused ValuePattern control (default) → keystroke injection."""
+    def test_type_text_falls_back_to_clipboard_paste_without_value_pattern(self, server, mock_backend):
+        """No writable ValuePattern (default) → clipboard paste: atomic and
+        IME-immune. A fast per-key SendInput drops chars on heavy controls like
+        Win11 Notepad ("hello from naturo" -> "hello      turo")."""
+        result = _call_tool(server, "type_text", {"text": "naturo"})
+        data = json.loads(result[0].text)
+        assert data["success"] is True
+        assert data["method"] == "clipboard_paste"
+        mock_backend.set_focused_element_value.assert_called_once()
+        # paste path used → no per-key keystroke injection
+        mock_backend.type_text.assert_not_called()
+
+    def test_type_text_falls_back_to_keystroke_when_paste_unavailable(self, server, mock_backend):
+        """Neither ValuePattern nor clipboard paste can apply → keystroke."""
+        mock_backend.clipboard_set.side_effect = RuntimeError("no clipboard")
         result = _call_tool(server, "type_text", {"text": "naturo"})
         data = json.loads(result[0].text)
         assert data["success"] is True
         assert data["method"] == "keystroke"
-        mock_backend.set_focused_element_value.assert_called_once()
         mock_backend.type_text.assert_called_once()
 
     def test_type_text_hardware_mode_skips_value_pattern(self, server, mock_backend):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -212,13 +212,17 @@ class TestToolFunctionsWithMockedBackend:
             mock_backend.click.assert_called_once()
 
     def test_type_text_valid(self, mock_backend):
-        """type_text with valid wpm."""
+        """type_text passes wpm to the keystroke fallback (profile='human' so
+        wpm is actually honored). Force that path by making paste unavailable."""
+        mock_backend.set_focused_element_value.return_value = False
+        mock_backend.clipboard_set.side_effect = RuntimeError("no clipboard")
         with patch("naturo.mcp_server.get_backend", return_value=mock_backend):
             srv = create_server()
             result = self._call_tool(srv, "type_text", {"text": "hello", "wpm": 60})
             data = json.loads(result[0].text)
             assert data["success"] is True
-            mock_backend.type_text.assert_called_once_with(text="hello", wpm=60, input_mode="normal")
+            mock_backend.type_text.assert_called_once_with(
+                text="hello", wpm=60, input_mode="normal", profile="human")
 
     def test_type_text_invalid_wpm(self, mock_backend):
         """type_text with wpm=0 returns validation error."""


### PR DESCRIPTION
Dogfooding naturo's MCP from Claude Code on a real Win11 desktop surfaced two agent-in-the-loop reliability bugs:

**1. `type_text` dropped characters** — `hello from naturo` → `hello      turo`. The MCP tool advertised `wpm` but never passed `profile` to the backend → it typed at `delay_ms=5` (wpm ignored) → fast SendInput outran Win11 Notepad's RichEdit under the TSF input host. **Fix:** reliability ladder — writable ValuePattern → **clipboard paste** (atomic, IME-immune) → keystroke that now honors wpm (`profile='human'`). **Live-verified** via the MCP: `method=clipboard_paste`, exact + instant.

**2. `focus_window` didn't actually foreground** from the background MCP process (Windows foreground-lock) — it returned success while the window stayed in back, so input landed in the wrong window intermittently. **Fix:** clear `SPI_SETFOREGROUNDLOCKTIMEOUT`, then retry AttachThreadInput + foreground + activate + focus, **verifying `GetForegroundWindow`** each round. Direct-verified: `fg==target`.

Tests updated for the paste-default behavior (mcp_input + mcp_server), 97 passed.

Follow-ups (separate): `launch_app` should return the real new-window hwnd so agents can tear down what they open (root of Notepad pile-up, alongside Win11 session-restore); MCP-flow slowness profiling.

**[Orc]**