### PR TITLE
fix(process): launch a full path passed as `name` directly (not blocking start /wait)

### DIFF
--- a/naturo/process.py
+++ b/naturo/process.py
@@ -346,6 +346,15 @@ def launch_app(
     if not launch_target:
         raise AppNotFoundError("(no name or path provided)")
 
+    # Agents commonly pass a full executable path as `name` (the prompt gave a
+    # path, not a friendly name). Treat a path-like name pointing at a real file
+    # as `path` so it launches directly (non-blocking Popen) instead of falling
+    # through where/start to a `cmd /c start /wait` that BLOCKS on a GUI app until
+    # it closes — that hang froze a real agent run mid-task.
+    if not path and name and ("\\" in name or "/" in name):
+        if os.path.isfile(name):
+            path = name
+
     # Guard: prevent launching GUI apps in non-interactive sessions (#351).
     # SSH sessions spawn processes in session 0 (invisible on the desktop),
     # creating orphaned processes that accumulate over time.

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1194,3 +1194,38 @@ class TestUWPQuitResolution:
 
         with pytest.raises(InteractionFailedError, match="still running"):
             _verify_quit("计算器", None, target_pid=1000, timeout=0.5)
+
+
+class TestPathLikeNameLaunch:
+    """A full path passed as ``name`` (agents do this — the prompt gives a path)
+    must launch directly, never fall through to a ``start /wait`` that blocks on a
+    GUI app until it closes. That hang froze a real agent run mid-task."""
+
+    def test_path_like_name_launches_directly_not_via_start_wait(self):
+        import naturo.process as P
+        from unittest.mock import patch, MagicMock
+        fake = MagicMock(pid=4321)
+        with patch("naturo.process.platform.system", return_value="Windows"), \
+             patch("naturo.cli.interaction._is_current_session_interactive", return_value=True), \
+             patch("os.path.isfile", return_value=True), \
+             patch("naturo.process.subprocess.Popen", return_value=fake) as popen, \
+             patch("naturo.process.subprocess.run") as run:
+            info = P.launch_app(name=r"C:\tools\jconsole.exe")
+        assert popen.call_args_list[0][0][0] == [r"C:\tools\jconsole.exe"]
+        assert info.pid == 4321
+        for c in run.call_args_list:
+            argv = c.args[0] if c.args else []
+            assert "/wait" not in argv, f"blocking start/wait used: {argv}"
+
+    def test_bare_name_still_resolves_normally(self):
+        """A friendly name (no separator) must NOT be treated as a path."""
+        import naturo.process as P
+        from unittest.mock import patch, MagicMock
+        with patch("naturo.process.platform.system", return_value="Windows"), \
+             patch("naturo.cli.interaction._is_current_session_interactive", return_value=True), \
+             patch("os.path.isfile", return_value=False), \
+             patch("naturo.process.subprocess.run",
+                   return_value=MagicMock(returncode=0)) as run, \
+             patch("naturo.process.subprocess.Popen", return_value=MagicMock(pid=7)):
+            P.launch_app(name="notepad")
+        assert any("where" in (c.args[0] if c.args else []) for c in run.call_args_list)


### PR DESCRIPTION
## Found by the eval loop (agent froze mid-task)
An agent given an executable path passed it as `launch_app(name=<path>)` instead of `path=<path>`. A full-path `name` misses the direct-Popen branch → `where` returns nonzero → falls to `cmd /c start /wait "" <path>`, which **blocks until the GUI app closes** (the child inherits the captured pipe, so even the 10s timeout can't return). `launch_app` **hung >45s** and the whole `claude -p` session froze at that call.

## Fix
A path-like `name` pointing at a real file is normalized to `path` → launched directly (non-blocking), ~0.3s. Bare names still resolve via `where`. 2 Linux-collectable unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)