### PR TITLE
feat(see): text-element content in the tree — bounded by default, --full-text for all

### DIFF
--- a/naturo/backends/windows/_element/_tree.py
+++ b/naturo/backends/windows/_element/_tree.py
@@ -321,6 +321,7 @@ class ElementTreeMixin:
         populate_hierarchy(result)
 
         # (#372) Roles that should include a text value preview
+        from naturo.value_preview import PREVIEW_LEN as _PREVIEW_LEN
         _PREVIEW_ROLES = {"Document", "Edit", "Text"}
 
         def convert(el) -> BaseElementInfo:
@@ -342,8 +343,8 @@ class ElementTreeMixin:
             # (#372) Add value preview for Document/Edit/Text elements
             if el.role in _PREVIEW_ROLES and el.value:
                 full_text = el.value
-                preview = full_text[:100]
-                if len(full_text) > 100:
+                preview = full_text[:_PREVIEW_LEN]
+                if len(full_text) > _PREVIEW_LEN:
                     preview += "…"
                 props["value_preview"] = preview
                 props["value_length"] = len(full_text)

--- a/naturo/cli/core/_see.py
+++ b/naturo/cli/core/_see.py
@@ -8,6 +8,7 @@ from typing import Any
 import click
 
 import naturo.cli.core._common as _common
+from naturo.value_preview import bounded_value
 
 
 @click.command()
@@ -50,6 +51,10 @@ import naturo.cli.core._common as _common
               help='Compact agent-friendly text: one line per element as '
                    '\'eN [role] "name" [=value]\' — no bounds/props/selectors '
                    '(fewest tokens; refs still work with \'naturo click eN\')')
+@click.option("--full-text", "full_text", is_flag=True,
+              help="Inline the COMPLETE text of each Document/Edit/Text element "
+                   "instead of a truncated preview (for dumping + searching all "
+                   "visible content in one call)")
 @click.option(
     "--backend", "--method", "-b", "-m",
     type=click.Choice(["uia", "msaa", "ia2", "jab", "cdp", "win32", "win32hybrid", "auto", "hybrid"]),
@@ -70,7 +75,7 @@ def see(app: str | None, window_title: str | None, hwnd: int | None, pid: int | 
         mode: str, depth: int, path: str | None, annotate: bool, store_snapshot: bool,
         session: str | None, cascade: bool, fill_gaps: bool, run_ocr: bool, show_stats: bool,
         coverage_target: float, visible_only: bool, show_selectors: bool,
-        json_output: bool, compact: bool, backend: str, app_id: str | None,
+        json_output: bool, compact: bool, full_text: bool, backend: str, app_id: str | None,
         ai_provider: str, ai_model: str | None, ai_api_key: str | None) -> None:
     """Capture screenshot and analyze UI elements.
 
@@ -465,9 +470,12 @@ def see(app: str | None, window_title: str | None, hwnd: int | None, pid: int | 
                 if _is_offscreen:
                     d["offscreen"] = True
 
-                # (#372) Value preview for Document/Edit/Text elements
+                # (#372) Value preview for Document/Edit/Text elements. The full
+                # value is already in d["value"]; preview + length let a consumer
+                # decide whether to read more without re-fetching.
                 if el.role and el.role.lower() in ("document", "edit", "text") and el.value:
-                    d["value_preview"] = el.value[:100]
+                    _pv, _ = bounded_value(el.value, full=full_text)
+                    d["value_preview"] = _pv
                     d["value_length"] = len(el.value)
 
                 # (#295) Always use naturo ref for parent, never raw
@@ -565,7 +573,12 @@ def see(app: str | None, window_title: str | None, hwnd: int | None, pid: int | 
                 if compact:
                     _name = f' "{el.name}"' if el.name else ""
                     _val = getattr(el, "value", None)
-                    _val_str = f" ={_val!r}" if _val else ""
+                    _val_str = ""
+                    if _val:
+                        _shown, _elided = bounded_value(_val, full=full_text)
+                        _val_str = f" ={_shown!r}"
+                        if _elided:
+                            _val_str += f" …(+{_elided} chars)"
                     if el.name or (el.role or "").lower() in _CLI_ACTIONABLE or _val:
                         click.echo(f"{prefix}{ref} [{el.role}]{_name}{_val_str}")
                     for child in el.children:
@@ -584,14 +597,14 @@ def see(app: str | None, window_title: str | None, hwnd: int | None, pid: int | 
                     selector_str = f"  {selector_uri}"
                 click.echo(f"{prefix}[{el.role}]{name_str}{pos_str} {ref}{source_str}{offscreen_str}{selector_str}")
 
-                # (#372) Show text preview for Document/Edit elements
-                _vp = props.get("value_preview")
-                if _vp:
-                    click.echo(f"{prefix}  \u00bb {_vp}")
-                elif el.role and el.role.lower() in ("document", "edit", "text") and el.value:
-                    preview = el.value[:100].replace("\n", "\\n").replace("\r", "")
-                    suffix = "\u2026" if len(el.value) > 100 else ""
-                    click.echo(f"{prefix}  \u00bb {preview}{suffix}")
+                # (#372) Show text content for Document/Edit/Text elements: full
+                # when --full-text, otherwise a bounded preview with a marker for
+                # how much was elided (read it all with `naturo get eN`).
+                if el.role and el.role.lower() in ("document", "edit", "text") and el.value:
+                    _shown, _elided = bounded_value(el.value, full=full_text)
+                    disp = _shown.replace("\n", "\\n").replace("\r", "")
+                    suffix = f" \u2026(+{_elided} chars)" if _elided else ""
+                    click.echo(f"{prefix}  \u00bb {disp}{suffix}")
 
                 for child in el.children:
                     print_tree(child, indent + 1, child_ancestors)

--- a/naturo/mcp/_inspect.py
+++ b/naturo/mcp/_inspect.py
@@ -5,6 +5,7 @@ import logging
 from typing import Optional
 
 from naturo.mcp._resolve import require_hwnd
+from naturo.value_preview import bounded_value
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +25,7 @@ def register_inspect_tools(server, _get_backend, _safe_tool):
         cascade: bool = False,
         format: str = "compact",
         match: Optional[str] = None,
+        full_text: bool = False,
     ) -> dict:
         """Read a window's UI as a structured element tree — naturo's core "see" tool.
 
@@ -38,6 +40,12 @@ def register_inspect_tools(server, _get_backend, _safe_tool):
         yields just the Save controls with their eN refs. Use it when you already
         know what you're looking for: fewer tokens, fewer turns (target directly
         instead of reading + scanning the whole tree). (compact format only.)
