### PR TITLE
refactor(depth): make tree depth fully caller-driven (0 = unlimited, no hidden clamps)

### DIFF
--- a/core/include/naturo/exports.h
+++ b/core/include/naturo/exports.h
@@ -26,6 +26,20 @@
 extern "C" {
 #endif
 
+/* ── Tree traversal depth ─────────────────────────────
+ *
+ * Depth is caller-driven, not clamped to a magic content limit: a caller depth
+ * of <= 0 means "unlimited" (walk the whole accessibility tree), and any
+ * positive depth is honored as-is. NATURO_MAX_TREE_DEPTH is NOT a content
+ * limit — it is a pure stack-safety backstop for the recursive tree walkers.
+ * Real accessibility trees are well under ~30 levels deep (JConsole's MBean
+ * view, one of the deepest, bottoms out around 24), so this ~4x-headroom bound
+ * is only ever reached by a pathological or cyclic tree, where it prevents a
+ * thread-stack overflow. "Unlimited" resolves to this bound; a positive caller
+ * depth larger than it is also clamped here.
+ */
+#define NATURO_MAX_TREE_DEPTH 100
+
 /* ── Lifecycle ────────────────────────────────────── */
 
 /**

--- a/core/src/element.cpp
+++ b/core/src/element.cpp
@@ -412,9 +412,9 @@ NATURO_API int naturo_get_element_tree(uintptr_t hwnd, int depth,
     // Honor the caller's depth up to a generous bound (matches the CLI's
     // --depth max). The old cap of 10 silently ignored any larger --depth, so
     // deeply-nested UIA trees (Electron/WebView DOM-as-UIA, complex WPF/WinForms,
-    // UWP frames) were truncated with no signal.
-    if (depth < 1) depth = 1;
-    if (depth > 50) depth = 50;
+    // UWP frames) were truncated with no signal. depth <= 0 means "unlimited";
+    // NATURO_MAX_TREE_DEPTH is a stack-safety backstop, not a content limit.
+    if (depth <= 0 || depth > NATURO_MAX_TREE_DEPTH) depth = NATURO_MAX_TREE_DEPTH;
 
     HWND target = (HWND)hwnd;
     if (!target) {

--- a/core/src/ia2.cpp
+++ b/core/src/ia2.cpp
@@ -483,10 +483,9 @@ extern "C" {
 NATURO_API int naturo_ia2_get_element_tree(uintptr_t hwnd, int depth,
                                             char* result_json, int buf_size) {
     if (!result_json || buf_size <= 0) return -1;
-    // Honor the caller's depth up to a generous bound (matches JAB/UIA and the
-    // CLI's --depth max). The old cap of 10 silently ignored any larger --depth.
-    if (depth < 1) depth = 1;
-    if (depth > 50) depth = 50;
+    // Honor the caller's depth. depth <= 0 means "unlimited";
+    // NATURO_MAX_TREE_DEPTH is a stack-safety backstop, not a content limit.
+    if (depth <= 0 || depth > NATURO_MAX_TREE_DEPTH) depth = NATURO_MAX_TREE_DEPTH;
 
     HWND target = (HWND)hwnd;
     if (!target) {

--- a/core/src/jab.cpp
+++ b/core/src/jab.cpp
@@ -679,11 +679,11 @@ NATURO_API int naturo_jab_get_element_tree(uintptr_t hwnd, int depth,
 
     // Java/Swing wraps content in many structural panes (a JDesktopPane >
     // InternalFrame dialog nests RootPane > LayeredPane > content pane > … before
-    // any control), so the real widgets routinely sit 10-12 levels deep. A cap of
-    // 10 silently truncated every --depth above it and hid those controls; allow
-    // the caller's depth up to a generous bound (matches the CLI's --depth max).
-    if (depth < 1) depth = 1;
-    if (depth > 50) depth = 50;
+    // any control), so the real widgets routinely sit deep — JConsole's MBean
+    // tree/table rows reach ~24 levels. depth <= 0 means "unlimited" so the
+    // default `see` surfaces all of it without a per-backend offset;
+    // NATURO_MAX_TREE_DEPTH is a stack-safety backstop, not a content limit.
+    if (depth <= 0 || depth > NATURO_MAX_TREE_DEPTH) depth = NATURO_MAX_TREE_DEPTH;
 
     if (!jab_ensure_init()) return -6; // JAB not available
 

--- a/core/src/msaa.cpp
+++ b/core/src/msaa.cpp
@@ -311,10 +311,9 @@ extern "C" {
 NATURO_API int naturo_msaa_get_element_tree(uintptr_t hwnd, int depth,
                                              char* result_json, int buf_size) {
     if (!result_json || buf_size <= 0) return -1;
-    // Honor the caller's depth up to a generous bound (matches JAB/UIA and the
-    // CLI's --depth max). The old cap of 10 silently ignored any larger --depth.
-    if (depth < 1) depth = 1;
-    if (depth > 50) depth = 50;
+    // Honor the caller's depth. depth <= 0 means "unlimited";
+    // NATURO_MAX_TREE_DEPTH is a stack-safety backstop, not a content limit.
+    if (depth <= 0 || depth > NATURO_MAX_TREE_DEPTH) depth = NATURO_MAX_TREE_DEPTH;
 
     HWND target = (HWND)hwnd;
     if (!target) {

--- a/naturo/backends/windows/_element/_tree.py
+++ b/naturo/backends/windows/_element/_tree.py
@@ -129,7 +129,7 @@ class ElementTreeMixin:
         return False
     @heal_core_on_failure(retry=True)
     def get_element_tree(self, window_title: Optional[str] = None,
-                         depth: int = 3,
+                         depth: int = 0,
                          app: Optional[str] = None,
                          hwnd: Optional[int] = None,
                          pid: Optional[int] = None,
@@ -202,9 +202,11 @@ class ElementTreeMixin:
                         return child_result
 
                 # (#394) WinUI 3 apps may need deeper traversal.
-                # Retry child HWNDs with increased depth if original
-                # depth was low and yielded nothing.
-                if depth < 15:
+                # Retry child HWNDs with increased depth if the original depth was
+                # an explicit low value that yielded nothing. depth <= 0 already
+                # means unlimited (the first pass went as deep as possible), so
+                # there is nothing deeper to retry — skip it.
+                if 0 < depth < 15:
                     deeper = min(depth * 2, 20)
                     logger.debug(
                         "UWP fallback: retrying children with depth=%d "
@@ -222,15 +224,14 @@ class ElementTreeMixin:
             return current_result
 
         if backend == "jab":
-            # Java/Swing buries logical content under many mandatory structural
-            # panes — a normal window spends ~4 levels on RootPane > LayeredPane >
-            # glass/content pane before any widget, and a JDesktopPane >
-            # InternalFrame dialog adds ~5 more. So the caller's logical depth
-            # under-reaches the real controls (JConsole's connection fields sit at
-            # depth ~12-15). Add that structural offset so the default `see` still
-            # surfaces the widgets; the native layer caps the total.
-            jab_depth = min(depth + 8, 50)
-            result = core.jab_get_element_tree(hwnd=handle, depth=jab_depth)
+            # Depth is honored as-is, with no per-backend offset. Java/Swing does
+            # bury content under many structural panes (JConsole's MBean tree and
+            # attribute-table rows sit ~24 levels deep), but the fix for that is
+            # the unlimited default (depth <= 0 walks the whole tree) rather than a
+            # magic "+N" that every deeper control forces us to keep raising. A
+            # positive --depth therefore means raw tree levels here, consistent
+            # with UIA/MSAA/IA2; the native layer treats <= 0 as unlimited.
+            result = core.jab_get_element_tree(hwnd=handle, depth=depth)
             result = _try_uwp_children(
                 result,
                 lambda h, d: core.jab_get_element_tree(hwnd=h, depth=d),

--- a/naturo/cascade/_run.py
+++ b/naturo/cascade/_run.py
@@ -358,7 +358,7 @@ def run_cascade(
     window_title: Optional[str] = None,
     hwnd: Optional[int] = None,
     pid: Optional[int] = None,
-    depth: int = 3,
+    depth: int = 0,
     backend_name: str = "uia",
     coverage_target: float = 0.0,
     fill_gaps_ai: bool = False,
@@ -658,7 +658,10 @@ def run_cascade(
                 # Electron apps that don't open a debug port (e.g. Clash Verge) are
                 # still readable, structurally, with zero debug port.
                 _t0w = time.monotonic()
-                _web_nodes = _webview_uia_content(backend, hwnd, max(depth, 12))
+                # Webview DOM-as-UIA needs a deeper probe than the surrounding
+                # chrome; keep a floor of 12 unless the caller asked for unlimited.
+                _web_depth = depth if depth <= 0 else max(depth, 12)
+                _web_nodes = _webview_uia_content(backend, hwnd, _web_depth)
                 if _web_nodes:
                     _graft_web_under_control(root_tree, _web_nodes)
                     for _n in _web_nodes:

--- a/naturo/cli/core/_find.py
+++ b/naturo/cli/core/_find.py
@@ -55,7 +55,9 @@ def _detect_query_strategy(query: str) -> str | None:
               help="Find all elements (equivalent to query \"*\"). Safe from shell glob expansion.")
 @click.option("--role", help="Filter by element role (e.g., Button, Edit)")
 @click.option("--actionable", is_flag=True, help="Only show actionable elements")
-@click.option("--depth", "-d", type=int, default=20, help="Maximum tree depth (default 20; use lower values for performance)")
+@click.option("--depth", "-d", type=int, default=0,
+              help="Maximum tree depth (0 = unlimited, the default; "
+                   "pass a positive N to cap traversal at N levels for performance)")
 @click.option("--limit", type=int, default=50, help="Maximum number of results")
 @click.option("--ai", is_flag=True, help="Use AI vision to find element by natural language")
 @click.option("--image", "image_template", type=click.Path(), default=None,
@@ -344,9 +346,10 @@ def find_cmd(query: str | None, query_opt: str | None, find_all: bool, role: str
                       model=ai_model, api_key=ai_api_key)
         return
 
-    # Validate --depth range (find supports deeper traversal than see)
-    if depth < 1 or depth > 50:
-        msg = f"--depth must be between 1 and 50, got {depth}"
+    # Validate --depth: 0 = unlimited (default), positive caps traversal, only
+    # negative is invalid. No upper bound — the native layer bounds the total.
+    if depth < 0:
+        msg = f"--depth must be 0 (unlimited) or a positive number, got {depth}"
         if json_output:
             click.echo(_common._json_error_str("INVALID_INPUT", msg))
         else:

--- a/naturo/cli/core/_see.py
+++ b/naturo/cli/core/_see.py
@@ -23,7 +23,9 @@ from naturo.value_preview import bounded_value
     default="full",
     help="Analysis mode: full (all elements), interactive (clickable only), fast (quick scan)",
 )
-@click.option("--depth", "-d", type=int, default=7, help="Maximum tree depth (1-50)")
+@click.option("--depth", "-d", type=int, default=0,
+              help="Maximum tree depth (0 = unlimited, the default; "
+                   "pass a positive N to cap traversal at N levels)")
 @click.option("--path", "-p", help="Save screenshot to path")
 @click.option("--annotate", is_flag=True, help="Annotate screenshot with element labels")
 @click.option("--snapshot/--no-snapshot", "store_snapshot", default=True, help="Store result in snapshot (default: on)")
@@ -141,9 +143,11 @@ def see(app: str | None, window_title: str | None, hwnd: int | None, pid: int | 
         hwnd = entry.handle
         pid = entry.pid
 
-    # BUG-028: Validate --depth range (before platform check — input validation first)
-    if depth < 1 or depth > 50:
-        msg = f"--depth must be between 1 and 50, got {depth}"
+    # BUG-028: Validate --depth (before platform check — input validation first).
+    # 0 = unlimited (walk the whole tree); any positive value caps traversal.
+    # Negative is the only invalid input now — the native layer bounds the total.
+    if depth < 0:
+        msg = f"--depth must be 0 (unlimited) or a positive number, got {depth}"
         if json_output:
             click.echo(_common._json_error_str("INVALID_INPUT", msg))
         else:

--- a/naturo/mcp/_inspect.py
+++ b/naturo/mcp/_inspect.py
@@ -20,7 +20,7 @@ def register_inspect_tools(server, _get_backend, _safe_tool):
         app: Optional[str] = None,
         hwnd: Optional[int] = None,
         pid: Optional[int] = None,
-        depth: int = 7,
+        depth: int = 0,
         accessibility_backend: str = "uia",
         cascade: bool = False,
         format: str = "compact",
@@ -64,7 +64,8 @@ def register_inspect_tools(server, _get_backend, _safe_tool):
                 hwnd, enumerates ALL windows of the app and merges their trees.
             hwnd: Window handle (integer). Overrides app/window_title.
             pid: Process ID. Filters windows to this process only.
-            depth: How deep to traverse the tree (1-10).
+            depth: How deep to traverse the tree. 0 = unlimited (the default,
+                walks the whole tree); pass a positive N to cap at N levels.
             accessibility_backend: "uia" (default), "msaa" (for legacy apps like
                 MFC, VB6, Delphi), "ia2" (for Firefox, Thunderbird, LibreOffice),
                 "jab" (for Java/Swing/AWT), or "auto" (try UIA → IA2 → JAB → MSAA).
@@ -79,8 +80,8 @@ def register_inspect_tools(server, _get_backend, _safe_tool):
         Returns:
             Dict with the element tree structure.
         """
-        if depth < 1 or depth > 10:
-            return {"success": False, "error": {"code": "INVALID_INPUT", "message": f"depth must be between 1 and 10, got {depth}"}}
+        if depth < 0:
+            return {"success": False, "error": {"code": "INVALID_INPUT", "message": f"depth must be 0 (unlimited) or a positive number, got {depth}"}}
         if accessibility_backend not in ("uia", "msaa", "ia2", "jab", "auto"):
             return {"success": False, "error": {"code": "INVALID_INPUT", "message": f"accessibility_backend must be uia, msaa, ia2, jab, or auto, got {accessibility_backend}"}}
         backend = _get_backend()

--- a/tests/test_bug_round_full.py
+++ b/tests/test_bug_round_full.py
@@ -157,26 +157,32 @@ class TestBUG027MenuInspectExitCode:
 class TestBUG028DepthValidation:
     """BUG-028: see/find --depth should validate range 1-10."""
 
-    def test_see_depth_zero(self, runner):
+    # Depth is now caller-driven (#1289): 0 = unlimited (the default), any
+    # positive value is honored (native-bounded), and only a negative value is
+    # rejected — no 1-50 / 1-10 clamp that would defeat the parameter.
+
+    def test_see_depth_zero_is_valid(self, runner):
+        # 0 = unlimited must NOT be rejected as invalid input (it proceeds and
+        # then fails for lack of a window on headless CI).
         result = runner.invoke(main, ["see", "--depth", "0"])
-        assert result.exit_code != 0
-        assert "must be between 1 and 10" in result.output or "error" in result.output.lower()
+        assert "must be 0 (unlimited) or a positive number" not in (result.output or "")
 
     def test_see_depth_negative(self, runner):
         result = runner.invoke(main, ["see", "--depth", "-1"])
         assert result.exit_code != 0
 
-    def test_see_depth_zero_json(self, runner):
+    def test_see_depth_zero_json_not_invalid_input(self, runner):
         result = runner.invoke(main, ["see", "--depth", "0", "--json"])
-        assert result.exit_code != 0
         data = json.loads(result.output)
-        assert data["success"] is False
-        assert data["error"]["code"] == "INVALID_INPUT"
+        # 0 is valid — it must not surface as an INVALID_INPUT depth error.
+        assert not (
+            data.get("success") is False
+            and data.get("error", {}).get("code") == "INVALID_INPUT"
+        )
 
-    def test_find_depth_zero(self, runner):
+    def test_find_depth_zero_is_valid(self, runner):
         result = runner.invoke(main, ["find", "Save", "--depth", "0"])
-        assert result.exit_code != 0
-        assert "must be between 1 and 50" in result.output or "error" in result.output.lower()
+        assert "must be 0 (unlimited) or a positive number" not in (result.output or "")
 
     def test_find_depth_negative_json(self, runner):
         result = runner.invoke(main, ["find", "Save", "--depth", "-1", "--json"])
@@ -185,28 +191,22 @@ class TestBUG028DepthValidation:
         assert data["success"] is False
         assert data["error"]["code"] == "INVALID_INPUT"
 
-    def test_see_depth_11(self, runner):
-        """Depth 11 is now accepted (limit raised to 50 for VB6/ActiveX)."""
+    def test_see_depth_11_accepted(self, runner):
         result = runner.invoke(main, ["see", "--depth", "11"])
-        assert result.exit_code == 0 or "must be between" not in (result.output or "")
+        assert "must be 0 (unlimited) or a positive number" not in (result.output or "")
 
-    def test_see_depth_51_rejected(self, runner):
-        """Depth > 50 should be rejected."""
+    def test_see_depth_beyond_old_ceiling_accepted(self, runner):
+        # Depth > 50 is now honored (native-bounded), not rejected.
         result = runner.invoke(main, ["see", "--depth", "51"])
-        assert result.exit_code != 0
+        assert "must be 0 (unlimited) or a positive number" not in (result.output or "")
 
     def test_find_depth_20_accepted(self, runner):
-        """Issue #284: find should accept depth > 10 (default is 20)."""
-        # depth=20 should be accepted (not rejected as out-of-range)
         result = runner.invoke(main, ["find", "Save", "--depth", "20"])
-        # Should not fail with INVALID_INPUT for depth
-        assert "must be between" not in (result.output or "")
+        assert "must be 0 (unlimited) or a positive number" not in (result.output or "")
 
-    def test_find_depth_51_rejected(self, runner):
-        """Issue #284: find depth max is 50."""
+    def test_find_depth_beyond_old_ceiling_accepted(self, runner):
         result = runner.invoke(main, ["find", "Save", "--depth", "51"])
-        assert result.exit_code != 0
-        assert "must be between 1 and 50" in result.output or "error" in result.output.lower()
+        assert "must be 0 (unlimited) or a positive number" not in (result.output or "")
 
 
 class TestBUG032TypeWpmValidation:

--- a/tests/test_cli_see.py
+++ b/tests/test_cli_see.py
@@ -156,28 +156,32 @@ def _patch_assign_refs(ref_map=None):
 
 
 class TestDepthValidation:
+    # Depth is caller-driven: 0 = unlimited (the default), any positive value is
+    # honored (the native layer bounds the total), and only a negative value is
+    # rejected. See #1288 follow-up — the old 1-50 clamp/offset was removed.
 
-    def test_depth_too_low(self, runner):
+    def test_negative_depth_rejected(self, runner):
+        result = runner.invoke(see, ["--depth", "-1"], catch_exceptions=False)
+        assert result.exit_code == 1
+        assert "--depth must be 0 (unlimited) or a positive number" in result.output
+
+    def test_negative_depth_rejected_json(self, runner):
+        result = runner.invoke(see, ["--depth", "-1", "--json"], catch_exceptions=False)
+        assert result.exit_code == 1
+        data = json.loads(result.output)
+        assert data["error"]["code"] == "INVALID_INPUT"
+
+    def test_zero_depth_is_valid_unlimited(self, runner):
+        # 0 (unlimited) must pass validation — it should NOT raise INVALID_INPUT.
+        # It proceeds past validation (and then fails later without a real
+        # window/platform), so we only assert the validation error is absent.
         result = runner.invoke(see, ["--depth", "0"], catch_exceptions=False)
-        assert result.exit_code == 1
-        assert "--depth must be between 1 and 50" in result.output
+        assert "must be 0 (unlimited) or a positive number" not in result.output
 
-    def test_depth_too_high(self, runner):
-        result = runner.invoke(see, ["--depth", "51"], catch_exceptions=False)
-        assert result.exit_code == 1
-        assert "--depth must be between 1 and 50" in result.output
-
-    def test_depth_too_low_json(self, runner):
-        result = runner.invoke(see, ["--depth", "0", "--json"], catch_exceptions=False)
-        assert result.exit_code == 1
-        data = json.loads(result.output)
-        assert data["error"]["code"] == "INVALID_INPUT"
-
-    def test_depth_too_high_json(self, runner):
-        result = runner.invoke(see, ["--depth", "51", "--json"], catch_exceptions=False)
-        assert result.exit_code == 1
-        data = json.loads(result.output)
-        assert data["error"]["code"] == "INVALID_INPUT"
+    def test_large_depth_is_valid(self, runner):
+        # A depth beyond the old 50 ceiling is now accepted (native-bounded).
+        result = runner.invoke(see, ["--depth", "100"], catch_exceptions=False)
+        assert "must be 0 (unlimited) or a positive number" not in result.output
 
 
 # ── Platform check ─────────────────────────────────────────────────────

--- a/tests/test_find_selector_backend_depth_1169.py
+++ b/tests/test_find_selector_backend_depth_1169.py
@@ -112,4 +112,6 @@ class TestSelectorForwardsBackendAndDepth:
         backend = _backend_returning(_sample_tree())
         result = _invoke(runner, backend, ["--selector", "//Button", "--json"])
         assert result.exit_code == 0, result.output
-        assert backend.get_element_tree.call_args.kwargs["depth"] == 20
+        # CLI default is now 0 = unlimited (was 20); the selector path must
+        # forward it verbatim, not substitute its own hardcoded value (#1169).
+        assert backend.get_element_tree.call_args.kwargs["depth"] == 0

--- a/tests/test_jab.py
+++ b/tests/test_jab.py
@@ -66,16 +66,21 @@ class TestJABBackend:
         backend = WindowsBackend.__new__(WindowsBackend)
         result = backend.get_element_tree(backend="jab")
 
-        # The JAB path adds a +8 structural offset to the requested depth so
-        # Java/Swing's deep chrome nesting doesn't hide the real widgets
-        # (default depth 3 -> 11). The native layer caps the total.
-        mock_core.jab_get_element_tree.assert_called_once_with(hwnd=0, depth=11)
+        # Depth is passed through with no per-backend offset. The default is 0 =
+        # unlimited, so Java/Swing's deep structural nesting (JConsole's MBean
+        # tree/tables at ~24 levels) is reached by walking the whole tree rather
+        # than by a magic "+N". The native layer treats <= 0 as unlimited.
+        mock_core.jab_get_element_tree.assert_called_once_with(hwnd=0, depth=0)
         assert result is None
 
     @patch("naturo.backends.windows.WindowsBackend._ensure_core")
     @patch("naturo.backends.windows.WindowsBackend._resolve_hwnd", return_value=0)
-    def test_jab_depth_offset_is_capped(self, mock_resolve, mock_core_fn):
-        """The +8 JAB structural offset is bounded at 50, not unbounded."""
+    def test_jab_depth_is_passed_through_unmodified(self, mock_resolve, mock_core_fn):
+        """Depth reaches JAB verbatim — no offset, no Python-side clamp.
+
+        A positive depth is honored as raw tree levels (the native layer bounds
+        the total), and 0 propagates as the 'unlimited' sentinel.
+        """
         from naturo.backends.windows import WindowsBackend
 
         mock_core = MagicMock()
@@ -83,9 +88,13 @@ class TestJABBackend:
         mock_core_fn.return_value = mock_core
 
         backend = WindowsBackend.__new__(WindowsBackend)
-        backend.get_element_tree(backend="jab", depth=48)  # 48 + 8 = 56 -> 50
 
-        mock_core.jab_get_element_tree.assert_called_once_with(hwnd=0, depth=50)
+        backend.get_element_tree(backend="jab", depth=48)
+        mock_core.jab_get_element_tree.assert_called_once_with(hwnd=0, depth=48)
+
+        mock_core.jab_get_element_tree.reset_mock()
+        backend.get_element_tree(backend="jab", depth=0)  # 0 = unlimited
+        mock_core.jab_get_element_tree.assert_called_once_with(hwnd=0, depth=0)
 
     @patch("naturo.backends.windows.WindowsBackend._ensure_core")
     @patch("naturo.backends.windows.WindowsBackend._resolve_hwnd", return_value=0)

--- a/tests/test_mcp_inspect.py
+++ b/tests/test_mcp_inspect.py
@@ -269,7 +269,7 @@ class TestSeeUiTree:
         _call_tool(server, "see_ui_tree", {"window_title": "Notepad"})
         mock_backend.get_element_tree.assert_any_call(
             app=None, window_title="Notepad", hwnd=None, pid=None,
-            depth=7, backend="uia",
+            depth=0, backend="uia",
         )
 
     def test_custom_depth_and_backend(self, server, mock_backend):
@@ -283,14 +283,14 @@ class TestSeeUiTree:
         _call_tool(server, "see_ui_tree", {"hwnd": 12345})
         mock_backend.get_element_tree.assert_any_call(
             app=None, window_title=None, hwnd=12345, pid=None,
-            depth=7, backend="uia",
+            depth=0, backend="uia",
         )
 
     def test_with_pid(self, server, mock_backend):
         _call_tool(server, "see_ui_tree", {"pid": 9999})
         mock_backend.get_element_tree.assert_any_call(
             app=None, window_title=None, hwnd=None, pid=9999,
-            depth=7, backend="uia",
+            depth=0, backend="uia",
         )
 
     def test_long_value_bounded_by_default(self, server, mock_backend):
@@ -350,7 +350,7 @@ class TestSeeUiTree:
         assert data["success"] is True
         mock_backend._resolve_hwnds.assert_called_once_with(app="MyApp")
         mock_backend.get_element_tree.assert_any_call(
-            hwnd=100, depth=7, backend="uia",
+            hwnd=100, depth=0, backend="uia",
         )
 
     def test_app_with_multiple_windows_merges_trees(self, server, mock_backend):
@@ -384,20 +384,34 @@ class TestSeeUiTree:
         mock_backend._resolve_hwnds.assert_not_called()
         mock_backend.get_element_tree.assert_any_call(
             app="MyApp", window_title=None, hwnd=12345, pid=None,
-            depth=7, backend="uia",
+            depth=0, backend="uia",
         )
 
-    def test_depth_below_range_returns_error(self, server):
-        result = _call_tool(server, "see_ui_tree", {"depth": 0})
+    def test_negative_depth_returns_error(self, server):
+        # Only a negative depth is invalid now — 0 = unlimited, positive = honored.
+        result = _call_tool(server, "see_ui_tree", {"depth": -1})
         data = json.loads(result[0].text)
         assert data["success"] is False
         assert data["error"]["code"] == "INVALID_INPUT"
 
-    def test_depth_above_range_returns_error(self, server):
-        result = _call_tool(server, "see_ui_tree", {"depth": 11})
+    def test_zero_depth_is_valid_unlimited(self, server):
+        # 0 (unlimited, the default) must NOT be rejected as invalid input.
+        result = _call_tool(server, "see_ui_tree", {"depth": 0})
         data = json.loads(result[0].text)
-        assert data["success"] is False
-        assert data["error"]["code"] == "INVALID_INPUT"
+        assert not (
+            data.get("success") is False
+            and data.get("error", {}).get("code") == "INVALID_INPUT"
+        )
+
+    def test_large_depth_is_valid(self, server):
+        # A depth beyond the old 10 ceiling is accepted (native-bounded), so
+        # setting the parameter is never silently useless.
+        result = _call_tool(server, "see_ui_tree", {"depth": 40})
+        data = json.loads(result[0].text)
+        assert not (
+            data.get("success") is False
+            and data.get("error", {}).get("code") == "INVALID_INPUT"
+        )
 
     def test_invalid_backend_returns_error(self, server):
         result = _call_tool(server, "see_ui_tree", {"accessibility_backend": "invalid"})

--- a/tests/test_uwp_fallback.py
+++ b/tests/test_uwp_fallback.py
@@ -209,7 +209,10 @@ class TestUwpElementTreeFallback:
         child_empty = _make_element(role="Pane", name="", children=[])
         child_empty_deeper = _make_element(role="Pane", name="", children=[])
 
-        # 3 calls: AFH(depth=3), child@depth=3, child@depth=6 (deeper retry)
+        # 3 calls: AFH(depth=3), child@depth=3, child@depth=6 (deeper retry).
+        # Pin an explicit shallow depth — the default is now 0 = unlimited, which
+        # skips the deeper-retry (the first pass already went as deep as possible),
+        # and this test specifically exercises that retry path.
         backend._core.get_element_tree = MagicMock(
             side_effect=[empty_root, child_empty, child_empty_deeper],
         )
@@ -219,7 +222,7 @@ class TestUwpElementTreeFallback:
         with patch.object(type(backend), "_find_uwp_content_hwnd",
                           return_value=[200]):
             with patch("naturo.backends.windows.populate_hierarchy"):
-                result = backend.get_element_tree(app="calc", backend="uia")
+                result = backend.get_element_tree(app="calc", depth=3, backend="uia")
 
         # Should return original empty result (post-processed)
         assert result is not None


### PR DESCRIPTION
## Why

`see` / `find` on deeply-nested apps (JConsole's MBean tree + attribute/descriptor tables) came back truncated, and the fix had become a **creeping pile of magic numbers**:

- a per-backend JAB **`+N` offset** (raised +8 → +13 → +16 as each deeper control was discovered),
- a native **`50` cap** duplicated in four backends,
- CLI/MCP validation rejecting any depth outside **`1-50`** (MCP: **`1-10`**).

Past a point, **setting the `--depth` parameter did nothing** — it was silently clamped. That's the anti-pattern this PR removes.

## Root cause

Raw tree depth is a **backend-dependent proxy**. Java/Swing wraps content in ~15 structural panes (RootPane → LayeredPane → DesktopPane → InternalFrame → SplitPane → ScrollPane → Viewport → …) before any real control, so "logical depth 7" means something completely different under UIA vs JAB. The offset was compensating for that — and no fixed value ever gets it right (each deeper control forced another bump).

## The change

One rule: **depth is exactly what the caller asks, and `depth <= 0` means unlimited** (walk the whole tree).

- No offset, no per-backend fudge. A positive `--depth N` = N **raw** levels, consistent across UIA/MSAA/IA2/JAB.
- **Default is now unlimited**, so `see` / `find` surface everything — the full MBean tree, attribute/descriptor rows and all — with no magic. `--depth N` and `match=` remain the way to trim tokens.
- The only remaining bound is `NATURO_MAX_TREE_DEPTH` (100): a **pure stack-safety backstop** for the recursive walkers, ~4× the deepest real UI ever observed (~24). It never clips content — it only stops a pathological/cyclic tree from overflowing the thread stack.

## Verified live (JConsole, default `see`, no `--depth`)

```
[Tree] … JMImplementation / com.sun.management / java.lang …
[Table] "MBeanAttributeInfo"
  名称 → SpecificationName
  说明 → The full name of the JMX specification…
  可读 → true    类型 → java.lang.String
```

540 nodes at unlimited; `--depth 12` → 91 nodes; `--depth 5` → 34 — the parameter now genuinely controls traversal, with nothing overriding it.

## Changes

- `core/include/naturo/exports.h` — `NATURO_MAX_TREE_DEPTH` + rationale.
- `core/src/{element,ia2,jab,msaa}.cpp` — honor caller depth; `<= 0` = unlimited; drop the `50` cap.
- `backends/windows/_element/_tree.py` — drop the JAB `+16` offset (pass depth through); default `0`; skip the UWP deeper-retry when already unlimited.
- `cascade/_run.py` — `run_cascade` default `0`; webview probe honors unlimited.
- `cli/core/_see.py`, `cli/core/_find.py`, `mcp/_inspect.py` — default `0`, reject only negative depth, no upper bound; help/description updated.
- `tests/` — depth passed through verbatim; `0` = unlimited valid; large depth valid; only negative rejected.

Supersedes #1288 (which bumped the offset to +16 — this removes the offset entirely).

🤖 Generated with [Claude Code](https://claude.com/claude-code)