### PR TITLE
fix(mcp): make screenshot base64 opt-in (default off) — stop context flood

### DIFF
--- a/naturo/mcp/_capture.py
+++ b/naturo/mcp/_capture.py
@@ -16,15 +16,24 @@ def register_capture_tools(server, _get_backend, _safe_tool):
     def capture_screen(
         output_path: str = "capture.png",
         screen_index: int = 0,
+        include_base64: bool = False,
     ) -> dict:
         """Capture a screenshot of the entire screen.
+
+        The image is saved to ``output_path`` — read that file to view it.
 
         Args:
             output_path: Path to save the screenshot (PNG/JPG).
             screen_index: Monitor index (0 = primary).
+            include_base64: Inline the PNG as base64 in the response. Off by
+                default: a full-resolution screenshot is hundreds of KB and
+                floods the caller's context (and is not rendered as an image
+                anyway) — prefer reading the saved ``path``. Set True only if
+                you specifically need the bytes in-band.
 
         Returns:
-            Dict with path, width, height, format, and base64-encoded image data.
+            Dict with path, width, height, format, scale_factor, dpi — plus
+            ``data_base64`` only when ``include_base64`` is True.
         """
         backend = _get_backend()
         result = backend.capture_screen(screen_index=screen_index, output_path=output_path)
@@ -37,8 +46,7 @@ def register_capture_tools(server, _get_backend, _safe_tool):
             "scale_factor": result.scale_factor,
             "dpi": result.dpi,
         }
-        # Include base64 data for AI vision
-        if os.path.exists(result.path):
+        if include_base64 and os.path.exists(result.path):
             with open(result.path, "rb") as f:
                 response["data_base64"] = base64.b64encode(f.read()).decode("ascii")
         return response
@@ -49,17 +57,25 @@ def register_capture_tools(server, _get_backend, _safe_tool):
         window_title: Optional[str] = None,
         output_path: str = "capture.png",
         hwnd: Optional[int] = None,
+        include_base64: bool = False,
     ) -> dict:
         """Capture a screenshot of a specific window.
+
+        The image is saved to ``output_path`` — read that file to view it.
 
         Args:
             window_title: Window title to capture (partial match).
             output_path: Path to save the screenshot.
             hwnd: Direct window handle (from ``launch_app``/``list_windows``) —
                 preferred; targets that exact window and skips title matching.
+            include_base64: Inline the PNG as base64 in the response. Off by
+                default: a full window screenshot is hundreds of KB and floods
+                the caller's context — prefer reading the saved ``path``. Set
+                True only if you specifically need the bytes in-band.
 
         Returns:
-            Dict with path, width, height, format, scale_factor, dpi.
+            Dict with path, width, height, format, scale_factor, dpi — plus
+            ``data_base64`` only when ``include_base64`` is True.
         """
         backend = _get_backend()
         # (#954/#957) Resolve window_title to a concrete hwnd via the shared
@@ -88,7 +104,7 @@ def register_capture_tools(server, _get_backend, _safe_tool):
             "scale_factor": result.scale_factor,
             "dpi": result.dpi,
         }
-        if os.path.exists(result.path):
+        if include_base64 and os.path.exists(result.path):
             with open(result.path, "rb") as f:
                 response["data_base64"] = base64.b64encode(f.read()).decode("ascii")
         return response

--- a/tests/test_mcp_capture.py
+++ b/tests/test_mcp_capture.py
@@ -69,7 +69,10 @@ class TestCaptureScreen:
         assert data["format"] == "png"
         assert data["scale_factor"] == 1.0
         assert data["dpi"] == 96
-        assert "data_base64" in data
+        assert data["path"] == str(png_file)
+        # base64 is opt-in — off by default so a large image never floods the
+        # caller's context; the image is read from the saved path instead.
+        assert "data_base64" not in data
 
     def test_default_arguments(self, server, mock_backend):
         capture_result = MagicMock()
@@ -117,10 +120,30 @@ class TestCaptureScreen:
         capture_result.dpi = 96
         mock_backend.capture_screen.return_value = capture_result
 
-        result = _call_tool(server, "capture_screen", {})
+        # Even when explicitly requested, a missing file yields no base64.
+        result = _call_tool(server, "capture_screen", {"include_base64": True})
         data = json.loads(result[0].text)
         assert data["success"] is True
         assert "data_base64" not in data
+
+    def test_base64_included_only_when_requested(self, server, mock_backend, tmp_path):
+        png_file = tmp_path / "s.png"
+        png_file.write_bytes(b"\x89PNGdata")
+        capture_result = MagicMock()
+        capture_result.path = str(png_file)
+        capture_result.width = 1920
+        capture_result.height = 1080
+        capture_result.format = "png"
+        capture_result.scale_factor = 1.0
+        capture_result.dpi = 96
+        mock_backend.capture_screen.return_value = capture_result
+
+        result = _call_tool(
+            server, "capture_screen",
+            {"output_path": str(png_file), "include_base64": True},
+        )
+        data = json.loads(result[0].text)
+        assert "data_base64" in data
 
 
 class TestCaptureWindow:
@@ -144,7 +167,7 @@ class TestCaptureWindow:
         assert data["success"] is True
         assert data["width"] == 800
         assert data["height"] == 600
-        assert "data_base64" in data
+        assert "data_base64" not in data  # opt-in only; off by default
         # window_title is resolved to an hwnd before capture (#954).
         mock_backend.capture_window.assert_called_once_with(
             hwnd=999, output_path="capture.png"


### PR DESCRIPTION
capture_window/capture_screen always inlined the PNG as data_base64 (one capture = 351,599 chars) — floods agent context every call, and it is not rendered as an image anyway. Add include_base64 (default False): return path only by default (read the saved file to view); inline base64 only on request. Verified: default 229 chars, opt-in has base64, path always present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)