### PR TITLE
fix(deps): revert #1312 — pin mcp back to <2.0 (not yet mcp-2.x compatible)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,12 @@ ai = [
     "openai>=1.0,<3.0",
 ]
 mcp = [
-    "mcp>=1.0,<3.0",
+    # Revert #1312's widening to <3.0: naturo's MCP server is built on mcp 1.x's
+    # `mcp.server.fastmcp.FastMCP` (subclassed as _SanitizingFastMCP) and is not yet
+    # mcp-2.x compatible, so 2.x must stay excluded. (CI resilience to a
+    # fastmcp-less mcp is handled separately by the importorskip guards already on
+    # develop.) Lift the cap only with a proper mcp-2.x FastMCP migration.
+    "mcp>=1.0,<2.0",
 ]
 cdp = [
     "websocket-client>=1.0,<2.0",


### PR DESCRIPTION
Reverts the widening from #1312 (`<2.0` → `<3.0`). naturo's MCP server subclasses mcp 1.x's `mcp.server.fastmcp.FastMCP` and doesn't work on mcp 2.x, so 2.x must stay excluded. CI resilience to a fastmcp-less 1.x is already handled by the `importorskip("mcp.server.fastmcp")` guards on develop (same fix landed on main via #1314). Lifting the cap needs a proper mcp-2.x migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)