### PR TITLE
fix(mcp): restore app_hide/app_unhide/hotkey/list_snapshots/get_snapshot dropped by develop MCP refactor (#1292)

### DIFF
--- a/naturo/mcp/_input.py
+++ b/naturo/mcp/_input.py
@@ -227,6 +227,27 @@ def register_input_tools(server, _get_backend, _safe_tool):
 
     @server.tool()
     @_safe_tool
+    def hotkey(keys: list[str], input_mode: str = "normal") -> dict:
+        """Press a keyboard shortcut (key combination).
+
+        Deprecated: prefer press_key with combo notation (e.g. press_key("ctrl+c")).
+        Kept for backward compatibility.
+
+        Args:
+            keys: List of keys to press simultaneously (e.g. ["ctrl", "s"] for Ctrl+S).
+            input_mode: Input method — "normal" (default) or "hardware" (Phys32 scan codes).
+
+        Returns:
+            Dict with success flag.
+        """
+        if not keys:
+            return {"success": False, "error": {"code": "INVALID_INPUT", "message": "keys list must not be empty"}}
+        backend = _get_backend()
+        backend.hotkey(*keys, input_mode=input_mode)
+        return {"success": True}
+
+    @server.tool()
+    @_safe_tool
     def scroll(
         direction: str = "down",
         amount: int = 3,

--- a/naturo/mcp/_snapshot.py
+++ b/naturo/mcp/_snapshot.py
@@ -1,0 +1,84 @@
+"""MCP tools for UI snapshot management."""
+from __future__ import annotations
+
+
+def register_snapshot_tools(server, _get_backend, _safe_tool):
+    """Register snapshot MCP tools."""
+
+    @server.tool()
+    @_safe_tool
+    def get_snapshot(snapshot_id: str) -> dict:
+        """Retrieve a previously created snapshot.
+
+        Args:
+            snapshot_id: The snapshot ID returned by a snapshot-creating tool.
+
+        Returns:
+            Dict with snapshot details including UI tree and screenshot path.
+        """
+        from naturo.models.snapshot import SnapshotNotFoundError
+        from naturo.snapshot import get_snapshot_manager
+
+        manager = get_snapshot_manager()
+        try:
+            snapshot = manager.get_snapshot(snapshot_id)
+        except SnapshotNotFoundError:
+            return {"success": False, "error": {"code": "SNAPSHOT_NOT_FOUND", "message": f"Snapshot '{snapshot_id}' not found"}}
+
+        response = {
+            "success": True,
+            "snapshot_id": snapshot.snapshot_id,
+            "last_update_time": snapshot.last_update_time.isoformat(),
+            "screenshot_path": snapshot.screenshot_path,
+            "window_title": snapshot.window_title,
+            "application_name": snapshot.application_name,
+        }
+
+        # Include element map summary
+        if snapshot.ui_map:
+            response["element_count"] = len(snapshot.ui_map)
+            response["elements"] = [
+                {
+                    "id": el.id,
+                    "role": el.role,
+                    "title": el.title,
+                    "frame": list(el.frame),
+                }
+                for el in snapshot.ui_map.values()
+            ]
+
+        return response
+
+    @server.tool()
+    @_safe_tool
+    def list_snapshots(limit: int = 10) -> dict:
+        """List recent snapshots.
+
+        Args:
+            limit: Maximum number of snapshots to return (default 10).
+
+        Returns:
+            Dict with list of snapshot summaries.
+        """
+        if limit < 1:
+            return {"success": False, "error": {"code": "INVALID_INPUT", "message": f"limit must be >= 1, got {limit}"}}
+
+        from naturo.snapshot import get_snapshot_manager
+        manager = get_snapshot_manager()
+        snapshots = manager.list_snapshots(limit=limit)
+
+        return {
+            "success": True,
+            "session": manager.session,
+            "snapshots": [
+                {
+                    "id": s.id,
+                    "created_at": s.created_at.isoformat(),
+                    "last_accessed_at": s.last_accessed_at.isoformat(),
+                    "size_bytes": s.size_in_bytes,
+                    "screenshot_count": s.screenshot_count,
+                    "application_name": s.application_name,
+                }
+                for s in snapshots
+            ],
+        }

--- a/naturo/mcp/_window.py
+++ b/naturo/mcp/_window.py
@@ -229,6 +229,60 @@ def register_window_tools(server, _get_backend, _safe_tool):
 
     @server.tool()
     @_safe_tool
+    def app_hide(name: str) -> dict:
+        """Hide (minimize) all windows of an application.
+
+        Args:
+            name: Application/process name (partial match).
+
+        Returns:
+            Dict with success flag and count of minimized windows.
+        """
+        backend = _get_backend()
+        windows = backend.list_windows()
+        name_lower = name.lower()
+        matched = [w for w in windows if name_lower in w.process_name.lower() or name_lower in w.title.lower()]
+        if not matched:
+            from naturo.errors import AppNotFoundError
+            raise AppNotFoundError(name)
+        count = 0
+        for w in matched:
+            try:
+                backend.minimize_window(hwnd=w.handle)
+                count += 1
+            except Exception as exc:
+                logger.debug("Failed to minimize window %s: %s", w.handle, exc)
+        return {"success": True, "action": "hide", "app": name, "windows_minimized": count}
+
+    @server.tool()
+    @_safe_tool
+    def app_unhide(name: str) -> dict:
+        """Unhide (restore) all windows of an application.
+
+        Args:
+            name: Application/process name (partial match).
+
+        Returns:
+            Dict with success flag and count of restored windows.
+        """
+        backend = _get_backend()
+        windows = backend.list_windows()
+        name_lower = name.lower()
+        matched = [w for w in windows if name_lower in w.process_name.lower() or name_lower in w.title.lower()]
+        if not matched:
+            from naturo.errors import AppNotFoundError
+            raise AppNotFoundError(name)
+        count = 0
+        for w in matched:
+            try:
+                backend.restore_window(hwnd=w.handle)
+                count += 1
+            except Exception as exc:
+                logger.debug("Failed to restore window %s: %s", w.handle, exc)
+        return {"success": True, "action": "unhide", "app": name, "windows_restored": count}
+
+    @server.tool()
+    @_safe_tool
     def app_switch(name: str) -> dict:
         """Switch to (focus) the most recent window of an application.
 

--- a/naturo/mcp_server.py
+++ b/naturo/mcp_server.py
@@ -28,6 +28,7 @@ from naturo.mcp._inspect import register_inspect_tools
 from naturo.mcp._input import register_input_tools
 from naturo.mcp._app import register_app_tools
 from naturo.mcp._wait import register_wait_tools
+from naturo.mcp._snapshot import register_snapshot_tools
 from naturo.mcp._clipboard import register_clipboard_tools
 from naturo.mcp._dialog import register_dialog_tools
 from naturo.mcp._system import register_system_tools
@@ -346,6 +347,7 @@ def create_server(host: str = "localhost", port: int = 3100) -> FastMCP:
     register_input_tools(server, _get_backend, _safe_tool)
     register_app_tools(server, _get_backend, _safe_tool, launch_app_fn=_launch_app)
     register_wait_tools(server, _get_backend, _safe_tool)
+    register_snapshot_tools(server, _get_backend, _safe_tool)
     register_clipboard_tools(server, _get_backend, _safe_tool)
     register_dialog_tools(server, _get_backend, _safe_tool)
     register_system_tools(server, _get_backend, _safe_tool)

--- a/packaging/mcpb/manifest.json
+++ b/packaging/mcpb/manifest.json
@@ -51,12 +51,20 @@
   "tools_generated": false,
   "tools": [
     {
+      "name": "app_hide",
+      "description": "Hide (minimize) all windows of an application."
+    },
+    {
       "name": "app_inspect",
       "description": "Probe an application to detect its UI framework and available interaction methods."
     },
     {
       "name": "app_switch",
       "description": "Switch to (focus) the most recent window of an application."
+    },
+    {
+      "name": "app_unhide",
+      "description": "Unhide (restore) all windows of an application."
     },
     {
       "name": "capture_screen",
@@ -135,20 +143,8 @@
       "description": "Write a value to a cell in an Excel workbook."
     },
     {
-      "name": "word_write",
-      "description": "Write text to a Word document programmatically (COM) — no UI needed."
-    },
-    {
-      "name": "word_read",
-      "description": "Read the full text of a Word document programmatically (COM)."
-    },
-    {
       "name": "expand_collapse_element",
       "description": "Expand or collapse a combo box or tree item via ExpandCollapsePattern."
-    },
-    {
-      "name": "read_web_text",
-      "description": "Read rendered text from a browser page via CDP — the static text that"
     },
     {
       "name": "find_element",
@@ -163,12 +159,16 @@
       "description": "Read the current value/text of a UI element."
     },
     {
-      "name": "launch_app",
-      "description": "Launch an application by name."
+      "name": "get_snapshot",
+      "description": "Retrieve a previously created snapshot."
     },
     {
-      "name": "office_dismiss_startup",
-      "description": "Get an Office app past its start screen into a ready, editable document."
+      "name": "hotkey",
+      "description": "Press a keyboard shortcut (key combination)."
+    },
+    {
+      "name": "launch_app",
+      "description": "Launch an application by name."
     },
     {
       "name": "launch_browser",
@@ -183,6 +183,10 @@
       "description": "List all connected monitors/displays."
     },
     {
+      "name": "list_snapshots",
+      "description": "List recent snapshots."
+    },
+    {
       "name": "list_windows",
       "description": "List all visible windows on the desktop."
     },
@@ -195,12 +199,20 @@
       "description": "Move the mouse cursor to a position."
     },
     {
+      "name": "office_dismiss_startup",
+      "description": "Get an Office app past its start screen into a ready, editable document."
+    },
+    {
       "name": "press_key",
       "description": "Press a key or key combination."
     },
     {
       "name": "quit_app",
       "description": "Quit an application."
+    },
+    {
+      "name": "read_web_text",
+      "description": "Read rendered text from a browser page via CDP — the static text that"
     },
     {
       "name": "scroll",
@@ -301,6 +313,14 @@
     {
       "name": "window_set_bounds",
       "description": "Set window position and size in one call."
+    },
+    {
+      "name": "word_read",
+      "description": "Read the full text of a Word document programmatically (COM)."
+    },
+    {
+      "name": "word_write",
+      "description": "Write text to a Word document programmatically (COM) — no UI needed."
     }
   ]
 }


### PR DESCRIPTION
## Problem
develop's MCP module refactor **dropped 5 MCP tool registrations** that shipped in v0.3.2 and still exist on `main`. Agents got `ToolError: Unknown tool: X`. This is a Pillar-B (agent-fit) regression and part of #1273's true Windows-failure set; it blocks flipping the Windows job to blocking (#1274).

Root cause (verified): `_snapshot.py` + these registrations existed at the develop/main fork point (2026-03-31) and remain on main/shipped v0.3.2; develop deleted them somewhere in its 965 post-fork commits. The 9 main-only commits are all chore/dependabot — none touch MCP.

## Fix
Re-register on develop's (differently-organized) MCP surface, mirroring main and adapting to develop's API:
- `app_hide`/`app_unhide` → `naturo/mcp/_window.py`
- `hotkey` → `naturo/mcp/_input.py`
- `get_snapshot`/`list_snapshots` → new `naturo/mcp/_snapshot.py` (`register_snapshot_tools`), wired into `create_server()`
- Regenerated `packaging/mcpb/manifest.json` (63→68 tools) via the same `scripts/build_mcpb.py` extractor the bundle build uses.

## Verification
- Targeted acceptance gate green: **215 passed, 1 skipped** (TestAppHide/Unhide, TestMcpListSnapshotsEndToEnd, hotkey guard, surface_guard_coverage_912, window_management, snapshot_list_limit).
- `ruff check naturo/` clean.
- 10 remaining `mcp/surface` failures confirmed **pre-existing** (fail identically on base `c477e7e` via stash-test) — unrelated to this change; no tests weakened/deleted.

Closes #1292.

**[Orc-Mycelium]**