### PR TITLE
feat(mcp): type_text accepts a target window (atomic focus+type)

### DIFF
--- a/naturo/mcp/_input.py
+++ b/naturo/mcp/_input.py
@@ -104,19 +104,26 @@ def register_input_tools(server, _get_backend, _safe_tool):
         wpm: int = 120,
         input_mode: str = "normal",
         method: str = "auto",
+        hwnd: Optional[int] = None,
+        window_title: Optional[str] = None,
     ) -> dict:
-        """Type text using keyboard input.
+        """Type text into a target window (or the focused window).
 
-        Types the given text character by character, simulating human typing.
+        Pass ``hwnd`` (from ``launch_app``/``list_windows``) or ``window_title``
+        to type into a specific window: naturo focuses it first so the text
+        lands there deterministically — no separate ``focus_window`` call and no
+        focus race. Omit both to type into whatever is currently focused.
 
         Args:
             text: Text to type.
-            wpm: Words per minute (typing speed).
-            input_mode: Input method — "normal" (default) or "hardware" (Phys32 scan codes, bypasses anti-cheat).
+            wpm: Words per minute (applies to the keystroke fallback only).
+            input_mode: "normal" (default) or "hardware" (Phys32 scan codes, bypasses anti-cheat).
             method: Interaction method override — "auto" (default), "cdp", "uia", "msaa", "ia2", "jab", "vision".
+            hwnd: Target window handle to focus + type into.
+            window_title: Target window title (partial match) to focus + type into.
 
         Returns:
-            Dict with success flag.
+            Dict with success flag and the delivery ``method``.
         """
         if wpm < 1:
             return {"success": False, "error": {"code": "INVALID_INPUT", "message": f"wpm must be >= 1, got {wpm}"}}
@@ -137,6 +144,16 @@ def register_input_tools(server, _get_backend, _safe_tool):
                 },
             }
         backend = _get_backend()
+        # Optional target: focus the requested window first, in-process and
+        # immediately before typing, so the text lands there deterministically —
+        # this is one atomic focus+type with no cross-call round-trip for the
+        # foreground to drift, the failure mode that made a separate
+        # focus_window + type_text land input in the wrong window.
+        if hwnd is not None or window_title is not None:
+            try:
+                backend.focus_window(hwnd=hwnd, title=window_title)
+            except Exception:
+                pass  # best-effort; fall through to whatever is focused
         # (#1219) Prefer IME-immune entry: keystroke injection (SendInput) is
         # intercepted by CJK/TSF IMEs and can corrupt text ("naturo" ->
         # "nature"). When the focused control exposes a writable ValuePattern,

--- a/tests/test_mcp_input.py
+++ b/tests/test_mcp_input.py
@@ -205,6 +205,20 @@ class TestTypeText:
         mock_backend.set_focused_element_value.assert_not_called()
         mock_backend.type_text.assert_called_once()
 
+    def test_type_text_with_hwnd_focuses_target_first(self, server, mock_backend):
+        """A target hwnd focuses that window first (atomic focus+type), so the
+        agent doesn't need a separate focus_window call and there's no
+        cross-call focus race."""
+        result = _call_tool(server, "type_text", {"text": "naturo", "hwnd": 4242})
+        data = json.loads(result[0].text)
+        assert data["success"] is True
+        mock_backend.focus_window.assert_called_once_with(hwnd=4242, title=None)
+
+    def test_type_text_without_target_does_not_focus(self, server, mock_backend):
+        """No target → type into the focused window; focus_window is not called."""
+        _call_tool(server, "type_text", {"text": "naturo"})
+        mock_backend.focus_window.assert_not_called()
+
 
 # ── Press Key ─────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Ease-of-use + reliability. `type_text` now takes optional `hwnd` / `window_title`: naturo focuses that window **in-process, immediately before typing**, so the text lands there deterministically.

- Removes the need for a separate `focus_window` call, and the cross-call round-trip where the foreground could drift — the wrong-window failure mode dogfooding surfaced.
- With `launch_app` now returning the hwnd (#1241), the common flow drops from `launch → list_windows → focus_window → type_text → read` (5 calls) to `launch → type_text(hwnd) → read` (3).
- Fully backward-compatible (both params optional; omit → type into the focused window).

Tests added; test_mcp_input passes.

**[Orc]**