+
+        Text elements (Document/Edit/Text) include their content as ``=<value>``.
+        Long values are truncated to a preview with a ``…(+N chars)`` marker to
+        stay token-lean — read the whole thing with ``get eN`` (returns the full
+        document). full_text=true inlines every value in full instead, for a
+        one-shot "dump all visible text and search it" read.
 
         Returns the hierarchy of UI elements (buttons, text fields, etc.) with
         their roles, names, bounds, and properties; element IDs (eN) feed into
@@ -257,7 +265,10 @@ def register_inspect_tools(server, _get_backend, _safe_tool):
                 if name:
                     line += f' "{name}"'
                 if value:
-                    line += f" ={value!r}"
+                    _shown, _elided = bounded_value(value, full=full_text)
+                    line += f" ={_shown!r}"
+                    if _elided:
+                        line += f" …(+{_elided} chars)"
                 _fusion = _annotate_correctness(el.properties or {})
                 if _fusion is not None and _fusion.get("correctness") != "deterministic":
                     line += " ~"  # uncertain (vision/image) — verify before trusting

--- a/naturo/value_preview.py
+++ b/naturo/value_preview.py
@@ -1,0 +1,32 @@
+"""Shared bounded value-preview policy for ``see`` / ``see_ui_tree`` output.
+
+Text elements (Document / Edit / Text) can hold an entire document. Dumping the
+full value into the default tree output would blow the token-lean budget that
+compact mode exists to protect — a 10 KB Notepad buffer becomes a 10 KB line.
+
+So the default is a *bounded* preview: short values render in full (a search
+box, a checkbox label, a few lines — the common case, unchanged), while long
+values are truncated to :data:`PREVIEW_LEN` with a marker saying how much was
+elided. The complete text is always one ``get eN`` away (which returns the whole
+document via TextPattern), and callers that genuinely want everything inline —
+"dump all visible text and search it" — opt in with ``full=True``
+(``--full-text`` on the CLI, ``full_text=true`` over MCP).
+"""
+from __future__ import annotations
+
+# Characters of an element value shown inline before truncating. Chosen to keep
+# a single tree line small while still carrying enough text for most at-a-glance
+# reads and content matches.
+PREVIEW_LEN = 200
+
+
+def bounded_value(value: str, *, full: bool = False) -> tuple[str, int]:
+    """Bound ``value`` for inline tree display.
+
+    Returns ``(shown, elided)`` where ``shown`` is the text to display and
+    ``elided`` is the number of trailing characters dropped (0 when the whole
+    value is shown). ``full=True`` always returns the complete value.
+    """
+    if full or len(value) <= PREVIEW_LEN:
+        return value, 0
+    return value[:PREVIEW_LEN], len(value) - PREVIEW_LEN

--- a/tests/test_cli_see.py
+++ b/tests/test_cli_see.py
@@ -282,6 +282,24 @@ class TestTextOutput:
         assert result.exit_code == 0
         assert "Hello world" in result.output
 
