### PR TITLE
fix: route --paste through NATURO_SAFE_INPUT guard (#1160); implement snapshot diff + --app-by-name (#1121)

### DIFF
--- a/naturo/cli/diff_cmd.py
+++ b/naturo/cli/diff_cmd.py
@@ -49,9 +49,13 @@ def diff(ctx: click.Context, snapshots: tuple[str, ...], window_title: str | Non
         return
     hwnd = resolved_hwnd
 
-    # If --app is given without --hwnd, use app as window title
-    if app and not hwnd and not window_title:
-        window_title = app
+    # (#1121) --app resolves by application/process NAME — the same resolver
+    # `see`/`capture`/`list windows` use — NOT by window title. The old code
+    # aliased `window_title = app`, so `diff --app Calculator` looked for a
+    # window whose *title* contained "Calculator" and failed on any app whose
+    # title differs from its name (e.g. the localized "计算器"). We now pass
+    # `app` straight through to `backend.get_element_tree(app=...)`, which runs
+    # `_resolve_hwnd(app=...)`.
 
     if interval is not None and interval <= 0:
         msg = f"--interval must be > 0, got {interval}"
@@ -62,7 +66,7 @@ def diff(ctx: click.Context, snapshots: tuple[str, ...], window_title: str | Non
         sys.exit(1)
         return
 
-    if not snapshots and not window_title and not hwnd:
+    if not snapshots and not window_title and not hwnd and not app:
         msg = "Specify two --snapshot IDs, --window, --app, --hwnd, or --app-id"
         if json_output:
             click.echo(_json_error_str("INVALID_INPUT", msg))
@@ -85,13 +89,15 @@ def diff(ctx: click.Context, snapshots: tuple[str, ...], window_title: str | Non
     from naturo.errors import NaturoError, WindowNotFoundError
 
     try:
-        if window_title or hwnd:
+        if window_title or hwnd or app:
             backend = get_backend()
-            target_label = window_title or f"hwnd={hwnd}"
+            target_label = window_title or app or f"hwnd={hwnd}"
             if not json_output:
                 click.echo(f"Capturing UI tree for '{target_label}'...")
 
             tree_kwargs: dict = {}
+            if app:
+                tree_kwargs["app"] = app
             if window_title:
                 tree_kwargs["window_title"] = window_title
             if hwnd:
@@ -111,21 +117,34 @@ def diff(ctx: click.Context, snapshots: tuple[str, ...], window_title: str | Non
 
             result = diff_trees(tree_before, tree_after)
         else:
-            # Snapshot-based diff
-            from naturo.snapshot import SnapshotManager
-            mgr = SnapshotManager()
-            _snap1 = mgr.get_snapshot(snapshots[0])
-            _snap2 = mgr.get_snapshot(snapshots[1])
+            # (#1121) Snapshot-based diff. `see` stores the full element tree in
+            # each snapshot's `ui_map` (a flat dict of UIElement keyed by eN ref,
+            # with parent_id/children links), so we can rebuild the two trees and
+            # feed them to the SAME `diff_trees` routine the live --window path
+            # uses. Previously this branch was a hard-coded "not yet implemented"
+            # placeholder even though it was the first documented example.
+            from naturo.snapshot import get_snapshot_manager
+            mgr = get_snapshot_manager()
+            snap_before = mgr.get_snapshot(snapshots[0])
+            snap_after = mgr.get_snapshot(snapshots[1])
 
-            # For snapshot diff, we'd need the element trees stored in snapshots
-            # This is a placeholder — real impl would extract trees from snapshot data
-            msg = "Snapshot-based diff requires element trees stored in snapshots (not yet implemented)"
-            if json_output:
-                click.echo(_json_error_str("INVALID_INPUT", msg))
-            else:
-                click.echo(f"Note: {msg}", err=True)
-            sys.exit(1)
-            return
+            tree_before = _tree_from_snapshot(snap_before)
+            tree_after = _tree_from_snapshot(snap_after)
+            if tree_before is None or tree_after is None:
+                missing = snapshots[0] if tree_before is None else snapshots[1]
+                msg = (
+                    f"Snapshot '{missing}' has no stored element tree "
+                    f"(ui_map is empty). Re-capture it with 'naturo see' before "
+                    f"diffing."
+                )
+                if json_output:
+                    click.echo(_json_error_str("INVALID_INPUT", msg))
+                else:
+                    click.echo(f"Error: {msg}", err=True)
+                sys.exit(1)
+                return
+
+            result = diff_trees(tree_before, tree_after)
 
         _output_diff(result, json_output)
 
@@ -149,6 +168,85 @@ def diff(ctx: click.Context, snapshots: tuple[str, ...], window_title: str | Non
         else:
             click.echo(f"Error: {exc}", err=True)
         sys.exit(1)
+
+
+def _tree_from_snapshot(snapshot):
+    """Rebuild an ``ElementInfo`` tree from a snapshot's ``ui_map`` (#1121).
+
+    ``see`` persists the captured element tree flattened into
+    ``snapshot.ui_map`` — a ``dict[str, UIElement]`` keyed by ``eN`` ref, where
+    each :class:`~naturo.models.snapshot.UIElement` carries ``parent_id`` and a
+    ``children`` list of child refs. This reconstructs the nested
+    :class:`~naturo.backends.base.ElementInfo` tree that :func:`diff_trees`
+    consumes, so a snapshot-to-snapshot diff runs through the exact same
+    comparison path as the live ``--window`` diff.
+
+    Returns the root ``ElementInfo``, or ``None`` when the snapshot stored no
+    elements (empty ``ui_map``).
+    """
+    from naturo.backends.base import ElementInfo
+
+    ui_map = snapshot.ui_map or {}
+    if not ui_map:
+        return None
+
+    # First pass: a childless ElementInfo per element, keyed by ref.
+    nodes: dict[str, ElementInfo] = {}
+    for ref, el in ui_map.items():
+        frame = el.frame or (0, 0, 0, 0)
+        x, y, w, h = (list(frame) + [0, 0, 0, 0])[:4]
+        nodes[ref] = ElementInfo(
+            id=el.id or ref,
+            role=el.role or "",
+            name=el.title or el.label or "",
+            value=el.value,
+            x=int(x), y=int(y), width=int(w), height=int(h),
+            children=[],
+            properties={},
+        )
+
+    # Second pass: wire children by ref and note which refs are children.
+    referenced: set[str] = set()
+    for ref, el in ui_map.items():
+        parent = nodes[ref]
+        for child_ref in el.children or []:
+            child = nodes.get(child_ref)
+            if child is not None:
+                parent.children.append(child)
+                referenced.add(child_ref)
+
+    # Roots: elements with no parent in the map and never linked as a child.
+    roots = [
+        nodes[ref]
+        for ref, el in ui_map.items()
+        if ref not in referenced
+        and (el.parent_id is None or el.parent_id not in ui_map)
+    ]
+    if not roots:
+        # Degenerate/cyclic map — fall back to anything not referenced.
+        roots = [nodes[ref] for ref in ui_map if ref not in referenced]
+    if not roots:
+        roots = list(nodes.values())
+
+    if len(roots) == 1:
+        return roots[0]
+
+    # Multiple top-level windows: wrap them under a synthetic root so the whole
+    # forest is compared (mirrors how `see --app` merges multi-window trees).
+    return ElementInfo(
+        id="snapshot_root",
+        role="Snapshot",
+        name=(
+            snapshot.application_name
+            or snapshot.window_title
+            or snapshot.snapshot_id
+            or "snapshot"
+        ),
+        value=None,
+        x=0, y=0, width=0, height=0,
+        children=roots,
+        properties={},
+    )
 
 
 def _output_diff(result, json_output: bool) -> None:

--- a/naturo/cli/interaction/_type.py
+++ b/naturo/cli/interaction/_type.py
@@ -154,6 +154,35 @@ def type_cmd(text, delay, profile, wpm, press_return, tab_count, escape,
 
     backend = _common._get_backend(json_output)
 
+    # (#1160) Close the clipboard-only paste bypass. A bare `type --paste`
+    # (text is None) injects the current clipboard via Ctrl+V — subject to the
+    # exact same SendInput/focus-race threat the #960 guard neutralizes — yet
+    # the text-argument guard above never ran because there was no text. When
+    # the guard is armed, read the clipboard now and run it through the SAME
+    # unsafe_input_reason() check, refusing with UNSAFE_INPUT_BLOCKED (and
+    # injecting nothing) if the pending content is dangerous. Normal users
+    # (guard off) are unaffected: unsafe_input_reason() short-circuits and the
+    # clipboard is not even read.
+    if paste_mode and text is None:
+        from naturo.safety import is_safe_input_enabled, unsafe_input_reason
+        if is_safe_input_enabled():
+            try:
+                _clip = backend.clipboard_get()
+            except Exception as exc:
+                logger.debug("Clipboard read for safety guard failed: %s", exc)
+                _clip = None
+            # Only a real string is inspectable content; anything else
+            # (None / unknown clipboard type) is treated as nothing to check.
+            _unsafe = unsafe_input_reason(_clip if isinstance(_clip, str) else None)
+            if _unsafe:
+                _common._json_err(
+                    f"Refusing to paste unsafe clipboard content ({_unsafe}) "
+                    f"because NATURO_SAFE_INPUT=1 is set. Nothing was pasted.",
+                    json_output,
+                    code="UNSAFE_INPUT_BLOCKED",
+                )
+                return
+
     # Auto-routing: detect best interaction method for target app
     route_info = _common._auto_route(app, None, method, json_output)
 

--- a/naturo/mcp/_input.py
+++ b/naturo/mcp/_input.py
@@ -22,8 +22,19 @@ def _paste_text(backend, text: str) -> bool:
     caller's clipboard is saved and restored so it is not clobbered.
 
     Returns True if the paste was delivered (clipboard set + Ctrl+V sent).
+
+    (#1160) The clipboard content is routed through the SAME NATURO_SAFE_INPUT
+    guard as keystroke typing before Ctrl+V: pasting is subject to the identical
+    SendInput/focus-race threat, so a bare paste must not become a bypass. When
+    the guard is armed and ``text`` is unsafe, nothing is set on the clipboard
+    and nothing is pasted — the helper returns False without delivering. The
+    caller (``type_text``) already validates ``text`` up front, so this is
+    defense-in-depth that keeps the guarantee at the paste boundary itself.
     """
     import time
+    from naturo.safety import unsafe_input_reason
+    if unsafe_input_reason(text):
+        return False
     try:
         saved = backend.clipboard_get()
     except Exception:

--- a/tests/test_diff_cmd.py
+++ b/tests/test_diff_cmd.py
@@ -1,6 +1,7 @@
 """Tests for naturo.cli.diff_cmd — UI tree diff command."""
 
 import json
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -160,14 +161,23 @@ class TestDiffWindow:
 
     @patch("naturo.cli.diff_cmd.time.sleep")
     @patch("naturo.diff.diff_trees")
-    def test_app_as_window_title(self, mock_diff, mock_sleep, runner, mock_backend):
-        """--app without --window should set window_title from app."""
+    def test_app_resolves_by_name(self, mock_diff, mock_sleep, runner, mock_backend):
+        """(#1121) --app resolves by application NAME, not window title.
+
+        The old code aliased ``window_title = app`` and matched a title
+        substring, so it failed on apps whose title differs from their name
+        (e.g. the localized "计算器" for Calculator). It must now pass ``app``
+        straight to ``get_element_tree(app=...)``.
+        """
         mock_backend.get_element_tree.return_value = {"root": {}}
         mock_diff.return_value = _make_diff_result(has_changes=False)
         with patch("naturo.backends.base.get_backend", return_value=mock_backend):
             result = runner.invoke(diff, ["--app", "notepad", "--interval", "0.01"])
         assert result.exit_code == 0
-        mock_backend.get_element_tree.assert_any_call(window_title="notepad")
+        mock_backend.get_element_tree.assert_any_call(app="notepad")
+        # And it must NOT have degraded --app into a window-title match.
+        for call in mock_backend.get_element_tree.call_args_list:
+            assert call.kwargs.get("window_title") != "notepad"
 
     @patch("naturo.cli.diff_cmd.time.sleep")
     @patch("naturo.diff.diff_trees")
@@ -181,27 +191,107 @@ class TestDiffWindow:
 
 
 # ---------------------------------------------------------------------------
-# Snapshot-based diff (not yet implemented)
+# Snapshot-based diff (#1121 — now implemented against stored ui_map trees)
 # ---------------------------------------------------------------------------
 
-class TestDiffSnapshot:
-    def test_two_snapshots_not_implemented(self, runner):
-        """Snapshot-based diff is a known placeholder, should return an error."""
-        with patch("naturo.snapshot.SnapshotManager") as mock_mgr_cls:
-            mock_mgr = MagicMock()
-            mock_mgr.get_snapshot.return_value = MagicMock()
-            mock_mgr_cls.return_value = mock_mgr
-            result = runner.invoke(diff, ["--snapshot", "s1", "--snapshot", "s2"])
-        # Currently returns error because snapshot diff isn't implemented
-        assert result.exit_code != 0
+def _ui_element(cls, ref, role, title, *, value=None, parent=None, children=None, frame=(0, 0, 10, 10)):
+    return cls(
+        id=ref,
+        element_id=f"element_{ref}",
+        role=role,
+        title=title,
+        label=title,
+        value=value,
+        frame=frame,
+        parent_id=parent,
+        children=list(children or []),
+    )
 
-    def test_snapshot_not_found(self, runner):
-        from naturo.models.snapshot import SnapshotNotFoundError
-        with patch("naturo.snapshot.SnapshotManager") as mock_mgr_cls:
-            mock_mgr = MagicMock()
-            mock_mgr.get_snapshot.side_effect = SnapshotNotFoundError("s1")
-            mock_mgr_cls.return_value = mock_mgr
-            result = runner.invoke(diff, ["--snapshot", "s1", "--snapshot", "s2"])
+
+class TestDiffSnapshot:
+    """The documented ``diff --snapshot A --snapshot B`` example must work.
+
+    Snapshots are written to a real (temp) store via ``get_snapshot_manager``
+    with ``Path.home()`` pointed at ``tmp_path``, exactly as ``see`` would
+    persist them — proving the command reconstructs both trees from ``ui_map``
+    and runs them through ``diff_trees``.
+    """
+
+    def _store(self, monkeypatch, tmp_path, ui_map, app_name="Calculator"):
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+        from naturo.snapshot import get_snapshot_manager
+        mgr = get_snapshot_manager()
+        sid = mgr.create_snapshot()
+        mgr.store_detection_result(sid, ui_map)
+        snap = mgr.get_snapshot(sid)
+        snap.application_name = app_name
+        mgr._write_json_atomic(mgr._snap_dir(sid) / "snapshot.json", snap.to_dict())
+        return mgr, sid
+
+    def test_snapshot_diff_detects_added_element(self, runner, monkeypatch, tmp_path):
+        from naturo.models.snapshot import UIElement
+
+        before = {
+            "e1": _ui_element(UIElement, "e1", "Window", "Calc", children=["e2"]),
+            "e2": _ui_element(UIElement, "e2", "Button", "Seven", parent="e1"),
+        }
+        after = {
+            "e1": _ui_element(UIElement, "e1", "Window", "Calc", children=["e2", "e3"]),
+            "e2": _ui_element(UIElement, "e2", "Button", "Seven", parent="e1"),
+            "e3": _ui_element(UIElement, "e3", "Button", "Eight", parent="e1"),
+        }
+        mgr, sid_before = self._store(monkeypatch, tmp_path, before)
+        sid_after = mgr.create_snapshot()
+        mgr.store_detection_result(sid_after, after)
+
+        result = runner.invoke(diff, ["--snapshot", sid_before, "--snapshot", sid_after, "--json"])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["success"] is True
+        assert "diff" in data
+        added_names = [c["element_name"] for c in data["diff"]["added"]]
+        assert "Eight" in added_names
+
+    def test_snapshot_diff_detects_modified_value(self, runner, monkeypatch, tmp_path):
+        from naturo.models.snapshot import UIElement
+
+        before = {
+            "e1": _ui_element(UIElement, "e1", "Window", "Calc", children=["e2"]),
+            "e2": _ui_element(UIElement, "e2", "Edit", "Display", value="0", parent="e1"),
+        }
+        after = {
+            "e1": _ui_element(UIElement, "e1", "Window", "Calc", children=["e2"]),
+            "e2": _ui_element(UIElement, "e2", "Edit", "Display", value="42", parent="e1"),
+        }
+        mgr, sid_before = self._store(monkeypatch, tmp_path, before)
+        sid_after = mgr.create_snapshot()
+        mgr.store_detection_result(sid_after, after)
+
+        result = runner.invoke(diff, ["--snapshot", sid_before, "--snapshot", sid_after, "--json"])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["success"] is True
+        modified = data["diff"]["modified"]
+        assert any(c.get("new_value") == "42" for c in modified)
+
+    def test_snapshot_diff_no_changes(self, runner, monkeypatch, tmp_path):
+        from naturo.models.snapshot import UIElement
+
+        ui_map = {
+            "e1": _ui_element(UIElement, "e1", "Window", "Calc", children=["e2"]),
+            "e2": _ui_element(UIElement, "e2", "Button", "Seven", parent="e1"),
+        }
+        mgr, sid_before = self._store(monkeypatch, tmp_path, ui_map)
+        sid_after = mgr.create_snapshot()
+        mgr.store_detection_result(sid_after, dict(ui_map))
+
+        result = runner.invoke(diff, ["--snapshot", sid_before, "--snapshot", sid_after])
+        assert result.exit_code == 0, result.output
+        assert "No changes" in result.output
+
+    def test_snapshot_not_found(self, runner, monkeypatch, tmp_path):
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+        result = runner.invoke(diff, ["--snapshot", "missing1", "--snapshot", "missing2"])
         assert result.exit_code != 0
         assert "Error" in result.output or "SNAPSHOT_NOT_FOUND" in result.output
 

--- a/tests/test_safe_input_guard.py
+++ b/tests/test_safe_input_guard.py
@@ -220,6 +220,61 @@ class TestCliTypeGuard:
         assert result.exit_code == 0
         backend.type_text.assert_called_once()
 
+    # ── #1160: the clipboard-only `--paste` path must honor the guard too ──
+
+    def test_paste_with_text_blocks_dangerous(self):
+        """`type "<dangerous>" --paste` is blocked (text-argument paste path)."""
+        from unittest.mock import MagicMock
+
+        backend = MagicMock()
+        with _enabled():
+            result = self._invoke(["test$(rm -rf /)", "--paste", "-j"], backend)
+        assert result.exit_code == 1
+        payload = json.loads(result.output)
+        assert payload["error"]["code"] == "UNSAFE_INPUT_BLOCKED"
+        backend.hotkey.assert_not_called()
+        backend.clipboard_set.assert_not_called()
+
+    def test_bare_paste_blocks_dangerous_clipboard(self):
+        """(#1160) bare `type --paste` reads the clipboard and refuses to
+        Ctrl+V destructive content when the guard is armed — the bypass the
+        issue reported."""
+        from unittest.mock import MagicMock
+
+        backend = MagicMock()
+        backend.clipboard_get.return_value = "$(rm -rf /)"
+        with _enabled():
+            result = self._invoke(["--paste", "-j"], backend)
+        assert result.exit_code == 1
+        payload = json.loads(result.output)
+        assert payload["success"] is False
+        assert payload["error"]["code"] == "UNSAFE_INPUT_BLOCKED"
+        # Nothing was pasted.
+        backend.hotkey.assert_not_called()
+
+    def test_bare_paste_allows_benign_clipboard(self):
+        """A benign clipboard still pastes normally under the armed guard."""
+        from unittest.mock import MagicMock
+
+        backend = MagicMock()
+        backend.clipboard_get.return_value = "hello world"
+        with _enabled():
+            result = self._invoke(["--paste", "-j"], backend)
+        assert result.exit_code == 0
+        backend.hotkey.assert_any_call("ctrl", "v")
+
+    def test_bare_paste_unaffected_when_guard_off(self):
+        """Guard off: bare paste injects whatever is on the clipboard, as before
+        (and does not even need to read it for the guard)."""
+        from unittest.mock import MagicMock
+
+        backend = MagicMock()
+        backend.clipboard_get.return_value = "$(rm -rf /)"
+        with mock.patch.dict("os.environ", {}, clear=True):
+            result = self._invoke(["--paste", "-j"], backend)
+        assert result.exit_code == 0
+        backend.hotkey.assert_any_call("ctrl", "v")
+
 
 # ── Integration: MCP `type` tool ─────────────────────────────────────
 
@@ -275,3 +330,45 @@ class TestMcpTypeGuard:
         data = json.loads(result[0].text)
         assert data["success"] is True
         backend.type_text.assert_called_once()
+
+
+class TestMcpPasteHelperGuard:
+    """(#1160) The MCP clipboard-paste helper honors the guard at the paste
+    boundary itself — belt-and-suspenders behind ``type_text``'s up-front check,
+    so no future caller can reintroduce a paste bypass."""
+
+    def test_paste_helper_refuses_dangerous_when_enabled(self):
+        from unittest.mock import MagicMock
+
+        from naturo.mcp._input import _paste_text
+
+        backend = MagicMock()
+        with _enabled():
+            delivered = _paste_text(backend, "$(rm -rf /)")
+        assert delivered is False
+        backend.clipboard_set.assert_not_called()
+        backend.hotkey.assert_not_called()
+
+    def test_paste_helper_delivers_benign_when_enabled(self):
+        from unittest.mock import MagicMock
+
+        from naturo.mcp._input import _paste_text
+
+        backend = MagicMock()
+        backend.clipboard_get.return_value = "prior"
+        with _enabled():
+            delivered = _paste_text(backend, "hello world")
+        assert delivered is True
+        backend.hotkey.assert_any_call("ctrl", "v")
+
+    def test_paste_helper_delivers_dangerous_when_guard_off(self):
+        from unittest.mock import MagicMock
+
+        from naturo.mcp._input import _paste_text
+
+        backend = MagicMock()
+        backend.clipboard_get.return_value = "prior"
+        with mock.patch.dict("os.environ", {}, clear=True):
+            delivered = _paste_text(backend, "$(rm -rf /)")
+        assert delivered is True
+        backend.hotkey.assert_any_call("ctrl", "v")


### PR DESCRIPTION
Two independent, file-disjoint fixes.

## #1160 — `type --paste` bypassed the NATURO_SAFE_INPUT content guard
The keystroke path ran clipboard/text through `unsafe_input_reason()`, but the clipboard-only `--paste` branch delivered content **without** the check — so the safety guard was bypassable via paste. Now, when the guard is armed (`NATURO_SAFE_INPUT=1`), a bare `--paste` reads the clipboard and runs it through the **same** `unsafe_input_reason()` check, emitting `UNSAFE_INPUT_BLOCKED` and pasting nothing on a match. Guard-off users never even trigger the clipboard read. MCP `_paste_text` got defense-in-depth at the paste boundary. The #960 guard design / trigger is untouched.

## #1121 — snapshot diff was an unimplemented placeholder; `diff --app` matched title not name
- **Snapshot diff IMPLEMENTED** (trees turned out to be available): snapshots persist the full tree in `ui_map` (flat UIElement dict keyed by eN ref with parent/children). New `_tree_from_snapshot` rebuilds an `ElementInfo` tree from each and feeds both to the **same** `diff_trees` routine the live `--window` before/after path uses → normal `{success:true, diff:{...}}` envelope. Empty `ui_map` → clear INVALID_INPUT instead of the old 'not yet implemented'. Now uses the session-aware `get_snapshot_manager()` so it finds snapshots made by `see`.
- **`--app` fix**: removed the `window_title = app` alias; `--app` now resolves by application/process **name** via `get_element_tree(app=...)` (works when title ≠ name, e.g. localized 计算器).

## Verification
- `pytest -m 'not ui and not integration and not desktop'`: 7016 passed / 169 skipped (6 pre-existing native-DLL host failures unrelated — pass in CI). Targeted suites 109 passed. New/updated: `tests/test_safe_input_guard.py`, `tests/test_diff_cmd.py`.
- `ruff check naturo/`: clean. Changed-file mypy: clean.

Closes #1160
Closes #1121

🤖 Generated with [Claude Code](https://claude.com/claude-code)