### PR TITLE
fix(mcp): hwnd->CDP port registry — read_web_text never cross-talks

### DIFF
--- a/naturo/browser/_registry.py
+++ b/naturo/browser/_registry.py
@@ -1,0 +1,35 @@
+"""Process-local map of a browser window handle to its CDP debug port.
+
+``launch_browser`` records the port it opened a window on; ``read_web_text``
+(and other CDP readers) look it up to attach to the *exact* instance behind a
+given hwnd, instead of blind-probing the common ports — which returns the wrong
+browser when more than one debuggable browser is alive (CDP cross-talk).
+
+The map lives for the life of the MCP server process. Both ends of the common
+flow (launch_browser -> read_web_text) run in that same process, so a lookup by
+hwnd is exact even when a stray debuggable browser from elsewhere is running.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+_HWND_PORT: dict[int, int] = {}
+
+
+def record(hwnd: Optional[int], port: Optional[int]) -> None:
+    """Remember that window ``hwnd`` exposes CDP on ``port``."""
+    if hwnd is not None and port:
+        _HWND_PORT[int(hwnd)] = int(port)
+
+
+def lookup(hwnd: Optional[int]) -> Optional[int]:
+    """Return the recorded CDP port for ``hwnd``, or None if unknown."""
+    if hwnd is None:
+        return None
+    return _HWND_PORT.get(int(hwnd))
+
+
+def forget(hwnd: Optional[int]) -> None:
+    """Drop ``hwnd`` from the map (e.g. after the window closes)."""
+    if hwnd is not None:
+        _HWND_PORT.pop(int(hwnd), None)

--- a/naturo/mcp/_app.py
+++ b/naturo/mcp/_app.py
@@ -232,6 +232,13 @@ def register_app_tools(server, _get_backend, _safe_tool, *, launch_app_fn):
                 break
             time.sleep(0.15)
 
+        # Remember hwnd -> port so read_web_text / CDP readers attach to THIS
+        # exact instance instead of blind-probing (which reads the wrong browser
+        # when several debuggable ones are alive).
+        from naturo.browser._registry import record as _record_port
+        for w in new_windows:
+            _record_port(w["hwnd"], chrome.port)
+
         return {
             "success": True,
             "debug_port": chrome.port,

--- a/naturo/mcp/_inspect.py
+++ b/naturo/mcp/_inspect.py
@@ -237,20 +237,25 @@ def register_inspect_tools(server, _get_backend, _safe_tool):
                 "message": "Provide hwnd or window_title of the browser window.",
             }}
 
-        # Resolve the window's PID so the CDP port is found from its command line
-        # (works for the auto-selected non-default port launch_browser may use).
-        pid = None
-        try:
-            import ctypes
-            import ctypes.wintypes
-            _pid = ctypes.wintypes.DWORD()
-            ctypes.windll.user32.GetWindowThreadProcessId(int(hwnd), ctypes.byref(_pid))
-            pid = _pid.value or None
-        except Exception:
+        # Prefer the exact port launch_browser recorded for this window — a blind
+        # CDP probe returns the wrong browser when several debuggable ones are
+        # alive (cross-talk). Fall back to PID-based discovery for windows we did
+        # not open ourselves.
+        from naturo.browser._registry import lookup as _lookup_port
+        port = _lookup_port(hwnd)
+        if not port:
             pid = None
+            try:
+                import ctypes
+                import ctypes.wintypes
+                _pid = ctypes.wintypes.DWORD()
+                ctypes.windll.user32.GetWindowThreadProcessId(int(hwnd), ctypes.byref(_pid))
+                pid = _pid.value or None
+            except Exception:
+                pid = None
 
-        from naturo.cascade import find_cdp_port
-        port = find_cdp_port(pid)
+            from naturo.cascade import find_cdp_port
+            port = find_cdp_port(pid)
         if not port:
             return {"success": False, "error": {
                 "code": "CDP_NOT_AVAILABLE",

--- a/tests/test_mcp_inspect.py
+++ b/tests/test_mcp_inspect.py
@@ -537,3 +537,23 @@ class TestReadWebText:
         data = json.loads(result[0].text)
         assert data["success"] is False
         assert data["error"]["code"] == "INVALID_INPUT"
+
+    def test_uses_recorded_port_not_probe(self, server, mock_backend):
+        # launch_browser records hwnd -> port; read_web_text must use that exact
+        # port and NOT blind-probe (which cross-talks when several debuggable
+        # browsers are alive).
+        from naturo.browser import _registry
+        _registry.record(777, 9250)
+        fake_client = MagicMock()
+        fake_client.evaluate.return_value = "this-window's-own-text"
+        try:
+            with patch("naturo.cascade.find_cdp_port", return_value=None) as fcp, \
+                 patch("naturo.cdp.CDPClient", return_value=fake_client) as cc:
+                result = _call_tool(server, "read_web_text", {"hwnd": 777})
+            data = json.loads(result[0].text)
+            assert data["success"] is True
+            assert data["text"] == "this-window's-own-text"
+            fcp.assert_not_called()
+            cc.assert_called_once_with(port=9250)
+        finally:
+            _registry.forget(777)


### PR DESCRIPTION
## Bug (found by the MCP eval loop, round 1 · probe E3)
Two debuggable browsers alive → `read_web_text(hwnd)` blind-probed 9222/9229/9333 and attached to the **wrong** instance. An eval case that opened a second browser read the *first* browser's page (stale result → screenshot fallback → 24-call thrash).

## Fix
`launch_browser` records `hwnd -> debug_port` in a process-local registry; `read_web_text` looks it up and attaches to that **exact** port, falling back to PID discovery only for windows it didn't open. Bonus: also reads browsers on an auto-selected **ephemeral** port (which the fixed probe list never covered).

## Verified live
Two browsers A/B on distinct ports each read their **own** page — zero cross-talk. One landed on ephemeral port 55676 and was still read exactly. Plus a regression test (registry hit → exact port, no probe).

## Cycle note
This closes eval-loop cycle 1: bug found (E3) → root cause → fix → re-tested → improvement confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)