### PR TITLE
test(mcp): realign #1293 contract/schema tests to intended design (no prod change)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **MCP contract/response-schema tests realigned to the intended design (no production change)** — a set of MCP tests had gone red against the *current, intended* MCP contract because they still encoded superseded pre-change behaviour; the production code was correct and is unchanged. Confirmed platform-independent (mock-based, no desktop). Realigned to the intended contracts: (a) `see_ui_tree` depth is fully caller-driven — `depth=0` means **unlimited** and there is **no upper clamp**, so `depth=0`/`depth=11` are valid and only a negative depth is an `INVALID_INPUT` validation error ([#1289](https://github.com/AcePeak/naturo/issues/1289)); (b) the **compact text (`tree_text`) is the default `see_ui_tree` response** and carries no `tree` key — the structured JSON `tree` is returned only with `format="json"`; the compact `see`→`eN`→`click` round-trip (the primary agent loop) resolves refs via the stored snapshot and is unchanged ([#1265](https://github.com/AcePeak/naturo/issues/1265)); (c) `find_element` forwards `hwnd` to the backend for uniform window targeting ([#1246](https://github.com/AcePeak/naturo/issues/1246)); (d) `type_text` follows the reliability ladder (writable ValuePattern → clipboard paste → keystroke, with `profile="human"` so `wpm` is honored), so keystroke injection runs only when the earlier rungs cannot apply ([#1219](https://github.com/AcePeak/naturo/issues/1219)/[#1239](https://github.com/AcePeak/naturo/issues/1239)). ([#1293](https://github.com/AcePeak/naturo/issues/1293))
+
 ## [0.3.2] - 2026-07-02
 
 ### Highlights

--- a/tests/test_mcp_click_ref.py
+++ b/tests/test_mcp_click_ref.py
@@ -76,8 +76,12 @@ class TestClickWithEnRef:
 
     def test_see_then_click_resolves_ref(self, server, mock_backend):
         """Core workflow: see_ui_tree → click(element_id=eN) succeeds."""
-        # Step 1: Call see_ui_tree to capture the element tree
-        see_result = _call_tool(server, "see_ui_tree", {})
+        # Step 1: Call see_ui_tree to capture the element tree. #1265 made the
+        # compact text (tree_text) the DEFAULT response; the structured JSON tree
+        # this test navigates now lives behind format="json". The compact-default
+        # see→click round-trip is covered by
+        # tests/test_mcp_inspect.py::test_compact_refs_stay_resolvable_for_click.
+        see_result = _call_tool(server, "see_ui_tree", {"format": "json"})
         see_data = json.loads(see_result[0].text)
         assert see_data["success"] is True
 
@@ -105,8 +109,9 @@ class TestClickWithEnRef:
                                x=0, y=0, width=800, height=50, children=[child])
         mock_backend.get_element_tree.return_value = parent
 
-        # Capture tree
-        see_result = _call_tool(server, "see_ui_tree", {})
+        # Capture tree (format="json" for structured child navigation; see note
+        # in test_see_then_click_resolves_ref re: #1265 compact default).
+        see_result = _call_tool(server, "see_ui_tree", {"format": "json"})
         see_data = json.loads(see_result[0].text)
         child_ref = see_data["tree"]["children"][0]["id"]
 
@@ -153,7 +158,7 @@ class TestClickWithEnRef:
 
     def test_click_right_button_with_ref(self, server, mock_backend):
         """Right-click using an eN ref."""
-        see_result = _call_tool(server, "see_ui_tree", {})
+        see_result = _call_tool(server, "see_ui_tree", {"format": "json"})
         see_data = json.loads(see_result[0].text)
         element_ref = see_data["tree"]["id"]
 
@@ -167,7 +172,7 @@ class TestClickWithEnRef:
 
     def test_click_double_with_ref(self, server, mock_backend):
         """Double-click using an eN ref."""
-        see_result = _call_tool(server, "see_ui_tree", {})
+        see_result = _call_tool(server, "see_ui_tree", {"format": "json"})
         see_data = json.loads(see_result[0].text)
         element_ref = see_data["tree"]["id"]
 

