### PR TITLE
feat(agent): export naturo's tools for any framework (D3)

### DIFF
--- a/docs/AGENT_INTEGRATION.md
+++ b/docs/AGENT_INTEGRATION.md
@@ -33,6 +33,26 @@ Any client that reads an MCP server config works — point it at the same comman
 No separate API key is needed for naturo itself — it drives the local desktop.
 (Your *agent* uses its own model credentials as usual.)
 
+## Use naturo's tools in any framework (not just MCP)
+
+Prefer to wire naturo directly into an agent framework's function-calling loop?
+naturo re-emits its **whole tool surface** in the two shapes every framework
+speaks — no naturo-specific glue, and the specs are derived from the same
+registry the MCP server serves, so they never drift:
+
+```python
+from naturo.agent_tools import to_openai_tools, to_anthropic_tools
+
+tools = to_openai_tools()      # OpenAI SDK / OpenAI Agents SDK / LangChain / LiteLLM
+tools = to_anthropic_tools()   # Anthropic Messages API
+```
+
+Pass `tools` straight to `client.chat.completions.create(tools=...)` or
+`client.messages.create(tools=...)`, then route each tool call the model
+returns back to naturo (via the CLI or an MCP client). A complete copy-paste
+wiring for OpenAI, Anthropic, and LangChain — including the dispatcher — is in
+[`examples/agent_frameworks.py`](../examples/agent_frameworks.py).
+
 ## The moat: one fused, correctness-tagged tree
 
 The `see_ui_tree` tool takes `cascade: true` to return the **Unified Auto Element

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,6 +11,7 @@ Working example scripts demonstrating naturo automation patterns.
 | `ui_inspector.py` | Interactive UI element tree explorer | Intermediate |
 | `form_filler.py` | Auto-fill form controls (Calculator demo) | Intermediate |
 | `agent_demo.py` | AI agent integration patterns (CLI, MCP, vision) | Advanced |
+| `agent_frameworks.py` | Plug naturo's tools into OpenAI / Anthropic / LangChain | Advanced |
 
 ## Prerequisites
 
@@ -37,6 +38,12 @@ python form_filler.py
 python agent_demo.py cli      # CLI subprocess loop
 python agent_demo.py mcp      # MCP server setup
 python agent_demo.py vision   # AI vision configuration
