### PR TITLE
fix(set): support Slider/Spinner via RangeValuePattern (+ NULL-pattern guard)

### DIFF
--- a/naturo/backends/windows/_input/_uia_interact.py
+++ b/naturo/backends/windows/_input/_uia_interact.py
@@ -541,23 +541,44 @@ class UIAInteractMixin:
                                  name, automation_id, role)
                     return False
 
-            # Try ValuePattern
+            # 1) ValuePattern — text/edit controls. NB: comtypes returns a
+            #    non-None NULL COM pointer for an UNSUPPORTED pattern (a Slider has
+            #    no ValuePattern), so gate on truthiness — `if ptr:` is False for a
+            #    NULL pointer — not `is not None`, which would QueryInterface a NULL
+            #    pointer and raise "NULL COM pointer access".
             pat_unk = elem.GetCurrentPattern(mod.UIA_ValuePatternId)
-            if pat_unk is None:
-                logger.debug("SetValue: element does not support ValuePattern")
-                return False
+            if pat_unk:
+                vp = pat_unk.QueryInterface(mod.IUIAutomationValuePattern)
+                if not vp.CurrentIsReadOnly:
+                    vp.SetValue(text)
+                    logger.info("SetValue: set via ValuePattern (name=%r, len=%d)",
+                                name, len(text))
+                    return True
+                logger.debug("SetValue: ValuePattern read-only; trying RangeValue")
 
-            vp = pat_unk.QueryInterface(mod.IUIAutomationValuePattern)
+            # 2) RangeValuePattern — Slider/Spinner/ProgressBar carry a numeric
+            #    value and do NOT support ValuePattern. Parse the number and clamp
+            #    to the control's [min, max] so an out-of-range request still lands.
+            rv_unk = elem.GetCurrentPattern(mod.UIA_RangeValuePatternId)
+            if rv_unk:
+                rv = rv_unk.QueryInterface(mod.IUIAutomationRangeValuePattern)
+                if rv.CurrentIsReadOnly:
+                    logger.debug("SetValue: RangeValuePattern is read-only")
+                    return False
+                try:
+                    num = float(text)
+                except (TypeError, ValueError):
+                    logger.debug("SetValue: RangeValue needs a number, got %r", text)
+                    return False
+                num = max(rv.CurrentMinimum, min(rv.CurrentMaximum, num))
+                rv.SetValue(num)
+                logger.info("SetValue: set via RangeValuePattern (name=%r, value=%s)",
+                            name, num)
+                return True
 
-            # Check if the value is read-only
-            if vp.CurrentIsReadOnly:
-                logger.debug("SetValue: element's ValuePattern is read-only")
-                return False
-
-            vp.SetValue(text)
-            logger.info("SetValue: successfully set text on element (name=%r, len=%d)",
-                        name, len(text))
-            return True
+            logger.debug("SetValue: element supports neither writable Value nor "
+                         "RangeValue pattern")
+            return False
 
         except (OSError, AttributeError) as exc:
             logger.debug("SetValue failed: %s", exc)

--- a/tests/test_set_cmd.py
+++ b/tests/test_set_cmd.py
@@ -669,3 +669,73 @@ class TestSetAppId:
         result = runner.invoke(main, ["set", "--help"])
         assert result.exit_code == 0
         assert "--app-id" in result.output
