### PR TITLE
fix(find): close the find/selector CLI contract-bug cluster (#1198 #1201 #1169 #1195 #1189)

### DIFF
--- a/naturo/cli/core/_find.py
+++ b/naturo/cli/core/_find.py
@@ -302,6 +302,34 @@ def find_cmd(query: str | None, query_opt: str | None, find_all: bool, role: str
         )
         return
 
+    # (#1198 / #1201) Conflict-guard the text-query sources. The positional
+    # QUERY, --query/-q and --all each supply the text-search target, and they
+    # are mutually exclusive: silently letting one win (the old precedence —
+    # --all over a query, -q over the positional) returns a confidently-wrong
+    # result set under success:true (the silent-wrong class #1193 closed for the
+    # empty query). Reject more than one text source with the same INVALID_INPUT
+    # envelope the --image/--selector conflicts already use. (--role/--actionable
+    # legitimately combine with --all, and --all still means "every match" for
+    # the image/selector/ocr strategies dispatched above — this guard is only the
+    # default text path.)
+    _text_sources: list[str] = []
+    if query is not None:
+        _text_sources.append("positional QUERY")
+    if query_opt is not None:
+        _text_sources.append("--query/-q")
+    if find_all:
+        _text_sources.append("--all")
+    if len(_text_sources) > 1:
+        msg = (f"Multiple query sources supplied ({', '.join(_text_sources)}); "
+               "use exactly one. --all matches every element, while a positional "
+               "QUERY or --query/-q searches for that text — combining them is "
+               "ambiguous, so the query is not silently dropped.")
+        if json_output:
+            click.echo(_common._json_error_str("INVALID_INPUT", msg))
+        else:
+            click.echo(f"Error: {msg}", err=True)
+        raise SystemExit(1)
+
     # Resolve query: --all flag → wildcard, --query option → override positional
     if find_all:
         query = "*"
@@ -453,6 +481,13 @@ def find_cmd(query: str | None, query_opt: str | None, find_all: bool, role: str
                 _el_to_selector_dict(r.element), ancestors_dicts, app=_selector_app)
 
         if json_output:
+            # (#1195) Emit the SAME per-element schema the --image/--ocr/--selector
+            # strategies do: populate center_x/center_y (from bounds) and a
+            # non-null coordinate_frame. A live UIA find reports screen-absolute
+            # x,y — identical to the frame --image labels "screen" — so consumers
+            # of `find -j` read one stable schema regardless of resolving strategy
+            # instead of branching on it (computing the center / guessing the
+            # frame for UIA, reading the fields for --image).
             data = [
                 {
                     "ref": _element_id_to_ref.get(id(r.element), r.element.id),
@@ -464,6 +499,8 @@ def find_cmd(query: str | None, query_opt: str | None, find_all: bool, role: str
                     "y": r.element.y,
                     "width": r.element.width,
                     "height": r.element.height,
+                    "center_x": r.element.x + r.element.width // 2,
+                    "center_y": r.element.y + r.element.height // 2,
                     "selector": _build_result_selector(r),
                     "breadcrumb": r.breadcrumb_str,
                     "keyboard_shortcut": r.element.keyboard_shortcut,
@@ -475,6 +512,7 @@ def find_cmd(query: str | None, query_opt: str | None, find_all: bool, role: str
                 "elements": data,
                 "count": len(data),
                 "snapshot_id": snapshot_id,
+                "coordinate_frame": "screen",
             }, indent=2))
         else:
             if not results:
@@ -1220,12 +1258,20 @@ def _find_with_selector(
         parse, SelectorParseError, SelectorResolver, normalize_app_name,
     )
 
-    def _emit_error(code: str, message: str) -> None:
+    def _emit_error(code: str, message: str, *,
+                    suggested_action: str | None = None) -> None:
         if json_output:
-            click.echo(_common._json_error_str(code, message))
+            click.echo(_common._json_error_str(
+                code, message, suggested_action=suggested_action))
         else:
             click.echo(f"Error: {message}", err=True)
         raise SystemExit(1)
+
+    # (#1189) Remember whether the caller reached us via a *saved* @app/name ref
+    # or a *structural* path (app://… URI or //Role short-form): the two need
+    # different SELECTOR_NOT_FOUND recovery hints, and the @name is rewritten to
+    # its stored structural path just below, erasing the distinction.
+    _is_saved_ref = selector_str.startswith("@")
 
     # Dereference a saved @name selector to its stored path (#105), matching the
     # click family's behavior exactly.
@@ -1297,7 +1343,21 @@ def _find_with_selector(
         resolved = [result.element] if result is not None else []
 
     if not resolved:
-        _emit_error("SELECTOR_NOT_FOUND", f"Selector matched no elements: {selector_str}")
+        # (#1189) A structural path (app://… / //Role) matched no element: the
+        # actionable recovery is tree inspection, NOT the saved-selector registry
+        # (the caller never used a saved selector). Mirror ELEMENT_NOT_FOUND's
+        # guidance. A genuine saved @app/name ref keeps the saved-selector hint
+        # (the registry default) — its own entry point.
+        structural_hint = (
+            "Element not found. Use 'naturo see' to inspect the current UI tree, "
+            "verify the selector path (e.g. Role:Name against what 'see' shows), "
+            "or 'naturo wait --element' to wait for it to appear."
+        )
+        _emit_error(
+            "SELECTOR_NOT_FOUND",
+            f"Selector matched no elements: {selector_str}",
+            suggested_action=None if _is_saved_ref else structural_hint,
+        )
 
     from naturo.bridge import ElementInfo as BridgeElementInfo
     from naturo.snapshot import get_snapshot_manager
@@ -1360,6 +1420,10 @@ def _find_with_selector(
             "elements": data,
             "count": len(data),
             "snapshot_id": snapshot_id,
+            # (#1195) One element/envelope schema across strategies: the selector
+            # path resolves a live UIA tree, so its coordinates are screen-absolute
+            # — labelled identically to the text and --image strategies.
+            "coordinate_frame": "screen",
         }, indent=2))
     else:
         for child in children:

--- a/naturo/cli/interaction/_common.py
+++ b/naturo/cli/interaction/_common.py
@@ -498,25 +498,30 @@ def _resolve_wildcard_host_forest(
 ) -> Optional[list[dict]]:
     """Build a window-tree forest for an emitted wildcard-host selector (#1190).
 
-    A selector that ``see``/``find`` emit leads with a concrete
-    ``Window[@name="…"]`` segment under the portable wildcard host ``app://*``
-    (e.g. ``app://*/Window[@name="无标题 - Notepad"]/Document[@name="…"]``). For
-    that emitted selector to round-trip without an extra ``--hwnd``/``--app``
-    flag, the named window must be located across ALL top-level windows — not
-    just the foreground window ``get_element_tree`` returns when no target is
-    given (which is usually NOT the window the selector names, hence the
-    ``SELECTOR_NOT_FOUND`` reported in #1190).
+    The wildcard host ``app://*`` with no ``--hwnd``/``--app``/``--window``/
+    ``--pid`` scope means "any app" — a desktop-wide descendant search. Two
+    emitted / hand-written shapes reach here:
 
-    The leading ``Window`` title narrows the search via ``_resolve_hwnds`` so
-    only the matching window's tree is fetched. The function deliberately acts
-    ONLY on this concrete-leading-window shape: it returns ``None`` for any other
-    selector (a bare ``//Role`` short-form, a wildcard/empty leading title, a
-    non-wildcard host), leaving the caller's normal single-window resolution path
-    — and its existing behavior — entirely untouched.
+    * a concrete leading ``Window[@name="…"]`` (what ``see``/``find`` emit, e.g.
+      ``app://*/Window[@name="无标题 - Notepad"]/Document[@name="…"]``) — the
+      named window is located across ALL top-level windows via ``_resolve_hwnds``
+      so only the matching window's tree is fetched (#1190);
+    * a bare ``//Role`` short-form (``app://*/Document``, ``//Button``) — the
+      documented *"any app, descendant search"*: with no leading window title to
+      narrow on, EVERY top-level window is enumerated (via ``list_windows``) and
+      its tree added to the forest, so the role resolves against the whole
+      desktop instead of only the foreground window ``get_element_tree`` returns
+      when no target is given (the #1169 facet-2 no-op).
+
+    Without a wildcard host, or when any scope flag is supplied, the caller does
+    NOT invoke this helper (it resolves the single targeted window directly), so
+    this function only ever runs for the genuinely target-less wildcard host and
+    returns ``None`` when the shape does not apply or no window matched — leaving
+    the caller's normal single-window resolution path untouched.
 
     Args:
-        backend: Platform backend exposing ``_resolve_hwnds`` and
-            ``get_element_tree``.
+        backend: Platform backend exposing ``get_element_tree`` and, for the
+            titled-window shape, ``_resolve_hwnds`` / ``list_windows``.
         ast: Parsed selector AST.
         depth: Maximum tree depth to fetch per window.
         method: Accessibility backend to forward to ``get_element_tree``
@@ -524,22 +529,31 @@ def _resolve_wildcard_host_forest(
 
     Returns:
         A list of window element dicts (a forest the resolver can walk), or
-        ``None`` when this narrow shape does not apply or no window matched.
+        ``None`` when this shape does not apply or no window matched.
     """
     if ast.app != "*" or not ast.nodes:
         return None
-    leading = ast.nodes[0]
-    if leading.role.lower() != "window":
-        return None
-    title = leading.name
-    if not title or "*" in title or "?" in title:
-        return None
-    if not (hasattr(backend, "_resolve_hwnds")
-            and hasattr(backend, "get_element_tree")):
+    if not hasattr(backend, "get_element_tree"):
         return None
 
+    leading = ast.nodes[0]
+    title = leading.name if leading.role.lower() == "window" else None
+    concrete_title = bool(title and "*" not in title and "?" not in title)
+
     try:
-        hwnds = backend._resolve_hwnds(window_title=title)
+        if concrete_title:
+            # Titled-window shape: narrow to the window(s) whose title matches.
+            if not hasattr(backend, "_resolve_hwnds"):
+                return None
+            hwnds = list(backend._resolve_hwnds(window_title=title))
+        else:
+            # Bare //Role short-form (or wildcard/empty leading title): the
+            # documented desktop-wide "any app" search — enumerate every
+            # top-level window and let the resolver walk each tree.
+            if not hasattr(backend, "list_windows"):
+                return None
+            hwnds = [w.handle for w in backend.list_windows()
+                     if getattr(w, "handle", None)]
     except Exception:
         # A window-enumeration fault must not escape uncaught — fall through to
         # the caller's normal single-window path, which attributes its own tree
@@ -595,6 +609,11 @@ def _resolve_selector_target(
     from naturo.selector import (
         parse, SelectorParseError, SelectorResolver, normalize_app_name,
     )
+
+    # (#1189) Track saved-ref vs structural path before the @name is rewritten
+    # to its stored path, so a no-match hint can point a structural selector at
+    # tree inspection instead of the saved-selector registry it never used.
+    _is_saved_ref = selector_str.startswith("@")
 
     # Resolve @app/name references to stored selector strings (#105)
     if selector_str.startswith("@"):
@@ -673,10 +692,19 @@ def _resolve_selector_target(
     result = resolver.resolve(ast, tree_dict)
 
     if result is None:
+        # (#1189) Structural path (app://… / //Role) no-match → point at tree
+        # inspection, not the saved-selector registry; a real saved @app/name ref
+        # keeps the registry's saved-selector guidance.
+        structural_hint = (
+            "Element not found. Use 'naturo see' to inspect the current UI tree, "
+            "verify the selector path (e.g. Role:Name against what 'see' shows), "
+            "or 'naturo wait --element' to wait for it to appear."
+        )
         _json_err(
             f"Selector matched no elements: {selector_str}",
             json_output,
             code="SELECTOR_NOT_FOUND",
+            suggested_action=None if _is_saved_ref else structural_hint,
         )
         return None
 
@@ -966,7 +994,8 @@ def _json_ok(data: dict, json_output: bool) -> None:
 def _json_err(msg: str, json_output: bool, exit_code: int = 1,
               code: str = "ACTION_ERROR", *,
               exc: Optional[BaseException] = None,
-              context: Optional[dict] = None) -> NoReturn:
+              context: Optional[dict] = None,
+              suggested_action: Optional[str] = None) -> NoReturn:
     """Emit error result as JSON or plain text, then exit.
 
     Includes agent-friendly recovery hints from the error_helpers registry.
@@ -1002,7 +1031,8 @@ def _json_err(msg: str, json_output: bool, exit_code: int = 1,
                              exit_code=exit_code)
     if json_output:
         from naturo.cli.error_helpers import json_error
-        click.echo(json_error(code, msg, context=context))
+        click.echo(json_error(code, msg, context=context,
+                              suggested_action=suggested_action))
     else:
         click.echo(f"Error: {msg}", err=True)
     sys.exit(exit_code)

--- a/tests/test_find_contract_cluster.py
+++ b/tests/test_find_contract_cluster.py
@@ -1,0 +1,254 @@
+"""Regression tests for the `find` selector/query contract cluster.
+
+Covers five sibling contract bugs closed together:
+
+* **#1198** — ``find <query> --all`` silently discarded the positional query and
+  matched every element as ``success:true``. Now a positional/``-q`` query
+  combined with ``--all`` is a conflict → ``INVALID_INPUT`` (never a silent
+  match-all).
+* **#1201** — ``find <query> -q <other>`` silently dropped the positional query
+  (``-q`` won). Same guard: more than one text-query source → ``INVALID_INPUT``.
+* **#1169** — ``find --selector //Role`` short-form. A role-only structural
+  selector must match by role, and the wildcard-host "any app" search must
+  actually enumerate top-level windows instead of only the foreground one.
+* **#1195** — the ``find`` element schema diverged by strategy: UIA results
+  omitted ``center_x``/``center_y`` and reported ``coordinate_frame: null`` while
+  ``--image`` populated both. Now every strategy emits one schema.
+* **#1189** — ``SELECTOR_NOT_FOUND`` for a structural ``app://`` / ``//`` path
+  suggested the *saved-selector* registry. The hint is now context-aware and
+  points a structural selector at tree inspection (``see``).
+
+Hermetic: small UIA-shaped trees behind a mocked backend — no real desktop, so
+these run on headless CI.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+
+import pytest
+from click.testing import CliRunner
+from unittest.mock import MagicMock, patch
+
+from naturo.backends.base import WindowInfo
+from naturo.cli.core import find_cmd
+
+
+@dataclass
+class _FakeElement:
+    """Minimal stand-in for a backend ``ElementInfo`` node."""
+
+    role: str
+    name: str = ""
+    id: str = ""
+    value: str = ""
+    x: int = 0
+    y: int = 0
+    width: int = 0
+    height: int = 0
+    children: list = field(default_factory=list)
+    properties: dict = field(default_factory=dict)
+
+
+def _sample_tree() -> _FakeElement:
+    return _FakeElement(
+        role="Window", name="Untitled - Notepad", width=800, height=600,
+        children=[
+            _FakeElement(role="Document", name="Text Editor",
+                         x=10, y=40, width=780, height=520),
+            _FakeElement(role="Button", name="Save",
+                         x=700, y=8, width=60, height=24),
+        ],
+    )
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _invoke(runner, backend, args):
+    with patch("naturo.cli.core._common._platform_supports_gui", return_value=True), \
+         patch("naturo.cli.core._common._get_backend", return_value=backend):
+        return runner.invoke(find_cmd, args)
+
+
+def _backend_returning(tree) -> MagicMock:
+    backend = MagicMock()
+    backend.get_element_tree.return_value = tree
+    return backend
+
+
+# ── #1198 / #1201 — text-query-source conflict guard ──────────────────────────
+
+
+class TestTextQuerySourceConflict:
+    """More than one text-query source must ERROR, never silently pick one."""
+
+    @pytest.mark.parametrize("args", [
+        pytest.param(["Save", "--all", "--json"], id="positional+--all (#1198)"),
+        pytest.param(["Save", "-q", "Edit", "--json"], id="positional+-q (#1201)"),
+        pytest.param(["-q", "Edit", "--all", "--json"], id="-q+--all (#1201)"),
+        pytest.param(["zzNoSuch", "--all", "--json"], id="no-match query+--all"),
+    ])
+    def test_conflict_errors_invalid_input(self, runner, args):
+        backend = _backend_returning(_sample_tree())
+        result = _invoke(runner, backend, args)
+        assert result.exit_code != 0, result.output
+        data = json.loads(result.output)
+        assert data["success"] is False
+        assert data["error"]["code"] == "INVALID_INPUT", data
+        # The query must NOT have been silently dropped into a match-all dump.
+        backend.get_element_tree.assert_not_called()
+
+    def test_query_plus_all_does_not_match_all(self, runner):
+        """The #1198 footgun: <query> --all must not return every element."""
+        backend = _backend_returning(_sample_tree())
+        result = _invoke(runner, backend, ["zzNoSuchElementzz", "--all", "--json"])
+        data = json.loads(result.output)
+        # Old (wrong) behavior: success:true with count == all elements. Now: error.
+        assert data["success"] is False, data
+
+    @pytest.mark.parametrize("args", [
+        pytest.param(["--all", "--json"], id="--all alone"),
+        pytest.param(["Save", "--json"], id="positional alone"),
+        pytest.param(["-q", "Save", "--json"], id="-q alone"),
+        pytest.param(["--all", "--role", "Button", "--json"], id="--all+--role"),
+    ])
+    def test_single_source_still_works(self, runner, args):
+        """One text source (or --all + a filter) must remain valid."""
+        backend = _backend_returning(_sample_tree())
+        result = _invoke(runner, backend, args)
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["success"] is True, data
+
+
+# ── #1195 — one element/envelope schema across strategies ─────────────────────
+
+
+class TestSchemaParity:
+    """UIA find results must carry center_x/center_y and a non-null frame."""
+
+    def test_uia_find_populates_center_and_frame(self, runner):
+        backend = _backend_returning(_sample_tree())
+        result = _invoke(runner, backend,
+                         ["--all", "--role", "Button", "--json"])
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        # Top-level coordinate_frame is populated (was null for UIA).
+        assert payload["coordinate_frame"] == "screen", payload
+        el = payload["elements"][0]
+        # center_x/center_y present (were absent for UIA) and computed from bounds.
+        assert "center_x" in el and "center_y" in el, el
+        assert el["center_x"] == el["x"] + el["width"] // 2
+        assert el["center_y"] == el["y"] + el["height"] // 2
+
+    def test_selector_find_populates_center_and_frame(self, runner):
+        backend = _backend_returning(_sample_tree())
+        result = _invoke(runner, backend, ["--selector", "//Button", "--json"])
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["coordinate_frame"] == "screen", payload
+        el = payload["elements"][0]
+        assert "center_x" in el and "center_y" in el, el
+
+
+# ── #1169 — role-only short-form + desktop-wide "any app" search ──────────────
+
+
+class TestShortFormRoleOnly:
+    """A role-only //Role short-form must resolve like role:Role / app://app/Role."""
+
+    def test_role_only_shortform_matches_scoped(self, runner):
+        backend = _backend_returning(_sample_tree())
+        result = _invoke(runner, backend,
+                         ["--selector", "//Document", "--hwnd", "398624", "--json"])
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["success"] is True and payload["count"] == 1, payload
+        assert payload["elements"][0]["role"] == "Document", payload
+
+
+DOC_HWND = 111
+OTHER_HWND = 222
+
+
+class TestShortFormDesktopWide:
+    """A bare //Role with NO scope must search across ALL top-level windows."""
+
+    @pytest.fixture
+    def desktop_backend(self):
+        """Two windows; the target Document lives only in the non-foreground one."""
+        doc_tree = _FakeElement(
+            role="Window", name="Doc Window", width=800, height=600,
+            children=[_FakeElement(role="Document", name="Body",
+                                   x=10, y=40, width=780, height=520)],
+        )
+        other_tree = _FakeElement(
+            role="Window", name="Other", width=400, height=300,
+            children=[_FakeElement(role="Button", name="OK")],
+        )
+
+        def _get_tree(*args, **kwargs):
+            hwnd = kwargs.get("hwnd")
+            if hwnd == DOC_HWND:
+                return doc_tree
+            # Foreground / no-hwnd path returns the window WITHOUT the Document,
+            # so a pass proves the across-windows enumeration is what resolves it.
+            return other_tree
+
+        be = MagicMock()
+        be.get_element_tree.side_effect = _get_tree
+        be.list_windows.return_value = [
+            WindowInfo(handle=OTHER_HWND, title="Other", process_name="other.exe",
+                       pid=2, x=0, y=0, width=400, height=300,
+                       is_visible=True, is_minimized=False),
+            WindowInfo(handle=DOC_HWND, title="Doc Window", process_name="app.exe",
+                       pid=1, x=0, y=0, width=800, height=600,
+                       is_visible=True, is_minimized=False),
+        ]
+        return be
+
+    def test_bare_shortform_searches_all_windows(self, runner, desktop_backend):
+        result = _invoke(runner, desktop_backend,
+                         ["--selector", "//Document", "--json"])
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["success"] is True and payload["count"] >= 1, payload
+        assert payload["elements"][0]["role"] == "Document", payload
+        # The desktop-wide path must actually enumerate windows (not a no-op).
+        desktop_backend.list_windows.assert_called()
+
+    def test_bare_shortform_no_match_is_honest(self, runner, desktop_backend):
+        """A role present in no window still fails honestly (no false match)."""
+        result = _invoke(runner, desktop_backend,
+                         ["--selector", "//Slider", "--json"])
+        assert result.exit_code != 0, result.output
+        payload = json.loads(result.output)
+        assert payload["success"] is False
+        assert payload["error"]["code"] == "SELECTOR_NOT_FOUND", payload
+
+
+# ── #1189 — context-aware SELECTOR_NOT_FOUND recovery hint ────────────────────
+
+
+class TestSelectorNotFoundHint:
+    """A structural no-match must not point at the saved-selector registry."""
+
+    @pytest.mark.parametrize("selector", [
+        '//Button[@name="DoesNotExist_QA_12345"]',
+        'app://notepad/Document[@name="DoesNotExist_QA"]',
+    ])
+    def test_structural_hint_avoids_saved_selectors(self, runner, selector):
+        backend = _backend_returning(_sample_tree())
+        result = _invoke(runner, backend, ["--selector", selector, "--json"])
+        assert result.exit_code != 0, result.output
+        payload = json.loads(result.output)
+        assert payload["error"]["code"] == "SELECTOR_NOT_FOUND", payload
+        action = payload["error"]["suggested_action"] or ""
+        # Must NOT misdirect to the saved-selector registry...
+        assert "saved selector" not in action.lower(), action
+        assert "selector list" not in action.lower(), action
+        # ...and SHOULD point at live-tree inspection instead.
+        assert "see" in action.lower(), action

--- a/tests/test_find_query_option.py
+++ b/tests/test_find_query_option.py
@@ -58,10 +58,20 @@ class TestFindQueryOption:
         assert "Missing argument" not in (result.output or "")
         mock_backend.get_element_tree.assert_called()
 
-    def test_query_option_overrides_positional(self, runner, mock_backend):
-        """When both provided, --query takes precedence over positional."""
+    def test_query_option_conflicts_with_positional(self, runner, mock_backend):
+        """Positional QUERY + --query is a conflict, not a silent override (#1201).
+
+        The old behavior silently let -q win and dropped the positional query;
+        supplying the text query via two sources now errors INVALID_INPUT rather
+        than returning a confidently-wrong result set.
+        """
+        import json
         result = runner.invoke(find_cmd, ["positional", "--query", "named", "--json"])
-        assert "Missing argument" not in (result.output or "")
+        assert result.exit_code != 0, result.output
+        data = json.loads(result.output)
+        assert data["success"] is False
+        assert data["error"]["code"] == "INVALID_INPUT", data
+        mock_backend.get_element_tree.assert_not_called()
 
     def test_no_query_gives_json_error(self, runner):
         """Missing both positional and --query gives a clear JSON error."""
@@ -114,8 +124,17 @@ class TestFindAllFlag:
         assert "Missing argument" not in (result.output or "")
         mock_backend.get_element_tree.assert_called()
 
-    def test_all_overrides_positional(self, runner, mock_backend):
-        """--all takes precedence even if a positional query is given."""
+    def test_all_conflicts_with_positional(self, runner, mock_backend):
+        """--all + a positional query is a conflict, not a silent override (#1198).
+
+        Previously --all silently discarded the positional query and matched
+        every element as success:true. A positional/-q query combined with --all
+        now errors INVALID_INPUT so the caller's real query is never dropped.
+        """
+        import json
         result = runner.invoke(find_cmd, ["Save", "--all", "--json"])
-        assert "Missing argument" not in (result.output or "")
-        mock_backend.get_element_tree.assert_called()
+        assert result.exit_code != 0, result.output
+        data = json.loads(result.output)
+        assert data["success"] is False
+        assert data["error"]["code"] == "INVALID_INPUT", data
+        mock_backend.get_element_tree.assert_not_called()


### PR DESCRIPTION
Closes a cluster of `naturo find` / selector contract bugs so results are consistent and query handling never silently drops user intent.

## Fixes
- **#1198 / #1201** — silent query-source drops. `find <query> --all`, `find <query> -q <other>`, and `find -q <q> --all` now **ERROR** with INVALID_INPUT ("Multiple query sources supplied … use exactly one") *before* any backend call, instead of silently discarding the positional query (#1198: --all match-all'd as success; #1201: -q won). `--all` alone (and with --role/--actionable) still means 'every match'.
- **#1169** — `find --selector //Role` short-form: role-only paths resolve by role, and a bare `//Role` wildcard-host selector with no scope now enumerates ALL top-level windows (was a foreground-only no-op). Enumerate-then-resolve logic is unit-covered with a two-window stub where the target is in the non-foreground window.
- **#1195** — schema parity: UIA text-search and `--selector` `-j` results now emit `center_x`/`center_y` and a top-level `coordinate_frame: "screen"`, matching `--image`/`--ocr`. One element schema regardless of strategy.
- **#1189** — context-aware SELECTOR_NOT_FOUND recovery: structural `app://` / `//` path no-matches now point to tree inspection (`naturo see`, verify the path, `wait --element`) instead of the saved-selector registry; genuine `@app/name` refs keep registry guidance.

## ⚠️ Behavior changes (CHANGELOG)
1. The three conflicting query-source combos now ERROR instead of silently picking one.
2. `find -j` UIA/`--selector` results gain `center_x`/`center_y` + `coordinate_frame` (additive).
3. Bare `find --selector //Role` (no scope) now searches all top-level windows.
4. Structural SELECTOR_NOT_FOUND `suggested_action` text changed to tree-inspection guidance.

## Verification
- `pytest -m 'not ui and not integration and not desktop'`: 7023 passed / 169 skipped (6 pre-existing native-DLL host failures unrelated — pass in CI). New tests: `tests/test_find_contract_cluster.py`, `tests/test_find_query_option.py`.
- `ruff check naturo/`: clean. `mypy naturo/`: clean (CI lint lane).
- Note: #1169 facet-2 desktop-wide *live* UIA enumeration is smoke-verifiable only on a real Windows desktop (native DLL); the enumerate→resolve logic itself is fully unit-covered.

Closes #1198
Closes #1201
Closes #1169
Closes #1195
Closes #1189

🤖 Generated with [Claude Code](https://claude.com/claude-code)