### PR TITLE
feat(see): per-node capability flags (readable/actionable/editable) for UIA + JAB

### DIFF
--- a/core/src/element.cpp
+++ b/core/src/element.cpp
@@ -185,6 +185,18 @@ static void append_keyboard_shortcut_field(const std::string& shortcut,
  * @param element Element with cached properties.
  * @param out Output string to append JSON to.
  */
+// Read a cached VT_BOOL property (pattern-availability etc.); false if absent.
+static bool cached_bool(IUIAutomationElement* element, PROPERTYID pid) {
+    VARIANT v;
+    VariantInit(&v);
+    bool result = false;
+    if (SUCCEEDED(element->GetCachedPropertyValue(pid, &v)) && v.vt == VT_BOOL) {
+        result = (v.boolVal != VARIANT_FALSE);
+    }
+    VariantClear(&v);
+    return result;
+}
+
 static void append_element_json_cached(IUIAutomationElement* element,
                                         std::string& out) {
     // Read from cache (no IPC — properties already fetched in batch)
@@ -228,6 +240,18 @@ static void append_element_json_cached(IUIAutomationElement* element,
     // (#886) Emit the keyboard shortcut so UIA elements expose the same
     // accessibility metadata as the MSAA/IA2 backends instead of always null.
     append_keyboard_shortcut_field(read_keyboard_shortcut(element, true), out);
+
+    // True per-node capabilities from UIA pattern availability (faithful, not
+    // role-guessed): readable = Value or Text pattern; editable = a writable
+    // ValuePattern; actionable = Invoke or Toggle pattern.
+    bool has_value = cached_bool(element, UIA_IsValuePatternAvailablePropertyId);
+    bool has_text = cached_bool(element, UIA_IsTextPatternAvailablePropertyId);
+    bool readonly = cached_bool(element, UIA_ValueIsReadOnlyPropertyId);
+    bool has_invoke = cached_bool(element, UIA_IsInvokePatternAvailablePropertyId);
+    bool has_toggle = cached_bool(element, UIA_IsTogglePatternAvailablePropertyId);
+    out += (has_value || has_text) ? ",\"readable\":true" : ",\"readable\":false";
+    out += (has_value && !readonly) ? ",\"editable\":true" : ",\"editable\":false";
+    out += (has_invoke || has_toggle) ? ",\"actionable\":true" : ",\"actionable\":false";
 }
 
 /**
@@ -367,6 +391,14 @@ static HRESULT create_element_cache_request(
     // get_CachedAccessKey resolve without extra cross-process COM calls.
     (*cache_request)->AddProperty(UIA_AcceleratorKeyPropertyId);
     (*cache_request)->AddProperty(UIA_AccessKeyPropertyId);
+    // Per-node capability truth (readable/actionable/editable) — pattern
+    // availability + ValuePattern read-only, batched into the cache so each node
+    // reports what it actually supports without extra COM round-trips.
+    (*cache_request)->AddProperty(UIA_IsValuePatternAvailablePropertyId);
+    (*cache_request)->AddProperty(UIA_IsTextPatternAvailablePropertyId);
+    (*cache_request)->AddProperty(UIA_IsInvokePatternAvailablePropertyId);
+    (*cache_request)->AddProperty(UIA_IsTogglePatternAvailablePropertyId);
+    (*cache_request)->AddProperty(UIA_ValueIsReadOnlyPropertyId);
 
     // Fetch direct children scope for tree walking
     (*cache_request)->put_TreeScope(TreeScope_Element);

--- a/core/src/jab.cpp
+++ b/core/src/jab.cpp
@@ -433,6 +433,9 @@ struct JABElement {
     std::string name;
     std::string value;    // from description
     std::string states;
+    bool readable;        // exposes text content (AccessibleText)
+    bool actionable;      // supports actions (AccessibleAction)
+    bool editable;        // states include "editable"
     int x, y, width, height;
     int child_count;
     std::vector<JABElement> children;
@@ -458,6 +461,16 @@ static JABElement jab_build_element(long vmID, AccessibleContext ac,
     el.name = jab_json_escape(info.name);
     el.value = jab_json_escape(info.description);
     el.states = jab_json_escape(info.states_en_US[0] ? info.states_en_US : info.states);
+    // True per-node capabilities read from JAB (faithful, not role-guessed):
+    //  readable   = exposes text content via the AccessibleText interface
+    //  actionable = supports AccessibleAction (click/invoke)
+    //  editable   = the states list marks it editable
+    el.readable = info.accessibleText ? true : false;
+    el.actionable = info.accessibleAction ? true : false;
+    {
+        const wchar_t* st = info.states_en_US[0] ? info.states_en_US : info.states;
+        el.editable = (st && wcsstr(st, L"editable") != NULL);
+    }
     el.x = info.x;
     el.y = info.y;
     el.width = info.width;
@@ -519,6 +532,9 @@ static void jab_element_to_json(const JABElement& el, std::string& out) {
 
     out += "\"states\":\"" + el.states + "\",";
     out += "\"jab_role\":\"" + el.raw_role + "\",";
+    out += std::string("\"readable\":") + (el.readable ? "true" : "false") + ",";
+    out += std::string("\"actionable\":") + (el.actionable ? "true" : "false") + ",";
+    out += std::string("\"editable\":") + (el.editable ? "true" : "false") + ",";
     out += "\"backend\":\"jab\",";
     out += "\"children\":[";
 

--- a/naturo/backends/windows/_element/_tree.py
+++ b/naturo/backends/windows/_element/_tree.py
@@ -345,6 +345,12 @@ class ElementTreeMixin:
                     # fallback, test fixtures) leave the attribute absent → None,
                     # matching the dataclass default rather than crashing.
                     "states": getattr(el, "states", None),
+                    # True per-node capabilities (readable/actionable/editable)
+                    # reported by the backend, surfaced so agents target the real
+                    # interactive node instead of guessing from role.
+                    "readable": getattr(el, "readable", None),
+                    "actionable": getattr(el, "actionable", None),
+                    "editable": getattr(el, "editable", None),
                 }.items() if v is not None
             }
 

--- a/naturo/bridge/_models.py
+++ b/naturo/bridge/_models.py
@@ -155,6 +155,12 @@ class ElementInfo:
     keyboard_shortcut: Optional[str] = None
     hwnd: Optional[int] = None
     states: Optional[str] = None
+    # True per-node capabilities reported by the backend (not role-guessed):
+    # readable = has readable content (Value/TextPattern, JAB AccessibleText);
+    # actionable = clickable/invokable; editable = accepts text input.
+    readable: Optional[bool] = None
+    actionable: Optional[bool] = None
+    editable: Optional[bool] = None
 
 
 def _parse_element(data: dict) -> ElementInfo:
@@ -180,6 +186,9 @@ def _parse_element(data: dict) -> ElementInfo:
         parent_id=data.get("parent_id"),
         keyboard_shortcut=data.get("keyboard_shortcut"),
         states=data.get("states"),
+        readable=data.get("readable"),
+        actionable=data.get("actionable"),
+        editable=data.get("editable"),
     )
 
 

--- a/naturo/cli/core/_see.py
+++ b/naturo/cli/core/_see.py
@@ -582,6 +582,12 @@ def see(app: str | None, window_title: str | None, hwnd: int | None, pid: int | 
                 # (goal) --compact: agent-friendly minimal line — eN [role] "name"
                 # [=value], no bounds/props/selectors. Refs still assigned for all
                 # nodes so `naturo click eN` resolves; only meaningful nodes print.
+                # True per-node capabilities: [r]eadable/[a]ctionable/[e]ditable
+                _cp = getattr(el, "properties", {}) or {}
+                _caps = "".join(c for c, k in (("r", "readable"), ("a", "actionable"),
+                                               ("e", "editable")) if _cp.get(k))
+                _caps_str = f" [{_caps}]" if _caps else ""
+
                 if compact:
                     _name = f' "{el.name}"' if el.name else ""
                     _val = getattr(el, "value", None)
@@ -592,7 +598,7 @@ def see(app: str | None, window_title: str | None, hwnd: int | None, pid: int | 
                         if _elided:
                             _val_str += f" …(+{_elided} chars)"
                     if el.name or (el.role or "").lower() in _CLI_ACTIONABLE or _val:
-                        click.echo(f"{prefix}{ref} [{el.role}]{_name}{_val_str}")
+                        click.echo(f"{prefix}{ref} [{el.role}]{_name}{_val_str}{_caps_str}")
                     for child in el.children:
                         print_tree(child, indent + 1, child_ancestors)
                     return
@@ -607,7 +613,7 @@ def see(app: str | None, window_title: str | None, hwnd: int | None, pid: int | 
                 if show_selectors:
                     selector_uri = _build_selector(el, ancestors_dicts)
                     selector_str = f"  {selector_uri}"
-                click.echo(f"{prefix}[{el.role}]{name_str}{pos_str} {ref}{source_str}{offscreen_str}{selector_str}")
+                click.echo(f"{prefix}[{el.role}]{name_str}{pos_str} {ref}{source_str}{offscreen_str}{_caps_str}{selector_str}")
 
                 # (#372) Show text content for Document/Edit/Text elements: full
                 # when --full-text, otherwise a bounded preview with a marker for

--- a/naturo/mcp/_inspect.py
+++ b/naturo/mcp/_inspect.py
@@ -275,7 +275,16 @@ def register_inspect_tools(server, _get_backend, _safe_tool):
                     line += f" ={_shown!r}"
                     if _elided:
                         line += f" …(+{_elided} chars)"
-                _fusion = _annotate_correctness(el.properties or {})
+                # True per-node capabilities: [r]eadable / [a]ctionable /
+                # [e]ditable, so the agent targets the real interactive node
+                # instead of guessing from role. Only present flags are shown.
+                _p = el.properties or {}
+                _caps = "".join(c for c, k in (("r", "readable"),
+                                               ("a", "actionable"),
+                                               ("e", "editable")) if _p.get(k))
+                if _caps:
+                    line += f" [{_caps}]"
+                _fusion = _annotate_correctness(_p)
                 if _fusion is not None and _fusion.get("correctness") != "deterministic":
                     line += " ~"  # uncertain (vision/image) — verify before trusting
                 _compact_lines.append(line)

--- a/tests/test_mcp_inspect.py
+++ b/tests/test_mcp_inspect.py
@@ -322,6 +322,23 @@ class TestSeeUiTree:
         assert "hello world" in text
         assert "chars)" not in text
 
+    def test_capability_flags_rendered(self, server, mock_backend):
+        # readable/actionable/editable from the backend surface as [rae] so the
+        # agent targets the real interactive node, not a role guess.
+        edit = _make_element(id="in", role="Edit", name="用户名",
+                             properties={"readable": True, "actionable": True,
+                                         "editable": True})
+        btn = _make_element(id="ok", role="Button", name="连接",
+                            properties={"actionable": True})
+        root = _make_element(id="w", role="Window", name="Dlg", children=[edit, btn])
+        mock_backend.get_element_tree.return_value = root
+        text = json.loads(_call_tool(server, "see_ui_tree", {})[0].text)["tree_text"]
+        # the input carries all three; the button only actionable
+        assert any('"用户名"' in ln and ln.rstrip().endswith("[rae]")
+                   for ln in text.splitlines())
+        assert any('"连接"' in ln and ln.rstrip().endswith("[a]")
+                   for ln in text.splitlines())
+
     def test_app_param_triggers_multi_window_enumeration(self, server, mock_backend):
         """When app is provided without hwnd, _resolve_hwnds is used (#737)."""
         child = _make_element(id="btn1", role="Button", name="Click Me")


### PR DESCRIPTION
## Why

Agents/users had to **guess** what they can do with a node from its `role` —
which breaks when roles are ambiguous:
- Windows Terminal exposes two same-named `Text` peers (a label vs the buffer).
- JConsole's read-only HTML **VM Summary** is an `Edit`, indistinguishable by
  role from a real input field.

Merging/deduping such nodes is a lossy guess that can misrepresent the UI. The
faithful fix is **additive**: give each node its TRUE capabilities, read from the
backend.

## What

Three per-node flags, read from the backend (not role-inferred):

| flag | means | UIA | JAB |
|---|---|---|---|
| **readable** | has readable content | Value/TextPattern | AccessibleText |
| **actionable** | clickable/invokable | Invoke/Toggle pattern | AccessibleAction |
| **editable** | accepts input | writable ValuePattern | `editable` state |

- **UIA** (element.cpp): pattern-availability (+ `ValueIsReadOnly`) is batched
  into the cache request; each node emits the three flags with no extra COM calls.
- **JAB** (jab.cpp): emitted from `accessibleText` / `accessibleAction` / the
  `editable` state token.
- Flows through `ElementInfo` → tree → compact renderer as a terse `[rae]` suffix
  (only present letters).

## Verified live

- Notepad `Document` → `[re]` (readable + editable)
- JConsole `用户名`/`口令` → `[rae]`; `连接` button → `[a]`; **VM Summary → `[ra]`**
  (readable, NOT editable → reads as content, not an input target)

Resolves the parent/child duplication dilemma by TRUTH, no lossy merge. Tests:
capability render test added; 747 passed, no new regressions (pre-existing
FindElement/click_ref locals unaffected). DLL is a gitignored artifact — CI
rebuilds. MSAA/IA2/CDP can follow the same pattern next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)