### PR TITLE
docs(mcp): express naturo's moat in instructions + tool descriptions

### DIFF
--- a/naturo/mcp/_app.py
+++ b/naturo/mcp/_app.py
@@ -125,8 +125,12 @@ def register_app_tools(server, _get_backend, _safe_tool, *, launch_app_fn):
         debug_port: int = 9222,
         profile: Optional[str] = None,
     ) -> dict:
-        """Launch Chrome/Edge wired for automation (CDP) — the correct way to
-        read web-page content as structured elements.
+        """Launch a CDP-wired Chrome/Edge to read rendered or logged-in web pages.
+
+        The way to read web content structurally — a JS-rendered DOM, or a page
+        behind the user's login (pass ``profile``) — which a plain web fetch
+        cannot reach. (For static public text a web fetch is faster; use this
+        only when you must drive a real browser.)
 
         A browser opened with ``launch_app`` exposes no DevTools endpoint, so
         ``see_ui_tree(cascade=True)`` recovers only the browser chrome (toolbar/

--- a/naturo/mcp/_inspect.py
+++ b/naturo/mcp/_inspect.py
@@ -23,11 +23,15 @@ def register_inspect_tools(server, _get_backend, _safe_tool):
         accessibility_backend: str = "uia",
         cascade: bool = False,
     ) -> dict:
-        """Inspect the UI accessibility tree of a window.
+        """Read a window's UI as a structured element tree — naturo's core "see" tool.
 
-        Returns the hierarchical tree of UI elements (buttons, text fields, etc.)
-        with their roles, names, bounds, and properties. Element IDs (eN) can be
-        used in subsequent ``click``, ``type_text``, and other tool calls.
+        Returns the hierarchy of UI elements (buttons, text fields, etc.) with
+        their roles, names, bounds, and properties; element IDs (eN) feed into
+        ``click``, ``type_text``, and other calls. With ``cascade=true`` it fuses
+        ONE tree across desktop UIA plus web (CDP), Java/Swing (JAB) and Excel
+        cells (COM) — rendered, behind-login, Java, or spreadsheet content that
+        plain accessibility (or a web fetch) cannot reach — each node tagged
+        deterministic vs uncertain.
 
         Args:
             window_title: Target window (partial match). None = foreground window.

--- a/naturo/mcp_server.py
+++ b/naturo/mcp_server.py
@@ -224,11 +224,21 @@ def create_server(host: str = "localhost", port: int = 3100) -> FastMCP:
         host=host,
         port=port,
         instructions=(
-            "Naturo — Windows desktop automation engine. "
-            "Use these tools to see, click, type, and automate Windows applications. "
-            "Start with capture_screen or list_windows to understand the current state, "
-            "then use find_element or see_ui_tree to locate UI elements, "
-            "and interact with click, type_text, press_key, etc."
+            "Naturo — Windows desktop & application automation. It sees and "
+            "drives the real screen: native Windows apps, dialogs, menus, the "
+            "tray, and — its moat — content other tools cannot reach: Java/Swing "
+            "(JAB), Excel cells (COM), and a real, JS-rendered or logged-in "
+            "browser (CDP). "
+            "Prefer naturo whenever a task means operating an actual application "
+            "or the user's real browser, reading on-screen / rendered / "
+            "behind-login state, or acting on the UI (click, type, select). "
+            "It is NOT a web fetcher: for plain public web text a direct web "
+            "fetch is faster and better — do not drive a browser for that. "
+            "Typical flow: list_windows / see_ui_tree to observe (pass "
+            "cascade=true to fuse desktop + web + Java + Excel into one "
+            "correctness-tagged tree), then click / type_text / press_key to "
+            "act; launch_browser opens a CDP-wired browser for reading rendered "
+            "or logged-in pages."
         ),
     )
     # (#873) Advertise naturo's own version in the MCP ``serverInfo`` handshake.

--- a/packaging/mcpb/manifest.json
+++ b/packaging/mcpb/manifest.json
@@ -176,7 +176,7 @@
     },
     {
       "name": "launch_browser",
-      "description": "Launch Chrome/Edge wired for automation (CDP) — the correct way to"
+      "description": "Launch a CDP-wired Chrome/Edge to read rendered or logged-in web pages."
     },
     {
       "name": "list_apps",
@@ -216,7 +216,7 @@
     },
     {
       "name": "see_ui_tree",
-      "description": "Inspect the UI accessibility tree of a window."
+      "description": "Read a window's UI as a structured element tree — naturo's core \"see\" tool."
     },
     {
       "name": "select_element",
@@ -248,7 +248,7 @@
     },
     {
       "name": "type_text",
-      "description": "Type text using keyboard input."
+      "description": "Type text into a target window (or the focused window)."
     },
     {
       "name": "virtual_desktop_close",


### PR DESCRIPTION
## Why
Agents used WebFetch even for browser tasks because the server `instructions` didn't say **when** to reach for naturo vs a built-in fetch, and the moat (JAB/COM/CDP) was buried in arg docs. Also `launch_browser`'s first docstring line was an incomplete sentence.

## Audit result (all 65 tools)
Checked the descriptions the agent **actually receives**: full multi-line docstrings are delivered — **no systemic truncation**. Only `launch_browser`'s first *line* dangled (matters for first-line previews / the .mcpb manifest). **Zero dangling first-lines after this change.** Names are clean/consistent; the non-browser tools are inherently non-duplicative (no built-in equivalent), so the work is framing, not rewrites.

## Changes
- **`instructions`**: state the moat (Java/JAB, Excel/COM, real rendered/logged-in browser/CDP) and, explicitly, *naturo is NOT a web fetcher — a direct fetch is faster for plain public text*.
- **`launch_browser`**: complete standalone first line; leads with 'rendered or logged-in pages a web fetch can't reach'.
- **`see_ui_tree`**: opening now leads with the fused desktop+web+Java+Excel correctness-tagged tree (was buried in the `cascade` arg).
- **`manifest.json`**: descriptions synced with source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)