--- a/tests/test_mcp_error_contract.py
+++ b/tests/test_mcp_error_contract.py
@@ -105,7 +105,10 @@ def test_unified_cascade_tree_is_reachable_via_mcp(server):
 
 
 def test_invalid_input_has_full_contract(server):
-    err = _error_of(_call(server, "see_ui_tree", {"depth": 99}))
+    # #1289 made tree depth fully caller-driven (0 = unlimited, no upper clamp),
+    # so a large positive depth is now VALID; a negative depth is the remaining
+    # input-validation failure and must surface the full INVALID_INPUT contract.
+    err = _error_of(_call(server, "see_ui_tree", {"depth": -1}))
     assert err["code"] == ErrorCode.INVALID_INPUT
     assert err["category"] == "validation"
     _assert_full_contract(err)

--- a/tests/test_mcp_inspect.py
+++ b/tests/test_mcp_inspect.py
@@ -456,14 +456,16 @@ class TestFindElement:
         assert data["success"] is True
         assert data["element"]["role"] == "Button"
         assert data["element"]["name"] == "OK"
+        # #1246 added hwnd to find_element for uniform window targeting, so the
+        # MCP tool now forwards hwnd (None when unspecified) to the backend.
         mock_backend.find_element.assert_called_once_with(
-            selector="Button:OK", window_title=None,
+            selector="Button:OK", window_title=None, hwnd=None,
         )
 
     def test_with_window_title(self, server, mock_backend):
         _call_tool(server, "find_element", {"selector": "Edit:*search*", "window_title": "Firefox"})
         mock_backend.find_element.assert_called_once_with(
-            selector="Edit:*search*", window_title="Firefox",
+            selector="Edit:*search*", window_title="Firefox", hwnd=None,
         )
 
     def test_element_not_found(self, server, mock_backend):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -222,13 +222,28 @@ class TestToolFunctionsWithMockedBackend:
             mock_backend.click.assert_called_once()
 
     def test_type_text_valid(self, mock_backend):
-        """type_text with valid wpm."""
+        """type_text reaches the backend on the keystroke path with the given wpm.
+
+        #1219/#1239 introduced a reliability ladder — writable ValuePattern →
+        clipboard paste → keystroke — so keystroke injection (the rung this test
+        asserts) only runs when the earlier rungs cannot apply: the fixture
+        already returns no writable ValuePattern (set_focused_element_value=False),
+        and we make clipboard paste unavailable here. wpm/input_mode reach the
+        backend; profile="human" is also passed (#1239, so wpm is honored), so we
+        assert the relevant kwargs rather than an exact call. The full ladder is
+        covered in tests/test_mcp_input.py.
+        """
+        mock_backend.clipboard_set.side_effect = RuntimeError("no clipboard")
         with patch("naturo.mcp_server.get_backend", return_value=mock_backend):
             srv = create_server()
             result = self._call_tool(srv, "type_text", {"text": "hello", "wpm": 60})
             data = json.loads(result[0].text)
             assert data["success"] is True
-            mock_backend.type_text.assert_called_once_with(text="hello", wpm=60, input_mode="normal")
+            mock_backend.type_text.assert_called_once()
+            call_kwargs = mock_backend.type_text.call_args.kwargs
+            assert call_kwargs["text"] == "hello"
+            assert call_kwargs["wpm"] == 60
+            assert call_kwargs["input_mode"] == "normal"
 
     def test_type_text_invalid_wpm(self, mock_backend):
         """type_text with wpm=0 returns validation error."""
@@ -321,23 +336,28 @@ class TestToolFunctionsWithMockedBackend:
             assert data["success"] is False
             assert "duration" in data["error"]["message"]
 
-    def test_see_ui_tree_invalid_depth_zero(self, mock_backend):
-        """see_ui_tree with depth=0 returns validation error."""
+    def test_see_ui_tree_depth_zero_is_unlimited(self, mock_backend):
+        """#1289: depth=0 means unlimited (the default), not an invalid value —
+        it must be accepted, never rejected as INVALID_INPUT."""
         with patch("naturo.mcp_server.get_backend", return_value=mock_backend):
             srv = create_server()
             result = self._call_tool(srv, "see_ui_tree", {"depth": 0})
             data = json.loads(result[0].text)
