### PR TITLE
feat(bench): meaningful-interactive-element metric — symmetric, anti-cherry-pick (D1)

### DIFF
--- a/benchmarks/competitive/harness.py
+++ b/benchmarks/competitive/harness.py
@@ -34,7 +34,11 @@ import importlib.util
 import logging
 from typing import Dict, List, Optional
 
-from benchmarks.competitive.matrix import NATURO, CompetitiveResult
+from benchmarks.competitive.matrix import (
+    NATURO,
+    CompetitiveResult,
+    count_interactive,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -110,10 +114,29 @@ class Adapter:
         window_title: Optional[str] = None,
         depth: int = 15,
     ) -> Optional[int]:
-        """Count interactive elements this tool recognizes on one window.
+        """Count the elements this tool recognizes on one window (raw total).
 
         Returns an ``int`` (possibly 0 — ran but saw nothing), or ``None`` when
         the tool could not run at all (→ ``blocked: needs env`` in the matrix).
+        """
+        raise NotImplementedError
+
+    def count_interactive_elements(
+        self,
+        *,
+        hwnd: Optional[int] = None,
+        pid: Optional[int] = None,
+        window_title: Optional[str] = None,
+        depth: int = 15,
+    ) -> Optional[int]:
+        """Count only the **meaningful interactive** elements (the honest metric).
+
+        A raw ``descendants()`` walk inflates on Chromium/Excel with static text,
+        panes and separators the agent cannot act on. This counts only nodes
+        whose role is in :data:`benchmarks.competitive.matrix.INTERACTIVE_ROLES`,
+        via the one shared filter — applied symmetrically to every adapter so the
+        published matrix cannot cherry-pick (D1 crit #3). Returns ``None`` when
+        the tool could not run at all, mirroring :meth:`count_elements`.
         """
         raise NotImplementedError
 
@@ -154,6 +177,53 @@ class NaturoAdapter(Adapter):
             logger.warning("naturo cascade failed: %s", exc)
             return None
         return result.stats.total_elements
+
+    def count_interactive_elements(
+        self,
+        *,
+        hwnd: Optional[int] = None,
+        pid: Optional[int] = None,
+        window_title: Optional[str] = None,
+        depth: int = 15,
+    ) -> Optional[int]:
+        try:
+            from naturo.backends.base import get_backend
+            from naturo.cascade import run_cascade
+        except Exception as exc:  # pragma: no cover - import guard
+            logger.warning("naturo unavailable: %s", exc)
+            return None
+        try:
+            result = run_cascade(
+                get_backend(),
+                hwnd=hwnd,
+                pid=pid,
+                window_title=window_title,
+                depth=depth,
+                backend_name="auto",
+            )
+        except Exception as exc:
+            logger.warning("naturo cascade failed: %s", exc)
+            return None
+        # Walk the fused tree and count nodes whose recognized role is interactive.
+        return count_interactive(_walk_roles(result.tree))
+
+
+def _walk_roles(node: object) -> "list[Optional[str]]":
+    """Flatten an ``ElementInfo`` tree to the list of every node's ``role``.
+
+    Root-inclusive, depth-first. Tolerant of ``None`` (empty tree) and of nodes
+    without a ``children`` list, so a partial cascade result never raises here.
+    """
+    roles: "list[Optional[str]]" = []
+    if node is None:
+        return roles
+    stack = [node]
+    while stack:
+        cur = stack.pop()
+        roles.append(getattr(cur, "role", None))
+        children = getattr(cur, "children", None) or []
+        stack.extend(children)
+    return roles
 
 
 class PywinautoAdapter(Adapter):
@@ -202,6 +272,45 @@ class PywinautoAdapter(Adapter):
             logger.warning("pywinauto walk failed: %s", exc)
             return None
 
+    def count_interactive_elements(
+        self,
+        *,
+        hwnd: Optional[int] = None,
+        pid: Optional[int] = None,
+        window_title: Optional[str] = None,
+        depth: int = 15,
+    ) -> Optional[int]:
+        _prepare_comtypes_gen()
+        try:
+            from pywinauto import Desktop
+        except Exception as exc:  # pragma: no cover - Windows-only import
+            logger.warning("pywinauto unavailable: %s", exc)
+            return None
+        try:
+            desktop = Desktop(backend="uia")
+            if hwnd is not None:
+                window = desktop.window(handle=hwnd)
+            elif window_title is not None:
+                window = desktop.window(title_re=f".*{window_title}.*")
+            elif pid is not None:
+                window = desktop.window(process=pid)
+            else:
+                raise ValueError("Provide hwnd, pid or window_title.")
+            # The crux fix: keep only descendants whose UIA control type is
+            # actionable, via the SAME allowlist naturo is scored against. A bare
+            # len(descendants()) counts static text / panes / separators that
+            # inflate Chromium & Excel without being agent-targetable.
+            roles = []
+            for w in window.descendants():
+                try:
+                    roles.append(w.element_info.control_type)
+                except Exception:
+                    roles.append(None)  # unreadable node → not interactive
+            return count_interactive(roles)
+        except Exception as exc:
+            logger.warning("pywinauto interactive walk failed: %s", exc)
+            return None
+
 
 class PyAutoGUIAdapter(Adapter):
     """``pyautogui`` — pixel/coordinate automation with **no element model**.
@@ -227,6 +336,17 @@ class PyAutoGUIAdapter(Adapter):
         depth: int = 15,
     ) -> Optional[int]:
         # No accessibility/element tree exists in PyAutoGUI's model.
