### PR TITLE
test: pin UTF-8 for guardrails YAML + _run_naturo stdout (#1192, #1232)

### DIFF
--- a/tests/integration/test_unified_app_model.py
+++ b/tests/integration/test_unified_app_model.py
@@ -80,6 +80,7 @@ def _run_naturo(*args: str, timeout: int = 15) -> Dict[str, Any]:
         cmd,
         capture_output=True,
         text=True,
+        encoding="utf-8",
         timeout=timeout,
     )
     return json.loads(result.stdout)

--- a/tests/test_cost_guardrails.py
+++ b/tests/test_cost_guardrails.py
@@ -11,7 +11,7 @@ GUARDRAILS_PATH = Path(__file__).resolve().parent.parent / "agents" / "config" /
 @pytest.fixture(scope="module")
 def config():
     assert GUARDRAILS_PATH.exists(), f"Missing {GUARDRAILS_PATH}"
-    with open(GUARDRAILS_PATH) as fh:
+    with open(GUARDRAILS_PATH, encoding="utf-8") as fh:
         return yaml.safe_load(fh)
 
 


### PR DESCRIPTION
## Problem
Two tests decode bytes with the host's *locale* codec, so they raise `UnicodeDecodeError` on non-UTF-8 (GBK/cp936) CJK Windows runners:
- `tests/test_cost_guardrails.py:14` — `open()` with no `encoding=` (#1192)
- `tests/integration/test_unified_app_model.py:_run_naturo` — `subprocess.run(..., text=True)` with no `encoding=` (#1232)

## Fix
Pin `encoding="utf-8"` at both sites. naturo's CLI emits UTF-8 JSON and the YAML is UTF-8; the decode should not depend on the runner's locale. Part of the #1175 locale-hardening umbrella.

## Verification
- `pytest tests/test_cost_guardrails.py` → 11 passed
- `ruff check` → clean
- `_run_naturo` change is decode-only; no behavior change on UTF-8 hosts

Closes #1192, closes #1232.

**[Orc-Mycelium]**