### PR TITLE
feat(mcp): launch_app returns real new-window hwnd(s) for teardown

### DIFF
--- a/naturo/mcp/_app.py
+++ b/naturo/mcp/_app.py
@@ -35,16 +35,57 @@ def register_app_tools(server, _get_backend, _safe_tool, *, launch_app_fn):
             name: Application name or executable path.
 
         Returns:
-            Dict with success flag, pid, and process info.
+            Dict with success, pid, and the **window(s) that actually appeared**
+            so the caller can ``focus_window``/``window_close`` exactly what it
+            launched — and tear it down afterwards. ``hwnd`` is the primary new
+            window (first one). Note: some apps (e.g. Win11 Notepad) restore
+            their previous session on start, so ``windows`` may list several
+            pre-existing documents that reappeared, not just a fresh one.
         """
+        import time
+
+        def _win_map() -> dict:
+            try:
+                out = {}
+                for w in backend.list_windows():
+                    h = getattr(w, "handle", None) or getattr(w, "hwnd", None)
+                    out[h] = getattr(w, "title", "") or ""
+                return out
+            except Exception:
+                return {}
+
+        backend = _get_backend()
+        before = set(_win_map())
         info = launch_app_fn(name=name)
+
+        # The process layer returns a transient launcher PID for UWP apps and
+        # hard-codes window_count=0, so the caller could not find (and later
+        # close) what it opened — a root cause of window pile-up. Resolve the
+        # real window(s) by diffing the window list, polling briefly.
+        # launch_app_fn already waited for the process, so the window usually
+        # exists on the first check (break immediately); the short cap only
+        # covers a slow-drawing window without adding latency to the fast path.
+        new_windows: list[dict] = []
+        deadline = time.monotonic() + 1.5
+        while time.monotonic() < deadline:
+            new_windows = [
+                {"hwnd": h, "title": t}
+                for h, t in _win_map().items()
+                if h is not None and h not in before
+            ]
+            if new_windows:
+                break
+            time.sleep(0.15)
+
         return {
             "success": True,
             "pid": info.pid,
             "name": info.name,
             "path": info.path,
             "is_running": info.is_running,
-            "window_count": info.window_count,
+            "window_count": len(new_windows),
+            "windows": new_windows,
+            "hwnd": new_windows[0]["hwnd"] if new_windows else None,
         }
 
     @server.tool()

--- a/tests/test_mcp_app.py
+++ b/tests/test_mcp_app.py
@@ -113,6 +113,11 @@ class TestListApps:
 class TestLaunchApp:
 
     def test_launch_app(self, server, mock_backend, mock_launch_app):
+        from types import SimpleNamespace
+        win = SimpleNamespace(handle=555, title="Untitled - Notepad")
+        # empty before launch, one new window after → resolved so the caller
+        # can focus_window/window_close exactly what it opened.
+        mock_backend.list_windows.side_effect = [[], [win], [win]]
         result = _call_tool(server, "launch_app", {"name": "notepad"})
         data = json.loads(result[0].text)
         assert data["success"] is True
@@ -120,6 +125,8 @@ class TestLaunchApp:
         assert data["name"] == "notepad.exe"
         assert data["is_running"] is True
         assert data["window_count"] == 1
+        assert data["hwnd"] == 555
+        assert data["windows"][0]["title"] == "Untitled - Notepad"
 
 
 # ── Quit App ──────────────────────────────────────────────────────────


### PR DESCRIPTION
Dogfooding follow-up. Root cause of the Notepad pile-up: `launch_app` returned a transient launcher pid + hard-coded `window_count=0`, so an agent could not find (and later close) what it opened → windows accumulated (amplified by Win11 Notepad **session restore**, which reopens all prior windows on start).

**Fix:** diff the window list around the launch and return `{windows: [{hwnd, title}], window_count, hwnd}` — the agent can now `focus_window`/`window_close` exactly what it launched. Breaks on the first new window (no added latency on the fast path; 1.5s cap).

Tests updated (test_mcp_app), 62 passed.

**[Orc]**