### PR TITLE
feat(excel): make COM/Excel scan/emit caps per-call configurable (concurrency-safe)

### DIFF
--- a/naturo/cascade/_com_excel.py
+++ b/naturo/cascade/_com_excel.py
@@ -15,7 +15,6 @@ port) — it never raises into the cascade.
 from __future__ import annotations
 
 import logging
-import os
 from typing import List, Optional
 
 from naturo.backends.base import ElementInfo
@@ -23,42 +22,13 @@ from naturo.backends.base import ElementInfo
 logger = logging.getLogger(__name__)
 
 # Defaults bound the tree size and COM round-trips on a huge sheet. They are not
-# silent: truncation is logged, and each is overridable via an env var so a user
-# who needs a bigger slice can raise it (e.g. NATURO_EXCEL_MAX_CELLS=5000):
-#   NATURO_EXCEL_MAX_CELLS — max non-empty cells emitted        (default 500)
-#   NATURO_EXCEL_MAX_ROWS  — max rows scanned of the used range (default 400)
-#   NATURO_EXCEL_MAX_COLS  — max cols scanned of the used range (default 100)
-_DEFAULT_MAX_EXCEL_CELLS = 500
-_DEFAULT_MAX_SCAN_ROWS = 400
-_DEFAULT_MAX_SCAN_COLS = 100
-
-
-def _env_int(name: str, default: int) -> int:
-    """Return positive int from env var ``name``, else ``default``.
-
-    A missing, non-integer, or non-positive value falls back to the default, so
-    a bad override degrades safely instead of disabling the bound.
-    """
-    raw = os.environ.get(name)
-    if raw is None:
-        return default
-    try:
-        value = int(raw)
-    except (TypeError, ValueError):
-        return default
-    return value if value > 0 else default
-
-
-def _max_excel_cells() -> int:
-    return _env_int("NATURO_EXCEL_MAX_CELLS", _DEFAULT_MAX_EXCEL_CELLS)
-
-
-def _max_scan_rows() -> int:
-    return _env_int("NATURO_EXCEL_MAX_ROWS", _DEFAULT_MAX_SCAN_ROWS)
-
-
-def _max_scan_cols() -> int:
-    return _env_int("NATURO_EXCEL_MAX_COLS", _DEFAULT_MAX_SCAN_COLS)
+# silent (truncation is logged) and, crucially, not global mutable state: a
+# caller that needs a bigger slice passes larger values PER CALL — threaded from
+# `see --excel-max-cells` / see_ui_tree(excel_max_cells=…) through run_cascade —
+# which is safe under multi-process/concurrent use, unlike a process-wide env var.
+_DEFAULT_MAX_EXCEL_CELLS = 500  #: max non-empty cells emitted
+_DEFAULT_MAX_SCAN_ROWS = 400    #: max rows scanned of the used range
+_DEFAULT_MAX_SCAN_COLS = 100    #: max cols scanned of the used range
 
 
 def _win32_class_name(hwnd: int) -> Optional[str]:
@@ -184,7 +154,11 @@ def _cell_to_element(win, cell) -> Optional[ElementInfo]:
 
 
 def fetch_excel_cells(
-    hwnd: int, *, max_cells: Optional[int] = None
+    hwnd: int,
+    *,
+    max_cells: Optional[int] = None,
+    max_rows: Optional[int] = None,
+    max_cols: Optional[int] = None,
 ) -> List[ElementInfo]:
     """Fetch non-empty cells of the active sheet's used range as ``com`` nodes.
 
@@ -192,13 +166,16 @@ def fetch_excel_cells(
     COM error) — the cascade treats it like an unavailable provider.
     Truncation (sheet larger than the scan/emit caps) is logged, never silent.
 
-    The caps default to NATURO_EXCEL_MAX_CELLS / _MAX_ROWS / _MAX_COLS (see the
-    module header); pass ``max_cells`` to override the emit cap for one call.
+    ``max_cells`` / ``max_rows`` / ``max_cols`` override the emit and scan caps
+    for THIS call (``None`` = the module defaults). They are per-call, not global
+    state, so concurrent callers can each choose their own bound safely.
     """
     if max_cells is None:
-        max_cells = _max_excel_cells()
-    max_rows = _max_scan_rows()
-    max_cols = _max_scan_cols()
+        max_cells = _DEFAULT_MAX_EXCEL_CELLS
+    if max_rows is None:
+        max_rows = _DEFAULT_MAX_SCAN_ROWS
+    if max_cols is None:
+        max_cols = _DEFAULT_MAX_SCAN_COLS
 
     xl = _get_running_excel()
     if xl is None:
