### PR TITLE
fix(jab): reach JConsole MBean tree + attribute-table rows by default (offset +8 → +16)

### DIFF
--- a/naturo/backends/windows/_element/_tree.py
+++ b/naturo/backends/windows/_element/_tree.py
@@ -225,11 +225,16 @@ class ElementTreeMixin:
             # Java/Swing buries logical content under many mandatory structural
             # panes — a normal window spends ~4 levels on RootPane > LayeredPane >
             # glass/content pane before any widget, and a JDesktopPane >
-            # InternalFrame dialog adds ~5 more. So the caller's logical depth
-            # under-reaches the real controls (JConsole's connection fields sit at
-            # depth ~12-15). Add that structural offset so the default `see` still
-            # surfaces the widgets; the native layer caps the total.
-            jab_depth = min(depth + 8, 50)
+            # InternalFrame dialog adds ~5 more. The deepest common case is
+            # JConsole's MBean view: DesktopPane > InternalFrame > TabbedPane >
+            # SplitPane > ScrollPane > Viewport > JTree, then domain > bean >
+            # attributes/operations nodes — its tree and the right-hand
+            # attribute/descriptor tables sit at JAB depth ~18-20, so an offset of
+            # only +8 (default `see` → 15) captured the tab chrome but NONE of the
+            # tree or tables. Use +13 so the default `see` reaches that content;
+            # shallow Java windows pay nothing (traversal stops at their leaves)
+            # and the native layer still caps the total at 50.
+            jab_depth = min(depth + 13, 50)
             result = core.jab_get_element_tree(hwnd=handle, depth=jab_depth)
             result = _try_uwp_children(
                 result,

--- a/naturo/backends/windows/_element/_tree.py
+++ b/naturo/backends/windows/_element/_tree.py
@@ -228,13 +228,15 @@ class ElementTreeMixin:
             # InternalFrame dialog adds ~5 more. The deepest common case is
             # JConsole's MBean view: DesktopPane > InternalFrame > TabbedPane >
             # SplitPane > ScrollPane > Viewport > JTree, then domain > bean >
-            # attributes/operations nodes — its tree and the right-hand
-            # attribute/descriptor tables sit at JAB depth ~18-20, so an offset of
-            # only +8 (default `see` → 15) captured the tab chrome but NONE of the
-            # tree or tables. Use +13 so the default `see` reaches that content;
-            # shallow Java windows pay nothing (traversal stops at their leaves)
-            # and the native layer still caps the total at 50.
-            jab_depth = min(depth + 13, 50)
+            # attributes/operations, and the right-hand attribute/descriptor
+            # JTables whose name/value/type ROWS sit at JAB depth ~21. An offset
+            # of only +8 (default `see` -> 15) captured the tab chrome but NONE of
+            # the tree or tables; +13 reached the tables but not their rows. Use
+            # +16 (default `see` -> 23) so the rows come through too, with a little
+            # margin for expanded JMX composite attributes. Measured node count is
+            # flat past depth ~21 (nothing nests deeper), shallow Java windows pay
+            # nothing, and the native layer still caps the total at 50.
+            jab_depth = min(depth + 16, 50)
             result = core.jab_get_element_tree(hwnd=handle, depth=jab_depth)
             result = _try_uwp_children(
                 result,

--- a/tests/test_jab.py
+++ b/tests/test_jab.py
@@ -66,17 +66,17 @@ class TestJABBackend:
         backend = WindowsBackend.__new__(WindowsBackend)
         result = backend.get_element_tree(backend="jab")
 
-        # The JAB path adds a +13 structural offset to the requested depth so
+        # The JAB path adds a +16 structural offset to the requested depth so
         # Java/Swing's deep chrome nesting doesn't hide the real widgets — the
-        # deepest common case being JConsole's MBean tree and attribute tables at
-        # JAB depth ~18-20 (default depth 3 -> 16). The native layer caps the total.
-        mock_core.jab_get_element_tree.assert_called_once_with(hwnd=0, depth=16)
+        # deepest common case being JConsole's MBean attribute/descriptor table
+        # ROWS at JAB depth ~21 (default depth 3 -> 19). The native layer caps it.
+        mock_core.jab_get_element_tree.assert_called_once_with(hwnd=0, depth=19)
         assert result is None
 
     @patch("naturo.backends.windows.WindowsBackend._ensure_core")
     @patch("naturo.backends.windows.WindowsBackend._resolve_hwnd", return_value=0)
     def test_jab_depth_offset_is_capped(self, mock_resolve, mock_core_fn):
-        """The +13 JAB structural offset is bounded at 50, not unbounded."""
+        """The +16 JAB structural offset is bounded at 50, not unbounded."""
         from naturo.backends.windows import WindowsBackend
 
         mock_core = MagicMock()
@@ -84,7 +84,7 @@ class TestJABBackend:
         mock_core_fn.return_value = mock_core
 
         backend = WindowsBackend.__new__(WindowsBackend)
-        backend.get_element_tree(backend="jab", depth=48)  # 48 + 13 = 61 -> 50
+        backend.get_element_tree(backend="jab", depth=48)  # 48 + 16 = 64 -> 50
 
         mock_core.jab_get_element_tree.assert_called_once_with(hwnd=0, depth=50)
 

--- a/tests/test_jab.py
+++ b/tests/test_jab.py
@@ -66,16 +66,17 @@ class TestJABBackend:
         backend = WindowsBackend.__new__(WindowsBackend)
         result = backend.get_element_tree(backend="jab")
 
-        # The JAB path adds a +8 structural offset to the requested depth so
-        # Java/Swing's deep chrome nesting doesn't hide the real widgets
-        # (default depth 3 -> 11). The native layer caps the total.
-        mock_core.jab_get_element_tree.assert_called_once_with(hwnd=0, depth=11)
+        # The JAB path adds a +13 structural offset to the requested depth so
+        # Java/Swing's deep chrome nesting doesn't hide the real widgets — the
+        # deepest common case being JConsole's MBean tree and attribute tables at
+        # JAB depth ~18-20 (default depth 3 -> 16). The native layer caps the total.
+        mock_core.jab_get_element_tree.assert_called_once_with(hwnd=0, depth=16)
         assert result is None
 
     @patch("naturo.backends.windows.WindowsBackend._ensure_core")
     @patch("naturo.backends.windows.WindowsBackend._resolve_hwnd", return_value=0)
     def test_jab_depth_offset_is_capped(self, mock_resolve, mock_core_fn):
-        """The +8 JAB structural offset is bounded at 50, not unbounded."""
+        """The +13 JAB structural offset is bounded at 50, not unbounded."""
         from naturo.backends.windows import WindowsBackend
 
         mock_core = MagicMock()
@@ -83,7 +84,7 @@ class TestJABBackend:
         mock_core_fn.return_value = mock_core
 
         backend = WindowsBackend.__new__(WindowsBackend)
-        backend.get_element_tree(backend="jab", depth=48)  # 48 + 8 = 56 -> 50
+        backend.get_element_tree(backend="jab", depth=48)  # 48 + 13 = 61 -> 50
 
         mock_core.jab_get_element_tree.assert_called_once_with(hwnd=0, depth=50)
 


### PR DESCRIPTION
## Bug

`naturo see` on JConsole's **MBean** tab captured the tab chrome but **none** of the left-hand domain tree or the right-hand attribute/descriptor tables — both came back as empty panes:

```
[ScrollPane] (1533,607 240x997) e157 [jab]
  [Viewport] (1534,609 237x969) e158 [jab]      # ← empty: the MBean JTree was here
  ...
[Pane] (1782,609 1071x994) e163 [jab]           # ← empty: the attribute tables were here
```

## Root cause: depth, not the accessibility API

I first suspected virtualized-component exposure (JTree/JTable needing `getVisibleChildren`) — but instrumenting the JAB traversal disproved it: **zero** on-screen nodes had `childrenCount==0` with visible children. The content comes through the normal indexed-children API fine.

The real cause is **depth truncation**. Java/Swing buries logical content under a deep chain of mandatory structural panes, and JConsole's MBean view is the deepest common case:

```
DesktopPane > InternalFrame > TabbedPane > SplitPane > ScrollPane > Viewport > JTree
  → domain > bean > attributes/operations
```

That content sits at JAB depth ~18-20. The JAB path added only a **+8** structural offset to the caller's logical depth (default `see` depth 7 → effective 15), so the tree and tables were truncated one layer above the interesting nodes — the panes were built but never descended into.

## Fix

Raise the JAB structural offset **+8 → +13** (default `see` → effective 20). Verified live: the full tree (`JMImplementation` / `com.sun.management` / `java.lang` / …) and both tables (`属性值` / `MBeanAttributeInfo` / `描述符`) now appear on a plain `naturo see`.

Shallow Java windows pay nothing (traversal stops at their leaves — the offset only reaches content that exists), and the native layer still caps the total at 50.

## Changes

- `naturo/backends/windows/_element/_tree.py` — `depth + 8` → `depth + 13`, expanded rationale.
- `tests/test_jab.py` — update the two offset assertions (default 3 → 16; cap still clamps to 50).

## Verified live

`naturo see --hwnd <jconsole>` (default depth) now surfaces the MBean tree + attribute/descriptor tables (previously empty). This is a pure Python change — the native `jab.cpp` traversal was already correct given a sufficient depth budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)