+
+# Plug naturo's full tool surface into an agent framework
+python agent_frameworks.py list        # print the exported tools (no framework needed)
+python agent_frameworks.py openai      # OpenAI function-calling wiring
+python agent_frameworks.py anthropic   # Anthropic tool-use wiring
+python agent_frameworks.py langchain   # LangChain StructuredTool wiring
 ```
 
 ## Common Patterns

--- a/examples/agent_frameworks.py
+++ b/examples/agent_frameworks.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Plug naturo into any AI-agent framework — copy-paste tool wiring.
+
+naturo exports its full Windows-automation tool surface in the two
+function-calling shapes every framework speaks (OpenAI + Anthropic). Give your
+agent those tools, then route each tool call the model returns back to naturo.
+
+    from naturo.agent_tools import to_openai_tools, to_anthropic_tools
+
+    tools = to_openai_tools()      # OpenAI SDK / Agents SDK / LangChain / LiteLLM
+    tools = to_anthropic_tools()   # Anthropic Messages API
+
+This file shows the wiring for three popular frameworks plus a single
+dispatcher (`run_tool`) that executes a tool call against the local desktop via
+the naturo CLI. The framework SDKs are imported lazily, so this module imports
+fine even when they are not installed.
+
+Requirements:
+    - Windows 10/11 with a desktop session (to actually *run* the tools)
+    - pip install naturo
+    - plus the SDK for whichever framework you use:
+        pip install openai        # openai_chat_demo
+        pip install anthropic      # anthropic_demo
+        pip install langchain-core # langchain_demo
+
+Usage:
+    python agent_frameworks.py list        # print the exported tool surface
+    python agent_frameworks.py openai       # OpenAI function-calling wiring
+    python agent_frameworks.py anthropic    # Anthropic tool-use wiring
+    python agent_frameworks.py langchain    # LangChain StructuredTool wiring
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from typing import Any, Dict
+
+from naturo.agent_tools import naturo_tool_specs, to_anthropic_tools, to_openai_tools
+
+# --- Dispatcher: execute one tool call against the local desktop -------------
+# The model returns a tool name + JSON arguments; map that to a naturo command.
+# The simplest robust bridge is the CLI (`naturo <tool> --json`); an MCP client
+# session works too if you prefer structured transport.
+
+
+def run_tool(name: str, arguments: Dict[str, Any]) -> Dict[str, Any]:
+    """Execute a tool call by shelling out to the naturo CLI, return its JSON."""
+    cmd = ["naturo", name.replace("_", "-")]
+    for key, value in arguments.items():
+        flag = "--" + key.replace("_", "-")
+        if isinstance(value, bool):
+            if value:
+                cmd.append(flag)
+        else:
+            cmd += [flag, str(value)]
+    cmd.append("--json")
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return {"success": proc.returncode == 0, "raw": proc.stdout, "error": proc.stderr}
+
+
+# --- Framework wiring --------------------------------------------------------
+
+
+def openai_demo() -> None:
+    """OpenAI function-calling (also OpenAI Agents SDK / LiteLLM / autogen)."""
+    from openai import OpenAI  # pip install openai
+
+    client = OpenAI()
+    tools = to_openai_tools()  # naturo's full surface, ready to pass through
+
+    messages = [{"role": "user", "content": "Open Notepad and type 'hi from naturo'."}]
+    resp = client.chat.completions.create(model="gpt-4o", messages=messages, tools=tools)
+
+    for call in resp.choices[0].message.tool_calls or []:
+        result = run_tool(call.function.name, json.loads(call.function.arguments))
+        print(call.function.name, "->", result.get("success"))
+
+
+def anthropic_demo() -> None:
+    """Anthropic Messages tool-use."""
+    import anthropic  # pip install anthropic
+
+    client = anthropic.Anthropic()
+    tools = to_anthropic_tools()  # naturo's full surface, ready to pass through
+
+    resp = client.messages.create(
+        model="claude-sonnet-4-20250514",
+        max_tokens=1024,
+        tools=tools,
+        messages=[{"role": "user", "content": "Open Notepad and type 'hi from naturo'."}],
+    )
+    for block in resp.content:
+        if getattr(block, "type", None) == "tool_use":
+            result = run_tool(block.name, dict(block.input))
+            print(block.name, "->", result.get("success"))
+
+
+def langchain_demo() -> None:
+    """LangChain / LangGraph StructuredTool wiring built from the OpenAI specs."""
+    from langchain_core.tools import StructuredTool  # pip install langchain-core
+
+    lc_tools = [
+        StructuredTool.from_function(
+            name=spec["function"]["name"],
+            description=spec["function"]["description"],
+            func=(lambda _name: (lambda **kwargs: run_tool(_name, kwargs)))(spec["function"]["name"]),
+        )
+        for spec in to_openai_tools()
+    ]
+    # Bind to any LangChain chat model:  model.bind_tools(lc_tools)
+    print(f"Built {len(lc_tools)} LangChain tools, e.g. {lc_tools[0].name}")
+
+
+def list_demo() -> None:
+    """Print the exported tool surface (no framework or desktop needed)."""
+    specs = naturo_tool_specs()
+    print(f"naturo exports {len(specs)} tools:")
+    for spec in specs:
+        summary = (spec["description"].splitlines() or [""])[0][:60]
+        print(f"  {spec['name']:<28} {summary}")
+
+
+DEMOS = {
+    "list": list_demo,
+    "openai": openai_demo,
+    "anthropic": anthropic_demo,
+    "langchain": langchain_demo,
+}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("demo", choices=sorted(DEMOS), help="which framework wiring to run")
+    args = parser.parse_args()
+    DEMOS[args.demo]()
+
+
+if __name__ == "__main__":
+    main()

--- a/naturo/agent_tools.py
+++ b/naturo/agent_tools.py
@@ -1,0 +1,128 @@
+"""Framework-ready tool specs — give any AI-agent framework naturo's Windows tools.
+
+naturo's MCP server exposes its Windows desktop automation (the unified
+correctness-tagged element tree, click, type, read, window/app/Excel/Word
+control, …) as tools with JSON-Schema inputs. This module re-emits that same
+surface in the two function-calling shapes every framework speaks:
+
+- **OpenAI** (also OpenAI Agents SDK, LangChain, LiteLLM, autogen, …):
+  ``{"type": "function", "function": {"name", "description", "parameters"}}``
+- **Anthropic** (Messages tool-use): ``{"name", "description", "input_schema"}``
+
+So any framework can drive a real Windows desktop through naturo without
+naturo-specific glue::
+
+    from naturo.agent_tools import to_openai_tools, to_anthropic_tools
+
+    tools = to_openai_tools()      # -> pass straight to client.chat.completions.create(tools=...)
+    tools = to_anthropic_tools()   # -> pass straight to client.messages.create(tools=...)
+
+The specs are derived from the *same* MCP registry the server serves, so they
+never drift from what the agent can actually call. Deriving them needs no
+Windows desktop — the schemas are declared statically — so this is safe to run
+anywhere (CI, macOS, Linux) to inspect or ship the tool surface.
+
+Dispatching a tool call the model returns is the framework's job; a copy-paste
+executor that routes a call to naturo (via MCP or the CLI) lives in
+``examples/agent_frameworks.py``.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, List, Optional
+
+__all__ = [
+    "ToolSpec",
+    "naturo_tool_specs",
+    "to_openai_tools",
+    "to_anthropic_tools",
+]
+
+# Canonical, framework-neutral spec: {"name", "description", "parameters"}
+# where ``parameters`` is a JSON-Schema object. Mirrors the internal shape used
+# by naturo.providers.agent_base.AGENT_TOOLS so the two never diverge in shape.
+ToolSpec = Dict[str, Any]
+
+
+def _run_coro(coro: Any) -> Any:
+    """Run *coro* to completion from sync code, tolerating an already-open loop.
+
+    ``asyncio.run`` raises if a loop is already running in this thread; in that
+    case we drive the coroutine on a throwaway loop in a worker thread so this
+    stays callable from notebooks / async apps as well as plain scripts.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+
+    import concurrent.futures
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+        return pool.submit(lambda: asyncio.run(coro)).result()
+
+
+def naturo_tool_specs() -> List[ToolSpec]:
+    """Return naturo's full tool surface as canonical, framework-neutral specs.
+
+    Each entry is ``{"name", "description", "parameters"}`` with ``parameters``
+    a JSON-Schema object. Sorted by name for deterministic, diff-friendly
+    output. Derived from the live MCP tool registry — no desktop required.
+    """
+    from naturo.mcp_server import create_server
+
+    server = create_server()
+    tools = _run_coro(server.list_tools())
+
+    specs: List[ToolSpec] = []
+    for tool in tools:
+        schema = getattr(tool, "inputSchema", None) or {"type": "object", "properties": {}}
+        specs.append(
+            {
+                "name": tool.name,
+                "description": tool.description or "",
+                "parameters": schema,
+            }
+        )
+    specs.sort(key=lambda s: s["name"])
+    return specs
+
+
+def to_openai_tools(specs: Optional[List[ToolSpec]] = None) -> List[Dict[str, Any]]:
+    """Convert canonical specs to OpenAI function-calling tool definitions.
+
+    Accepted as-is by the OpenAI SDK (``tools=``), the OpenAI Agents SDK,
+    LangChain, LiteLLM and any framework that speaks the OpenAI function shape.
+    Defaults to naturo's full tool surface when *specs* is omitted.
+    """
+    if specs is None:
+        specs = naturo_tool_specs()
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": s["name"],
+                "description": s["description"],
+                "parameters": s["parameters"],
+            },
+        }
+        for s in specs
+    ]
+
+
+def to_anthropic_tools(specs: Optional[List[ToolSpec]] = None) -> List[Dict[str, Any]]:
+    """Convert canonical specs to Anthropic Messages tool-use definitions.
+
+    Accepted as-is by the Anthropic SDK (``client.messages.create(tools=...)``).
+    Defaults to naturo's full tool surface when *specs* is omitted.
+    """
+    if specs is None:
+        specs = naturo_tool_specs()
+    return [
+        {
+            "name": s["name"],
+            "description": s["description"],
+            "input_schema": s["parameters"],
+        }
+        for s in specs
+    ]

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -1,0 +1,101 @@
+"""Tests for naturo.agent_tools — framework-ready tool-spec export.
+
+These pin the *contract* of the exported specs (shape + fidelity to the MCP
+registry) so any framework can consume them. They run with no Windows desktop —
+tool schemas are declared statically — so they are Linux/CI-collectable.
+"""
+from __future__ import annotations
+
+import json
+
+from naturo.agent_tools import (
+    naturo_tool_specs,
+    to_anthropic_tools,
+    to_openai_tools,
+)
+
+
+def test_specs_are_non_empty_and_canonical() -> None:
+    specs = naturo_tool_specs()
+    assert specs, "expected naturo to export at least one tool spec"
+    for s in specs:
+        assert set(s) == {"name", "description", "parameters"}
+        assert isinstance(s["name"], str) and s["name"]
+        assert isinstance(s["description"], str) and s["description"].strip()
+        params = s["parameters"]
+        assert isinstance(params, dict)
+        # A function-calling parameters block is a JSON-Schema object.
+        assert params.get("type") == "object"
+
+
+def test_specs_are_sorted_and_unique() -> None:
+    names = [s["name"] for s in naturo_tool_specs()]
+    assert names == sorted(names), "specs must be deterministically ordered by name"
+    assert len(names) == len(set(names)), "tool names must be unique"
+
+
+def test_specs_match_the_live_mcp_registry() -> None:
+    """The export is derived from — and complete against — the MCP server."""
+    import asyncio
+
+    from naturo.mcp_server import create_server
+
+    server = create_server()
+    registry_names = {t.name for t in asyncio.run(server.list_tools())}
+    exported_names = {s["name"] for s in naturo_tool_specs()}
+    assert exported_names == registry_names
+
+
+def test_openai_shape() -> None:
+    tools = to_openai_tools()
+    assert len(tools) == len(naturo_tool_specs())
+    for t in tools:
+        assert t["type"] == "function"
+        fn = t["function"]
+        assert set(fn) == {"name", "description", "parameters"}
+        assert fn["name"] and fn["description"]
+        assert fn["parameters"]["type"] == "object"
+
+
+def test_anthropic_shape() -> None:
+    tools = to_anthropic_tools()
+    assert len(tools) == len(naturo_tool_specs())
+    for t in tools:
+        assert set(t) == {"name", "description", "input_schema"}
+        assert t["name"] and t["description"]
+        assert t["input_schema"]["type"] == "object"
+
+
+def test_both_formats_carry_the_same_tool_names() -> None:
+    openai_names = {t["function"]["name"] for t in to_openai_tools()}
+    anthropic_names = {t["name"] for t in to_anthropic_tools()}
+    assert openai_names == anthropic_names
+
+
+def test_exported_tools_are_json_serializable() -> None:
+    # Frameworks send these over the wire — they must round-trip through JSON.
+    json.dumps(to_openai_tools())
+    json.dumps(to_anthropic_tools())
+
+
+def test_conversion_helpers_accept_explicit_specs() -> None:
+    specs = [
+        {"name": "demo", "description": "d", "parameters": {"type": "object", "properties": {}}}
+    ]
+    assert to_openai_tools(specs) == [
+        {
+            "type": "function",
+            "function": {
+                "name": "demo",
+                "description": "d",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+    assert to_anthropic_tools(specs) == [
+        {
+            "name": "demo",
+            "description": "d",
+            "input_schema": {"type": "object", "properties": {}},
+        }
+    ]

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -1,14 +1,28 @@
 """Tests for naturo.agent_tools — framework-ready tool-spec export.
 
 These pin the *contract* of the exported specs (shape + fidelity to the MCP
-registry) so any framework can consume them. They run with no Windows desktop —
-tool schemas are declared statically — so they are Linux/CI-collectable.
+registry) so any framework can consume them. They need no Windows desktop —
+tool schemas are declared statically — but deriving the specs walks the live
+MCP registry, so the optional ``mcp`` package must be importable. Like every
+other MCP-touching test in the suite, they ``skipif`` it is absent (the default
+``[dev]`` CI env on Ubuntu/macOS omits the ``mcp`` extra; the Windows CI job
+installs ``[dev,mcp,...]`` and runs them fully).
 """
 from __future__ import annotations
 
 import json
 
-from naturo.agent_tools import (
+import pytest
+
+mcp_available = True
+try:
+    from naturo.mcp_server import create_server  # noqa: F401
+except ImportError:
+    mcp_available = False
+
+pytestmark = pytest.mark.skipif(not mcp_available, reason="mcp package not installed")
+
+from naturo.agent_tools import (  # noqa: E402
     naturo_tool_specs,
     to_anthropic_tools,
     to_openai_tools,


### PR DESCRIPTION
## What
`naturo.agent_tools` re-emits naturo's **full MCP tool surface (62 tools)** in the two function-calling shapes every framework speaks:

```python
from naturo.agent_tools import to_openai_tools, to_anthropic_tools
tools = to_openai_tools()      # OpenAI SDK / Agents SDK / LangChain / LiteLLM
tools = to_anthropic_tools()   # Anthropic Messages API
```

Specs are derived from the same MCP registry the server serves, so they **never drift** from what the agent can actually call. Derivation needs **no Windows desktop** (schemas are static) → Linux/CI-collectable.

## Why (D3 — AI-agent fit)
Advances the north-star pillar B: *"3 lines to give your agent Windows control"* now works for any framework, not only MCP clients. No Ace/NATUROBOT dependency — purely CI-gated engineering.

## Contents
- `naturo/agent_tools.py` — `naturo_tool_specs()` + `to_openai_tools()` / `to_anthropic_tools()`
- `tests/test_agent_tools.py` — 8 contract tests (shape + fidelity to the live registry)
- `examples/agent_frameworks.py` — copy-paste OpenAI / Anthropic / LangChain wiring + CLI dispatcher
- docs: `AGENT_INTEGRATION.md` "use naturo in any framework" + `examples/README` row

## Verification
- `pytest tests/test_agent_tools.py` → 8 passed; `ruff` clean; runs on macOS/Linux (no desktop).
- **Independent fresh-context agent** re-derived registry parity (62 == 62, no drift), confirmed JSON-safe specs, no desktop side effects, and that the LangChain closure binds per-tool (no late-binding bug).

Not a public/competitive claim — engineering only.

**[Orc-Mycelium]**