### PR TITLE
feat(mcp): word_read / word_write — programmatic Word text via COM

### DIFF
--- a/naturo/mcp/_word.py
+++ b/naturo/mcp/_word.py
@@ -1,0 +1,53 @@
+"""MCP tools for Word COM automation."""
+from __future__ import annotations
+
+
+def register_word_tools(server, _get_backend, _safe_tool):
+    """Register Word COM MCP tools."""
+
+    @server.tool()
+    @_safe_tool
+    def word_write(
+        path: str,
+        text: str,
+        create: bool = True,
+        append: bool = False,
+    ) -> dict:
+        """Write text to a Word document programmatically (COM) — no UI needed.
+
+        The direct way to put text in a .docx: no start-screen click, no typing
+        into the window, no clipboard round-trip. Uses a dedicated Word instance
+        (DispatchEx) so it never stalls on the Backstage start screen, and works
+        from the MCP worker thread. For reading a document back, use word_read.
+
+        Args:
+            path: Path to the .docx file.
+            text: Text to write.
+            create: Create the document if it does not exist (default True).
+            append: Append to the end instead of replacing the whole document.
+
+        Returns:
+            Dict with path and chars (document length after write).
+        """
+        from naturo.word import word_write as _word_write
+        result = _word_write(path, text, create=create, append=append)
+        return {"success": True, **result}
+
+    @server.tool()
+    @_safe_tool
+    def word_read(path: str) -> dict:
+        """Read the full text of a Word document programmatically (COM).
+
+        Returns the document body text directly — far cleaner than opening the
+        window and doing select-all / copy / read-clipboard. Uses a dedicated
+        Word instance (DispatchEx), works from the MCP worker thread.
+
+        Args:
+            path: Path to the .docx/.doc file.
+
+        Returns:
+            Dict with path, text (full document text), and chars.
+        """
+        from naturo.word import word_read as _word_read
+        result = _word_read(path)
+        return {"success": True, **result}

--- a/naturo/mcp_server.py
+++ b/naturo/mcp_server.py
@@ -33,6 +33,7 @@ from naturo.mcp._clipboard import register_clipboard_tools
 from naturo.mcp._dialog import register_dialog_tools
 from naturo.mcp._system import register_system_tools
 from naturo.mcp._excel import register_excel_tools
+from naturo.mcp._word import register_word_tools
 
 logger = logging.getLogger(__name__)
 
@@ -342,6 +343,7 @@ def create_server(host: str = "localhost", port: int = 3100) -> FastMCP:
     register_dialog_tools(server, _get_backend, _safe_tool)
     register_system_tools(server, _get_backend, _safe_tool)
     register_excel_tools(server, _get_backend, _safe_tool)
+    register_word_tools(server, _get_backend, _safe_tool)
 
     # Pydantic parameter-validation errors are sanitized by the
     # _SanitizingFastMCP.call_tool override, which is wired into the low-level

