### PR TITLE
fix(ci): install mcp in [dev] so the MCP tests run cross-platform (stop skipping)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,12 @@ dev = [
     # ``tomllib`` is stdlib only on Python 3.11+; tests read pyproject.toml on
     # 3.9/3.10 via the ``tomli`` backport (#910).
     "tomli>=2.0; python_version < '3.11'",
+    # The MCP tool tests (test_desktop/test_excel/test_jab/test_msaa + test_mcp_server)
+    # need the mcp package to actually RUN — otherwise they importorskip and are
+    # silently skipped. The cross-platform "Python Tests" CI jobs install only
+    # ``.[dev]`` (the Windows-DLL job adds ``mcp``), so without this the MCP server
+    # was untested on Ubuntu/macOS. Pull in the pinned mcp so the tests run everywhere.
+    "naturo[mcp]",
 ]
 ai = [
     "anthropic>=0.20,<2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,8 +60,11 @@ dev = [
     # need the mcp package to actually RUN — otherwise they importorskip and are
     # silently skipped. The cross-platform "Python Tests" CI jobs install only
     # ``.[dev]`` (the Windows-DLL job adds ``mcp``), so without this the MCP server
-    # was untested on Ubuntu/macOS. Pull in the pinned mcp so the tests run everywhere.
-    "naturo[mcp]",
+    # was untested on Ubuntu/macOS. Pull in the pinned mcp so the tests run.
+    # Gated to py>=3.10: EVERY mcp release requires Python >=3.10, so on 3.9 there is
+    # no installable mcp at all — the tests legitimately skip there (mcp genuinely
+    # unavailable), and 3.9 must not try to install it or the whole `.[dev]` fails.
+    "naturo[mcp]; python_version >= '3.10'",
 ]
 ai = [
     "anthropic>=0.20,<2.0",

--- a/tests/test_silent_failure_guard.py
+++ b/tests/test_silent_failure_guard.py
@@ -90,7 +90,15 @@ def test_backend_exception_reports_failure(tool, args, method):
     """When the backend op raises (even an unexpected error), the tool must
     return success:false — never swallow it into a success envelope."""
     backend = MagicMock()
-    backend.set_focused_element_value.return_value = False  # type_text → keystroke path
+    backend.set_focused_element_value.return_value = False  # type_text: fail the value-pattern rung
+    if tool == "type_text":
+        # type_text's delivery ladder is value-pattern → clipboard paste → keystroke
+        # (#1219). The value-pattern rung is failed above; also fail the clipboard rung
+        # (_paste_text sends backend.hotkey("ctrl","v")) so the op genuinely reaches the
+        # keystroke backend call whose RuntimeError this case asserts must surface —
+        # otherwise the clipboard rung "delivers" on the mock and honestly reports
+        # success (a real success via fallback, not a silent failure).
+        backend.hotkey.side_effect = RuntimeError("clipboard paste blocked")
     getattr(backend, method).side_effect = RuntimeError(f"{method} exploded")
     p1, p2 = _server_patches(backend)
     with p1, p2:


### PR DESCRIPTION
## Problem (the real "masking")
The cross-platform **Python Tests** CI jobs run `pip install -e ".[dev]"`. `[dev]` pulled no `mcp`, so `mcp.server.fastmcp` was unimportable on Ubuntu/macOS and the MCP tool tests (`test_desktop`/`test_excel`/`test_jab`/`test_msaa` + `test_mcp_server`) silently `importorskip`'d. Only the Windows-DLL job (which installs `.[dev,mcp,annotate,windows]`) actually ran them. → the MCP server was untested cross-platform.

## Fix
Add `naturo[mcp]` to the `[dev]` extra (DRY — reuses the `mcp>=1.0,<2.0` pin). Verified in a clean venv: `.[dev]` now resolves **mcp-1.29.0** (which has `mcp.server.fastmcp.FastMCP`), so the tests **run** instead of skipping.

Not a mask: mcp 1.x (→1.29.0) genuinely supports naturo's FastMCP server — this makes CI exercise it everywhere.

## Context
mcp **2.0** removed FastMCP from the SDK; real mcp-2.x support = migrating to the standalone `fastmcp` package (different API). Tracked as a separate backlog item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)