### PR TITLE
feat(set): write Scintilla editor content on `set eN` (Notepad++/SciTE)

### DIFF
--- a/naturo/backends/windows/_input/_uia_interact.py
+++ b/naturo/backends/windows/_input/_uia_interact.py
@@ -509,6 +509,23 @@ class UIAInteractMixin:
         Returns:
             True if SetValue succeeded, False otherwise.
         """
+        # Scintilla editors (Notepad++/SciTE) are synthetic cascade nodes with no
+        # live UIA element, carrying identifier "scintilla_<child_hwnd>". A normal
+        # SetValue would fail the UIA lookup, so write the document live via the
+        # provider's cross-process SCI_SETTEXT — the write-side mirror of the
+        # get eN live read. Returns False for a read-only editor (never a phantom
+        # success), letting the caller report SET_VALUE_FAILED.
+        if automation_id and automation_id.startswith("scintilla_"):
+            try:
+                sci_hwnd = int(automation_id.split("_", 1)[1])
+            except (ValueError, IndexError):
+                return False
+            from naturo.cascade._scintilla import set_scintilla_text
+            ok = set_scintilla_text(sci_hwnd, text)
+            if ok:
+                logger.info("SetValue: wrote Scintilla document (len=%d)", len(text))
+            return ok
+
         try:
             uia, mod = self._init_comtypes_uia()
         except (ImportError, Exception):

--- a/naturo/cascade/__init__.py
+++ b/naturo/cascade/__init__.py
@@ -70,6 +70,7 @@ from naturo.cascade._com_excel import (
 from naturo.cascade._scintilla import (
     fetch_scintilla_content as _fetch_scintilla_content,
     is_scintilla_window as _is_scintilla_window,
+    set_scintilla_text as _set_scintilla_text,
 )
 from naturo.cascade._ocr import fetch_ocr_elements as _fetch_ocr_elements
 from naturo.cascade._correctness import (
@@ -128,6 +129,7 @@ __all__ = [
     "_is_excel_window",
     "_fetch_scintilla_content",
     "_is_scintilla_window",
+    "_set_scintilla_text",
     "_fetch_ocr_elements",
     # Correctness / fusion tagging (M1 Unified Auto Element Tree)
     "DETERMINISTIC",

--- a/naturo/cascade/_scintilla.py
+++ b/naturo/cascade/_scintilla.py
@@ -26,6 +26,8 @@ logger = logging.getLogger(__name__)
 # Scintilla messages (Scintilla.h).
 _SCI_GETLENGTH = 2006
 _SCI_GETTEXT = 2182
+_SCI_SETTEXT = 2181  # replace the WHOLE document (lParam = zero-terminated bytes)
+_SCI_GETREADONLY = 2140
 
 _SCINTILLA_CLASS = "Scintilla"
 #: Upper bound on bytes read from one editor (a giant file must not blow memory).
@@ -66,6 +68,11 @@ def _win32():
     ]
     kernel32.ReadProcessMemory.restype = wintypes.BOOL
     kernel32.ReadProcessMemory.argtypes = [
+        wintypes.HANDLE, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t,
+        ctypes.POINTER(ctypes.c_size_t),
+    ]
+    kernel32.WriteProcessMemory.restype = wintypes.BOOL
+    kernel32.WriteProcessMemory.argtypes = [
         wintypes.HANDLE, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t,
         ctypes.POINTER(ctypes.c_size_t),
     ]
@@ -155,6 +162,90 @@ def _read_scintilla_text(sci_hwnd: int) -> Optional[str]:
         if remote:
             kernel32.VirtualFreeEx(proc, remote, 0, _MEM_RELEASE)
         kernel32.CloseHandle(proc)
+
+
+def _write_scintilla_text(sci_hwnd: int, text: str) -> bool:
+    """Replace a Scintilla control's whole document across the process boundary.
+
+    Mirror of :func:`_read_scintilla_text`: SCI_SETTEXT takes a zero-terminated
+    byte buffer whose pointer must live in the *target* process, so we encode the
+    text as UTF-8 (Scintilla stores bytes; the read path decodes UTF-8), allocate
+    the buffer in that process (VirtualAllocEx), copy the bytes in
+    (WriteProcessMemory), then send SCI_SETTEXT. Returns False on any failure —
+    including a read-only control, which must not silently look like success.
+    """
+    win = _win32()
+    if win is None:
+        return False
+    user32, kernel32 = win
+
+    # Refuse a read-only editor rather than reporting a phantom success.
+    if user32.SendMessageW(sci_hwnd, _SCI_GETREADONLY, 0, 0):
+        logger.debug("Scintilla: control is read-only, refusing write")
+        return False
+
+    payload = text.encode("utf-8") + b"\x00"  # SCI_SETTEXT wants a NUL terminator
+    if len(payload) - 1 > _MAX_SCINTILLA_BYTES:
+        logger.debug("Scintilla: write payload exceeds cap, refusing")
+        return False
+
+    pid = wintypes.DWORD()
+    user32.GetWindowThreadProcessId(sci_hwnd, ctypes.byref(pid))
+    if not pid.value:
+        return False
+
+    proc = kernel32.OpenProcess(
+        _PROCESS_VM_OPERATION | _PROCESS_VM_READ | _PROCESS_VM_WRITE,
+        False, pid.value,
+    )
+    if not proc:
+        logger.debug("Scintilla: OpenProcess failed for pid %s", pid.value)
+        return False
+
+    remote = None
+    try:
+        remote = kernel32.VirtualAllocEx(
+            proc, None, len(payload), _MEM_COMMIT | _MEM_RESERVE, _PAGE_READWRITE,
+        )
+        if not remote:
+            return False
+        written = ctypes.c_size_t(0)
+        ok = kernel32.WriteProcessMemory(
+            proc, remote, payload, len(payload), ctypes.byref(written),
+        )
+        if not ok:
+            logger.debug("Scintilla: WriteProcessMemory failed")
+            return False
+        # SCI_SETTEXT(<unused>, lParam = buffer) replaces the whole document.
+        user32.SendMessageW(sci_hwnd, _SCI_SETTEXT, 0, remote)
+        return True
+    finally:
+        if remote:
+            kernel32.VirtualFreeEx(proc, remote, 0, _MEM_RELEASE)
+        kernel32.CloseHandle(proc)
+
+
+def set_scintilla_text(hwnd: int, text: str) -> bool:
+    """Replace the document of the (biggest) Scintilla editor under ``hwnd``.
+
+    ``hwnd`` may be either the top-level window OR the Scintilla child handle
+    itself (as encoded in a ``scintilla_<hwnd>`` node id). Returns True only if
+    the write landed; False if there is no Scintilla control or it is read-only.
+    """
+    if not hwnd:
+        return False
+    # If hwnd is already a Scintilla control, write to it directly; otherwise
+    # find the biggest Scintilla child (same choice the reader/graft makes).
+    win = _win32()
+    if win is not None:
+        buf = ctypes.create_unicode_buffer(64)
+        win[0].GetClassNameW(wintypes.HWND(hwnd), buf, 64)
+        if buf.value == _SCINTILLA_CLASS:
+            return _write_scintilla_text(hwnd, text)
+    found = _find_scintilla_windows(hwnd)
+    if not found:
+        return False
+    return _write_scintilla_text(found[0][0], text)
 
 
 def is_scintilla_window(hwnd: int) -> bool:

--- a/tests/test_scintilla.py
+++ b/tests/test_scintilla.py
@@ -216,3 +216,114 @@ def test_get_ref_live_none_when_control_gone(monkeypatch):
     # None → control can't be read → fall through to the normal path.
     monkeypatch.setattr(_scintilla, "_read_scintilla_text", lambda h: None)
     assert mixin._read_scintilla_ref_live(_Elem("scintilla_9")) is None
+
+
+# ── Write side: set_scintilla_text routing + `set eN` short-circuit ───────────
+
+
+def test_set_scintilla_text_writes_to_scintilla_child(monkeypatch):
+    # hwnd is already a Scintilla control → write to it directly (no child search).
+    class _U:
+        def GetClassNameW(self, hwnd, buf, n):
+            buf.value = "Scintilla"
+            return 9
+
+    monkeypatch.setattr(_scintilla, "_win32", lambda: (_U(), object()))
+    calls = {}
+    monkeypatch.setattr(
+        _scintilla, "_write_scintilla_text",
+        lambda h, t: (calls.__setitem__("args", (h, t)), True)[1],
+    )
+    assert _scintilla.set_scintilla_text(4242, "new text") is True
+    assert calls["args"] == (4242, "new text")
+
+
+def test_set_scintilla_text_finds_child_when_given_parent(monkeypatch):
+    # hwnd is NOT a Scintilla control → find the biggest Scintilla child first.
+    class _U:
+        def GetClassNameW(self, hwnd, buf, n):
+            buf.value = "Notepad++"
+            return 9
+
+    monkeypatch.setattr(_scintilla, "_win32", lambda: (_U(), object()))
+    monkeypatch.setattr(
+        _scintilla, "_find_scintilla_windows", lambda h: [(777, (0, 0, 800, 600))]
+    )
+    seen = {}
+    monkeypatch.setattr(
+        _scintilla, "_write_scintilla_text",
+        lambda h, t: (seen.__setitem__("hwnd", h), True)[1],
+    )
+    assert _scintilla.set_scintilla_text(100, "x") is True
+    assert seen["hwnd"] == 777
+
+
+def test_set_scintilla_text_false_when_no_scintilla(monkeypatch):
+    class _U:
+        def GetClassNameW(self, hwnd, buf, n):
+            buf.value = "Notepad++"
+            return 9
+
+    monkeypatch.setattr(_scintilla, "_win32", lambda: (_U(), object()))
+    monkeypatch.setattr(_scintilla, "_find_scintilla_windows", lambda h: [])
+    assert _scintilla.set_scintilla_text(100, "x") is False
+
+
+def test_set_scintilla_text_false_for_zero_hwnd():
+    assert _scintilla.set_scintilla_text(0, "x") is False
+
+
+def test_write_refuses_readonly_control(monkeypatch):
+    # SCI_GETREADONLY -> 1 must abort the write (never a phantom success), and
+    # must NOT reach OpenProcess/WriteProcessMemory.
+    reached = {"open": False}
+
+    class _U:
+        def SendMessageW(self, hwnd, msg, w, l):
+            if msg == _scintilla._SCI_GETREADONLY:
+                return 1  # read-only
+            return 0
+
+    class _K:
+        def OpenProcess(self, *a):
+            reached["open"] = True
+            return 0
+
+    monkeypatch.setattr(_scintilla, "_win32", lambda: (_U(), _K()))
+    assert _scintilla._write_scintilla_text(555, "nope") is False
+    assert reached["open"] is False
+
+
+def test_set_element_value_routes_scintilla_identifier(monkeypatch):
+    # `set eN` on a Scintilla node passes automation_id="scintilla_<hwnd>" into
+    # set_element_value, which must short-circuit to the cross-process writer
+    # (parsing the child hwnd) instead of the doomed UIA path.
+    import pytest
+
+    try:
+        from naturo.backends.windows._input._uia_interact import UIAInteractMixin
+    except Exception:  # pragma: no cover - non-Windows CI without the DLL
+        pytest.skip("Windows interaction backend unavailable on this platform")
+
+    seen = {}
+    monkeypatch.setattr(
+        _scintilla, "set_scintilla_text",
+        lambda h, t: (seen.__setitem__("args", (h, t)), True)[1],
+    )
+    mixin = UIAInteractMixin.__new__(UIAInteractMixin)
+    ok = mixin.set_element_value(text="payload", automation_id="scintilla_8066078")
+    assert ok is True
+    assert seen["args"] == (8066078, "payload")
+
+
+def test_set_element_value_scintilla_bad_identifier(monkeypatch):
+    import pytest
+
+    try:
+        from naturo.backends.windows._input._uia_interact import UIAInteractMixin
+    except Exception:  # pragma: no cover
+        pytest.skip("Windows interaction backend unavailable on this platform")
+
+    # Malformed "scintilla_" id (no parseable hwnd) → False, no crash.
+    mixin = UIAInteractMixin.__new__(UIAInteractMixin)
+    assert mixin.set_element_value(text="x", automation_id="scintilla_notanint") is False


### PR DESCRIPTION
## What

Completes the **Scintilla read/write pair**. `see` / `get` could already read a Scintilla document (Notepad++/SciTE — the moat capability UIA can't reach), but `set eN` on that node failed: Scintilla nodes are synthetic cascade nodes with `identifier = "scintilla_<hwnd>"` and no live UIA element, so `ValuePattern.SetValue` never found a target.

Add a cross-process writer mirroring the reader: **SCI_SETTEXT** with the UTF-8 payload copied into the target process (`VirtualAllocEx` + `WriteProcessMemory`), replacing the whole document. `set_element_value` short-circuits when the `automation_id` is a `scintilla_<hwnd>` id — parsing the child hwnd and writing live — before the doomed UIA path. This is the write-side mirror of the `get eN` live read (#1287).

A read-only editor (`SCI_GETREADONLY`) is refused with `False`, never a phantom success, so the CLI reports `SET_VALUE_FAILED`.

## Verified live (Notepad++)

```
$ naturo set e72 "Hello from naturo set!
Line 2 written cross-process.
中文写入 ✓"
Set value on e72: 'Hello from naturo set!\nLine 2 written cross-process.\n中文写入 ✓'

$ naturo get e72
[Document] "Scintilla editor" e72
Value: Hello from naturo set!
Line 2 written cross-process.
中文写入 ✓
Pattern: Scintilla
```

Multi-line + CJK + emoji all land. A `SCI_SETREADONLY` editor correctly refuses the write and keeps its content.

## Changes

- `naturo/cascade/_scintilla.py` — `_write_scintilla_text` + `set_scintilla_text` (auto-detects whether the hwnd is the Scintilla child or a parent to search), `WriteProcessMemory` signature, and the correct `SCI_GETREADONLY` (2140) / `SCI_SETTEXT` (2181) message constants.
- `naturo/backends/windows/_input/_uia_interact.py` — Scintilla short-circuit in `set_element_value`, so **both** the CLI `set` and the MCP `set_element_value` tool route through it.
- `naturo/cascade/__init__.py` — export `_set_scintilla_text`.
- `tests/test_scintilla.py` — routing (child / parent / none / zero hwnd), read-only refusal (must not reach OpenProcess), and the `set_element_value` short-circuit (+ malformed-identifier guard).

Pure Python — no native/DLL change. Follows #1286 (provider) and #1287 (live `get`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)