### PR TITLE
fix(qa-loop): hard Step-0 preflight — import naturo must resolve under the QA worktree (#969)

### DIFF
--- a/agents/local/qa-cycle.md
+++ b/agents/local/qa-cycle.md
@@ -52,6 +52,19 @@ git config user.email "ace.busy@gmail.com"
 git fetch origin && git checkout qa-work && git reset --hard origin/develop
 [ -f naturo/bin/naturo_core.dll ] || { mkdir -p naturo/bin; cp ../naturo/naturo/bin/naturo_core.dll naturo/bin/; }
 export PYTHONUTF8=1 PYTHONIOENCODING=utf-8   # forestall the cp936/gbk console mojibake that has cost a re-run every cycle (Step 2.4)
+
+# (#969) BLOCKING PREFLIGHT — refuse to verify if `import naturo` resolves OUTSIDE this
+# worktree. An editable install (egg-link/.pth) pointing at a sibling worktree (e.g. the
+# stale naturo-qa-mariana) makes every `python -m naturo` probe below silently exercise the
+# WRONG code → false PASS/FAIL verdicts (this already produced one false FAIL). Hard-abort
+# the whole cycle here, loudly, instead of trusting a probe against stale code. This is a
+# GATE, not the reactive Step-2.4 re-check: it runs once, up front, before any verification.
+WT="$(pwd)"
+NF="$(python -c 'import naturo,sys;print(naturo.__file__)' 2>/dev/null)"
+case "$NF" in
+  "$WT"/*) echo "preflight ok: naturo -> $NF (under this worktree)" ;;
+  *) echo "ABORT (#969): 'import naturo' resolves to '${NF:-<import failed>}', NOT under $WT — the editable install points at another/stale worktree. Re-pin with 'pip install -e .' in THIS worktree before verifying. Refusing to run probes against stale code." >&2; exit 1 ;;
+esac
 ```
 **Harness hygiene (preventive, not just reactive).** The two artifacts in Step 2.4 — a cp936/gbk console
 mangling valid UTF-8, and `naturo … | head` reporting the *pipe's* exit code instead of naturo's — recur


### PR DESCRIPTION
Implements the decided fix for #969 (harden the harness, not a one-time env re-pin).

## Problem
The QA cycle's editable install can resolve `import naturo` to a **sibling** worktree (the stale `naturo-qa-mariana`), so `python -m naturo` probes silently exercise the wrong code → false PASS/FAIL (this already produced one false FAIL). The existing `naturo.__file__` check lived only inside Step 2.4 ('before you FAIL an issue') — reactive, after probes had already run.

## Fix
A **blocking Step-0 preflight** in `agents/local/qa-cycle.md`: resolve `import naturo` once up front and hard-abort the cycle (loud, non-zero) if it doesn't live under the active worktree, before any verification runs. A gate, not a re-check.

Docs/ops-script change only (agents/local/), no product code — CI is trivially green.

Closes #969

🤖 Generated with [Claude Code](https://claude.com/claude-code)