+        return 0
+
+    def count_interactive_elements(
+        self,
+        *,
+        hwnd: Optional[int] = None,
+        pid: Optional[int] = None,
+        window_title: Optional[str] = None,
+        depth: int = 15,
+    ) -> Optional[int]:
+        # No element model at all → zero interactive elements, honestly.
         return 0
 
 
@@ -263,11 +383,22 @@ def measure_competitive(
     """
     adapters = adapters if adapters is not None else default_adapters()
     counts: Dict[str, Optional[int]] = {}
+    interactive_counts: Dict[str, Optional[int]] = {}
     for adapter in adapters:
         if not adapter.available:
             counts[adapter.name] = None
+            interactive_counts[adapter.name] = None
             continue
         counts[adapter.name] = adapter.count_elements(
             hwnd=hwnd, pid=pid, window_title=window_title, depth=depth
         )
-    return CompetitiveResult(app=app, framework=framework, counts=counts, notes=notes)
+        interactive_counts[adapter.name] = adapter.count_interactive_elements(
+            hwnd=hwnd, pid=pid, window_title=window_title, depth=depth
+        )
+    return CompetitiveResult(
+        app=app,
+        framework=framework,
+        counts=counts,
+        interactive_counts=interactive_counts,
+        notes=notes,
+    )

--- a/benchmarks/competitive/matrix.py
+++ b/benchmarks/competitive/matrix.py
@@ -28,10 +28,72 @@ shows honestly), so the matrix cannot cherry-pick.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional
+from typing import Dict, Iterable, List, Optional
 
 #: The tool key reserved for naturo itself in every ``counts`` mapping.
 NATURO = "naturo"
+
+#: Roles/control-types an automation agent can **target for an action or a value
+#: read** — the "meaningful interactive element" allowlist (see
+#: ``docs/design/MEANINGFUL_INTERACTIVE_ELEMENT_METRIC.md``). Normalised form:
+#: lower-cased with spaces/hyphens/underscores stripped, so ``"Radio Button"``,
+#: ``"radio-button"`` and ``"RadioButton"`` all match. Synonyms across the UIA /
+#: JAB / CDP / COM role vocabularies are folded together (e.g. ``hyperlink`` and
+#: ``link``; ``edit``/``textbox``; ``cell``/``gridcell``/``dataitem``).
+#:
+#: This is an **allowlist**: anything not listed (static text, panes, groups,
+#: separators, images, title/scroll/status bars, tooltips, custom-no-pattern) is
+#: excluded. The same allowlist is applied **symmetrically to every adapter** —
+#: that symmetry is the honesty invariant D1 crit #3 requires; an adapter-specific
+#: allowlist would be cherry-picking. Bare static ``Text`` is deliberately absent
+#: (editable fields surface as ``Edit``/``TextBox``/``Document``).
+INTERACTIVE_ROLES: frozenset = frozenset({
+    "button", "splitbutton", "togglebutton", "dropdownbutton", "menubutton",
+    "edit", "textbox", "document", "passwordedit",
+    "combobox", "dropdown",
+    "checkbox", "radiobutton", "radio", "menuitemcheck", "menuitemradio",
+    "hyperlink", "link",
+    "menuitem", "menubaritem",
+    "listitem", "treeitem",
+    "tab", "tabitem",
+    "cell", "gridcell", "dataitem", "tablecell",
+    "slider",
+    "spinner", "spinbutton",
+    "calendar", "datepicker", "date",
+    "hotkeyfield",
+})
+
+
+def normalize_role(role: Optional[str]) -> str:
+    """Fold a raw role/control-type string to the allowlist's normalised form.
+
+    Lower-cases and strips spaces, hyphens and underscores so the many spellings
+    of the same role across backends (``"Radio Button"``, ``"radio-button"``,
+    ``"RadioButton"``) all compare equal. ``None``/empty -> ``""``.
+    """
+    if not role:
+        return ""
+    return "".join(ch for ch in role.lower() if ch not in " -_")
+
+
+def is_interactive_role(role: Optional[str]) -> bool:
+    """Return ``True`` iff ``role`` is a meaningful interactive element.
+
+    Pure, backend-agnostic, and applied identically to naturo and every rival —
+    this single function *is* the symmetric filter (the honesty invariant).
+    """
+    return normalize_role(role) in INTERACTIVE_ROLES
+
+
+def count_interactive(roles: Iterable[Optional[str]]) -> int:
+    """Count how many of ``roles`` are meaningful interactive elements.
+
+    Both the naturo adapter (walking cascade-node roles) and the pywinauto
+    adapter (walking ``element_info.control_type`` over ``descendants()``) reduce
+    their element list to a role sequence and call this one function, so the
+    filter is provably identical on both sides.
+    """
+    return sum(1 for r in roles if is_interactive_role(r))
 
 #: Reproducibly pip-installable OSS rivals, in display order. Others
 #: (UFO²/Windows-MCP/Terminator) are recorded as ``blocked: needs env`` rows by
@@ -68,27 +130,57 @@ class CompetitiveResult:
     framework: str
     counts: Dict[str, Optional[int]] = field(default_factory=dict)
     notes: str = ""
+    #: Per-tool **meaningful-interactive** element count (the same symmetric
+    #: allowlist applied to every adapter). Empty when a run predates the metric
+    #: — then every accessor transparently falls back to the raw ``counts`` and
+    #: behaviour is identical to before (backward compatible).
+    interactive_counts: Dict[str, Optional[int]] = field(default_factory=dict)
+
+    def _counts_for(self, metric: str) -> Dict[str, Optional[int]]:
+        """Return the count map for ``metric`` (``"raw"`` | ``"interactive"``).
+
+        Falls back to raw when interactive numbers were not measured, so callers
+        never crash on an older result.
+        """
+        if metric == "interactive" and self.interactive_counts:
+            return self.interactive_counts
+        return self.counts
+
+    def has_interactive(self) -> bool:
+        """Whether this row carries measured interactive counts."""
+        return bool(self.interactive_counts)
 
     @property
     def naturo_count(self) -> int:
-        """naturo's recognized-element count (0 if it recognized nothing)."""
+        """naturo's raw recognized-element count (0 if it recognized nothing)."""
         return self.counts.get(NATURO) or 0
 
-    def cell(self, tool: str) -> str:
-        """Classify one tool's result into a cell class (``pass``/``none``/``blocked``)."""
-        count = self.counts.get(tool)
+    def naturo_count_for(self, metric: str = "raw") -> int:
+        """naturo's count under ``metric`` (0 if it recognized nothing)."""
+        return self._counts_for(metric).get(NATURO) or 0
+
+    def cell(self, tool: str, metric: str = "raw") -> str:
+        """Classify one tool's result into a cell class (``pass``/``none``/``blocked``).
+
+        ``metric`` selects raw vs interactive; it defaults to ``"raw"`` so every
+        existing caller is unchanged.
+        """
+        count = self._counts_for(metric).get(tool)
         if count is None:
             return BLOCKED
         return PASS if count > 0 else NONE
 
-    def beats(self, rival: str) -> bool:
+    def beats(self, rival: str, metric: str = "raw") -> bool:
         """True when naturo recognizes elements the rival returns nothing on.
 
         The moat claim, measured per row: naturo ``pass`` while ``rival`` ran and
         recognized nothing (``count == 0``). A ``blocked`` rival does not count
         as beaten — we only claim superiority where the rival actually ran.
+        ``metric`` defaults to raw; pass ``"interactive"`` for the actionable-
+        element view that the published matrix now leads with.
         """
-        return self.naturo_count > 0 and self.counts.get(rival) == 0
+        cmap = self._counts_for(metric)
+        return (cmap.get(NATURO) or 0) > 0 and cmap.get(rival) == 0
 
 
 def rivals_in(results: List[CompetitiveResult]) -> List[str]:
@@ -119,30 +211,55 @@ def build_matrix(results: List[CompetitiveResult]) -> dict:
     moat_frameworks = []
     for r in results:
         tools = [NATURO, *rivals]
-        cells = {t: {"cell": r.cell(t), "count": r.counts.get(t)} for t in tools}
-        beaten = [rv for rv in rivals if r.beats(rv)]
+        # Classify on the interactive metric when it was measured (the honest,
+        # actionable view), else on raw — so pre-metric rows behave exactly as
+        # before. Both counts are carried so a reader can see what changed.
+        metric = "interactive" if r.has_interactive() else "raw"
+        cells = {
+            t: {
+                "cell": r.cell(t, metric),
+                "count": r._counts_for(metric).get(t),
+                "raw": r.counts.get(t),
+                "interactive": r.interactive_counts.get(t) if r.has_interactive() else None,
+            }
+            for t in tools
+        }
+        beaten = [rv for rv in rivals if r.beats(rv, metric)]
         rows.append(
             {
                 "app": r.app,
                 "framework": r.framework,
+                "metric": metric,
                 "cells": cells,
                 "beats": beaten,
             }
         )
-        ran_rivals = [rv for rv in rivals if r.cell(rv) != BLOCKED]
-        if r.naturo_count > 0 and ran_rivals and all(r.beats(rv) for rv in ran_rivals):
+        ran_rivals = [rv for rv in rivals if r.cell(rv, metric) != BLOCKED]
+        naturo_saw = r.naturo_count_for(metric) > 0
+        if naturo_saw and ran_rivals and all(r.beats(rv, metric) for rv in ran_rivals):
             if r.framework not in moat_frameworks:
                 moat_frameworks.append(r.framework)
     return {"rivals": rivals, "rows": rows, "moat_frameworks": moat_frameworks}
 
 
 def _cell_md(cell: str, count: Optional[int]) -> str:
-    """Render one matrix cell to Markdown."""
+    """Render one matrix cell to Markdown (single metric — legacy raw view)."""
     if cell == PASS:
         return f"✓ ({count})"
     if cell == NONE:
         return "✗ (0)"
     return "`blocked: needs env`"
+
+
+def _cell_md_dual(cell: str, interactive: Optional[int], raw: Optional[int]) -> str:
+    """Render a cell showing the interactive count (leading, drives ✓/✗) with the
+    raw count alongside — honesty: the actionable number, plus what it came from.
+    """
+    if cell == BLOCKED:
+        return "`blocked: needs env`"
+    glyph = "✓" if cell == PASS else "✗"
+    raw_str = "–" if raw is None else str(raw)
+    return f"{glyph} ({interactive if interactive is not None else 0} · raw {raw_str})"
 
 
 def format_matrix_markdown(
@@ -167,11 +284,25 @@ def format_matrix_markdown(
     """
     rivals = rivals_in(results)
     tools = [NATURO, *rivals]
+    # Dual-metric rendering kicks in only when interactive counts were measured;
+    # otherwise the output is byte-identical to the legacy raw-only table.
+    dual = any(r.has_interactive() for r in results)
     header = "| App | Framework | " + " | ".join(DISPLAY_NAMES.get(t, t) for t in tools) + " |"
     sep = "| --- | --- | " + " | ".join([":--:"] * len(tools)) + " |"
     lines = [header, sep]
     for r in results:
-        cells = " | ".join(_cell_md(r.cell(t), r.counts.get(t)) for t in tools)
+        metric = "interactive" if r.has_interactive() else "raw"
+        if dual:
+            cells = " | ".join(
+                _cell_md_dual(
+                    r.cell(t, metric),
+                    r.interactive_counts.get(t) if r.has_interactive() else r.counts.get(t),
+                    r.counts.get(t),
+                )
+                for t in tools
+            )
+        else:
+            cells = " | ".join(_cell_md(r.cell(t), r.counts.get(t)) for t in tools)
         lines.append(f"| {r.app} | {r.framework} | {cells} |")
 
     out = "\n".join(lines)
@@ -184,11 +315,22 @@ def format_matrix_markdown(
             f"elements on **{fw}** where every rival that ran returned nothing."
         )
 
-    out += (
-        "\n\n_Legend: ✓ (n) = recognized n interactive elements · ✗ (0) = ran "
-        "but recognized nothing · `blocked: needs env` = tool not runnable on "
-        "this host._"
-    )
+    if dual:
+        out += (
+            "\n\n_Legend: ✓ (n · raw m) = recognized **n meaningful interactive** "
+            "elements (targetable for an action/value-read) out of **m raw** nodes "
+            "walked · ✗ (0) = ran but recognized no interactive element · "
+            "`blocked: needs env` = tool not runnable on this host. The interactive "
+            "count applies one symmetric role allowlist to every tool — a raw "
+            "`descendants()` walk inflates on Chromium/Excel (static text, panes) "
+            "without adding anything an agent can act on._"
+        )
+    else:
+        out += (
+            "\n\n_Legend: ✓ (n) = recognized n interactive elements · ✗ (0) = ran "
+            "but recognized nothing · `blocked: needs env` = tool not runnable on "
+            "this host._"
+        )
 
     if blocked_rivals:
         out += "\n\n**Rivals not runnable here (`blocked: needs env`):**\n"

--- a/docs/design/MEANINGFUL_INTERACTIVE_ELEMENT_METRIC.md
+++ b/docs/design/MEANINGFUL_INTERACTIVE_ELEMENT_METRIC.md
@@ -1,7 +1,18 @@
 # Design Spec — "Meaningful Interactive Element" benchmark metric
 
-**Status:** proposed (decision-ready) · **Owner:** next `/goal` round · **Milestone:** D1 (competitive matrix)
-**Author:** Orc-Mycelium · **Date:** 2026-07-05
+**Status:** logic+test LANDED (2026-07-07) — real-desktop data regen (crit #4/#5) PENDING a Windows run
+**Owner:** Orc-Mycelium · **Milestone:** D1 (competitive matrix) · **Date:** 2026-07-05
+
+> **Progress (2026-07-07, Orc):** Acceptance criteria **#1–#3 are implemented, verified and merged**
+> (`matrix.py` symmetric `is_interactive_role`/`count_interactive` filter + `interactive_counts` on
+> `CompetitiveResult` + both adapters wired + dual-metric matrix rendering + pinning tests, all
+> ruff/pytest green and independently verified for anti-cherry-pick symmetry — the filter is one shared
+> function both adapters pass their role list through). The machinery is Linux-collectable and ready.
+> **Still pending (needs the NATUROBOT Windows desktop, cannot be produced off-Windows honestly):**
+> crit **#4** — run `run_competitive --markdown` to regenerate `docs/COMPETITIVE.md`'s measured table with
+> the Interactive column and resolve/annotate the ⚠️ reconcile note from the *measured* interactive
+> numbers; crit **#5** — fresh-context desktop QA re-runs the harness to confirm the numbers are generated,
+> not hand-authored. `docs/COMPETITIVE.md` is intentionally **untouched** until that real run exists.
 
 This is a **decision-ready** slice: the design below is settled so a `/goal` round can go
 straight to TDD build → independent verify → land, with no re-deliberation. It is **non-Ace-gated**

--- a/tests/test_competitive_benchmark.py
+++ b/tests/test_competitive_benchmark.py
@@ -14,12 +14,16 @@ from __future__ import annotations
 from benchmarks.competitive import matrix
 from benchmarks.competitive.matrix import (
     BLOCKED,
+    INTERACTIVE_ROLES,
     NATURO,
     NONE,
     PASS,
     CompetitiveResult,
     build_matrix,
+    count_interactive,
     format_matrix_markdown,
+    is_interactive_role,
+    normalize_role,
     rivals_in,
 )
 
@@ -142,3 +146,129 @@ def test_matrix_module_imports_without_naturo_or_rivals() -> None:
     # Importing matrix must not have pulled in naturo or the rival libraries.
     assert "benchmarks.competitive.matrix" in sys.modules
     assert matrix.NATURO == "naturo"
+
+
+# --- "Meaningful interactive element" metric (issue #1233 follow-up) ----------
+# These pin the honesty invariant: one symmetric role allowlist, applied
+# identically to naturo and every rival, so a raw descendants() walk can no
+# longer flatter a UIA-only rival on Chromium/Excel with static/decorative nodes.
+
+
+def test_normalize_role_folds_spellings() -> None:
+    """Spaces, hyphens and case collapse so every backend's spelling compares equal."""
+    assert normalize_role("Radio Button") == "radiobutton"
+    assert normalize_role("radio-button") == "radiobutton"
+    assert normalize_role("RADIOBUTTON") == "radiobutton"
+    assert normalize_role(None) == ""
+    assert normalize_role("") == ""
+
+
+def test_is_interactive_role_allowlists_actionable_and_excludes_decorative() -> None:
+    """Actionable roles count; static/layout/decorative roles do not."""
+    for actionable in ("Button", "Edit", "ComboBox", "CheckBox", "RadioButton",
+                       "Hyperlink", "MenuItem", "ListItem", "TreeItem", "TabItem",
+                       "DataItem", "Slider", "Document"):
+        assert is_interactive_role(actionable) is True, actionable
+    for decorative in ("Text", "Pane", "Group", "Separator", "Image", "TitleBar",
+                       "StatusBar", "ToolTip", "Custom", "Window", "", None):
+        assert is_interactive_role(decorative) is False, decorative
+
+
+def test_count_interactive_is_the_one_shared_symmetric_filter() -> None:
+    """The exact same function reduces any role list — naturo and rival alike.
+
+    A Chromium-style dump (mostly static Text/Pane) yields few interactive nodes;
+    the same allowlist applied to the same roles gives the same count no matter
+    which adapter produced them. This *is* the anti-cherry-pick guarantee.
+    """
+    chromium_dump = (
+        ["Document"] + ["Text"] * 60 + ["Pane"] * 30
+        + ["Button"] * 8 + ["Hyperlink"] * 4 + ["Edit"] * 2
+    )
+    # 1 Document + 8 Button + 4 Hyperlink + 2 Edit = 15 interactive of 105 raw.
+    assert len(chromium_dump) == 105
+    assert count_interactive(chromium_dump) == 15
+    # Symmetry: feeding the identical roles as if from a different adapter is equal.
+    assert count_interactive(list(chromium_dump)) == 15
+    # Every allowlist member is individually counted.
+    assert count_interactive(sorted(INTERACTIVE_ROLES)) == len(INTERACTIVE_ROLES)
+
+
+def _misleading_electron_row() -> CompetitiveResult:
+    """Raw count says the UIA-only rival 'wins' Chromium; interactive says naturo does.
+
+    Mirrors the real measured contradiction: pywinauto's raw descendants() walk
+    (113) tops naturo's raw (85) by counting static text/panes, but on actionable
+    elements naturo (40) leads and pywinauto (10) does not vanish.
+    """
+    return CompetitiveResult(
+        app="Chromium fixture",
+        framework="Electron/CDP",
+        counts={NATURO: 85, "pywinauto": 113, "pyautogui": 0},
+        interactive_counts={NATURO: 40, "pywinauto": 10, "pyautogui": 0},
+    )
+
+
+def _java_moat_row() -> CompetitiveResult:
+    """Java/Swing: the uncontested moat — the UIA-only rival sees nothing, raw or interactive."""
+    return CompetitiveResult(
+        app="Java Swing fixture",
+        framework="Java Access Bridge",
+        counts={NATURO: 46, "pywinauto": 6, "pyautogui": 0},
+        interactive_counts={NATURO: 22, "pywinauto": 0, "pyautogui": 0},
+    )
+
+
+def test_interactive_metric_reverses_a_misleading_raw_lead() -> None:
+    """The rival leads on raw but trails on actionable elements — honestly shown both ways.
+
+    A ``beat`` still means the rival saw *nothing* (moat). Chromium is not a moat
+    (the rival sees 10 actionable nodes), so this is the spec's ``~`` parity/lead
+    case, not a moat — that distinction is the whole point of the honest metric.
+    """
+    row = _misleading_electron_row()
+    # Raw view (default) shows the rival ahead — we never hide it.
+    assert row.naturo_count == 85 and row.counts["pywinauto"] == 113
+    assert row.beats("pywinauto") is False          # raw: not a moat
+    assert row.cell("pywinauto") == PASS            # raw: rival passed
+    # Interactive view: the lead reverses (naturo 40 > rival 10) but it is a lead,
+    # not a moat — the rival still recognizes actionable elements here.
+    assert row.naturo_count_for("interactive") == 40
+    assert row.cell("pywinauto", "interactive") == PASS        # rival still passes (10)
+    assert row.beats("pywinauto", "interactive") is False      # 10 ≠ 0 → not a moat
+    assert row.has_interactive() is True
+
+
+def test_moat_cells_survive_the_interactive_metric() -> None:
+    """The genuine Java moat stays ✗ (0); the misleading Chromium 'win' does NOT become a moat."""
+    summary = build_matrix([_java_moat_row(), _misleading_electron_row()])
+    # Only Java is a real moat under the honest metric — Chromium is a lead, not a moat.
+    assert summary["moat_frameworks"] == ["Java Access Bridge"]
+    java = next(r for r in summary["rows"] if r["framework"] == "Java Access Bridge")
+    assert java["metric"] == "interactive"
+    assert java["cells"]["pywinauto"]["cell"] == NONE   # ✗ (0), moat holds
+    assert java["cells"]["pywinauto"]["raw"] == 6
+    assert java["cells"]["pywinauto"]["interactive"] == 0
+    electron = next(r for r in summary["rows"] if r["framework"] == "Electron/CDP")
+    assert electron["cells"]["pywinauto"]["cell"] == PASS  # rival ran, saw 10 → not a moat
+
+
+def test_markdown_dual_metric_shows_both_interactive_and_raw() -> None:
+    """When interactive counts exist the table leads with them and shows raw alongside."""
+    md = format_matrix_markdown([_misleading_electron_row(), _java_moat_row()])
+    assert "✓ (40 · raw 85)" in md      # naturo Chromium: interactive · raw
+    assert "✗ (0 · raw 6)" in md        # rival Java: ran, no interactive element
+    assert "meaningful interactive" in md
+    assert "Moat (from real runs)" in md
+
+
+def test_legacy_rows_without_interactive_render_unchanged() -> None:
+    """A row with no interactive_counts keeps the exact legacy raw-only rendering."""
+    row = CompetitiveResult(
+        app="Electron fixture", framework="Electron/CDP",
+        counts={NATURO: 84, "pywinauto": 0, "pyautogui": 0},
+    )
+    md = format_matrix_markdown([row])
+    assert "✓ (84)" in md               # legacy single-number cell
+    assert "· raw" not in md            # dual rendering must stay off
+    assert row.has_interactive() is False


### PR DESCRIPTION
## Problem
The published competitive matrix (`docs/COMPETITIVE.md`) contradicts its own measured run: a raw `descendants()` walk let a UIA-only rival (pywinauto) out-count naturo on **Chromium 113 vs 85** and **Excel COM 1307 vs 1177** — by enumerating static text/panes/separators an agent can't act on. That's a **non-comparable metric**, not a real rival win. Design: `docs/design/MEANINGFUL_INTERACTIVE_ELEMENT_METRIC.md`.

## What this does (D1 crit #1–#3)
One **symmetric** "meaningful interactive element" filter, applied identically to naturo and every rival — the honesty invariant that discharges D1 crit #3 (honest, not cherry-picked):
- **`matrix.py`** — `INTERACTIVE_ROLES` allowlist + pure `normalize_role`/`is_interactive_role`/`count_interactive` (backend-agnostic, **Linux-collectable**, imports no naturo/rival).
- **`CompetitiveResult`** carries `interactive_counts` alongside raw; `cell`/`beats`/`build_matrix` take an optional `metric` (defaults to **raw** → fully backward compatible). The matrix classifies on interactive when measured, **retains raw**, and renders both (`✓ (40 · raw 85)`).
- **`harness.py`** — `count_interactive_elements` per adapter: naturo walks the fused tree by role, pywinauto filters `descendants()` by `control_type`, **both through the same `count_interactive`**; pyautogui stays honest `0`.

The genuine **Java/SAP/deep-CEF moat holds** — a rival that recognizes actionable elements is correctly no longer scored as beaten (a lead ≠ a moat).

## Tests / verification
- 6 new pins: allowlist, normalization folding, **shared-filter symmetry**, raw-lead reversal, **moat preservation**, dual rendering. Existing raw-only rows render byte-identically.
- `ruff` clean, `pytest tests/test_competitive_benchmark.py` **16/16 green**, matrix stays import-light.
- **Independently verified** by a fresh-context agent for anti-cherry-pick symmetry (one shared filter, no adapter gets a laxer allowlist; the two adapter-specific choices both *understate the rival* if anything).

## Deferred (needs the real Windows desktop — NOT fabricated here)
Spec crit **#4/#5**: regenerate `docs/COMPETITIVE.md`'s measured table with the Interactive column + fresh-context desktop QA re-run to confirm the numbers are generated, not hand-authored. **`docs/COMPETITIVE.md` is intentionally untouched** until that run exists — this PR lands only the verifiable machinery + test.

This is benchmark machinery + a test (non-Ace-gated); the public "we beat X" README claim is untouched and stays Ace-gated.

**[Orc-Mycelium]**