+
+
+# ── RangeValuePattern fallback (Slider/Spinner/ProgressBar) ──────────────────
+
+
+class TestSetValueRangeValue:
+    """set_element_value falls back to RangeValuePattern when a control (e.g. a
+    Zoom Slider) has no ValuePattern — and it must not choke on comtypes' NULL
+    pointer for the unsupported pattern."""
+
+    @pytest.mark.skipif(platform.system() != "Windows", reason="comtypes/UIA is Windows-only")
+    def test_slider_set_via_rangevalue(self):
+        from naturo.backends.windows import WindowsBackend
+
+        mod = MagicMock()
+        mod.UIA_ValuePatternId = 10002
+        mod.UIA_RangeValuePatternId = 10003
+
+        # ValuePattern → a NULL-like (falsy) COM pointer, as comtypes returns for
+        # an unsupported pattern. Truthiness must skip it, not QueryInterface it.
+        null_vp = MagicMock()
+        null_vp.__bool__.return_value = False
+
+        rv_pattern = MagicMock()
+        rv_pattern.CurrentIsReadOnly = False
+        rv_pattern.CurrentMinimum = 0.0
+        rv_pattern.CurrentMaximum = 100.0
+        rv_ptr = MagicMock()
+        rv_ptr.__bool__.return_value = True
+        rv_ptr.QueryInterface.return_value = rv_pattern
+
+        elem = MagicMock()
+        elem.GetCurrentPattern.side_effect = (
+            lambda pid: rv_ptr if pid == mod.UIA_RangeValuePatternId else null_vp
+        )
+
+        b = WindowsBackend.__new__(WindowsBackend)
+        with patch.object(b, "_init_comtypes_uia", return_value=(MagicMock(), mod)), \
+             patch.object(b, "_resolve_interaction_element", return_value=elem):
+            ok = b.set_element_value(text="50", hwnd=1, name="Zoom", role="Slider")
+
+        assert ok is True
+        rv_pattern.SetValue.assert_called_once_with(50.0)
+
+    @pytest.mark.skipif(platform.system() != "Windows", reason="comtypes/UIA is Windows-only")
+    def test_rangevalue_clamped_to_max(self):
+        from naturo.backends.windows import WindowsBackend
+
+        mod = MagicMock()
+        mod.UIA_ValuePatternId = 10002
+        mod.UIA_RangeValuePatternId = 10003
+        null_vp = MagicMock()
+        null_vp.__bool__.return_value = False
+        rv_pattern = MagicMock()
+        rv_pattern.CurrentIsReadOnly = False
+        rv_pattern.CurrentMinimum = 0.0
+        rv_pattern.CurrentMaximum = 100.0
+        rv_ptr = MagicMock()
+        rv_ptr.__bool__.return_value = True
+        rv_ptr.QueryInterface.return_value = rv_pattern
+        elem = MagicMock()
+        elem.GetCurrentPattern.side_effect = (
+            lambda pid: rv_ptr if pid == mod.UIA_RangeValuePatternId else null_vp
+        )
+        b = WindowsBackend.__new__(WindowsBackend)
+        with patch.object(b, "_init_comtypes_uia", return_value=(MagicMock(), mod)), \
+             patch.object(b, "_resolve_interaction_element", return_value=elem):
+            ok = b.set_element_value(text="9999", hwnd=1, name="Zoom", role="Slider")
+        assert ok is True
+        rv_pattern.SetValue.assert_called_once_with(100.0)  # clamped to max


### PR DESCRIPTION
## Symptom

`naturo set e28 50` on a `[Slider] "Zoom"` failed with `Failed to set value`.

## Root cause (two bugs)

1. Sliders/spinners/progress bars expose their **numeric value via
   RangeValuePattern**, not ValuePattern — but `set_element_value` only tried
   ValuePattern.
2. The deeper reason it *failed* rather than falling through: comtypes'
   `GetCurrentPattern` returns a **non-None NULL COM pointer** for an
   unsupported pattern. The old `if pat_unk is not None:` passed, then
   `QueryInterface` on the NULL pointer raised **"NULL COM pointer access"** —
   so it broke on any ValuePattern-less control.

## Fix

- Gate `GetCurrentPattern` on **truthiness** (`if ptr:`) — a NULL comtypes
  pointer is falsy — instead of `is not None`.
- Add a **RangeValuePattern.SetValue** fallback: parse the number and clamp to
  the control's `[Minimum, Maximum]`.

## Verified live

Photos "Zoom" slider: `set e28 50` moves it (read-back 72 → 50). Tests cover the
RangeValue path and clamping (mocking the NULL ValuePattern + RangeValue
pattern); 38 set tests pass, ruff/mypy clean.

Note: the read side already handled RangeValuePattern (#value read); this brings
the write side to parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)