### PR TITLE
fix(get): read Scintilla content live on `get eN` instead of the stale snapshot

### DIFF
--- a/naturo/backends/windows/_element/_tree.py
+++ b/naturo/backends/windows/_element/_tree.py
@@ -377,6 +377,47 @@ class ElementTreeMixin:
             )
 
         return convert(result)
+    @staticmethod
+    def _read_scintilla_ref_live(elem) -> Optional[dict]:
+        """Live-read a Scintilla node's text, or ``None`` if not a Scintilla ref.
+
+        Scintilla nodes carry ``identifier == "scintilla_<child_hwnd>"`` (the id
+        the cascade provider assigned). We recover the HWND and read the current
+        document across the process boundary, so ``get eN`` reflects live edits
+        instead of the value snapshotted at ``see`` time. Returns ``None`` when
+        the ref is not a Scintilla node or the control can no longer be read
+        (caller then falls through to the normal path / snapshot fallback).
+        """
+        ident = getattr(elem, "identifier", None) or ""
+        if not ident.startswith("scintilla_"):
+            return None
+        try:
+            sci_hwnd = int(ident.split("_", 1)[1])
+        except (ValueError, IndexError):
+            return None
+        try:
+            from naturo.cascade._scintilla import _read_scintilla_text
+            text = _read_scintilla_text(sci_hwnd)
+        except Exception:
+            text = None
+        if text is None:  # control gone — let the caller degrade gracefully
+            return None
+        if "\r" in text:
+            text = text.replace("\r\n", "\n").replace("\r", "\n")
+        ex, ey, ew, eh = elem.frame
+        return {
+            "role": elem.role,
+            "name": elem.title or elem.label,
+            "value": text,
+            "pattern": "Scintilla",
+            "automation_id": None,
+            "x": ex,
+            "y": ey,
+            "width": ew,
+            "height": eh,
+            "source": "scintilla",
+        }
+
     def get_element_value(
         self,
         ref: Optional[str] = None,
@@ -425,6 +466,15 @@ class ElementTreeMixin:
             result = mgr.resolve_ref_element(ref)
             if result:
                 elem, _snap_id = result
+                # Scintilla nodes (Notepad++/SciTE) are synthetic — grafted by
+                # the cascade, with no live UIA element behind them. A normal ref
+                # lookup would fail the UIA probe and fall back to the value
+                # captured at ``see`` time, which goes stale the moment the user
+                # edits the document. Re-read the control live from the Scintilla
+                # child HWND embedded in the node's id (``scintilla_<hwnd>``).
+                _sci = self._read_scintilla_ref_live(elem)
+                if _sci is not None:
+                    return _sci
                 # Cache the element's own screen point as a disambiguation hint.
                 # A role+name lookup can match several elements (e.g. Windows
                 # Terminal exposes two "命令提示符" Text peers — a label and the

--- a/tests/test_scintilla.py
+++ b/tests/test_scintilla.py
@@ -132,3 +132,87 @@ def test_run_cascade_grafts_scintilla_onto_tree():
     assert any(
         p.name == "scintilla" and p.status == "ok" for p in result.stats.providers
     )
+
+
+# ── Live re-read on `get eN` (snapshot staleness fix) ────────────────────────
+
+
+def _element_tree_mixin():
+    """Import ElementTreeMixin, skipping if the Windows backend can't load here."""
+    import pytest
+
+    try:
+        from naturo.backends.windows._element._tree import ElementTreeMixin
+    except Exception:  # pragma: no cover - non-Windows CI without the DLL
+        pytest.skip("Windows element backend unavailable on this platform")
+    return ElementTreeMixin
+
+
+class _Elem:
+    """Minimal stand-in for a resolved snapshot UIElement."""
+
+    def __init__(self, identifier, role="Document", name="Scintilla editor",
+                 frame=(1, 2, 3, 4)):
+        self.identifier = identifier
+        self.role = role
+        self.title = name
+        self.label = name
+        self.frame = frame
+
+
+def test_get_ref_live_reads_scintilla_control(monkeypatch):
+    mixin = _element_tree_mixin()
+    from naturo.cascade import _scintilla
+
+    # A Scintilla ref must be read LIVE (not from the snapshot value), so an edit
+    # after `see` is reflected. CRLF is normalised to LF like other doc reads.
+    monkeypatch.setattr(_scintilla, "_read_scintilla_text", lambda h: "line1\r\nline2")
+
+    out = mixin._read_scintilla_ref_live(_Elem("scintilla_4242"))
+
+    assert out is not None
+    assert out["value"] == "line1\nline2"
+    assert out["pattern"] == "Scintilla"
+    assert out["source"] == "scintilla"
+    assert (out["x"], out["y"], out["width"], out["height"]) == (1, 2, 3, 4)
+
+
+def test_get_ref_live_reads_hwnd_from_identifier(monkeypatch):
+    mixin = _element_tree_mixin()
+    from naturo.cascade import _scintilla
+
+    seen = {}
+
+    def _read(h):
+        seen["hwnd"] = h
+        return "text"
+
+    monkeypatch.setattr(_scintilla, "_read_scintilla_text", _read)
+    mixin._read_scintilla_ref_live(_Elem("scintilla_8066078"))
+    assert seen["hwnd"] == 8066078
+
+
+def test_get_ref_live_ignores_non_scintilla():
+    mixin = _element_tree_mixin()
+    assert mixin._read_scintilla_ref_live(_Elem("txtSearch", role="Edit")) is None
+    assert mixin._read_scintilla_ref_live(_Elem(None)) is None
+
+
+def test_get_ref_live_empty_document_is_still_read(monkeypatch):
+    mixin = _element_tree_mixin()
+    from naturo.cascade import _scintilla
+
+    # "" is a valid (empty) document — distinct from None (unreadable control).
+    monkeypatch.setattr(_scintilla, "_read_scintilla_text", lambda h: "")
+    out = mixin._read_scintilla_ref_live(_Elem("scintilla_9"))
+    assert out is not None
+    assert out["value"] == ""
+
+
+def test_get_ref_live_none_when_control_gone(monkeypatch):
+    mixin = _element_tree_mixin()
+    from naturo.cascade import _scintilla
+
+    # None → control can't be read → fall through to the normal path.
+    monkeypatch.setattr(_scintilla, "_read_scintilla_text", lambda h: None)
+    assert mixin._read_scintilla_ref_live(_Elem("scintilla_9")) is None


### PR DESCRIPTION
## Bug

`naturo get eN` on a Scintilla editor node (Notepad++/SciTE) returned the text captured at **`see` time**, not the current document. After editing the file the value went stale:

```
$ naturo get e72
[Document] "Scintilla editor" e72
Value: Launched notepad (PID: 40628)      # one line — but the editor now holds nine
```

## Root cause

Scintilla nodes are **synthetic** — grafted by the cascade with no live UIA element behind them (that's the whole point of the provider; UIA can't see Scintilla text). So the ref lookup failed the UIA probe and fell back to the snapshot's stored value (the #229 "return snapshot metadata instead of ELEMENT_NOT_FOUND" fallback), which is frozen at `see` time.

## Fix

Recover the Scintilla child HWND from the node's id (`scintilla_<hwnd>`, preserved in the snapshot's `identifier` field) and re-read the document **live** via the provider's cross-process reader, short-circuiting before the doomed UIA lookup.

- Empty document (`""`) is read as-is.
- Only an unreadable control (`None` — editor closed) falls through to the normal path, so a gone window still degrades gracefully to the existing snapshot fallback.

## Verified live

On Notepad++, after `see`, appended text via `SCI_APPENDTEXT`, then:

```
$ naturo get e72
...
APPENDED-LIVE-EDIT-12345        # live edit reflected immediately
Pattern: Scintilla
```

`get` now returns full current content (all nine lines), and reflects edits made after `see`.

## Changes

- `naturo/backends/windows/_element/_tree.py` — `_read_scintilla_ref_live()` helper + short-circuit at the top of `get_element_value`'s ref-resolution path.
- `tests/test_scintilla.py` — live-read + CRLF normalisation, HWND-from-identifier parse, non-Scintilla passthrough, empty-document, and control-gone coverage.

Follow-up to #1286 (the Scintilla provider).

🤖 Generated with [Claude Code](https://claude.com/claude-code)