### PR TITLE
feat(mcp): read_web_text — read rendered page text via CDP (kills the screenshot fallback)

### DIFF
--- a/naturo/mcp/_inspect.py
+++ b/naturo/mcp/_inspect.py
@@ -198,6 +198,98 @@ def register_inspect_tools(server, _get_backend, _safe_tool):
 
     @server.tool()
     @_safe_tool
+    def read_web_text(
+        hwnd: Optional[int] = None,
+        window_title: Optional[str] = None,
+        selector: Optional[str] = None,
+        max_chars: int = 20000,
+    ) -> dict:
+        """Read rendered text from a browser page via CDP — the static text that
+        see_ui_tree / find_element miss.
+
+        see_ui_tree(cascade) surfaces *interactive* elements (buttons, inputs,
+        links); the visible text of a result — a translation output, an article
+        body, a price, a status line — usually lives in a plain element the
+        interactive tree skips, which otherwise forces a screenshot. This returns
+        that text straight from the rendered DOM (``innerText``), so it reads
+        JS-rendered or logged-in content a web fetch cannot. Point it at a
+        browser opened with ``launch_browser``. A dynamic result may need a
+        moment to appear — read again if the first call comes back empty.
+
+        Args:
+            hwnd: Browser window handle (from ``launch_browser``/``list_windows``).
+            window_title: Browser window title (partial) if ``hwnd`` is unknown.
+            selector: CSS selector to read one element's text; omit to read the
+                whole page's visible text.
+            max_chars: Truncate the returned text to this many characters.
+
+        Returns:
+            Dict with ``text``, ``selector``, ``char_count``, ``truncated``.
+        """
+        import json as _json
+
+        backend = _get_backend()
+        if hwnd is None and window_title is not None and hasattr(backend, "_resolve_hwnd"):
+            hwnd = backend._resolve_hwnd(window_title=window_title)
+        if hwnd is None:
+            return {"success": False, "error": {
+                "code": "INVALID_INPUT",
+                "message": "Provide hwnd or window_title of the browser window.",
+            }}
+
+        # Resolve the window's PID so the CDP port is found from its command line
+        # (works for the auto-selected non-default port launch_browser may use).
+        pid = None
+        try:
+            import ctypes
+            import ctypes.wintypes
+            _pid = ctypes.wintypes.DWORD()
+            ctypes.windll.user32.GetWindowThreadProcessId(int(hwnd), ctypes.byref(_pid))
+            pid = _pid.value or None
+        except Exception:
+            pid = None
+
+        from naturo.cascade import find_cdp_port
+        port = find_cdp_port(pid)
+        if not port:
+            return {"success": False, "error": {
+                "code": "CDP_NOT_AVAILABLE",
+                "message": "No DevTools endpoint for this window.",
+                "suggested_action": "Open the page with launch_browser (it enables CDP), then read it with the returned hwnd.",
+                "recoverable": True,
+            }}
+
+        if selector:
+            expr = (
+                "(function(){var el=document.querySelector(" + _json.dumps(selector)
+                + ");return el?el.innerText:'';})()"
+            )
+        else:
+            expr = "document.body?document.body.innerText:''"
+
+        from naturo.cdp import CDPClient
+        client = CDPClient(port=port)
+        try:
+            client.connect()
+            text = client.evaluate(expr)
+        finally:
+            try:
+                client.close()
+            except Exception:
+                pass
+
+        text = text if isinstance(text, str) else ("" if text is None else str(text))
+        full_len = len(text)
+        return {
+            "success": True,
+            "text": text[:max_chars],
+            "selector": selector,
+            "char_count": full_len,
+            "truncated": full_len > max_chars,
+        }
+
+    @server.tool()
+    @_safe_tool
     def find_element(
         selector: str,
         window_title: Optional[str] = None,

--- a/packaging/mcpb/manifest.json
+++ b/packaging/mcpb/manifest.json
@@ -151,6 +151,10 @@
       "description": "Expand or collapse a combo box or tree item via ExpandCollapsePattern."
     },
     {
+      "name": "read_web_text",
+      "description": "Read rendered text from a browser page via CDP — the static text that"
+    },
+    {
       "name": "find_element",
       "description": "Find a UI element by selector."
     },

--- a/tests/test_mcp_inspect.py
+++ b/tests/test_mcp_inspect.py
@@ -490,3 +490,50 @@ class TestExpandCollapseElement:
             "expand": True, "name": "Tree", "window_title": "Explorer",
         })
         mock_backend._resolve_hwnd.assert_called_once_with(window_title="Explorer")
+
+
+# ── read_web_text ────────────────────────────────────────────────────
+
+
+class TestReadWebText:
+
+    def test_reads_rendered_text_via_cdp(self, server, mock_backend):
+        fake_client = MagicMock()
+        fake_client.evaluate.return_value = (
+            "Artificial intelligence is transforming the world"
+        )
+        with patch("naturo.cascade.find_cdp_port", return_value=9222), \
+             patch("naturo.cdp.CDPClient", return_value=fake_client):
+            result = _call_tool(server, "read_web_text", {"hwnd": 4332842})
+        data = json.loads(result[0].text)
+        assert data["success"] is True
+        assert "Artificial intelligence" in data["text"]
+        assert data["char_count"] == len(fake_client.evaluate.return_value)
+        fake_client.connect.assert_called_once()
+
+    def test_selector_targets_element(self, server, mock_backend):
+        fake_client = MagicMock()
+        fake_client.evaluate.return_value = "42"
+        with patch("naturo.cascade.find_cdp_port", return_value=9222), \
+             patch("naturo.cdp.CDPClient", return_value=fake_client):
+            result = _call_tool(
+                server, "read_web_text", {"hwnd": 1, "selector": ".result"}
+            )
+        data = json.loads(result[0].text)
+        assert data["text"] == "42"
+        assert data["selector"] == ".result"
+        expr = fake_client.evaluate.call_args[0][0]
+        assert "querySelector" in expr and ".result" in expr
+
+    def test_no_cdp_endpoint_returns_actionable_error(self, server, mock_backend):
+        with patch("naturo.cascade.find_cdp_port", return_value=None):
+            result = _call_tool(server, "read_web_text", {"hwnd": 1})
+        data = json.loads(result[0].text)
+        assert data["success"] is False
+        assert data["error"]["code"] == "CDP_NOT_AVAILABLE"
+
+    def test_requires_a_target_window(self, server, mock_backend):
+        result = _call_tool(server, "read_web_text", {})
+        data = json.loads(result[0].text)
+        assert data["success"] is False
+        assert data["error"]["code"] == "INVALID_INPUT"


### PR DESCRIPTION
## Why
`see_ui_tree(cascade)` surfaces only **interactive** DOM elements (buttons/inputs/links). The visible text of a *result* — a translation output, article body, price, status line — sits in a plain element the tree skips, so agents fall back to **screenshot + vision**. A real Baidu-translate run took **~11 calls + 2 screenshots** just to read one output line (full chain pulled from the session transcript).

## Fix
`read_web_text(hwnd, selector?)` runs `innerText` over the **existing** `CDPClient.evaluate()` and returns the text directly — rendered or logged-in content a web fetch can't reach. Resolves the CDP port from the window's PID (so it works with the auto-selected port from #1250).

## Impact
The translate flow collapses to **`launch_browser` → `read_web_text(hwnd)`** — no screenshot, no foreground, seconds not minutes.

## Verified
End-to-end on fanyi.baidu.com: `read_web_text` returns **'Artificial intelligence is transforming the world'** with no screenshot. 4 unit tests (read, selector, no-CDP error, no-target error) validated on-host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)