### PR TITLE
feat(mcp): office_dismiss_startup + cascade multi-window parity for see_ui_tree

### DIFF
--- a/naturo/mcp/_app.py
+++ b/naturo/mcp/_app.py
@@ -251,6 +251,87 @@ def register_app_tools(server, _get_backend, _safe_tool, *, launch_app_fn):
 
     @server.tool()
     @_safe_tool
+    def office_dismiss_startup(
+        app: Optional[str] = None,
+        hwnd: Optional[int] = None,
+        window_title: Optional[str] = None,
+    ) -> dict:
+        """Get an Office app past its start screen into a ready, editable document.
+
+        Word / Excel / PowerPoint launch to a Backstage *start screen* — a
+        template picker with **no active document**, where typing and COM writes
+        do not land and agents otherwise waste calls hunting for the blank item.
+        This finds and clicks the blank-document template (空白文档 / 空白工作簿 /
+        空白演示文稿 / Blank document / workbook / presentation) in one call. If the
+        window already shows a document (no start screen), it does nothing and
+        reports ``already_ready``.
+
+        (For pure read/write of Office content, prefer the COM tools —
+        excel_read/write, word_read/write — which never hit the start screen.
+        Use this when you must drive the Office UI itself.)
+
+        Args:
+            app: Office app name (e.g. "word", "excel", "powerpoint").
+            hwnd: Target window handle.
+            window_title: Target window title (partial match).
+
+        Returns:
+            Dict with ``clicked`` (template name, or None) and ``already_ready``.
+        """
+        import time
+
+        backend = _get_backend()
+        if hwnd is None and hasattr(backend, "_resolve_hwnd"):
+            try:
+                hwnd = backend._resolve_hwnd(app=app, window_title=window_title)
+            except Exception:
+                hwnd = None
+        if hwnd is None:
+            return {"success": False, "error": {
+                "code": "WINDOW_NOT_FOUND",
+                "message": "Provide app / hwnd / window_title of an Office window.",
+            }}
+
+        tree = backend.get_element_tree(hwnd=hwnd, depth=10, backend="uia")
+
+        _BLANK_EXACT = {
+            "空白文档", "空白工作簿", "空白演示文稿",
+            "blank document", "blank workbook", "blank presentation",
+        }
+
+        def _is_blank(name: str) -> bool:
+            n = (name or "").strip().lower()
+            return n in _BLANK_EXACT or n.startswith("空白") or n.startswith("blank ")
+
+        found = {"node": None}
+
+        def _walk(node) -> None:
+            if node is None or found["node"] is not None:
+                return
+            role = getattr(node, "role", "") or ""
+            if role in ("ListItem", "Button", "Hyperlink") and _is_blank(getattr(node, "name", "")):
+                found["node"] = node
+                return
+            for child in (getattr(node, "children", None) or []):
+                _walk(child)
+
+        _walk(tree)
+        target = found["node"]
+
+        if target is None:
+            return {
+                "success": True, "clicked": None, "already_ready": True,
+                "note": "No Office start-screen blank template found (likely already in a document).",
+            }
+
+        cx = getattr(target, "x", 0) + (getattr(target, "width", 0) // 2)
+        cy = getattr(target, "y", 0) + (getattr(target, "height", 0) // 2)
+        backend.click(x=cx, y=cy)
+        time.sleep(1.0)
+        return {"success": True, "clicked": getattr(target, "name", ""), "already_ready": False}
+
+    @server.tool()
+    @_safe_tool
     def quit_app(name: str, force: bool = False) -> dict:
         """Quit an application.
 

--- a/naturo/mcp/_inspect.py
+++ b/naturo/mcp/_inspect.py
@@ -80,11 +80,22 @@ def register_inspect_tools(server, _get_backend, _safe_tool):
             # multi-framework cascade so every node carries techniques[] +
             # correctness + confidence and the caller gets a recognition_summary.
             from naturo.cascade import run_cascade
-            cascade_result = run_cascade(
-                backend, app=app, window_title=window_title,
-                hwnd=hwnd, pid=pid, depth=depth, backend_name="auto",
-            )
-            tree = cascade_result.tree
+            tree = None
+            # (calc-zombie) --app can resolve to several UWP windows (empty ghost
+            # frames + the live CoreWindow). Gather all of them, cascade each, and
+            # keep only content-bearing ones so we never return a chrome-only ghost.
+            # Shared with the `see` CLI.
+            if app and hwnd is None and not window_title and pid is None:
+                from naturo.cascade._appwindows import app_content_tree
+                tree, _ = app_content_tree(
+                    backend, app, depth=depth, backend_name="auto",
+                )
+            if tree is None:
+                cascade_result = run_cascade(
+                    backend, app=app, window_title=window_title,
+                    hwnd=hwnd, pid=pid, depth=depth, backend_name="auto",
+                )
+                tree = cascade_result.tree
         # (#737) When --app is used without --hwnd, enumerate ALL windows
         # of the application and merge their UI trees (matching CLI behavior).
         elif app and not hwnd and hasattr(backend, "_resolve_hwnds"):

--- a/packaging/mcpb/manifest.json
+++ b/packaging/mcpb/manifest.json
@@ -167,6 +167,10 @@
       "description": "Launch an application by name."
     },
     {
+      "name": "office_dismiss_startup",
+      "description": "Get an Office app past its start screen into a ready, editable document."
+    },
+    {
       "name": "launch_browser",
       "description": "Launch a CDP-wired Chrome/Edge to read rendered or logged-in web pages."
     },

--- a/tests/test_mcp_app.py
+++ b/tests/test_mcp_app.py
@@ -251,3 +251,35 @@ class TestMenuInspect:
         data = json.loads(result[0].text)
         assert data["success"] is True
         assert data["menu_items"] == []
+
+
+class TestOfficeDismissStartup:
+
+    def test_clicks_blank_template(self, server, mock_backend):
+        blank = SimpleNamespace(role="ListItem", name="空白文档",
+                                x=200, y=200, width=40, height=20, children=[])
+        root = SimpleNamespace(role="Window", name="Word",
+                               x=0, y=0, width=100, height=100, children=[blank])
+        mock_backend._resolve_hwnd.return_value = 123
+        mock_backend.get_element_tree.return_value = root
+        result = _call_tool(server, "office_dismiss_startup", {"window_title": "Word"})
+        data = json.loads(result[0].text)
+        assert data["success"] is True
+        assert data["clicked"] == "空白文档"
+        assert data["already_ready"] is False
+        _, kwargs = mock_backend.click.call_args
+        assert kwargs.get("x") == 220 and kwargs.get("y") == 210  # element center
+
+    def test_already_ready_when_no_start_screen(self, server, mock_backend):
+        root = SimpleNamespace(
+            role="Window", name="文档1 - Word", x=0, y=0, width=100, height=100,
+            children=[SimpleNamespace(role="Edit", name="", x=0, y=0,
+                                      width=100, height=100, children=[])],
+        )
+        mock_backend._resolve_hwnd.return_value = 123
+        mock_backend.get_element_tree.return_value = root
+        result = _call_tool(server, "office_dismiss_startup", {"window_title": "Word"})
+        data = json.loads(result[0].text)
+        assert data["already_ready"] is True
+        assert data["clicked"] is None
+        assert not mock_backend.click.called

--- a/tests/test_mcp_inspect.py
+++ b/tests/test_mcp_inspect.py
@@ -133,6 +133,32 @@ class TestSeeUiTreeCascade:
         assert data["recognition_summary"]["by_technique"].get("cdp") == 1
         assert data["recognition_summary"]["has_uncertain"] is False
 
+    def test_cascade_with_app_routes_through_app_content_tree(self, server, mock_backend):
+        # (calc-zombie) cascade + --app + no hwnd must gather ALL of the app's
+        # windows via app_content_tree (dropping empty UWP ghost frames), mirroring
+        # `see --app --cascade`, instead of a single run_cascade that can land on a
+        # chrome-only ghost.
+        from naturo.backends.base import ElementInfo
+
+        root = ElementInfo(
+            id="w", role="Window", name="Live", value=None,
+            x=0, y=0, width=200, height=200, children=[],
+            properties={"source": "uia"},
+        )
+        with (
+            patch("naturo.cascade._appwindows.app_content_tree",
+                  return_value=(root, None)) as mock_act,
+            patch("naturo.cascade.run_cascade") as mock_cascade,
+        ):
+            out = _call_tool(server, "see_ui_tree",
+                             {"cascade": True, "app": "calc", "format": "json"})
+
+        mock_act.assert_called_once()
+        mock_cascade.assert_not_called()
+        data = json.loads(out[0].text)
+        assert data["success"] is True
+        assert data["tree"]["name"] == "Live"
+
     def test_non_cascade_tree_has_no_fusion_tags(self, server, mock_backend):
         # plain (single-backend) path stays unchanged — no techniques/correctness.
         out = _call_tool(server, "see_ui_tree", {"format": "json"})


### PR DESCRIPTION
## Summary

Recovers two MCP capabilities from an earlier parallel WIP branch. Most of that
branch's work had already landed on develop through other PRs (word.py, mcp/_word.py,
the competitive benchmark harness, the snapshot cleanup, etc.); these two pieces had
not, so they're ported clean onto current develop and nothing else is duplicated.

- **`office_dismiss_startup`** — gets Word/Excel/PowerPoint past the Backstage
  *start screen* into a ready, editable document in one call by clicking the
  blank-document template (空白文档 / 空白工作簿 / 空白演示文稿 / Blank
  document/workbook/presentation); reports `already_ready` when a document is
  already open. Complements the COM read/write tools (excel/word) which never hit
  the start screen — this one is for when you must drive the Office UI itself.
  Added to the mcpb manifest.
- **`see_ui_tree` cascade multi-window parity** — `cascade` + `--app` + no hwnd
  now gathers ALL of the app's windows via `app_content_tree` (dropping empty UWP
  ghost frames) instead of a single `run_cascade` that can land on a chrome-only
  ghost, mirroring the calc-zombie fix already shipped for `see --app --cascade`
  on the CLI (#1276). The non-cascade `_resolve_hwnds` multi-window path is
  untouched.

## Tests

- `office_dismiss_startup`: clicks-blank-template + already-ready cases.
- New `test_cascade_with_app_routes_through_app_content_tree` covers the parity
  branch (asserts `app_content_tree` is used and `run_cascade` is not).
- ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)