+    def test_long_document_bounded_by_default_full_on_flag(self, runner, mock_backend):
+        # A long Document body is previewed (bounded) by default with a marker,
+        # and inlined in full only with --full-text — so `naturo see` can dump
+        # all visible text for search without every call paying for huge buffers.
+        long_text = "".join(f"para{i} " for i in range(300))  # ~2k chars
+        doc = FakeElementInfo(id="doc", role="Document", name="Editor",
+                              value=long_text, x=0, y=0, width=800, height=600)
+        mock_backend.get_element_tree.return_value = doc
+        with _patch_platform(), _patch_backend(mock_backend):
+            default = runner.invoke(see, ["--no-snapshot"], catch_exceptions=False)
+            full = runner.invoke(see, ["--no-snapshot", "--full-text"], catch_exceptions=False)
+        assert default.exit_code == 0 and full.exit_code == 0
+        # default: truncated with elision marker, full body absent
+        assert "chars)" in default.output
+        assert long_text.replace("\n", "\\n") not in default.output
+        # --full-text: the complete body is present
+        assert long_text.replace("\n", "\\n") in full.output
+
     def test_no_window_found(self, runner, mock_backend):
         mock_backend.get_element_tree.return_value = None
         with _patch_platform(), _patch_backend(mock_backend):

--- a/tests/test_mcp_inspect.py
+++ b/tests/test_mcp_inspect.py
@@ -293,6 +293,35 @@ class TestSeeUiTree:
             depth=7, backend="uia",
         )
 
+    def test_long_value_bounded_by_default(self, server, mock_backend):
+        # A big Document value must NOT be dumped in full (token-lean); it is
+        # truncated to a preview with a marker for how much was elided.
+        long_text = "".join(f"line{i} " for i in range(200))  # ~1.7k chars
+        doc = _make_element(id="doc", role="Document", name="Editor", value=long_text)
+        mock_backend.get_element_tree.return_value = doc
+        result = _call_tool(server, "see_ui_tree", {})
+        text = json.loads(result[0].text)["tree_text"]
+        assert "chars)" in text          # "…(+N chars)" elision marker
+        assert long_text not in text     # full body not inlined
+        assert len(text) < len(long_text)
+
+    def test_full_text_inlines_complete_value(self, server, mock_backend):
+        long_text = "".join(f"line{i} " for i in range(200))
+        doc = _make_element(id="doc", role="Document", name="Editor", value=long_text)
+        mock_backend.get_element_tree.return_value = doc
+        result = _call_tool(server, "see_ui_tree", {"full_text": True})
+        text = json.loads(result[0].text)["tree_text"]
+        assert long_text in text         # complete value present
+        assert "chars)" not in text      # no truncation marker
+
+    def test_short_value_shown_in_full_by_default(self, server, mock_backend):
+        doc = _make_element(id="e", role="Edit", name="Search", value="hello world")
+        mock_backend.get_element_tree.return_value = doc
+        result = _call_tool(server, "see_ui_tree", {})
+        text = json.loads(result[0].text)["tree_text"]
+        assert "hello world" in text
+        assert "chars)" not in text
+
     def test_app_param_triggers_multi_window_enumeration(self, server, mock_backend):
         """When app is provided without hwnd, _resolve_hwnds is used (#737)."""
         child = _make_element(id="btn1", role="Button", name="Click Me")


### PR DESCRIPTION
## Motivation

`see` / `see_ui_tree` is how you capture what's on screen — including for the
"dump all visible text and search it" use case. But a text element's actual
content was handled inconsistently:

- **compact tree** (CLI `--compact` + MCP `see_ui_tree`): inlined the **full**
  value with no bound → a 10 KB Notepad buffer becomes a 10 KB line, defeating
  the token-lean budget compact mode exists for.
- **CLI verbose**: truncated to **100 chars**, silently dropping the rest → a
  content-search read came back incomplete.

## Change

One shared policy (`naturo/value_preview.py`), consistent across CLI and MCP:

- **Default** — show the value, bounded to a **200-char preview** with a
  `…(+N chars)` marker when truncated. Short values (search boxes, labels, a few
  lines) still render in full, unchanged. The full document is one `get eN` away
  (TextPattern returns it complete — see #1276).
- **Opt-in full** — `--full-text` (CLI) / `full_text=true` (MCP `see_ui_tree`)
  inlines every value in full, for one-shot capture-and-search over all visible
  text.

Token-lean default stays intact; the content-search case becomes complete and
explicit; CLI and MCP now behave identically.

## Tests

- MCP: long value bounded by default, `full_text=true` inlines full, short value
  shown in full.
- CLI: long Document previewed by default with marker, `--full-text` inlines full;
  existing short-value preview unchanged.
- ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)