+            # mock_backend.get_element_tree returns None → WINDOW_NOT_FOUND, which
+            # proves depth=0 passed validation (a rejected depth would short-circuit
+            # to INVALID_INPUT before ever reaching the backend).
             assert data["success"] is False
-            assert data["error"]["code"] == "INVALID_INPUT"
-            assert "depth" in data["error"]["message"]
+            assert data["error"]["code"] != "INVALID_INPUT"
 
-    def test_see_ui_tree_invalid_depth_eleven(self, mock_backend):
-        """see_ui_tree with depth=11 returns validation error."""
+    def test_see_ui_tree_large_depth_is_valid(self, mock_backend):
+        """#1289: depth has no upper clamp — a large positive depth is valid and
+        passed through verbatim (was rejected as >10 under the old 1-10 rule)."""
         with patch("naturo.mcp_server.get_backend", return_value=mock_backend):
             srv = create_server()
             result = self._call_tool(srv, "see_ui_tree", {"depth": 11})
             data = json.loads(result[0].text)
             assert data["success"] is False
+            assert data["error"]["code"] != "INVALID_INPUT"
 
     def test_see_ui_tree_no_window(self, mock_backend):
         """see_ui_tree returns WINDOW_NOT_FOUND when no matching window."""

--- a/tests/test_safe_input_guard.py
+++ b/tests/test_safe_input_guard.py
@@ -262,6 +262,12 @@ class TestMcpTypeGuard:
         from unittest.mock import MagicMock
 
         backend = MagicMock()
+        # #1219/#1239: type_text prefers ValuePattern → clipboard paste before the
+        # keystroke rung. Steer to keystroke (no writable ValuePattern, no paste)
+        # so backend.type_text is the delivery proof that the content was NOT
+        # blocked when NATURO_SAFE_INPUT is unset.
+        backend.set_focused_element_value.return_value = False
+        backend.clipboard_set.side_effect = RuntimeError("no clipboard")
         with self._server(backend):
             server = create_server()
             with mock.patch.dict("os.environ", {}, clear=True):


### PR DESCRIPTION
## Summary

The remaining Windows failures triaged in **#1293** (the last blocker set for **#1274**) were **stale tests, not regressions**. Each still encoded pre-change behaviour the codebase has intentionally moved past; the production code is correct and **unchanged**. All changes are mock-based and **platform-independent** — reproduced failing then passing on macOS (167 passed), so this does not need a real-Windows run to verify the fix itself.

## Re-triage (per-failure)

| # | Test(s) | Root cause | Resolution |
|---|---------|-----------|------------|
| A | `test_invalid_input_has_full_contract` | #1289 made depth caller-driven → `depth=99` is now **valid** (no upper clamp) | assert on `depth=-1` (the genuine invalid input) → `INVALID_INPUT` |
| B | `test_see_then_click_*` (`KeyError: 'tree'`) | #1265 made compact `tree_text` the **default** response; structured `tree` moved behind `format="json"` | pass `format="json"` where the test navigates the JSON tree |
| C | `TestFindElement::{test_found_element_returned,test_with_window_title}` | #1246/#1291 added `hwnd` to the `find_element` call path | assert `hwnd=None` in the forwarded call |
| D | `test_type_text_valid`, `test_allows_dangerous_when_disabled` | #1219/#1239 reliability ladder (ValuePattern → clipboard → keystroke) | steer to the keystroke rung, assert delivery kwargs |
| depth | `see_ui_tree_invalid_depth_{zero,eleven}` | #1289 redefined `depth=0` as unlimited / no clamp | renamed + assert 0 and large depths are **valid** |

Per GOAL's rule, tests were **realigned to the intended contract, not deleted**.

## Verification
- `pytest` on all five touched files: **167 passed** (macOS, Python 3.14).
- `ruff check` clean on touched files.
- No production/source files changed (test + CHANGELOG only).

## Note on #1274
This clears the last non-flake blocker set enumerated in #1293. The residual is the known **#1175** coarse-Windows-clock flake (`test_total_time_recorded`). Flipping the #1274 mask still requires a real-Windows run reporting 0 failures before dropping `continue-on-error` — cross-platform green here is necessary but not sufficient for the mask flip.

Refs #1293 #1274

**[Orc-Mycelium]**