### PR TITLE
fix(bench): call comtypes prep at harness import (pywinauto was still blocked)

### DIFF
--- a/benchmarks/competitive/harness.py
+++ b/benchmarks/competitive/harness.py
@@ -83,6 +83,14 @@ def _prepare_comtypes_gen() -> None:
         pass  # no comtypes (non-Windows / not installed) — nothing to prepare
 
 
+# Run at import: this module is imported before naturo (lazily loaded inside the
+# adapters below) touches comtypes, so the gen dir is redirected to a writable
+# location first. Calling it only inside count_elements was too late — naturo
+# imports comtypes first and locks the gen dir to the read-only default, leaving
+# pywinauto falsely scored `blocked: needs env` in a real run (verified on host).
+_prepare_comtypes_gen()
+
+
 class Adapter:
     """Base class: how many interactive elements does one tool recognize?"""
 


### PR DESCRIPTION
Follow-up to #1262. That prep only ran inside `count_elements` — too late: naturo (lazily imported by the adapters) imports comtypes first and locks the gen dir to the read-only default, so pywinauto still failed and was scored `blocked: needs env` in a real run. `harness` imports naturo lazily, so running the prep at **harness module-import** redirects the gen dir before anything touches comtypes.

**Verified on host**: `run_competitive` now produces real rival numbers. Honest head-to-head: **moat is Java/JAB (naturo 46 vs pywinauto 6)**; pywinauto is competitive by raw count on Electron (85 vs 113) and Excel COM (1177 vs 1307) — metric caveat: naturo counts cascade-recognized elements vs pywinauto raw UIA descendants; a meaningful-element metric is a follow-up. Linux matrix test stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)