### PR TITLE
fix(ci): restore the Windows test signal — unmask a suite red since 07-04 (#1273)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -270,7 +270,10 @@ jobs:
             2>&1 | tail -10
 
       - name: Run all tests
-        continue-on-error: true  # Step failures must not fail the job check run (#603)
+        # NOTE: still non-blocking — see #603 and the follow-up issue that flips this
+        # job to blocking once the full-suite failure set is known.  The step outcome
+        # is now honest (it reports pytest's real exit code) even while swallowed here.
+        continue-on-error: true
         shell: bash
         timeout-minutes: 10
         run: |
@@ -279,19 +282,29 @@ jobs:
           #
           # Desktop tests run on the self-hosted runner (desktop-tests.yml).
           # See docs/DECISIONS.md "GitHub Actions Windows Runner"
+          #
+          # No `-x`: a single early failure used to abort the session at ~9% of the
+          # suite (632/7030 tests), so the other 91% never ran while the job still
+          # reported success.  Run everything and report the full failure set.
           MARKERS="not ui and not integration and not desktop"
           echo "⚠️ Skipping desktop-dependent tests on CI (covered by self-hosted runner)"
           echo "⚠️ Setting NATURO_CI_NO_UIA=1 to prevent DLL UIA calls during tests"
           export NATURO_CI_NO_UIA=1
+          set +e
           pytest -v -m "$MARKERS" \
             --timeout=60 \
             --ignore=tests/integration \
-            -x --tb=short \
+            --tb=short \
             --junit-xml=pytest-results.xml \
             --cov=naturo --cov-report=xml --cov-report=term-missing \
             -p no:cacheprovider \
             2>&1 | tee pytest-output.txt
-          echo "EXIT_CODE=$?" >> pytest-output.txt
+          # $? here would be tee's status, not pytest's — capture PIPESTATUS instead.
+          status=${PIPESTATUS[0]}
+          set -e
+          echo "EXIT_CODE=$status" >> pytest-output.txt
+          echo "pytest exited $status"
+          exit "$status"
         env:
           PYTEST_TIMEOUT: "30"
           NATURO_CI_NO_UIA: "1"

--- a/tests/test_bridge_models.py
+++ b/tests/test_bridge_models.py
@@ -31,20 +31,37 @@ class TestDecodeNative:
         assert _decode_native(text.encode("utf-8")) == text
 
     def test_fallback_to_system_encoding(self):
-        """When UTF-8 fails, should fall back to locale preferred encoding."""
+        """When UTF-8 fails, should fall back to the locale preferred encoding.
+
+        ``sys.platform`` is pinned off-``win32`` because that is the only branch
+        of :func:`_system_ansi_encoding` that consults ``locale``; on Windows the
+        OS codepage comes from ``GetACP`` and the locale mock is ignored by
+        design (#1150).  Without the pin this asserted GBK output on a host whose
+        real ANSI codepage is cp1252, so it failed on every non-GBK Windows
+        runner.  Windows behaviour is covered by
+        ``test_ansi_fallback_ignores_utf8_mode_locale_on_windows``.
+        """
         # GBK-encoded Chinese text that is NOT valid UTF-8
         gbk_bytes = "测试".encode("gbk")
-        with patch("locale.getpreferredencoding", return_value="gbk"):
+        with patch("naturo.bridge._models.sys.platform", "linux"), patch(
+            "locale.getpreferredencoding", return_value="gbk"
+        ):
             result = _decode_native(gbk_bytes)
             assert result == "测试"
 
     def test_fallback_default_cp936(self):
-        """When locale returns empty string, should default to cp936."""
+        """When locale returns empty string, should default to cp936.
+
+        Pinned off-``win32`` for the same reason as
+        ``test_fallback_to_system_encoding``.
+        """
         gbk_bytes = "你好".encode("gbk")
-        with patch("locale.getpreferredencoding", return_value=""):
+        with patch("naturo.bridge._models.sys.platform", "linux"), patch(
+            "locale.getpreferredencoding", return_value=""
+        ):
             result = _decode_native(gbk_bytes)
             # cp936 is compatible with gbk
-            assert "你好" in result or len(result) > 0
+            assert result == "你好"
 
     def test_empty_bytes(self):
         assert _decode_native(b"") == ""


### PR DESCRIPTION
Fixes #1273. Follow-up: #1274.

## What was wrong

The `Python Tests with DLL (Windows)` job has reported **success** on every `develop` merge since at least 07-04 while its pytest run reported `1 failed` — and while **91% of the suite never executed**.

Latest `develop` run [28881705637](https://github.com/AcePeak/naturo/actions/runs/28881705637):
```
tests/test_bridge_models.py::TestDecodeNative::test_fallback_to_system_encoding FAILED [  8%]
E   AssertionError: assert '\xb2\xe2\xca\xd4' == '测试'
========= 1 failed, 587 passed, 44 skipped, 191 deselected in 14.34s ==========
```
Collect step: `7030/7221 tests collected`. Executed: `587+44+1 = 632` = the `8%`. **No `[100%]` line** — `-x` aborted the session. Job conclusion: `success`.

## Root cause

`_system_ansi_encoding()` reads `GetACP()` on win32 and **deliberately** does not use `locale.getpreferredencoding` there (it returns `utf-8` under `PYTHONUTF8=1` — #1150). The test patched exactly that ignored function, so on a cp1252 runner GBK bytes decoded to `'²âÊÔ'`.

**The product code is correct; the test was wrong.** The same file already had the right pattern in `test_ansi_fallback_ignores_utf8_mode_locale_on_windows`.

## Changes

- **`tests/test_bridge_models.py`** — pin `sys.platform` off-win32 in the two `_decode_native` locale-fallback tests so they exercise the branch that actually consults `locale`, and pass on any host codepage. Windows behaviour remains covered by `test_ansi_fallback_ignores_utf8_mode_locale_on_windows`; `_system_ansi_encoding` itself by `TestSystemAnsiEncoding`. Also tightened `test_fallback_default_cp936`, whose `or len(result) > 0` let it pass vacuously on mojibake.
- **`.github/workflows/build.yml`** — drop `-x` so the full suite runs and reports its whole failure set (Ubuntu/macOS already run without `-x`, and they block). Capture `${PIPESTATUS[0]}` instead of `$?` after the `tee` pipe, which made `EXIT_CODE=` unconditionally `0`, and exit with it.

## Deliberately NOT in this PR

`continue-on-error` stays on the job and step. **This run is diagnostic**: it surfaces the true Windows failure set without red-walling `develop`. Flipping the job to blocking + adding `build-python` to `ci-gate.needs` is **#1274**, gated on triaging what this reveals. Doing both at once would block every PR on an unknown number of unrun tests.

## Verification

- `pytest tests/test_bridge_models.py` → **53 passed** on macOS (no regression).
- Both fixed tests pass under a **simulated Windows host with `GetACP() -> 1252`** — the exact CI condition, where `_system_ansi_encoding()` returns `cp1252`:
  ```
  host simulated as: win32 | GetACP -> 1252
  bare _system_ansi_encoding(): cp1252 (would mojibake GBK)
  test_fallback_to_system_encoding -> '测试' PASS
  test_fallback_default_cp936      -> '你好' PASS
  ```
- The old test was reproduced failing byte-for-byte against the CI assertion (`'²âÊÔ'`) before the fix.

**The real check on this PR is the Windows job's own log** — it should now run to `[100%]` instead of stopping at 8%.

**[Orc-Mycelium]**