### PR TITLE
fix(get): disambiguate role+name reads by the ref's screen point (Windows Terminal buffer)

### DIFF
--- a/core/include/naturo/exports.h
+++ b/core/include/naturo/exports.h
@@ -321,6 +321,7 @@ NATURO_API int naturo_get_element_value(uintptr_t hwnd,
                                          const char* automation_id,
                                          const char* role,
                                          const char* name,
+                                         int hint_x, int hint_y,
                                          char* result_json, int buf_size);
 
 /* ── Hardware-level Keyboard (Phys32) ─────────────── */

--- a/core/src/element.cpp
+++ b/core/src/element.cpp
@@ -17,6 +17,7 @@
 #include <uiautomation.h>
 #include <cstdio>
 #include <cstring>
+#include <climits>
 #include <string>
 #include <atomic>
 
@@ -702,9 +703,16 @@ NATURO_API int naturo_find_element(uintptr_t hwnd, const char* role,
  */
 static IUIAutomationElement* find_element_by_id_or_role(
     IUIAutomation* uia, IUIAutomationElement* root,
-    const char* automation_id, const char* role, const char* name)
+    const char* automation_id, const char* role, const char* name,
+    int hint_x, int hint_y)
 {
     IUIAutomationElement* found = NULL;
+    // A snapshot ref carries the exact element's screen point. When several
+    // elements share the same role+name and no AutomationId (e.g. Windows
+    // Terminal exposes two "命令提示符" Text peers — a tiny label and the full
+    // buffer), a bare FindFirst grabs the wrong one. If a hint point is given,
+    // prefer the match whose bounds contain it; fall back to the first match.
+    const bool have_hint = (hint_x != INT_MIN && hint_y != INT_MIN);
 
     if (automation_id && automation_id[0]) {
         // Search by AutomationId
@@ -776,8 +784,25 @@ static IUIAutomationElement* find_element_by_id_or_role(
                 }
 
                 if (match) {
-                    found = elem;
-                    break;
+                    if (!have_hint) {
+                        found = elem;       // no hint: first match wins (legacy)
+                        break;
+                    }
+                    // With a hint, keep the first match as a fallback but prefer
+                    // the one whose bounds contain the hint point.
+                    RECT r = {0, 0, 0, 0};
+                    elem->get_CurrentBoundingRectangle(&r);
+                    bool contains = (hint_x >= r.left && hint_x < r.right &&
+                                     hint_y >= r.top && hint_y < r.bottom);
+                    if (contains) {
+                        if (found) found->Release();
+                        found = elem;       // exact hit — done
+                        break;
+                    }
+                    if (!found) {
+                        found = elem;       // remember first match, keep scanning
+                        continue;           // (don't Release the one we kept)
+                    }
                 }
                 elem->Release();
             }
@@ -797,6 +822,7 @@ NATURO_API int naturo_get_element_value(uintptr_t hwnd,
                                          const char* automation_id,
                                          const char* role_filter,
                                          const char* name_filter,
+                                         int hint_x, int hint_y,
                                          char* result_json, int buf_size) {
     if (!result_json || buf_size <= 0) return -1;
     if (!automation_id && !role_filter && !name_filter) return -1;
@@ -821,7 +847,7 @@ NATURO_API int naturo_get_element_value(uintptr_t hwnd,
     }
 
     IUIAutomationElement* elem = find_element_by_id_or_role(
-        uia, root, automation_id, role_filter, name_filter);
+        uia, root, automation_id, role_filter, name_filter, hint_x, hint_y);
 
     if (!elem) {
         root->Release();
@@ -1109,11 +1135,14 @@ NATURO_API int naturo_get_element_value(uintptr_t hwnd,
                                          const char* automation_id,
                                          const char* role,
                                          const char* name,
+                                         int hint_x, int hint_y,
                                          char* result_json, int buf_size) {
     (void)hwnd;
     (void)automation_id;
     (void)role;
     (void)name;
+    (void)hint_x;
+    (void)hint_y;
     (void)result_json;
     (void)buf_size;
     return -2;  // Not supported on this platform

--- a/naturo/backends/windows/_element/_tree.py
+++ b/naturo/backends/windows/_element/_tree.py
@@ -419,6 +419,16 @@ class ElementTreeMixin:
             result = mgr.resolve_ref_element(ref)
             if result:
                 elem, _snap_id = result
+                # Cache the element's own screen point as a disambiguation hint.
+                # A role+name lookup can match several elements (e.g. Windows
+                # Terminal exposes two "命令提示符" Text peers — a label and the
+                # full buffer); the point picks the exact one the snapshot meant.
+                # Harmless when the match is unique, and it does NOT trigger the
+                # coordinate-read path below (that stays gated on no role+name).
+                _hint_frame = getattr(elem, "frame", None)
+                if _hint_frame and (_hint_frame[2] > 0 or _hint_frame[3] > 0):
+                    coords = (_hint_frame[0] + _hint_frame[2] // 2,
+                              _hint_frame[1] + _hint_frame[3] // 2)
                 # Use the element's identifier (AutomationId) if available
                 if elem.identifier:
                     resolved_aid = elem.identifier
@@ -523,6 +533,8 @@ class ElementTreeMixin:
             automation_id=resolved_aid,
             role=resolved_role,
             name=resolved_name,
+            hint_x=coords[0] if coords else None,
+            hint_y=coords[1] if coords else None,
         )
 
         # (#352) Role alias fallback: when an explicit role search fails,
@@ -544,6 +556,8 @@ class ElementTreeMixin:
                     automation_id=resolved_aid,
                     role=alias_role,
                     name=resolved_name,
+                    hint_x=coords[0] if coords else None,
+                    hint_y=coords[1] if coords else None,
                 )
                 if result is not None:
                     break

--- a/naturo/bridge/_core.py
+++ b/naturo/bridge/_core.py
@@ -204,7 +204,8 @@ class NaturoCore:
             self._lib.naturo_get_element_value.restype = ctypes.c_int
             self._lib.naturo_get_element_value.argtypes = [
                 ctypes.c_size_t, ctypes.c_char_p, ctypes.c_char_p,
-                ctypes.c_char_p, ctypes.c_char_p, ctypes.c_int
+                ctypes.c_char_p, ctypes.c_int, ctypes.c_int,
+                ctypes.c_char_p, ctypes.c_int
             ]
         except AttributeError:
             pass  # DLL lacks this export; get_element_value() will raise
@@ -556,6 +557,8 @@ class NaturoCore:
         automation_id: Optional[str] = None,
         role: Optional[str] = None,
         name: Optional[str] = None,
+        hint_x: Optional[int] = None,
+        hint_y: Optional[int] = None,
     ) -> Optional[dict]:
         """Read the current value of a UI element using UIA patterns.
 
@@ -568,6 +571,9 @@ class NaturoCore:
             automation_id: AutomationId of the target element.
             role: Element role filter (used when automation_id is None).
             name: Element name filter (used when automation_id is None).
+            hint_x, hint_y: Optional screen point disambiguating a role+name
+                search when several elements share them (no AutomationId). The
+                match whose bounds contain the point wins; else the first match.
 
         Returns:
             Dict with keys: value, pattern, role, name, automation_id,
@@ -592,7 +598,11 @@ class NaturoCore:
                 "(recompile the DLL with the latest source)",
             )
 
-        rc = fn(hwnd, aid_bytes, role_bytes, name_bytes, buf, buf_size)
+        # INT_MIN sentinel = "no hint" (matches the native have_hint check).
+        _NO_HINT = -2147483648
+        hx = hint_x if hint_x is not None else _NO_HINT
+        hy = hint_y if hint_y is not None else _NO_HINT
+        rc = fn(hwnd, aid_bytes, role_bytes, name_bytes, hx, hy, buf, buf_size)
 
         if rc == 1:
             return None  # Not found

--- a/tests/test_get_cmd.py
+++ b/tests/test_get_cmd.py
@@ -392,7 +392,7 @@ class TestGetElementValueBridge:
             "x": 10, "y": 20, "width": 100, "height": 30,
         }).encode("utf-8")
 
-        def fake_get(hwnd, aid, role, name, buf, size):
+        def fake_get(hwnd, aid, role, name, hint_x, hint_y, buf, size):
             buf.value = mock_response
             return 0
 
@@ -408,6 +408,30 @@ class TestGetElementValueBridge:
         assert result is not None
         assert result["value"] == "test"
         assert result["pattern"] == "ValuePattern"
+
+    def test_bridge_passes_point_hint(self):
+        """A role+name read forwards the disambiguation point; None -> INT_MIN."""
+        from naturo.bridge import NaturoCore
+
+        captured = {}
+
+        def fake_get(hwnd, aid, role, name, hint_x, hint_y, buf, size):
+            captured["hint"] = (hint_x, hint_y)
+            buf.value = json.dumps({"value": "x", "pattern": "TextPattern"}).encode()
+            return 0
+
+        mock_lib = MagicMock()
+        mock_lib.naturo_get_element_value = MagicMock(side_effect=fake_get)
+        core = NaturoCore.__new__(NaturoCore)
+        core._lib = mock_lib
+        core._initialized = True
+
+        core.get_element_value(hwnd=5, role="Text", name="命令提示符",
+                               hint_x=1920, hint_y=1080)
+        assert captured["hint"] == (1920, 1080)
+
+        core.get_element_value(hwnd=5, role="Text", name="命令提示符")
+        assert captured["hint"] == (-2147483648, -2147483648)  # INT_MIN = no hint
 
     def test_bridge_not_found(self):
         """Bridge returns None when element not found (rc=1)."""


### PR DESCRIPTION
## Symptom

`naturo get eN` on the Windows Terminal content element returned only the control
name `"命令提示符"` (5 chars), not the terminal scrollback buffer.

## Root cause

Windows Terminal exposes **two** `Text` peers with the same name `"命令提示符"` and
**no AutomationId** — a tiny label and the real full-buffer provider (~19.5k
chars). The C++ reader resolved `eN` by role+name via `FindFirst`/first-match and
grabbed the wrong one. The snapshot already knew the exact element (its bounds),
but that was dropped on re-resolution. (Confirmed by probe: both peers are
`ct=Text name="命令提示符"`, `textLen` 5 vs 19541.)

## Fix

Thread the ref's own screen point through as a disambiguation hint:

- `naturo_get_element_value` / `find_element_by_id_or_role` take `(hint_x,
  hint_y)`; among role+name matches, prefer the one whose bounds **contain** the
  point, else the first match. `INT_MIN` sentinel = no hint → legacy first-match
  behavior preserved.
- bridge `get_element_value` forwards `hint_x`/`hint_y` (`None` → INT_MIN).
- the ref resolver caches the snapshot element's center point and passes it on
  the role+name and role-alias reads. It does **not** trigger the coordinate-read
  path (still gated on no-role+name).

## Result

`get eN` on the WT terminal now returns the full ~20k-char buffer (verified live:
5 → 20566 chars, containing real terminal text). Tests: bridge hint pass-through
+ INT_MIN sentinel; 226 passed across value/get/element/jab/bridge suites, no
regressions. DLL is a gitignored artifact — CI rebuilds from source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)