### PR TITLE
fix(ci): make dependabot target-branch=develop take effect (land on default branch main) (#1295)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,10 @@ version: 2
 updates:
   - package-ecosystem: "pip"
     directory: "/"
+    # All development happens on `develop`; `main` only receives releases.
+    # Without this, dependabot targets the default branch (main) and develop's
+    # pins silently age (see #1295).
+    target-branch: "develop"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -13,6 +17,8 @@ updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
+    # See note above (#1295): keep develop's CI action pins current.
+    target-branch: "develop"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
## Problem
Dependabot reads `.github/dependabot.yml` **only from the repository's default branch**, which is `main`. #1295 added `target-branch: develop` to the config on `develop` only — where dependabot never reads it. **The fix is inert.**

**Proof:** PR #1294 (`actions/setup-python` bump) was opened by dependabot on **2026-07-21, after** #1295 landed, and still targeted **`base: main`**. Develop's action/dep pins continue to silently age.

## Fix
Bring `main`'s `dependabot.yml` in line with `develop`'s: add `target-branch: "develop"` to both the `pip` and `github-actions` ecosystems. Once this is on the default branch, dependabot will open its PRs against `develop`.

## Notes
- Config-only change; no code/runtime impact. Safe for the release branch.
- Not auto-merged — `main` is release/Ace-gated. Verify: next Monday (2026-07-27) dependabot run opens PRs against `develop`, not `main`.
- Reopens the verification on #1295 (which was prematurely marked `status:done`).

**[Orc-Mycelium]**