### PR TITLE
feat(cascade): read Scintilla editor content (Notepad++/SciTE) as a moat provider

### DIFF
--- a/naturo/cascade/__init__.py
+++ b/naturo/cascade/__init__.py
@@ -67,6 +67,10 @@ from naturo.cascade._com_excel import (
     fetch_excel_cells as _fetch_excel_cells,
     is_excel_window as _is_excel_window,
 )
+from naturo.cascade._scintilla import (
+    fetch_scintilla_content as _fetch_scintilla_content,
+    is_scintilla_window as _is_scintilla_window,
+)
 from naturo.cascade._ocr import fetch_ocr_elements as _fetch_ocr_elements
 from naturo.cascade._correctness import (
     DETERMINISTIC,
@@ -122,6 +126,8 @@ __all__ = [
     "_fetch_cdp_elements",
     "_fetch_excel_cells",
     "_is_excel_window",
+    "_fetch_scintilla_content",
+    "_is_scintilla_window",
     "_fetch_ocr_elements",
     # Correctness / fusion tagging (M1 Unified Auto Element Tree)
     "DETERMINISTIC",

--- a/naturo/cascade/_run.py
+++ b/naturo/cascade/_run.py
@@ -774,6 +774,33 @@ def run_cascade(
                     name="com", elapsed_ms=elapsed, status="no_elements",
                 ))
 
+        # Provider 2d: Scintilla (Notepad++/SciTE/IDE editors). The Scintilla
+        # editing surface is opaque to UIA — the tree shows the pane but no text.
+        # Read the document via Scintilla's own message API and graft it as a
+        # deterministic node, mirroring the COM/CDP/JAB providers.
+        if com_hwnd is not None and _get_cascade_pkg()._is_scintilla_window(com_hwnd):
+            t0 = time.monotonic()
+            sci_nodes: List[ElementInfo] = []
+            try:
+                sci_nodes = _get_cascade_pkg()._fetch_scintilla_content(com_hwnd)
+            except Exception as exc:
+                logger.debug("Auto cascade: Scintilla probe failed: %s", exc)
+            elapsed = (time.monotonic() - t0) * 1000
+
+            if sci_nodes and root_tree is not None:
+                for node in sci_nodes:
+                    tagged = _tag_source(node, "scintilla")
+                    root_tree.children.append(tagged)
+                    merged_elements.append(tagged)
+                stats.providers.append(ProviderStat(
+                    name="scintilla", elements=len(sci_nodes),
+                    elapsed_ms=elapsed, status="ok",
+                ))
+            else:
+                stats.providers.append(ProviderStat(
+                    name="scintilla", elapsed_ms=elapsed, status="no_elements",
+                ))
+
     # ── Shallow tree detection (issue #275) ────────────────────────────────
     # When the UIA tree is too shallow (few elements, mostly invalid bounds),
     # automatically enable AI vision fallback even without --fill-gaps.

--- a/naturo/cascade/_scintilla.py
+++ b/naturo/cascade/_scintilla.py
@@ -1,0 +1,189 @@
+"""Scintilla text provider — read the content of Scintilla-based editors.
+
+Notepad++, SciTE, and many IDEs render their editor with the **Scintilla**
+control which — like Excel's grid — is opaque to UIA/MSAA: a UIA-only tool sees
+the editor *pane* but none of the text. This provider finds the Scintilla child
+window(s) of a target window and reads the full document via Scintilla's own
+message API (``SCI_GETLENGTH`` / ``SCI_GETTEXT``) across the process boundary,
+emitting it as a ``scintilla``-tagged (deterministic) node. It is naturo's moat
+on Scintilla editors, mirroring the CDP (web), JAB (Java) and COM (Excel)
+providers.
+
+Windows-only; degrades to an empty result on any failure (never raises into the
+cascade).
+"""
+from __future__ import annotations
+
+import ctypes
+import logging
+from ctypes import wintypes
+from typing import List, Optional
+
+from naturo.backends.base import ElementInfo
+
+logger = logging.getLogger(__name__)
+
+# Scintilla messages (Scintilla.h).
+_SCI_GETLENGTH = 2006
+_SCI_GETTEXT = 2182
+
+_SCINTILLA_CLASS = "Scintilla"
+#: Upper bound on bytes read from one editor (a giant file must not blow memory).
+_MAX_SCINTILLA_BYTES = 8 * 1024 * 1024
+
+# Win32 process/memory constants.
+_PROCESS_VM_OPERATION = 0x0008
+_PROCESS_VM_READ = 0x0010
+_PROCESS_VM_WRITE = 0x0020
+_MEM_COMMIT = 0x1000
+_MEM_RESERVE = 0x2000
+_MEM_RELEASE = 0x8000
+_PAGE_READWRITE = 0x04
+
+
+def _win32():
+    """Return (user32, kernel32) with the signatures this module needs, or None."""
+    try:
+        user32 = ctypes.WinDLL("user32", use_last_error=True)
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    except Exception:
+        return None
+
+    user32.SendMessageW.restype = ctypes.c_ssize_t
+    user32.SendMessageW.argtypes = [
+        wintypes.HWND, wintypes.UINT, ctypes.c_size_t, ctypes.c_ssize_t,
+    ]
+    kernel32.OpenProcess.restype = wintypes.HANDLE
+    kernel32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+    kernel32.VirtualAllocEx.restype = ctypes.c_void_p
+    kernel32.VirtualAllocEx.argtypes = [
+        wintypes.HANDLE, ctypes.c_void_p, ctypes.c_size_t,
+        wintypes.DWORD, wintypes.DWORD,
+    ]
+    kernel32.VirtualFreeEx.restype = wintypes.BOOL
+    kernel32.VirtualFreeEx.argtypes = [
+        wintypes.HANDLE, ctypes.c_void_p, ctypes.c_size_t, wintypes.DWORD,
+    ]
+    kernel32.ReadProcessMemory.restype = wintypes.BOOL
+    kernel32.ReadProcessMemory.argtypes = [
+        wintypes.HANDLE, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t,
+        ctypes.POINTER(ctypes.c_size_t),
+    ]
+    kernel32.CloseHandle.restype = wintypes.BOOL
+    kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+    return user32, kernel32
+
+
+def _find_scintilla_windows(hwnd: int) -> List[tuple]:
+    """Return ``[(sci_hwnd, (x, y, w, h)), …]`` — Scintilla children, biggest first."""
+    win = _win32()
+    if win is None or not hwnd:
+        return []
+    user32 = win[0]
+    found: List[tuple] = []
+    buf = ctypes.create_unicode_buffer(64)
+
+    @ctypes.WINFUNCTYPE(wintypes.BOOL, wintypes.HWND, wintypes.LPARAM)
+    def _cb(child, _lparam):
+        user32.GetClassNameW(child, buf, 64)
+        if buf.value == _SCINTILLA_CLASS:
+            r = wintypes.RECT()
+            user32.GetWindowRect(child, ctypes.byref(r))
+            found.append((child, (r.left, r.top, r.right - r.left, r.bottom - r.top)))
+        return True
+
+    try:
+        user32.EnumChildWindows(wintypes.HWND(hwnd), _cb, 0)
+    except Exception as exc:
+        logger.debug("Scintilla: EnumChildWindows failed: %s", exc)
+        return []
+    found.sort(key=lambda t: t[1][2] * t[1][3], reverse=True)
+    return found
+
+
+def _read_scintilla_text(sci_hwnd: int) -> Optional[str]:
+    """Read a Scintilla control's full document text across the process boundary.
+
+    Scintilla stores text as bytes (UTF-8 in Notepad++/most editors); SCI_GETTEXT
+    writes into a caller buffer, so cross-process we allocate that buffer inside
+    the target process (VirtualAllocEx) and read it back (ReadProcessMemory).
+    """
+    win = _win32()
+    if win is None:
+        return None
+    user32, kernel32 = win
+
+    length = int(user32.SendMessageW(sci_hwnd, _SCI_GETLENGTH, 0, 0))
+    if length <= 0:
+        return "" if length == 0 else None
+    if length > _MAX_SCINTILLA_BYTES:
+        length = _MAX_SCINTILLA_BYTES
+
+    pid = wintypes.DWORD()
+    user32.GetWindowThreadProcessId(sci_hwnd, ctypes.byref(pid))
+    if not pid.value:
+        return None
+
+    proc = kernel32.OpenProcess(
+        _PROCESS_VM_OPERATION | _PROCESS_VM_READ | _PROCESS_VM_WRITE,
+        False, pid.value,
+    )
+    if not proc:
+        logger.debug("Scintilla: OpenProcess failed for pid %s", pid.value)
+        return None
+
+    remote = None
+    try:
+        remote = kernel32.VirtualAllocEx(
+            proc, None, length + 1, _MEM_COMMIT | _MEM_RESERVE, _PAGE_READWRITE,
+        )
+        if not remote:
+            return None
+        # SCI_GETTEXT(wParam = bufferLength, lParam = buffer) -> copies text + NUL.
+        user32.SendMessageW(sci_hwnd, _SCI_GETTEXT, length + 1, remote)
+        local = ctypes.create_string_buffer(length + 1)
+        read = ctypes.c_size_t(0)
+        ok = kernel32.ReadProcessMemory(
+            proc, remote, local, length + 1, ctypes.byref(read),
+        )
+        if not ok:
+            logger.debug("Scintilla: ReadProcessMemory failed")
+            return None
+        raw = local.raw[:length]
+        return raw.decode("utf-8", errors="replace")
+    finally:
+        if remote:
+            kernel32.VirtualFreeEx(proc, remote, 0, _MEM_RELEASE)
+        kernel32.CloseHandle(proc)
+
+
+def is_scintilla_window(hwnd: int) -> bool:
+    """True if ``hwnd`` hosts at least one Scintilla editor control."""
+    return bool(_find_scintilla_windows(hwnd))
+
+
+def fetch_scintilla_content(hwnd: int) -> List[ElementInfo]:
+    """Return one ``scintilla``-tagged Document node per editor, carrying its text.
+
+    Empty list on any failure (no Scintilla, permission denied, etc.) — the
+    cascade treats it like an unavailable provider.
+    """
+    nodes: List[ElementInfo] = []
+    for i, (sci_hwnd, (x, y, w, h)) in enumerate(_find_scintilla_windows(hwnd)):
+        try:
+            text = _read_scintilla_text(sci_hwnd)
+        except Exception as exc:
+            logger.debug("Scintilla: read failed for hwnd %s: %s", sci_hwnd, exc)
+            continue
+        if not text:
+            continue
+        nodes.append(ElementInfo(
+            id=f"scintilla_{sci_hwnd}",
+            role="Document",
+            name="Scintilla editor" if i == 0 else f"Scintilla editor {i + 1}",
+            value=text,
+            x=x, y=y, width=max(0, w), height=max(0, h),
+            children=[],
+            properties={"source": "scintilla", "readable": True, "editable": True},
+        ))
+    return nodes

--- a/tests/test_scintilla.py
+++ b/tests/test_scintilla.py
@@ -1,0 +1,134 @@
+"""Tests for the Scintilla text provider (Notepad++/SciTE/IDE editors).
+
+The cross-process ctypes reads (SCI_GETLENGTH/SCI_GETTEXT via VirtualAllocEx)
+require a live Scintilla control, so these tests mock the two Win32-touching
+seams — ``_find_scintilla_windows`` and ``_read_scintilla_text`` — and exercise
+the pure node-building / cascade-graft logic (Linux-collectable in CI).
+"""
+from __future__ import annotations
+
+from naturo.backends.base import ElementInfo
+from naturo.cascade import _scintilla
+
+
+def test_fetch_builds_document_node(monkeypatch):
+    monkeypatch.setattr(
+        _scintilla, "_find_scintilla_windows", lambda h: [(123, (10, 20, 800, 600))]
+    )
+    monkeypatch.setattr(_scintilla, "_read_scintilla_text", lambda h: "hello\nworld")
+
+    nodes = _scintilla.fetch_scintilla_content(999)
+
+    assert len(nodes) == 1
+    node = nodes[0]
+    assert node.role == "Document"
+    assert node.name == "Scintilla editor"
+    assert node.value == "hello\nworld"
+    assert (node.x, node.y, node.width, node.height) == (10, 20, 800, 600)
+    assert node.properties["source"] == "scintilla"
+    assert node.properties["readable"] is True
+    assert node.properties["editable"] is True
+
+
+def test_fetch_names_multiple_editors(monkeypatch):
+    monkeypatch.setattr(
+        _scintilla,
+        "_find_scintilla_windows",
+        lambda h: [(1, (0, 0, 800, 600)), (2, (0, 0, 400, 300))],
+    )
+    monkeypatch.setattr(_scintilla, "_read_scintilla_text", lambda h: f"text-{h}")
+
+    nodes = _scintilla.fetch_scintilla_content(999)
+
+    assert [n.name for n in nodes] == ["Scintilla editor", "Scintilla editor 2"]
+    assert [n.value for n in nodes] == ["text-1", "text-2"]
+
+
+def test_fetch_empty_when_no_scintilla(monkeypatch):
+    monkeypatch.setattr(_scintilla, "_find_scintilla_windows", lambda h: [])
+    assert _scintilla.fetch_scintilla_content(999) == []
+
+
+def test_fetch_skips_empty_and_unreadable_text(monkeypatch):
+    monkeypatch.setattr(
+        _scintilla,
+        "_find_scintilla_windows",
+        lambda h: [(1, (0, 0, 10, 10)), (2, (0, 0, 10, 10))],
+    )
+    # First editor is empty (""), second unreadable (None) — both dropped.
+    reads = {1: "", 2: None}
+    monkeypatch.setattr(_scintilla, "_read_scintilla_text", lambda h: reads[h])
+    assert _scintilla.fetch_scintilla_content(999) == []
+
+
+def test_fetch_swallows_read_exceptions(monkeypatch):
+    def _boom(_h):
+        raise OSError("cross-process read failed")
+
+    monkeypatch.setattr(
+        _scintilla, "_find_scintilla_windows", lambda h: [(1, (0, 0, 10, 10))]
+    )
+    monkeypatch.setattr(_scintilla, "_read_scintilla_text", _boom)
+    assert _scintilla.fetch_scintilla_content(999) == []
+
+
+def test_is_scintilla_window(monkeypatch):
+    monkeypatch.setattr(
+        _scintilla, "_find_scintilla_windows", lambda h: [(1, (0, 0, 5, 5))]
+    )
+    assert _scintilla.is_scintilla_window(1) is True
+
+    monkeypatch.setattr(_scintilla, "_find_scintilla_windows", lambda h: [])
+    assert _scintilla.is_scintilla_window(1) is False
+
+
+# ── Cascade graft ──────────────────────────────────────────────────────────
+
+
+def _win(role, name, source=None, x=0, y=0, w=10, h=10, children=None):
+    props = {"source": source} if source else {}
+    return ElementInfo(
+        id=f"{role}-{name}", role=role, name=name, value=None,
+        x=x, y=y, width=w, height=h, children=children or [], properties=props,
+    )
+
+
+class _FakeBackend:
+    def __init__(self, tree):
+        self._tree = tree
+
+    def get_element_tree(self, backend="uia", **kwargs):
+        return self._tree if backend == "uia" else None
+
+
+def test_run_cascade_grafts_scintilla_onto_tree():
+    from unittest.mock import patch
+
+    from naturo import cascade as cascade_pkg
+    from naturo.cascade import _flatten, run_cascade
+
+    root = _win("Window", "new 1 - Notepad++", w=800, h=600,
+                children=[_win("Pane", "editor pane", w=800, h=560)])
+    backend = _FakeBackend(root)
+    doc = _win("Document", "Scintilla editor", source="scintilla",
+               x=0, y=0, w=800, h=560)
+    doc.value = "int main() {}"
+    doc.properties.update({"readable": True, "editable": True})
+
+    with patch.object(cascade_pkg, "_is_scintilla_window", lambda h: True), \
+         patch.object(cascade_pkg, "_fetch_scintilla_content", lambda h: [doc]), \
+         patch.object(cascade_pkg, "_is_excel_window", lambda h: False), \
+         patch.object(cascade_pkg, "_is_java_window", lambda h: False), \
+         patch.object(cascade_pkg, "find_cdp_port", lambda pid: None), \
+         patch.object(cascade_pkg, "_fetch_cdp_elements", lambda *a, **k: []):
+        result = run_cascade(backend, backend_name="auto", hwnd=999)
+
+    grafted = [
+        e for e in _flatten(result.tree)
+        if e.properties.get("source") == "scintilla"
+    ]
+    assert len(grafted) == 1, "Scintilla content was not grafted onto the fused tree"
+    assert grafted[0].value == "int main() {}"
+    assert any(
+        p.name == "scintilla" and p.status == "ok" for p in result.stats.providers
+    )


### PR DESCRIPTION
## What

Adds a **Scintilla text provider** to the cascade. Scintilla is the editing control behind Notepad++, SciTE, and many IDEs — and, like Excel's grid and Java/Swing before their providers, it is **opaque to UIA/MSAA**: `see --cascade` showed the editor *pane* but none of its text.

This provider finds the Scintilla child window(s) of the target and reads the full document across the process boundary via Scintilla's own message API (`SCI_GETLENGTH` / `SCI_GETTEXT` with `VirtualAllocEx` + `ReadProcessMemory`), grafting it as a deterministic `scintilla`-tagged `Document` node that carries the text plus `readable`/`editable` capability flags.

It mirrors the existing **CDP (web)**, **JAB (Java)** and **COM (Excel)** moat providers: additive, best-effort, and degrades to an empty result on any failure (never raises into the cascade).

## Why

This is a differentiating capability — pywinauto/UIA cannot read a Scintilla document at all. It closes the "Notepad++ shows toolbar but no body" gap.

## Verified live

On Notepad++, `see --cascade` now surfaces the editor body:

```
[Document] "Scintilla editor" (1328,879 1546x908) e72 [scintilla] [re]
  » Launched notepad (PID: 40628)
```

(`[re]` = readable + editable; `[scintilla]` = deterministic source tag.)

## Changes

- `naturo/cascade/_scintilla.py` — new provider (find windows + cross-process read + node build), bounded to 8 MB/editor.
- `naturo/cascade/_run.py` — graft Scintilla content in `run_cascade`, mirroring the COM/Excel block (tag `scintilla`, append to tree + merged elements, record a `ProviderStat`).
- `naturo/cascade/__init__.py` — export `_is_scintilla_window` / `_fetch_scintilla_content`.
- `tests/test_scintilla.py` — node-building, multi-editor naming, empty/unreadable/exception edge cases, and end-to-end cascade-graft coverage (mocks the two Win32 seams so it runs on Linux CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)