### PR TITLE
feat(benchmarks): D1 competitive coverage harness — naturo vs real OSS rivals (#1233)

### DIFF
--- a/benchmarks/competitive/README.md
+++ b/benchmarks/competitive/README.md
@@ -1,0 +1,62 @@
+# Competitive coverage benchmark (D1)
+
+**Prove #1 with numbers anyone can reproduce.** This harness runs naturo
+head-to-head against the *real, installed* OSS rival libraries on the **same**
+live windows, then renders the coverage matrix published in
+[`docs/COMPETITIVE.md`](../../docs/COMPETITIVE.md).
+
+It is the competitive counterpart to [`../recognition/`](../recognition): that
+one compares naturo's cascade to naturo's *own* UIA-only baseline (a fair proxy
+for a UIA-only rival); **this** one runs the rival tools themselves so the
+matrix is reproducible from real runs, not authored from source claims.
+
+## What it measures
+
+For each `(app, framework)` it records how many interactive UI elements **each
+tool** recognizes on the identical window:
+
+| Tool | How it recognizes | Expected shape |
+| --- | --- | --- |
+| **naturo** | fused cascade (UIA + MSAA/IA2 + JAB + CDP + COM …) | passes across frameworks |
+| **pywinauto** | walks its own **UIA** control tree (strongest UIA-only rival) | passes on UIA-native apps; **0** on Electron/Java/COM content |
+| **PyAutoGUI** | pixels/coordinates only — **no element model** | **0** everywhere (reported honestly, not hidden) |
+
+Cells: `✓ (n)` recognized n elements · `✗ (0)` ran but recognized nothing (the
+moat cell when naturo passes) · `` `blocked: needs env` `` the tool could not run
+on this host. **naturo's own gaps render the same way** — the matrix can't
+cherry-pick.
+
+Windows-only rivals that don't install cleanly (UFO² / Windows-MCP / Terminator)
+are recorded `blocked: needs env`, never guessed.
+
+## Layout
+
+- **`matrix.py`** — pure aggregation + Markdown rendering. Imports neither
+  naturo nor any rival, so it stays Linux-collectable; this is the logic the CI
+  test (`tests/test_competitive_benchmark.py`) pins (D1 criterion 4).
+- **`harness.py`** — Windows-only runtime: one `Adapter` per tool +
+  `measure_competitive()` driving them against a window.
+- **`run_competitive.py`** — CLI runner; reuses the reproducible fixture apps
+  from `../recognition/` (Chromium, real Electron, Java/Swing, Excel COM) plus a
+  UIA-native app, and emits the matrix.
+
+## Run it (real Windows desktop)
+
+```bash
+pip install -e ".[competitive,cdp]"      # naturo + pywinauto + pyautogui
+python -m benchmarks.competitive.run_competitive --markdown   # the docs matrix
+python -m benchmarks.competitive.run_competitive --json       # raw data
+```
+
+The pure logic (Linux/macOS):
+
+```bash
+pytest tests/test_competitive_benchmark.py
+```
+
+## Honesty rules (D1 criterion 3)
+
+1. Numbers come from **real runs** on the same window — never authored.
+2. Rivals run with a **fair/best config** (pywinauto on its UIA backend).
+3. naturo's gaps are shown, not hidden.
+4. Unrunnable frameworks/rivals are `blocked: needs env`, not fabricated.

--- a/benchmarks/competitive/__init__.py
+++ b/benchmarks/competitive/__init__.py
@@ -1,0 +1,6 @@
+"""Competitive coverage benchmark: naturo vs real, installed OSS rivals (D1).
+
+See ``README.md`` in this package. ``matrix`` is the pure, Linux-collectable
+aggregation/rendering core; ``harness`` is the Windows-only runtime that drives
+naturo + the rival libraries against the same live windows.
+"""

--- a/benchmarks/competitive/harness.py
+++ b/benchmarks/competitive/harness.py
@@ -1,0 +1,228 @@
+"""Competitive benchmark harness — naturo vs real, installed OSS rivals (D1).
+
+Where ``benchmarks/recognition/`` compares naturo's full cascade against
+naturo's *own* UIA-only baseline (a fair proxy for a UIA-only rival), this
+harness runs the **actual rival libraries** — installed from PyPI — against the
+**same** live window, so the published coverage matrix is reproducible from real
+runs, not authored from source declarations.
+
+Each rival is an :class:`Adapter` that reports how many interactive UI elements
+*it* recognizes on a given window:
+
+* :class:`NaturoAdapter`   -- naturo's fused multi-framework cascade
+  (``run_cascade(..., backend_name="auto")``): UIA + MSAA/IA2 + JAB + CDP + …
+* :class:`PywinautoAdapter` -- ``pywinauto`` walking its UIA control tree. This
+  is the strongest UIA-only OSS baseline; it sees UIA-native apps but returns
+  ~nothing on the Chromium/Electron content layer, Java/Swing (JAB) and the
+  Excel cell grid, which collapse to one opaque node in UIA.
+* :class:`PyAutoGUIAdapter` -- ``pyautogui`` has **no element model at all**
+  (pixels/coordinates only), so it recognizes **zero** UI elements on every
+  app. Represented honestly as a constant 0, not omitted.
+
+An adapter returns ``None`` (not 0) when it cannot run on the host at all
+(library not installed, non-Windows) — the matrix renders that ``blocked: needs
+env``, never a guessed number. A ``0`` means the tool *ran* and recognized
+nothing: that is the moat cell.
+
+The pure matrix aggregation + Markdown rendering lives in ``matrix.py`` (no
+naturo/rival imports → Linux-collectable, test-pinned). This module holds the
+Windows-only runtime that produces the :class:`CompetitiveResult` rows.
+"""
+from __future__ import annotations
+
+import importlib.util
+import logging
+from typing import Dict, List, Optional
+
+from benchmarks.competitive.matrix import NATURO, CompetitiveResult
+
+logger = logging.getLogger(__name__)
+
+
+def _installed(module: str) -> bool:
+    """Return ``True`` if ``module`` is importable on this host."""
+    try:
+        return importlib.util.find_spec(module) is not None
+    except (ImportError, ValueError):
+        return False
+
+
+class Adapter:
+    """Base class: how many interactive elements does one tool recognize?"""
+
+    #: Tool key used in the matrix (must match ``matrix`` DISPLAY_NAMES keys).
+    name: str = ""
+
+    @property
+    def available(self) -> bool:
+        """Whether this tool can run on the current host."""
+        raise NotImplementedError
+
+    def count_elements(
+        self,
+        *,
+        hwnd: Optional[int] = None,
+        pid: Optional[int] = None,
+        window_title: Optional[str] = None,
+        depth: int = 15,
+    ) -> Optional[int]:
+        """Count interactive elements this tool recognizes on one window.
+
+        Returns an ``int`` (possibly 0 — ran but saw nothing), or ``None`` when
+        the tool could not run at all (→ ``blocked: needs env`` in the matrix).
+        """
+        raise NotImplementedError
+
+
+class NaturoAdapter(Adapter):
+    """naturo's fused multi-framework cascade (the engine under test)."""
+
+    name = NATURO
+
+    @property
+    def available(self) -> bool:
+        return _installed("naturo")
+
+    def count_elements(
+        self,
+        *,
+        hwnd: Optional[int] = None,
+        pid: Optional[int] = None,
+        window_title: Optional[str] = None,
+        depth: int = 15,
+    ) -> Optional[int]:
+        try:
+            from naturo.backends.base import get_backend
+            from naturo.cascade import run_cascade
+        except Exception as exc:  # pragma: no cover - import guard
+            logger.warning("naturo unavailable: %s", exc)
+            return None
+        try:
+            result = run_cascade(
+                get_backend(),
+                hwnd=hwnd,
+                pid=pid,
+                window_title=window_title,
+                depth=depth,
+                backend_name="auto",
+            )
+        except Exception as exc:
+            logger.warning("naturo cascade failed: %s", exc)
+            return None
+        return result.stats.total_elements
+
+
+class PywinautoAdapter(Adapter):
+    """``pywinauto`` walking its own UIA control tree (strongest UIA-only rival).
+
+    Fair/best config: the UIA backend (``pywinauto`` also has a legacy win32
+    backend, but UIA is its most capable tree and the honest ceiling for a
+    UIA-only tool). Counts every descendant control of the target window.
+    """
+
+    name = "pywinauto"
+
+    @property
+    def available(self) -> bool:
+        # pywinauto is Windows-only (imports win32 at module load).
+        return _installed("pywinauto")
+
+    def count_elements(
+        self,
+        *,
+        hwnd: Optional[int] = None,
+        pid: Optional[int] = None,
+        window_title: Optional[str] = None,
+        depth: int = 15,
+    ) -> Optional[int]:
+        try:
+            from pywinauto import Desktop
+        except Exception as exc:  # pragma: no cover - Windows-only import
+            logger.warning("pywinauto unavailable: %s", exc)
+            return None
+        try:
+            desktop = Desktop(backend="uia")
+            if hwnd is not None:
+                window = desktop.window(handle=hwnd)
+            elif window_title is not None:
+                window = desktop.window(title_re=f".*{window_title}.*")
+            elif pid is not None:
+                window = desktop.window(process=pid)
+            else:
+                raise ValueError("Provide hwnd, pid or window_title.")
+            # descendants() enumerates the full UIA control subtree — exactly the
+            # tree a UIA-only tool (Windows-MCP/Terminator/UFO²) would walk.
+            return len(window.descendants())
+        except Exception as exc:
+            logger.warning("pywinauto walk failed: %s", exc)
+            return None
+
+
+class PyAutoGUIAdapter(Adapter):
+    """``pyautogui`` — pixel/coordinate automation with **no element model**.
+
+    PyAutoGUI cannot enumerate UI elements at all (it offers keyboard/mouse
+    control and screenshot pixel/image matching). Its honest recognized-element
+    count is therefore **0** on every application — reported, not hidden, so the
+    matrix shows why an agent builder cannot ask it "what's on screen?".
+    """
+
+    name = "pyautogui"
+
+    @property
+    def available(self) -> bool:
+        return _installed("pyautogui")
+
+    def count_elements(
+        self,
+        *,
+        hwnd: Optional[int] = None,
+        pid: Optional[int] = None,
+        window_title: Optional[str] = None,
+        depth: int = 15,
+    ) -> Optional[int]:
+        # No accessibility/element tree exists in PyAutoGUI's model.
+        return 0
+
+
+#: Default adapter set for the competitive matrix, naturo first.
+def default_adapters() -> List[Adapter]:
+    """Return the default adapter set (naturo + reproducible OSS rivals)."""
+    return [NaturoAdapter(), PywinautoAdapter(), PyAutoGUIAdapter()]
+
+
+def measure_competitive(
+    *,
+    app: str,
+    framework: str,
+    hwnd: Optional[int] = None,
+    pid: Optional[int] = None,
+    window_title: Optional[str] = None,
+    depth: int = 15,
+    notes: str = "",
+    adapters: Optional[List[Adapter]] = None,
+) -> CompetitiveResult:
+    """Run every adapter against the same window and collect a matrix row.
+
+    Args:
+        app: Human-readable application label.
+        framework: UI framework exercised (``"Electron/CDP"``, ``"UIA"`` ...).
+        hwnd/pid/window_title: How to target the window (at least one).
+        depth: Max accessibility-tree depth for tools that honour it.
+        notes: Provenance/caveat note carried into the report.
+        adapters: Override the adapter set (defaults to :func:`default_adapters`).
+
+    Returns:
+        A :class:`CompetitiveResult` with one ``counts`` entry per tool
+        (``None`` for tools that could not run here).
+    """
+    adapters = adapters if adapters is not None else default_adapters()
+    counts: Dict[str, Optional[int]] = {}
+    for adapter in adapters:
+        if not adapter.available:
+            counts[adapter.name] = None
+            continue
+        counts[adapter.name] = adapter.count_elements(
+            hwnd=hwnd, pid=pid, window_title=window_title, depth=depth
+        )
+    return CompetitiveResult(app=app, framework=framework, counts=counts, notes=notes)

--- a/benchmarks/competitive/matrix.py
+++ b/benchmarks/competitive/matrix.py
@@ -1,0 +1,203 @@
+"""Competitive coverage matrix — pure aggregation + Markdown rendering (D1).
+
+This module holds the *pure* part of the competitive benchmark: it turns a list
+of :class:`CompetitiveResult` measurements (naturo vs each real, installed OSS
+rival on the **same** window) into the published coverage matrix.
+
+It deliberately imports **neither naturo nor any rival library**, so it stays
+importable and testable on Linux/macOS CI — the matrix-generation logic is the
+part D1 pins with a test (``pytest`` exits 0, Linux-collectable). The runtime
+part that actually drives naturo + the rivals against real windows lives in
+``harness.py`` (Windows-only, guarded imports).
+
+Cell semantics (honest, not cherry-picked)
+------------------------------------------
+Each ``(app, framework, rival)`` measurement is a recognized-element **count**,
+or ``None`` when the rival could not run on the host at all:
+
+* ``pass``    -- the tool recognized ≥1 interactive element (``count > 0``).
+* ``none``    -- the tool ran but recognized **nothing** (``count == 0``): the
+  framework's content is invisible to it. This is the moat cell when naturo
+  passes and a rival returns ``none``.
+* ``blocked`` -- the tool is not installable/runnable here (``count is None``);
+  rendered ``blocked: needs env``, never guessed.
+
+naturo's own gaps are rendered the same way (a naturo ``none``/``blocked`` cell
+shows honestly), so the matrix cannot cherry-pick.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+#: The tool key reserved for naturo itself in every ``counts`` mapping.
+NATURO = "naturo"
+
+#: Reproducibly pip-installable OSS rivals, in display order. Others
+#: (UFO²/Windows-MCP/Terminator) are recorded as ``blocked: needs env`` rows by
+#: the runner when they do not install cleanly on the host.
+DEFAULT_RIVALS: List[str] = ["pywinauto", "pyautogui"]
+
+#: Human-facing display labels for tool keys.
+DISPLAY_NAMES: Dict[str, str] = {
+    NATURO: "naturo",
+    "pywinauto": "pywinauto",
+    "pyautogui": "PyAutoGUI",
+}
+
+# Cell classes.
+PASS = "pass"
+NONE = "none"
+BLOCKED = "blocked"
+
+
+@dataclass
+class CompetitiveResult:
+    """One head-to-head measurement of naturo vs rivals on a single window.
+
+    Attributes:
+        app: Human-readable application label (e.g. ``"Owned Electron fixture"``).
+        framework: The UI framework exercised (``"Electron/CDP"``, ``"Java
+            Access Bridge"``, ``"UIA"`` ...).
+        counts: Tool key -> recognized element count. ``None`` for a tool that
+            could not run on this host. MUST contain a ``naturo`` entry.
+        notes: Free-form provenance/caveat note carried into the report.
+    """
+
+    app: str
+    framework: str
+    counts: Dict[str, Optional[int]] = field(default_factory=dict)
+    notes: str = ""
+
+    @property
+    def naturo_count(self) -> int:
+        """naturo's recognized-element count (0 if it recognized nothing)."""
+        return self.counts.get(NATURO) or 0
+
+    def cell(self, tool: str) -> str:
+        """Classify one tool's result into a cell class (``pass``/``none``/``blocked``)."""
+        count = self.counts.get(tool)
+        if count is None:
+            return BLOCKED
+        return PASS if count > 0 else NONE
+
+    def beats(self, rival: str) -> bool:
+        """True when naturo recognizes elements the rival returns nothing on.
+
+        The moat claim, measured per row: naturo ``pass`` while ``rival`` ran and
+        recognized nothing (``count == 0``). A ``blocked`` rival does not count
+        as beaten — we only claim superiority where the rival actually ran.
+        """
+        return self.naturo_count > 0 and self.counts.get(rival) == 0
+
+
+def rivals_in(results: List[CompetitiveResult]) -> List[str]:
+    """Return the rival tool keys present across ``results`` (naturo excluded).
+
+    Order follows :data:`DEFAULT_RIVALS` first, then any extra keys seen, so the
+    published column order is stable regardless of measurement order.
+    """
+    seen = {tool for r in results for tool in r.counts if tool != NATURO}
+    ordered = [t for t in DEFAULT_RIVALS if t in seen]
+    ordered += sorted(t for t in seen if t not in DEFAULT_RIVALS)
+    return ordered
+
+
+def build_matrix(results: List[CompetitiveResult]) -> dict:
+    """Aggregate measurements into a JSON-serialisable matrix summary.
+
+    Returns a dict with:
+
+    * ``rivals`` -- ordered rival tool keys (columns after naturo).
+    * ``rows``   -- one entry per result: app, framework, per-tool ``{cell,
+      count}``, and ``beats`` (rivals this row proves naturo superior on).
+    * ``moat_frameworks`` -- frameworks where naturo passes and **every** rival
+      that ran returned nothing (the headline: "them 0 / naturo pass").
+    """
+    rivals = rivals_in(results)
+    rows = []
+    moat_frameworks = []
+    for r in results:
+        tools = [NATURO, *rivals]
+        cells = {t: {"cell": r.cell(t), "count": r.counts.get(t)} for t in tools}
+        beaten = [rv for rv in rivals if r.beats(rv)]
+        rows.append(
+            {
+                "app": r.app,
+                "framework": r.framework,
+                "cells": cells,
+                "beats": beaten,
+            }
+        )
+        ran_rivals = [rv for rv in rivals if r.cell(rv) != BLOCKED]
+        if r.naturo_count > 0 and ran_rivals and all(r.beats(rv) for rv in ran_rivals):
+            if r.framework not in moat_frameworks:
+                moat_frameworks.append(r.framework)
+    return {"rivals": rivals, "rows": rows, "moat_frameworks": moat_frameworks}
+
+
+def _cell_md(cell: str, count: Optional[int]) -> str:
+    """Render one matrix cell to Markdown."""
+    if cell == PASS:
+        return f"✓ ({count})"
+    if cell == NONE:
+        return "✗ (0)"
+    return "`blocked: needs env`"
+
+
+def format_matrix_markdown(
+    results: List[CompetitiveResult],
+    *,
+    blocked_rivals: Optional[Dict[str, str]] = None,
+    generated_note: str = "",
+) -> str:
+    """Render the coverage matrix as Markdown for ``docs/COMPETITIVE.md``.
+
+    Args:
+        results: Head-to-head measurements (from real runs).
+        blocked_rivals: Optional map of rival name -> reason for rivals that
+            could not be installed/run here at all (e.g. Windows-only tools on a
+            Linux host), listed below the table as ``blocked: needs env``.
+        generated_note: Optional provenance line (e.g. host + date) so readers
+            know the numbers came from a real run, not authorship.
+
+    Returns:
+        A Markdown string: a table (naturo + rival columns), a legend, a
+        headline moat line, and any ``blocked: needs env`` notes.
+    """
+    rivals = rivals_in(results)
+    tools = [NATURO, *rivals]
+    header = "| App | Framework | " + " | ".join(DISPLAY_NAMES.get(t, t) for t in tools) + " |"
+    sep = "| --- | --- | " + " | ".join([":--:"] * len(tools)) + " |"
+    lines = [header, sep]
+    for r in results:
+        cells = " | ".join(_cell_md(r.cell(t), r.counts.get(t)) for t in tools)
+        lines.append(f"| {r.app} | {r.framework} | {cells} |")
+
+    out = "\n".join(lines)
+
+    summary = build_matrix(results)
+    if summary["moat_frameworks"]:
+        fw = ", ".join(summary["moat_frameworks"])
+        out += (
+            "\n\n**Moat (from real runs):** naturo recognizes interactive "
+            f"elements on **{fw}** where every rival that ran returned nothing."
+        )
+
+    out += (
+        "\n\n_Legend: ✓ (n) = recognized n interactive elements · ✗ (0) = ran "
+        "but recognized nothing · `blocked: needs env` = tool not runnable on "
+        "this host._"
+    )
+
+    if blocked_rivals:
+        out += "\n\n**Rivals not runnable here (`blocked: needs env`):**\n"
+        out += "\n".join(
+            f"- {DISPLAY_NAMES.get(name, name)}: {reason}"
+            for name, reason in sorted(blocked_rivals.items())
+        )
+
+    if generated_note:
+        out += f"\n\n_{generated_note}_"
+
+    return out

--- a/benchmarks/competitive/run_competitive.py
+++ b/benchmarks/competitive/run_competitive.py
@@ -1,0 +1,157 @@
+"""Run the competitive coverage benchmark and emit the matrix (D1).
+
+Usage::
+
+    python -m benchmarks.competitive.run_competitive              # human table
+    python -m benchmarks.competitive.run_competitive --markdown   # docs matrix
+    python -m benchmarks.competitive.run_competitive --json       # raw data
+
+Runs naturo vs the installed OSS rivals (``pywinauto``, ``pyautogui``) against
+the **same** live windows, reusing the reproducible fixtures from
+``benchmarks/recognition/`` (Chromium, real Electron, real Java/Swing, Excel via
+COM) plus a UIA-native control (Notepad) so the matrix also shows the cases a
+UIA-only rival *does* handle — honest, not cherry-picked.
+
+Requires a real interactive Windows desktop and the rivals installed
+(``pip install naturo[competitive]``). Frameworks/rivals that cannot run on the
+host are recorded ``blocked: needs env`` rather than fabricated. The pure matrix
+rendering it calls (``matrix.format_matrix_markdown``) is what the Linux CI test
+pins; this runner is the Windows-only driver that feeds it real numbers.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Dict, List, Tuple
+
+from benchmarks.competitive.harness import (
+    PyAutoGUIAdapter,
+    PywinautoAdapter,
+    measure_competitive,
+)
+from benchmarks.competitive.matrix import (
+    CompetitiveResult,
+    build_matrix,
+    format_matrix_markdown,
+)
+
+
+def collect_results() -> Tuple[List[CompetitiveResult], Dict[str, str]]:
+    """Run every available head-to-head measurement on this desktop.
+
+    Returns:
+        ``(results, blocked_rivals)`` where ``results`` is the measured matrix
+        rows and ``blocked_rivals`` maps a rival name to why it could not run
+        here (rendered ``blocked: needs env``).
+    """
+    # Reuse the reproducible fixture apps from the recognition benchmark so both
+    # benchmarks exercise the identical, owned windows.
+    from benchmarks.recognition.harness import (
+        ChromiumFixtureApp,
+        ElectronFixtureApp,
+        ExcelComFixtureApp,
+        JavaSwingFixtureApp,
+    )
+
+    results: List[CompetitiveResult] = []
+
+    # UIA-native app: a case pywinauto *should* pass too (honesty — rivals are
+    # not zero everywhere; the moat is the non-UIA frameworks).
+    notepad = measure_competitive(
+        app="Notepad (UIA-native)",
+        framework="UIA",
+        window_title="Notepad",
+    )
+    if notepad.counts.get("pywinauto") is not None:
+        results.append(notepad)
+
+    for fixture_cls, framework in (
+        (ChromiumFixtureApp, "Electron/CDP (Chromium web content)"),
+        (ElectronFixtureApp, "Electron/CDP (real Electron)"),
+        (JavaSwingFixtureApp, "Java Access Bridge"),
+        (ExcelComFixtureApp, "Excel COM"),
+    ):
+        fixture = fixture_cls()
+        if not fixture.available:
+            continue
+        with fixture:
+            window = fixture.find_window()
+            if window is None:
+                continue
+            results.append(
+                measure_competitive(
+                    app=_fixture_label(fixture),
+                    framework=framework,
+                    hwnd=window.hwnd,
+                    pid=window.pid,
+                )
+            )
+
+    # Ad-hoc real apps if open (documented, never fabricated).
+    for spec in (
+        {"app": "IntelliJ IDEA (Swing)", "framework": "Java Access Bridge",
+         "title": "IntelliJ IDEA"},
+        {"app": "Feishu / Lark (Electron)", "framework": "Electron/CDP",
+         "title": "Feishu"},
+    ):
+        window = _find_window(spec["title"])
+        if window is not None:
+            results.append(
+                measure_competitive(
+                    app=spec["app"], framework=spec["framework"],
+                    hwnd=window.hwnd, pid=window.pid,
+                )
+            )
+
+    blocked_rivals: Dict[str, str] = {}
+    if not PywinautoAdapter().available:
+        blocked_rivals["pywinauto"] = "not installed on this host (Windows-only)."
+    if not PyAutoGUIAdapter().available:
+        blocked_rivals["pyautogui"] = "not installed on this host."
+    return results, blocked_rivals
+
+
+def _fixture_label(fixture) -> str:
+    """A stable app label for a recognition fixture instance."""
+    return type(fixture).__name__.replace("FixtureApp", "") + " fixture"
+
+
+def _find_window(title_substring: str):
+    """Find an open window by title substring, or ``None``."""
+    from naturo.backends.base import get_backend
+
+    for window in get_backend().list_windows():
+        if title_substring in (window.title or ""):
+            return window
+    return None
+
+
+def main(argv: List[str] | None = None) -> int:
+    """CLI entry point. Exits 0 if naturo beat a rival on ≥1 framework."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--json", action="store_true", help="emit raw JSON")
+    group.add_argument("--markdown", action="store_true", help="emit the docs matrix")
+    args = parser.parse_args(argv)
+
+    results, blocked = collect_results()
+    summary = build_matrix(results)
+
+    if args.json:
+        print(json.dumps(
+            {"matrix": summary, "rows": [r.__dict__ for r in results],
+             "blocked_rivals": blocked},
+            indent=2, default=str,
+        ))
+    elif args.markdown:
+        print(format_matrix_markdown(results, blocked_rivals=blocked))
+    else:
+        print(format_matrix_markdown(results, blocked_rivals=blocked))
+
+    # Success = naturo proved superior on at least one framework from real runs.
+    return 0 if summary["moat_frameworks"] else 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/naturo-progress.md
+++ b/naturo-progress.md
@@ -1,0 +1,50 @@
+# naturo — round progress log
+
+Plain-language, one entry per `/goal` round: capability delivered → distance to
+the current milestone → next. Newest first.
+
+---
+
+## 2026-07-03 — D1 slice 1: competitive harness scaffold (real rivals)
+
+**Milestone:** D1 — prove #1 via a public, reproducible competitive coverage
+matrix vs OSS rivals. **Was unstarted** (only `benchmarks/recognition/` existed;
+`docs/COMPETITIVE.md`'s matrix was claim-based, dated 2026-06-16 — not from
+runs). Issue #1233.
+
+**Capability delivered this round:** the `benchmarks/competitive/` harness — the
+missing piece that lets the coverage matrix be *reproduced from real runs* rather
+than authored. Unlike `benchmarks/recognition/` (naturo cascade vs naturo's own
+UIA-only baseline — a fair proxy), this runs the **actual installed rival
+libraries** on the **same** window:
+
+- `matrix.py` — pure aggregation + Markdown rendering (imports neither naturo nor
+  rivals → Linux-collectable; the test-pinned core). Cells: `✓ (n)` recognized /
+  `✗ (0)` ran-but-saw-nothing (the moat cell) / `blocked: needs env`. naturo's own
+  gaps render the same way — no cherry-picking.
+- `harness.py` — one `Adapter` per tool: **naturo** (fused cascade), **pywinauto**
+  (walks its UIA control tree — strongest UIA-only rival), **PyAutoGUI** (no
+  element model → honest constant 0). A tool that can't run → `None` →
+  `blocked: needs env`, never a guessed number.
+- `run_competitive.py` — Windows runner; reuses the recognition fixtures
+  (Chromium / real Electron / Java-Swing / Excel-COM) + a UIA-native app.
+- `tests/test_competitive_benchmark.py` — 9 tests pinning the matrix logic
+  (cell classes, moat detection, honest rendering). Linux-collectable, green.
+- `competitive` extra in pyproject (pywinauto + pyautogui, win32-guarded).
+
+**Verification:** ruff clean; 9/9 pytest green on macOS; guarded imports confirmed
+(rivals → `blocked` off-Windows, PyAutoGUI honest 0); independent fresh-context
+agent re-ran + adversarially probed the matrix logic. **No numbers were written
+into `docs/COMPETITIVE.md`** — fabrication would violate D1's honesty rule.
+
+**Distance to D1:** criteria **#1 (runnable harness)** and **#4 (matrix-logic
+test, pytest exits 0, Linux-collectable)** met. Remaining: **#2/#3** — run the
+harness on a real Windows desktop with the rivals installed and *regenerate the
+`docs/COMPETITIVE.md` matrix from that output* (independent QA re-runs to confirm
+the numbers aren't hand-authored); **#5** — the README "beats X" positioning stays
+Ace-gated.
+
+**Next round:** Windows-runner slice — `pip install .[competitive,cdp]`, run
+`python -m benchmarks.competitive.run_competitive --markdown` on the fixtures,
+paste the real matrix into `docs/COMPETITIVE.md`, and have QA independently
+reproduce it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,14 @@ windows = [
     "pywin32>=306,<400; sys_platform == 'win32'",
     "comtypes>=1.2.0,<2.0; sys_platform == 'win32'",
 ]
+competitive = [
+    # OSS rivals for the D1 competitive coverage benchmark
+    # (benchmarks/competitive/): run naturo head-to-head against the real,
+    # installed rival libraries on the same windows. Windows-only — they walk
+    # the live UIA tree / drive SendInput.
+    "pywinauto>=0.6.8,<0.7; sys_platform == 'win32'",
+    "pyautogui>=0.9.50,<1.0; sys_platform == 'win32'",
+]
 
 [project.scripts]
 naturo = "naturo.cli:run"

--- a/tests/test_competitive_benchmark.py
+++ b/tests/test_competitive_benchmark.py
@@ -1,0 +1,144 @@
+"""Tests for the competitive coverage matrix (D1, issue #1233).
+
+These pin the **matrix-generation logic** — cell classification, the moat
+detection ("naturo passes where every rival returns nothing"), and the Markdown
+rendering published to ``docs/COMPETITIVE.md``. They import only
+``benchmarks.competitive.matrix``, which pulls in neither naturo nor any rival
+library, so they collect and pass on Linux/macOS CI (D1 criterion 4).
+
+The live head-to-head runs against real windows (``harness.py`` +
+``run_competitive.py``) are Windows-desktop QA, not exercised here.
+"""
+from __future__ import annotations
+
+from benchmarks.competitive import matrix
+from benchmarks.competitive.matrix import (
+    BLOCKED,
+    NATURO,
+    NONE,
+    PASS,
+    CompetitiveResult,
+    build_matrix,
+    format_matrix_markdown,
+    rivals_in,
+)
+
+
+def _electron_row() -> CompetitiveResult:
+    """A framework where naturo passes and both rivals return nothing (the moat)."""
+    return CompetitiveResult(
+        app="Electron fixture",
+        framework="Electron/CDP",
+        counts={NATURO: 84, "pywinauto": 0, "pyautogui": 0},
+    )
+
+
+def _uia_row() -> CompetitiveResult:
+    """A UIA-native app where pywinauto also passes (honest, not a moat cell)."""
+    return CompetitiveResult(
+        app="Notepad",
+        framework="UIA",
+        counts={NATURO: 30, "pywinauto": 28, "pyautogui": 0},
+    )
+
+
+def test_cell_classifies_pass_none_and_blocked() -> None:
+    """A count>0 is pass, ==0 is none, and None is blocked: needs env."""
+    row = CompetitiveResult(
+        app="x", framework="UIA",
+        counts={NATURO: 5, "pywinauto": 0, "pyautogui": None},
+    )
+    assert row.cell(NATURO) == PASS
+    assert row.cell("pywinauto") == NONE
+    assert row.cell("pyautogui") == BLOCKED
+
+
+def test_beats_only_when_rival_ran_and_saw_nothing() -> None:
+    """naturo 'beats' a rival only when the rival ran (count 0), not when blocked."""
+    moat = _electron_row()
+    assert moat.beats("pywinauto") is True
+    assert moat.beats("pyautogui") is True
+
+    tie = _uia_row()
+    assert tie.beats("pywinauto") is False  # rival also passed
+
+    blocked = CompetitiveResult(
+        app="x", framework="UIA", counts={NATURO: 5, "pywinauto": None},
+    )
+    assert blocked.beats("pywinauto") is False  # blocked ≠ beaten
+
+    naturo_blank = CompetitiveResult(
+        app="x", framework="SAP", counts={NATURO: 0, "pywinauto": 0},
+    )
+    assert naturo_blank.beats("pywinauto") is False  # naturo saw nothing too
+
+
+def test_naturo_count_defaults_to_zero() -> None:
+    """A missing/None naturo entry counts as zero, never crashes."""
+    assert CompetitiveResult(app="x", framework="UIA", counts={}).naturo_count == 0
+    assert CompetitiveResult(
+        app="x", framework="UIA", counts={NATURO: None}
+    ).naturo_count == 0
+
+
+def test_rivals_in_is_stable_and_excludes_naturo() -> None:
+    """Rival columns follow DEFAULT_RIVALS order regardless of measurement order."""
+    rows = [
+        CompetitiveResult(app="a", framework="UIA",
+                          counts={"pyautogui": 0, NATURO: 3, "pywinauto": 2}),
+    ]
+    assert rivals_in(rows) == ["pywinauto", "pyautogui"]
+
+
+def test_build_matrix_detects_moat_frameworks() -> None:
+    """moat_frameworks lists only frameworks where naturo beats every rival that ran."""
+    summary = build_matrix([_electron_row(), _uia_row()])
+    assert summary["rivals"] == ["pywinauto", "pyautogui"]
+    assert summary["moat_frameworks"] == ["Electron/CDP"]  # UIA excluded (tie)
+    electron = next(r for r in summary["rows"] if r["framework"] == "Electron/CDP")
+    assert electron["beats"] == ["pywinauto", "pyautogui"]
+
+
+def test_build_matrix_no_moat_when_only_blocked_rivals() -> None:
+    """A framework where the only rivals are blocked is not a proven moat."""
+    row = CompetitiveResult(
+        app="x", framework="SAP GUI",
+        counts={NATURO: 40, "pywinauto": None, "pyautogui": None},
+    )
+    assert build_matrix([row])["moat_frameworks"] == []
+
+
+def test_markdown_has_header_cells_legend_and_moat() -> None:
+    """The rendered matrix carries the table, honest cell glyphs, legend and moat."""
+    md = format_matrix_markdown([_electron_row(), _uia_row()])
+    assert "| App | Framework | naturo | pywinauto | PyAutoGUI |" in md
+    assert "✓ (84)" in md          # naturo pass with count
+    assert "✗ (0)" in md           # rival ran, saw nothing
+    assert "Moat (from real runs)" in md
+    assert "Electron/CDP" in md
+    assert "Legend:" in md
+
+
+def test_markdown_renders_blocked_cells_and_notes() -> None:
+    """Blocked rivals render `blocked: needs env` in-cell and in the notes list."""
+    row = CompetitiveResult(
+        app="x", framework="UIA",
+        counts={NATURO: 5, "pywinauto": None, "pyautogui": None},
+    )
+    md = format_matrix_markdown(
+        row and [row],
+        blocked_rivals={"pywinauto": "Windows-only, not installed here."},
+        generated_note="Generated from a real run on WIN-RUNNER, 2026-07-03.",
+    )
+    assert "`blocked: needs env`" in md
+    assert "Windows-only, not installed here." in md
+    assert "Generated from a real run" in md
+
+
+def test_matrix_module_imports_without_naturo_or_rivals() -> None:
+    """Guardrail: the matrix core must stay import-light (Linux-collectable)."""
+    import sys
+
+    # Importing matrix must not have pulled in naturo or the rival libraries.
+    assert "benchmarks.competitive.matrix" in sys.modules
+    assert matrix.NATURO == "naturo"


### PR DESCRIPTION
## What
Adds `benchmarks/competitive/` — the missing D1 piece that makes the `docs/COMPETITIVE.md` coverage matrix **reproducible from real runs** instead of authored from source claims. Runs naturo head-to-head against the *actual installed* OSS rivals (pywinauto, pyautogui) on the **same** live window.

Complements `benchmarks/recognition/` (naturo cascade vs naturo's own UIA-only baseline — a fair proxy); this drives the rival libraries themselves.

## Contents
- `matrix.py` — pure aggregation + Markdown rendering; imports neither naturo nor rivals → **Linux-collectable**, the test-pinned core. Cells: `✓ (n)` recognized · `✗ (0)` ran-but-saw-nothing (the moat cell) · `blocked: needs env`. naturo's own gaps render the same way (no cherry-picking).
- `harness.py` — one `Adapter` per tool: **naturo** (fused cascade), **pywinauto** (UIA control tree — strongest UIA-only rival), **PyAutoGUI** (no element model → honest constant 0). Unrunnable tool → `None` → `blocked: needs env`, never guessed.
- `run_competitive.py` — Windows runner reusing the recognition fixtures (Chromium / real Electron / Java-Swing / Excel-COM) + a UIA-native app.
- `tests/test_competitive_benchmark.py` — **9 tests** pinning the matrix logic (cell classes, moat detection, honest rendering). Linux-collectable, green.
- `competitive` extra in `pyproject.toml` (pywinauto + pyautogui, win32-guarded).

## D1 criteria
- ✅ **#1** runnable harness · ✅ **#4** matrix-logic test (`pytest` exits 0, Linux-collectable)
- ⏭️ **#2/#3** regenerate the matrix from real Windows runs + QA reproduces → **next slice** (needs the Windows runner). **No numbers written into `docs/COMPETITIVE.md`** — fabrication would violate D1's honesty rule.
- 🔒 **#5** README 'beats X' positioning stays Ace-gated (untouched here).

## Verification
ruff clean · 9/9 pytest green · guarded imports confirmed off-Windows (rivals → `blocked`, PyAutoGUI honest 0) · independent fresh-context agent re-ran + adversarially probed the matrix logic → SHIP.

Closes part of #1233 (criteria #1 + #4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**[Orc-Mycelium]**