### PR TITLE
fix(agent): perf_counter timing to fix #1175 Windows clock flake

### DIFF
--- a/naturo/agent.py
+++ b/naturo/agent.py
@@ -307,7 +307,7 @@ def run_agent(
 
     executor = ToolExecutor(backend)
     result = AgentResult(instruction=instruction)
-    start_time = time.monotonic()
+    start_time = time.perf_counter()
 
     if capture_dir is None:
         import tempfile
@@ -384,7 +384,7 @@ def run_agent(
         # Reached max steps
         result.error = f"Reached maximum steps ({max_steps}) without completion"
 
-    result.total_time = time.monotonic() - start_time
+    result.total_time = time.perf_counter() - start_time
     return result
 
 


### PR DESCRIPTION
## Problem
`test_total_time_recorded` (tests/test_agent.py:393) asserts `result.total_time > 0`. On Windows CI, `time.monotonic()` has ~15 ms resolution on older CPython, so a fast single-step `run_agent` reads the same tick at start and end → `total_time = 0.0` → `assert 0.0 > 0` fails. This is the residual #1175 flake and the **last engineering blocker of the #1274 Windows mask** (#1291/#1292/#1293 already landed via #1303/#1304/#1306).

## Fix
Switch `run_agent` timing (naturo/agent.py:310,387) from `time.monotonic()` to `time.perf_counter()` — the documented highest-resolution clock for measuring short durations (QueryPerformanceCounter on Windows, sub-µs), and monotonic on all platforms. No test weakened; the assertion stays `> 0`.

## Verification
- `pytest tests/test_agent.py` → 46 passed; `ruff check` clean (macOS).
- **Honest caveat:** the flake is Windows-clock-resolution-specific and does not reproduce on macOS/Linux (their monotonic clocks are already high-res), so fail→pass cannot be shown here. The fix is the standard, documented remedy for coarse-clock zero-duration reads.

Refs #1175, #1274

**[Orc-Mycelium]**