### PR TITLE
fix(ci): make the CI-Windows NaturoCore stub subclass the real core (part of #1274)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,12 @@ if _CI_WINDOWS:
                 allow_module_level=True,
             )
 
-    class _SkippingNaturoCore:
+    class _SkippingNaturoCore(_OrigNaturoCore):
+        # Must subclass the real core (like _SkippingWindowsBackend above): tests
+        # introspect the class itself — signature checks, `mock.patch.object`,
+        # `MagicMock(spec=NaturoCore)` — and a bare stub exposes none of the 34
+        # native methods, so those tests raise AttributeError instead of skipping.
+        # Overriding __init__ keeps the DLL unloaded, which is the actual guard.
         def __init__(self, *args, **kwargs):
             import threading
             if threading.current_thread() is not threading.main_thread():


### PR DESCRIPTION
## Problem

Now that #1273 landed (dropped `pytest -x`, honest exit code), the Windows suite runs to completion for the first time and reports the true failure set: **63 failed, 6636 passed**.

The single largest cause is a defect in `tests/conftest.py`. The CI-Windows guard replaces two constructors:

- `_SkippingWindowsBackend(_OrigWindowsBackend)` — **subclasses** the real backend ✅
- `_SkippingNaturoCore` — a **bare class**, subclasses nothing ❌

`NaturoCore` defines 34 class-level methods and loads the DLL in `__init__`. Tests that introspect the *class* — signature assertions, `mock.patch.object(NaturoCore, ...)`, `MagicMock(spec=NaturoCore)` — resolve against the bare stub, which exposes none of them, and raise `AttributeError` instead of skipping cleanly:

```
AttributeError: type object '_SkippingNaturoCore' has no attribute 'msaa_get_element_tree'
AttributeError: '_SkippingNaturoCore' object has no attribute 'phys_key_type'
```

## Fix

Make `_SkippingNaturoCore` subclass `_OrigNaturoCore`, exactly as `_SkippingWindowsBackend` already does. Overriding `__init__` still short-circuits before `self._load(...)`, so **no DLL is loaded and no desktop session is touched** — the actual purpose of the guard is preserved.

## Expected effect

Should clear the ~39 `AttributeError` failures across `test_phys_input` (13), `test_cli_phase2` (6), `test_ia2` (4), `test_get_cmd` (4), `test_msaa` (3), `test_input_keyboard` (3), `test_input_mouse` (2), `test_jab` (2), `test_security` (2).

The remaining ~24 are **separate, real** defects that this PR deliberately does not touch — they need their own issues (MCP tool-registry drift; and two genuine Never-Lie violations in `test_mcp_window_selector_contract_957` where `type_text`/`press_key` return success on an unresolvable `window_title`).

## Verification

This is a CI-Windows-only code path (`_CI_WINDOWS` is False elsewhere), so it **cannot be exercised on Linux/macOS**. Not marking auto-merge: the Windows job is still non-blocking (#1274), so it would merge green regardless. I will read the Windows job log on this PR and confirm the failure count drops from 63 to ~24 before merging.

Refs #1273 #1274

**[Orc-Mycelium]**