--- a/naturo/word.py
+++ b/naturo/word.py
@@ -1,0 +1,188 @@
+"""Windows Word COM Automation backend.
+
+Read/write Word document text via ``win32com.client`` (pywin32), mirroring
+:mod:`naturo.excel`:
+
+* **DispatchEx** — a dedicated, automation-ready Word instance (never attaches to
+  an interactively-launched Word stuck on the Backstage start screen, where COM
+  operations fail with OLE 0x800a01a8).
+* **CoInitialize** (via the shared ``_com_apartment`` decorator) — works from the
+  FastMCP worker thread that dispatches synchronous MCP tools.
+* **Quit in a finally** — nothing leaks.
+
+Requires: Windows, Microsoft Word, pywin32.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import platform
+from typing import Any
+
+from naturo.errors import NaturoError, ErrorCode, ErrorCategory
+from naturo.excel import _com_apartment  # shared COM-apartment (CoInitialize) helper
+
+logger = logging.getLogger(__name__)
+
+# Word constants (avoid the makepy type library).
+_WD_COLLAPSE_END = 0
+_WD_FORMAT_DOCX = 16
+
+
+class WordError(NaturoError):
+    """Word COM automation error."""
+
+    def __init__(self, message: str, **kwargs: Any) -> None:
+        kwargs.setdefault("category", ErrorCategory.AUTOMATION)
+        super().__init__(message, code=kwargs.pop("code", "WORD_ERROR"), **kwargs)
+
+
+class WordNotAvailableError(WordError):
+    """Word or pywin32 is not available."""
+
+    def __init__(self, detail: str = "") -> None:
+        msg = "Microsoft Word is not available"
+        if detail:
+            msg += f": {detail}"
+        super().__init__(
+            msg,
+            code="WORD_NOT_AVAILABLE",
+            suggested_action="Install Microsoft Word and pywin32 (pip install pywin32).",
+        )
+
+
+def _require_windows() -> None:
+    if platform.system() != "Windows":
+        raise WordError(
+            "Word COM automation requires Windows",
+            code=ErrorCode.PERMISSION_DENIED,
+        )
+
+
+def _normalize_path(path: str) -> str:
+    return os.path.abspath(os.path.expanduser(path))
+
+
+def _get_word():  # type: ignore[no-untyped-def]
+    """Return a dedicated Word.Application COM instance (DispatchEx)."""
+    _require_windows()
+    try:
+        import win32com.client  # type: ignore[import-untyped]
+    except ImportError:
+        raise WordNotAvailableError("pywin32 is not installed (pip install pywin32)")
+    try:
+        app = win32com.client.DispatchEx("Word.Application")
+    except Exception as exc:
+        raise WordNotAvailableError(str(exc))
+    app.Visible = False
+    app.DisplayAlerts = 0
+    return app
+
+
+_COM_HINT = (
+    "Word COM automation failed. Ensure Microsoft Word is installed and "
+    "activated — an un-activated or first-run Office can block COM automation. "
+    "Try opening the document in Word once, and verify the path."
+)
+
+
+@_com_apartment
+def word_write(
+    path: str,
+    text: str,
+    create: bool = True,
+    append: bool = False,
+) -> dict[str, Any]:
+    """Write text to a Word document.
+
+    Args:
+        path: Path to the .docx file.
+        text: Text to write.
+        create: Create the document if it does not exist.
+        append: Append to the end instead of replacing the whole document.
+
+    Returns:
+        Dict with path, chars (document length after write).
+    """
+    _require_windows()
+    abs_path = _normalize_path(path)
+    if not os.path.isfile(abs_path) and not create:
+        raise WordError(
+            f"Document not found: {path}",
+            code=ErrorCode.FILE_NOT_FOUND,
+            context={"path": abs_path},
+        )
+
+    app = _get_word()
+    try:
+        existed = os.path.isfile(abs_path)
+        doc = app.Documents.Open(abs_path) if existed else app.Documents.Add()
+
+        if append:
+            rng = doc.Content
+            rng.Collapse(_WD_COLLAPSE_END)
+            rng.InsertAfter(text)
+        else:
+            doc.Content.Text = text
+
+        if existed:
+            doc.Save()
+        else:
+            doc.SaveAs(abs_path, FileFormat=_WD_FORMAT_DOCX)
+
+        chars = len(doc.Content.Text)
+        doc.Close(SaveChanges=False)
+        return {"path": abs_path, "chars": chars, "appended": append}
+    except WordError:
+        raise
+    except Exception as exc:
+        raise WordError(
+            f"Failed to write document: {exc}",
+            context={"path": abs_path},
+            suggested_action=_COM_HINT,
+        )
+    finally:
+        try:
+            app.Quit()
+        except Exception as exc:
+            logger.debug("Word COM cleanup failed: %s", exc)
+
+
+@_com_apartment
+def word_read(path: str) -> dict[str, Any]:
+    """Read the full text of a Word document.
+
+    Args:
+        path: Path to the .docx/.doc file.
+
+    Returns:
+        Dict with path, text (full document text), chars.
+    """
+    _require_windows()
+    abs_path = _normalize_path(path)
+    if not os.path.isfile(abs_path):
+        raise WordError(
+            f"Document not found: {path}",
+            code=ErrorCode.FILE_NOT_FOUND,
+            context={"path": abs_path},
+        )
+
+    app = _get_word()
+    try:
+        doc = app.Documents.Open(abs_path, ReadOnly=True)
+        text = doc.Content.Text
+        doc.Close(SaveChanges=False)
+        return {"path": abs_path, "text": text, "chars": len(text)}
+    except WordError:
+        raise
+    except Exception as exc:
+        raise WordError(
+            f"Failed to read document: {exc}",
+            context={"path": abs_path},
+            suggested_action=_COM_HINT,
+        )
+    finally:
+        try:
+            app.Quit()
+        except Exception as exc:
+            logger.debug("Word COM cleanup failed: %s", exc)

--- a/packaging/mcpb/manifest.json
+++ b/packaging/mcpb/manifest.json
@@ -147,6 +147,14 @@
       "description": "Write a value to a cell in an Excel workbook."
     },
     {
+      "name": "word_write",
+      "description": "Write text to a Word document programmatically (COM) — no UI needed."
+    },
+    {
+      "name": "word_read",
+      "description": "Read the full text of a Word document programmatically (COM)."
+    },
+    {
       "name": "expand_collapse_element",
       "description": "Expand or collapse a combo box or tree item via ExpandCollapsePattern."
     },

--- a/tests/test_word.py
+++ b/tests/test_word.py
@@ -1,0 +1,69 @@
+"""Tests for naturo.word — Word COM automation (mock-based, Linux-collectable)."""
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _inject_win32com(app):
+    """Return a patch.dict context injecting a fake win32com whose DispatchEx
+    returns *app*."""
+    win32com = types.ModuleType("win32com")
+    client = types.ModuleType("win32com.client")
+    client.DispatchEx = MagicMock(return_value=app)
+    win32com.client = client  # type: ignore[attr-defined]
+    return {"win32com": win32com, "win32com.client": client}, client
+
+
+class TestWordCom:
+
+    def test_get_word_uses_dispatchex(self):
+        import naturo.word as W
+        app = MagicMock()
+        mods, client = _inject_win32com(app)
+        with patch("naturo.word.platform.system", return_value="Windows"), \
+             patch.dict(sys.modules, mods):
+            W._get_word()
+        assert client.DispatchEx.called
+        assert app.Visible is False
+
+    def test_word_write_new_doc_sets_content_saves_and_quits(self):
+        import naturo.word as W
+        app = MagicMock()
+        doc = MagicMock()
+        app.Documents.Add.return_value = doc
+        doc.Content.Text = ""
+        mods, _ = _inject_win32com(app)
+        with patch("naturo.word.platform.system", return_value="Windows"), \
+             patch("naturo.word.os.path.isfile", return_value=False), \
+             patch.dict(sys.modules, mods):
+            result = W.word_write(r"C:\x\a.docx", "hello world", create=True)
+        assert doc.Content.Text == "hello world"  # whole-document replace
+        assert doc.SaveAs.called                   # new file → SaveAs
+        assert app.Quit.called                     # cleanup in finally
+        assert result["path"].endswith("a.docx")
+
+    def test_word_read_returns_document_text(self):
+        import naturo.word as W
+        app = MagicMock()
+        doc = MagicMock()
+        doc.Content.Text = "the document body"
+        app.Documents.Open.return_value = doc
+        mods, _ = _inject_win32com(app)
+        with patch("naturo.word.platform.system", return_value="Windows"), \
+             patch("naturo.word.os.path.isfile", return_value=True), \
+             patch.dict(sys.modules, mods):
+            result = W.word_read(r"C:\x\a.docx")
+        assert result["text"] == "the document body"
+        assert result["chars"] == len("the document body")
+        assert app.Quit.called
+
+    def test_word_read_missing_file_raises(self):
+        import naturo.word as W
+        with patch("naturo.word.platform.system", return_value="Windows"), \
+             patch("naturo.word.os.path.isfile", return_value=False):
+            with pytest.raises(W.WordError):
+                W.word_read(r"C:\x\nope.docx")


### PR DESCRIPTION
## Why (from the Word UI-automation eval case)
Writing/reading Word via UI meant fighting the Backstage start screen (click 空白文档) and reading the body via **select-all → copy → clipboard_get** — clumsy and error-prone.

## What
Dedicated COM tools mirroring Excel: **`word_write`** / **`word_read`** on `Word.Application`, reusing the proven **`DispatchEx`** (dedicated instance, no start screen) + **`CoInitialize`** (`_com_apartment` decorator → works on the MCP worker thread) + **finally-Quit** pattern. Direct read/write of the document body — no UI, no clipboard.

## Verified
Live on a worker thread: write + read round-trips **exactly** (`'naturo Word COM 测试:你好世界 Hello'`). 4 mock-based unit tests, manifest synced (68 tools).

Note: shares `_com_apartment` with excel.py; a future refactor could extract a common Office-COM base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)