@@ -234,7 +211,8 @@ def fetch_excel_cells(
     if truncated:
         logger.info(
             "COM/Excel: output bounded to %d cells / %dx%d scan; sheet is larger. "
-            "Raise NATURO_EXCEL_MAX_CELLS / _MAX_ROWS / _MAX_COLS to read more.",
+            "Raise it with `see --excel-max-cells/--excel-max-rows/--excel-max-cols` "
+            "(or the see_ui_tree excel_max_* args) to read more.",
             max_cells, max_rows, max_cols,
         )
     return elements

--- a/naturo/cascade/_com_excel.py
+++ b/naturo/cascade/_com_excel.py
@@ -15,17 +15,50 @@ port) — it never raises into the cascade.
 from __future__ import annotations
 
 import logging
+import os
 from typing import List, Optional
 
 from naturo.backends.base import ElementInfo
 
 logger = logging.getLogger(__name__)
 
-#: Max non-empty cells emitted (a huge sheet must not explode the tree).
-_MAX_EXCEL_CELLS = 500
-#: Max cells *scanned* (bounds COM round-trips on a large used range).
-_MAX_SCAN_ROWS = 400
-_MAX_SCAN_COLS = 100
+# Defaults bound the tree size and COM round-trips on a huge sheet. They are not
+# silent: truncation is logged, and each is overridable via an env var so a user
+# who needs a bigger slice can raise it (e.g. NATURO_EXCEL_MAX_CELLS=5000):
+#   NATURO_EXCEL_MAX_CELLS — max non-empty cells emitted        (default 500)
+#   NATURO_EXCEL_MAX_ROWS  — max rows scanned of the used range (default 400)
+#   NATURO_EXCEL_MAX_COLS  — max cols scanned of the used range (default 100)
+_DEFAULT_MAX_EXCEL_CELLS = 500
+_DEFAULT_MAX_SCAN_ROWS = 400
+_DEFAULT_MAX_SCAN_COLS = 100
+
+
+def _env_int(name: str, default: int) -> int:
+    """Return positive int from env var ``name``, else ``default``.
+
+    A missing, non-integer, or non-positive value falls back to the default, so
+    a bad override degrades safely instead of disabling the bound.
+    """
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return default
+    return value if value > 0 else default
+
+
+def _max_excel_cells() -> int:
+    return _env_int("NATURO_EXCEL_MAX_CELLS", _DEFAULT_MAX_EXCEL_CELLS)
+
+
+def _max_scan_rows() -> int:
+    return _env_int("NATURO_EXCEL_MAX_ROWS", _DEFAULT_MAX_SCAN_ROWS)
+
+
+def _max_scan_cols() -> int:
+    return _env_int("NATURO_EXCEL_MAX_COLS", _DEFAULT_MAX_SCAN_COLS)
 
 
 def _win32_class_name(hwnd: int) -> Optional[str]:
@@ -151,14 +184,22 @@ def _cell_to_element(win, cell) -> Optional[ElementInfo]:
 
 
 def fetch_excel_cells(
-    hwnd: int, *, max_cells: int = _MAX_EXCEL_CELLS
+    hwnd: int, *, max_cells: Optional[int] = None
 ) -> List[ElementInfo]:
     """Fetch non-empty cells of the active sheet's used range as ``com`` nodes.
 
     Returns an empty list on any failure (no Excel running, pywin32 missing,
     COM error) — the cascade treats it like an unavailable provider.
     Truncation (sheet larger than the scan/emit caps) is logged, never silent.
+
+    The caps default to NATURO_EXCEL_MAX_CELLS / _MAX_ROWS / _MAX_COLS (see the
+    module header); pass ``max_cells`` to override the emit cap for one call.
     """
+    if max_cells is None:
+        max_cells = _max_excel_cells()
+    max_rows = _max_scan_rows()
+    max_cols = _max_scan_cols()
+
     xl = _get_running_excel()
     if xl is None:
         return []
