### PR TITLE
feat(mcp): capture_window + find_element accept hwnd (uniform targeting)

### DIFF
--- a/naturo/mcp/_capture.py
+++ b/naturo/mcp/_capture.py
@@ -48,12 +48,15 @@ def register_capture_tools(server, _get_backend, _safe_tool):
     def capture_window(
         window_title: Optional[str] = None,
         output_path: str = "capture.png",
+        hwnd: Optional[int] = None,
     ) -> dict:
         """Capture a screenshot of a specific window.
 
         Args:
             window_title: Window title to capture (partial match).
             output_path: Path to save the screenshot.
+            hwnd: Direct window handle (from ``launch_app``/``list_windows``) —
+                preferred; targets that exact window and skips title matching.
 
         Returns:
             Dict with path, width, height, format, scale_factor, dpi.
@@ -68,9 +71,12 @@ def register_capture_tools(server, _get_backend, _safe_tool):
         # naturo/cli/core/_capture.py — to keep the CLI and MCP contracts aligned.
         # Backends whose capture_window does its own title matching (e.g. macOS,
         # which has no _resolve_hwnd) keep receiving the raw window_title.
-        if window_title and hasattr(backend, "_resolve_hwnd"):
-            hwnd = require_hwnd(backend, window_title=window_title)
+        if hwnd is not None:
+            # Direct handle from launch_app/list_windows — no title guessing.
             result = backend.capture_window(hwnd=hwnd, output_path=output_path)
+        elif window_title and hasattr(backend, "_resolve_hwnd"):
+            resolved = require_hwnd(backend, window_title=window_title)
+            result = backend.capture_window(hwnd=resolved, output_path=output_path)
         else:
             result = backend.capture_window(window_title=window_title, output_path=output_path)
         response = {

--- a/naturo/mcp/_inspect.py
+++ b/naturo/mcp/_inspect.py
@@ -197,6 +197,7 @@ def register_inspect_tools(server, _get_backend, _safe_tool):
     def find_element(
         selector: str,
         window_title: Optional[str] = None,
+        hwnd: Optional[int] = None,
     ) -> dict:
         """Find a UI element by selector.
 
@@ -206,12 +207,14 @@ def register_inspect_tools(server, _get_backend, _safe_tool):
         Args:
             selector: Element selector string.
             window_title: Target window (partial match).
+            hwnd: Direct window handle (from ``launch_app``/``list_windows``) —
+                preferred; searches that exact window, no title matching.
 
         Returns:
             Dict with the found element's info or error.
         """
         backend = _get_backend()
-        element = backend.find_element(selector=selector, window_title=window_title)
+        element = backend.find_element(selector=selector, window_title=window_title, hwnd=hwnd)
         if element is None:
             return {"success": False, "error": {"code": "ELEMENT_NOT_FOUND", "message": f"No element matching '{selector}'"}}
         return {


### PR DESCRIPTION
Analyzing a **real user test session** of naturo's MCP surfaced the last targeting-inconsistency friction:

The agent did `launch_app` (got hwnd) → `type_text(hwnd=…)` (exact) → then `capture_window(window_title='Notepad')` **WINDOW_NOT_FOUND**, `capture_window(window_title='无标题')` **WINDOW_NOT_FOUND**, even **re-launched a second Notepad**, before a content-derived title finally matched. 9 calls for a 3-call task.

**Root cause:** `capture_window` and `find_element` took only `window_title` — an agent holding the exact `hwnd` from `launch_app` couldn't use it and had to **guess titles**.

**Fix:** add `hwnd` to both (backends already support it). Now **every** window/element tool (type_text, see_ui_tree, get_element_value, focus_window, window_close, capture_window, find_element) targets the same way — pass the hwnd from `launch_app`/`list_windows`, no title guessing. The elegant flow: `launch_app → {hwnd} → type_text(hwnd) → capture_window(hwnd) → get_element_value(hwnd)`.

capture/inspect tests pass (the 42 ERRORs are a local pytest-temp permission artifact, green on CI).

**[Orc]**