@@ -167,14 +208,14 @@ def fetch_excel_cells(
         return []
     try:
         used = win.ActiveSheet.UsedRange
-        nrows = min(int(used.Rows.Count), _MAX_SCAN_ROWS)
-        ncols = min(int(used.Columns.Count), _MAX_SCAN_COLS)
+        nrows = min(int(used.Rows.Count), max_rows)
+        ncols = min(int(used.Columns.Count), max_cols)
     except Exception as exc:
         logger.debug("COM/Excel: cannot read used range: %s", exc)
         return []
 
     elements: List[ElementInfo] = []
-    truncated = int(used.Rows.Count) > _MAX_SCAN_ROWS or int(used.Columns.Count) > _MAX_SCAN_COLS
+    truncated = int(used.Rows.Count) > max_rows or int(used.Columns.Count) > max_cols
     for r in range(1, nrows + 1):
         for c in range(1, ncols + 1):
             if len(elements) >= max_cells:
@@ -192,7 +233,8 @@ def fetch_excel_cells(
 
     if truncated:
         logger.info(
-            "COM/Excel: output bounded to %d cells / %dx%d scan; sheet is larger.",
-            max_cells, _MAX_SCAN_ROWS, _MAX_SCAN_COLS,
+            "COM/Excel: output bounded to %d cells / %dx%d scan; sheet is larger. "
+            "Raise NATURO_EXCEL_MAX_CELLS / _MAX_ROWS / _MAX_COLS to read more.",
+            max_cells, max_rows, max_cols,
         )
     return elements

--- a/naturo/cascade/_run.py
+++ b/naturo/cascade/_run.py
@@ -368,6 +368,9 @@ def run_cascade(
     screenshot_path: Optional[str] = None,
     screenshot_scale_factor: float = 1.0,
     run_ocr: bool = False,
+    excel_max_cells: Optional[int] = None,
+    excel_max_rows: Optional[int] = None,
+    excel_max_cols: Optional[int] = None,
 ) -> CascadeResult:
     """Run progressive recognition and return a merged element tree.
 
@@ -747,7 +750,12 @@ def run_cascade(
             t0 = time.monotonic()
             com_cells: List[ElementInfo] = []
             try:
-                com_cells = _get_cascade_pkg()._fetch_excel_cells(com_hwnd)
+                com_cells = _get_cascade_pkg()._fetch_excel_cells(
+                    com_hwnd,
+                    max_cells=excel_max_cells,
+                    max_rows=excel_max_rows,
+                    max_cols=excel_max_cols,
+                )
             except Exception as exc:
                 logger.debug("Auto cascade: COM/Excel probe failed: %s", exc)
             elapsed = (time.monotonic() - t0) * 1000

--- a/naturo/cli/core/_see.py
+++ b/naturo/cli/core/_see.py
@@ -39,6 +39,14 @@ from naturo.value_preview import bounded_value
 @click.option("--ocr", "run_ocr", is_flag=True,
               help="Run local OCR (rapidocr) to recover text baked into images/canvas; "
                    "nodes are tagged 'ocr' (uncertain) and warned")
+@click.option("--excel-max-cells", "excel_max_cells", type=int, default=None,
+              help="Cascade Excel: max non-empty cells to emit (default 500). "
+                   "Raise for large sheets; per-invocation, so concurrent runs "
+                   "can differ.")
+@click.option("--excel-max-rows", "excel_max_rows", type=int, default=None,
+              help="Cascade Excel: max rows of the used range to scan (default 400)")
+@click.option("--excel-max-cols", "excel_max_cols", type=int, default=None,
+              help="Cascade Excel: max cols of the used range to scan (default 100)")
 @click.option("--stats", "show_stats", is_flag=True,
               help="Show per-provider recognition statistics after output")
 @click.option("--coverage", "coverage_target", type=float, default=0.0,
@@ -75,6 +83,7 @@ def see(app: str | None, window_title: str | None, hwnd: int | None, pid: int | 
         mode: str, depth: int, path: str | None, annotate: bool, store_snapshot: bool,
         session: str | None, cascade: bool, fill_gaps: bool, run_ocr: bool, show_stats: bool,
         coverage_target: float, visible_only: bool, show_selectors: bool,
+        excel_max_cells: int | None, excel_max_rows: int | None, excel_max_cols: int | None,
         json_output: bool, compact: bool, full_text: bool, backend: str, app_id: str | None,
         ai_provider: str, ai_model: str | None, ai_api_key: str | None) -> None:
     """Capture screenshot and analyze UI elements.
@@ -232,6 +241,9 @@ def see(app: str | None, window_title: str | None, hwnd: int | None, pid: int | 
                         if cascade_capture_result else 1.0
                     ),
                     run_ocr=run_ocr,
+                    excel_max_cells=excel_max_cells,
+                    excel_max_rows=excel_max_rows,
+                    excel_max_cols=excel_max_cols,
                 )
                 tree = cascade_result.tree
                 cascade_stats = cascade_result.stats

--- a/naturo/mcp/_inspect.py
+++ b/naturo/mcp/_inspect.py
@@ -26,6 +26,9 @@ def register_inspect_tools(server, _get_backend, _safe_tool):
         format: str = "compact",
         match: Optional[str] = None,
         full_text: bool = False,
+        excel_max_cells: Optional[int] = None,
+        excel_max_rows: Optional[int] = None,
+        excel_max_cols: Optional[int] = None,
     ) -> dict:
         """Read a window's UI as a structured element tree — naturo's core "see" tool.
 
@@ -102,6 +105,9 @@ def register_inspect_tools(server, _get_backend, _safe_tool):
                 cascade_result = run_cascade(
                     backend, app=app, window_title=window_title,
                     hwnd=hwnd, pid=pid, depth=depth, backend_name="auto",
+                    excel_max_cells=excel_max_cells,
+                    excel_max_rows=excel_max_rows,
+                    excel_max_cols=excel_max_cols,
                 )
                 tree = cascade_result.tree
         # (#737) When --app is used without --hwnd, enumerate ALL windows

--- a/tests/test_com_excel.py
+++ b/tests/test_com_excel.py
@@ -166,7 +166,7 @@ def test_run_cascade_grafts_com_cells_onto_tree():
     com_cell = _win("DataItem", "Widget", source="com", x=100, y=120, w=48, h=16)
 
     with patch.object(cascade_pkg, "_is_excel_window", lambda h: True), \
-         patch.object(cascade_pkg, "_fetch_excel_cells", lambda h: [com_cell]), \
+         patch.object(cascade_pkg, "_fetch_excel_cells", lambda h, **k: [com_cell]), \
          patch.object(cascade_pkg, "_is_java_window", lambda h: False), \
          patch.object(cascade_pkg, "find_cdp_port", lambda pid: None), \
          patch.object(cascade_pkg, "_fetch_cdp_elements", lambda *a, **k: []):
@@ -186,39 +186,49 @@ def test_run_cascade_grafts_com_cells_onto_tree():
     assert any(p.name == "com" and p.status == "ok" for p in result.stats.providers)
 
 
-# ── configurable scan/emit caps (env override) ───────────────────────────────
+# ── configurable scan/emit caps (per-call params, concurrency-safe) ──────────
 
 
 class TestExcelLimitsConfigurable:
-    """The Excel scan/emit caps default sensibly but are env-overridable."""
+    """The Excel caps default sensibly but are overridable per call — no global
+    (env/module) mutable state, so concurrent callers can each choose a bound."""
 
-    def test_env_int_parsing(self):
-        from naturo.cascade._com_excel import _env_int
+    @staticmethod
+    def _grid3x3():
+        return {(r, c): _FakeCell(f"v{r}.{c}", 10 * c, 10 * r, addr=f"{chr(64 + c)}{r}")
+                for r in range(1, 4) for c in range(1, 4)}
 
-        with patch.dict("os.environ", {"X": "1500"}):
-            assert _env_int("X", 500) == 1500
-        # missing / non-integer / non-positive all fall back to the default
-        with patch.dict("os.environ", {}, clear=True):
-            assert _env_int("X", 500) == 500
-        with patch.dict("os.environ", {"X": "nope"}):
-            assert _env_int("X", 500) == 500
-        with patch.dict("os.environ", {"X": "0"}):
-            assert _env_int("X", 500) == 500
-        with patch.dict("os.environ", {"X": "-10"}):
-            assert _env_int("X", 500) == 500
+    def test_defaults_apply_when_unset(self):
+        # None on every knob -> the module defaults, no reliance on process env.
+        with patch("naturo.cascade._com_excel._get_running_excel",
+                   return_value=_excel_with(self._grid3x3(), hwnd=123)):
+            cells = fetch_excel_cells(123)  # 9 cells < default 500 -> all emitted
+        assert len(cells) == 9
 
-    def test_caps_read_from_env(self):
-        from naturo.cascade import _com_excel as m
+    def test_scan_rows_cols_are_per_call(self):
+        # A 3x3 grid scanned with max_rows=1, max_cols=2 -> only (1,1),(1,2).
+        with patch("naturo.cascade._com_excel._get_running_excel",
+                   return_value=_excel_with(self._grid3x3(), hwnd=123)):
+            cells = fetch_excel_cells(123, max_rows=1, max_cols=2)
+        names = sorted(e.name for e in cells)
+        assert names == ["v1.1", "v1.2"]
 
-        with patch.dict("os.environ", {}, clear=True):
-            assert m._max_excel_cells() == 500
-            assert m._max_scan_rows() == 400
-            assert m._max_scan_cols() == 100
-        with patch.dict("os.environ", {
-            "NATURO_EXCEL_MAX_CELLS": "5000",
-            "NATURO_EXCEL_MAX_ROWS": "2000",
-            "NATURO_EXCEL_MAX_COLS": "256",
-        }):
-            assert m._max_excel_cells() == 5000
-            assert m._max_scan_rows() == 2000
-            assert m._max_scan_cols() == 256
+    def test_run_cascade_threads_excel_limits(self):
+        # run_cascade forwards excel_max_* to the provider per call.
+        captured = {}
+
+        def _spy(hwnd, **kw):
+            captured.update(kw)
+            return []
+
+        root = _win("Window", "Book1 - Excel", w=800, h=600)
+        backend = _FakeBackend(root)
+        with patch.object(cascade_pkg, "_is_excel_window", lambda h: True), \
+             patch.object(cascade_pkg, "_fetch_excel_cells", _spy), \
+             patch.object(cascade_pkg, "_is_java_window", lambda h: False), \
+             patch.object(cascade_pkg, "find_cdp_port", lambda pid: None), \
+             patch.object(cascade_pkg, "_fetch_cdp_elements", lambda *a, **k: []):
+            run_cascade(backend, backend_name="auto", hwnd=999,
+                        excel_max_cells=5000, excel_max_rows=2000, excel_max_cols=256)
+
+        assert captured == {"max_cells": 5000, "max_rows": 2000, "max_cols": 256}

--- a/tests/test_com_excel.py
+++ b/tests/test_com_excel.py
@@ -184,3 +184,41 @@ def test_run_cascade_grafts_com_cells_onto_tree():
     assert fusion["techniques"] == ["com"]
     # provider stat recorded
     assert any(p.name == "com" and p.status == "ok" for p in result.stats.providers)
+
+
+# ── configurable scan/emit caps (env override) ───────────────────────────────
+
+
+class TestExcelLimitsConfigurable:
+    """The Excel scan/emit caps default sensibly but are env-overridable."""
+
+    def test_env_int_parsing(self):
+        from naturo.cascade._com_excel import _env_int
+
+        with patch.dict("os.environ", {"X": "1500"}):
+            assert _env_int("X", 500) == 1500
+        # missing / non-integer / non-positive all fall back to the default
+        with patch.dict("os.environ", {}, clear=True):
+            assert _env_int("X", 500) == 500
+        with patch.dict("os.environ", {"X": "nope"}):
+            assert _env_int("X", 500) == 500
+        with patch.dict("os.environ", {"X": "0"}):
+            assert _env_int("X", 500) == 500
+        with patch.dict("os.environ", {"X": "-10"}):
+            assert _env_int("X", 500) == 500
+
+    def test_caps_read_from_env(self):
+        from naturo.cascade import _com_excel as m
+
+        with patch.dict("os.environ", {}, clear=True):
+            assert m._max_excel_cells() == 500
+            assert m._max_scan_rows() == 400
+            assert m._max_scan_cols() == 100
+        with patch.dict("os.environ", {
+            "NATURO_EXCEL_MAX_CELLS": "5000",
+            "NATURO_EXCEL_MAX_ROWS": "2000",
+            "NATURO_EXCEL_MAX_COLS": "256",
+        }):
+            assert m._max_excel_cells() == 5000
+            assert m._max_scan_rows() == 2000
+            assert m._max_scan_cols() == 256


### PR DESCRIPTION
Follow-up to the depth-cap audit (#1279), reworked per review: **no env vars**.

The Excel cascade bounds how much of a sheet it reads — 500 emitted cells,
400×100 scanned — to keep the tree small and cap COM round-trips. That truncation
was already **logged** (not silent), but the limits were hard-coded.

An earlier draft used `NATURO_EXCEL_*` env vars; that's process-global mutable
state and can't differ per concurrent operation, which breaks naturo's
multi-process/concurrent model. This instead threads the caps as **per-call
parameters** with immutable module defaults:

- `fetch_excel_cells(hwnd, *, max_cells=, max_rows=, max_cols=)`
- `run_cascade(..., excel_max_cells=, excel_max_rows=, excel_max_cols=)`
- CLI: `see --excel-max-cells/--excel-max-rows/--excel-max-cols`
- MCP: `see_ui_tree(excel_max_cells=, excel_max_rows=, excel_max_cols=)`

`None` on any knob = the default (500 / 400 / 100). Each invocation/caller picks
its own bound with no shared state — concurrent runs never interfere. The
truncation log names the flags to raise.

Tests cover the defaults, per-call row/col scan bounds, and run_cascade threading
the values through to the provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)