### PR TITLE
fix(mcp): unify window-target param on window_title across all tools (#900)

### DIFF
--- a/naturo/mcp/_wait.py
+++ b/naturo/mcp/_wait.py
@@ -68,22 +68,29 @@ def register_wait_tools(server, _get_backend, _safe_tool):
     @server.tool()
     @_safe_tool
     def wait_for_window(
-        title: str,
+        window_title: Optional[str] = None,
         timeout: float = 10.0,
         interval: float = 0.5,
+        title: Optional[str] = None,
     ) -> dict:
         """Wait for a window to appear.
 
         Polls until a window matching the title is found or timeout.
 
         Args:
-            title: Window title to wait for (partial match).
+            window_title: Window title to wait for (partial match). Canonical
+                selector name, consistent across all MCP window tools (#900).
             timeout: Maximum wait time in seconds (default 10).
             interval: Poll interval in seconds (default 0.5).
+            title: Deprecated alias for ``window_title`` (kept for back-compat);
+                ``window_title`` wins if both are given.
 
         Returns:
             Dict with success flag and wait_time.
         """
+        target = window_title if window_title is not None else title
+        if not target:
+            return {"success": False, "error": {"code": "INVALID_INPUT", "message": "window_title is required"}}
         if timeout < 0:
             return {"success": False, "error": {"code": "INVALID_INPUT", "message": f"timeout must be >= 0, got {timeout}"}}
         if interval <= 0:
@@ -92,7 +99,7 @@ def register_wait_tools(server, _get_backend, _safe_tool):
         from naturo.wait import wait_for_window as _wait_window
         backend = _get_backend()
         result = _wait_window(
-            title=title,
+            title=target,
             timeout=timeout,
             poll_interval=interval,
             backend=backend,
@@ -107,7 +114,7 @@ def register_wait_tools(server, _get_backend, _safe_tool):
             "success": False,
             "found": False,
             "wait_time": round(result.wait_time, 3),
-            "error": {"code": "TIMEOUT", "message": f"Window '{title}' not found within {timeout}s"},
+            "error": {"code": "TIMEOUT", "message": f"Window '{target}' not found within {timeout}s"},
         }
 
     @server.tool()

--- a/naturo/mcp/_window.py
+++ b/naturo/mcp/_window.py
@@ -40,107 +40,124 @@ def register_window_tools(server, _get_backend, _safe_tool):
     @server.tool()
     @_safe_tool
     def focus_window(
-        title: Optional[str] = None,
+        window_title: Optional[str] = None,
         app: Optional[str] = None,
         hwnd: Optional[int] = None,
+        title: Optional[str] = None,
     ) -> dict:
         """Bring a window to the foreground and give it focus.
 
         Args:
-            title: Window title (partial match).
+            window_title: Window title (partial match). Canonical selector name,
+                consistent across all MCP window-targeting tools (#900).
             app: Application/process name (partial match).
             hwnd: Direct window handle.
+            title: Deprecated alias for ``window_title`` (kept for
+                back-compat); ``window_title`` wins if both are given.
 
         Returns:
             Dict with success flag.
         """
         backend = _get_backend()
+        title = window_title if window_title is not None else title
         backend.focus_window(title=app or title, hwnd=hwnd)
         return {"success": True, "action": "focus"}
 
     @server.tool()
     @_safe_tool
     def window_close(
+        window_title: Optional[str] = None,
         app: Optional[str] = None,
-        title: Optional[str] = None,
         hwnd: Optional[int] = None,
         force: bool = False,
+        title: Optional[str] = None,
     ) -> dict:
         """Close a window (graceful or forced).
 
         Args:
+            window_title: Window title (partial match). Canonical selector name (#900).
             app: Application/process name (partial match).
-            title: Window title (partial match).
             hwnd: Direct window handle.
             force: If True, forcefully terminate the owning process.
+            title: Deprecated alias for ``window_title``; ``window_title`` wins.
 
         Returns:
             Dict with success flag.
         """
         backend = _get_backend()
+        title = window_title if window_title is not None else title
         backend.close_window(title=app or title, hwnd=hwnd, force=force)
         return {"success": True, "action": "close"}
 
     @server.tool()
     @_safe_tool
     def window_minimize(
+        window_title: Optional[str] = None,
         app: Optional[str] = None,
-        title: Optional[str] = None,
         hwnd: Optional[int] = None,
+        title: Optional[str] = None,
     ) -> dict:
         """Minimize a window.
 
         Args:
+            window_title: Window title (partial match). Canonical selector name (#900).
             app: Application/process name (partial match).
-            title: Window title (partial match).
             hwnd: Direct window handle.
+            title: Deprecated alias for ``window_title``; ``window_title`` wins.
 
         Returns:
             Dict with success flag.
         """
         backend = _get_backend()
+        title = window_title if window_title is not None else title
         backend.minimize_window(title=app or title, hwnd=hwnd)
         return {"success": True, "action": "minimize"}
 
     @server.tool()
     @_safe_tool
     def window_maximize(
+        window_title: Optional[str] = None,
         app: Optional[str] = None,
-        title: Optional[str] = None,
         hwnd: Optional[int] = None,
+        title: Optional[str] = None,
     ) -> dict:
         """Maximize a window.
 
         Args:
+            window_title: Window title (partial match). Canonical selector name (#900).
             app: Application/process name (partial match).
-            title: Window title (partial match).
             hwnd: Direct window handle.
+            title: Deprecated alias for ``window_title``; ``window_title`` wins.
 
         Returns:
             Dict with success flag.
         """
         backend = _get_backend()
+        title = window_title if window_title is not None else title
         backend.maximize_window(title=app or title, hwnd=hwnd)
         return {"success": True, "action": "maximize"}
 
     @server.tool()
     @_safe_tool
     def window_restore(
+        window_title: Optional[str] = None,
         app: Optional[str] = None,
-        title: Optional[str] = None,
         hwnd: Optional[int] = None,
+        title: Optional[str] = None,
     ) -> dict:
         """Restore a minimized or maximized window to normal state.
 
         Args:
+            window_title: Window title (partial match). Canonical selector name (#900).
             app: Application/process name (partial match).
-            title: Window title (partial match).
             hwnd: Direct window handle.
+            title: Deprecated alias for ``window_title``; ``window_title`` wins.
 
         Returns:
             Dict with success flag.
         """
         backend = _get_backend()
+        title = window_title if window_title is not None else title
         backend.restore_window(title=app or title, hwnd=hwnd)
         return {"success": True, "action": "restore"}
 
@@ -149,23 +166,26 @@ def register_window_tools(server, _get_backend, _safe_tool):
     def window_move(
         x: int,
         y: int,
+        window_title: Optional[str] = None,
         app: Optional[str] = None,
-        title: Optional[str] = None,
         hwnd: Optional[int] = None,
+        title: Optional[str] = None,
     ) -> dict:
         """Move a window to a position (keeps current size).
 
         Args:
             x: Target X coordinate.
             y: Target Y coordinate.
+            window_title: Window title (partial match). Canonical selector name (#900).
             app: Application/process name (partial match).
-            title: Window title (partial match).
             hwnd: Direct window handle.
+            title: Deprecated alias for ``window_title``; ``window_title`` wins.
 
         Returns:
             Dict with success flag.
         """
         backend = _get_backend()
+        title = window_title if window_title is not None else title
         backend.move_window(x=x, y=y, title=app or title, hwnd=hwnd)
         return {"success": True, "action": "move", "x": x, "y": y}
 
@@ -174,18 +194,20 @@ def register_window_tools(server, _get_backend, _safe_tool):
     def window_resize(
         width: int,
         height: int,
+        window_title: Optional[str] = None,
         app: Optional[str] = None,
-        title: Optional[str] = None,
         hwnd: Optional[int] = None,
+        title: Optional[str] = None,
     ) -> dict:
         """Resize a window (keeps current position).
 
         Args:
             width: Target width in pixels (must be >= 1).
             height: Target height in pixels (must be >= 1).
+            window_title: Window title (partial match). Canonical selector name (#900).
             app: Application/process name (partial match).
-            title: Window title (partial match).
             hwnd: Direct window handle.
+            title: Deprecated alias for ``window_title``; ``window_title`` wins.
 
         Returns:
             Dict with success flag.
@@ -193,6 +215,7 @@ def register_window_tools(server, _get_backend, _safe_tool):
         if width < 1 or height < 1:
             return {"success": False, "error": {"code": "INVALID_INPUT", "message": f"width and height must be >= 1, got {width}x{height}"}}
         backend = _get_backend()
+        title = window_title if window_title is not None else title
         backend.resize_window(width=width, height=height, title=app or title, hwnd=hwnd)
         return {"success": True, "action": "resize", "width": width, "height": height}
 
@@ -203,9 +226,10 @@ def register_window_tools(server, _get_backend, _safe_tool):
         y: int,
         width: int,
         height: int,
+        window_title: Optional[str] = None,
         app: Optional[str] = None,
-        title: Optional[str] = None,
         hwnd: Optional[int] = None,
+        title: Optional[str] = None,
     ) -> dict:
         """Set window position and size in one call.
 
@@ -214,9 +238,10 @@ def register_window_tools(server, _get_backend, _safe_tool):
             y: Target Y coordinate.
             width: Target width in pixels (must be >= 1).
             height: Target height in pixels (must be >= 1).
+            window_title: Window title (partial match). Canonical selector name (#900).
             app: Application/process name (partial match).
-            title: Window title (partial match).
             hwnd: Direct window handle.
+            title: Deprecated alias for ``window_title``; ``window_title`` wins.
 
         Returns:
             Dict with success flag.
@@ -224,6 +249,7 @@ def register_window_tools(server, _get_backend, _safe_tool):
         if width < 1 or height < 1:
             return {"success": False, "error": {"code": "INVALID_INPUT", "message": f"width and height must be >= 1, got {width}x{height}"}}
         backend = _get_backend()
+        title = window_title if window_title is not None else title
         backend.set_bounds(x=x, y=y, width=width, height=height, title=app or title, hwnd=hwnd)
         return {"success": True, "action": "set-bounds", "x": x, "y": y, "width": width, "height": height}
 

--- a/tests/test_mcp_unknown_args_891.py
+++ b/tests/test_mcp_unknown_args_891.py
@@ -2,11 +2,16 @@
 
 FastMCP generates each tool's argument model from the function signature with
 Pydantic's default config, which *silently discards* arguments not declared in
-the schema.  A client that mistypes a parameter name (e.g. ``window_title``
-instead of ``title`` for ``focus_window``) — or one targeting a schema that
-drifted between naturo versions — then gets a call that runs with default
-behaviour instead of a validation error.  That is a silent failure: the wrong
-window is focused, the wrong text is typed, and the agent has no signal.
+the schema.  A client that mistypes a parameter name (e.g. ``winndow_title``
+for ``focus_window``) — or one targeting a schema that drifted between naturo
+versions — then gets a call that runs with default behaviour instead of a
+validation error.  That is a silent failure: the wrong window is focused, the
+wrong text is typed, and the agent has no signal.
+
+(Note: ``window_title`` itself is now the *canonical* selector accepted on
+``focus_window`` and every other window-targeting tool (#900); ``title`` is
+kept as a deprecated alias.  The repro below therefore uses a clearly-bogus
+name, not ``window_title``.)
 
 These tests pin the fix: unknown arguments are rejected before dispatch with a
 clean ``Invalid parameters for <tool>`` message (``isError: true``), consistent
@@ -58,11 +63,11 @@ class TestFormatUnknownArgumentsError:
 
     def test_single_unknown_argument(self):
         msg = _format_unknown_arguments_error(
-            "focus_window", ["window_title"], ["app", "hwnd", "title"],
+            "focus_window", ["winndow_title"], ["app", "hwnd", "title", "window_title"],
         )
         assert msg == (
             "Invalid parameters for focus_window: unexpected argument "
-            "'window_title'. Valid arguments: app, hwnd, title."
+            "'winndow_title'. Valid arguments: app, hwnd, title, window_title."
         )
         assert "pydantic" not in msg.lower()
 
@@ -92,8 +97,10 @@ class TestAllowedArgumentNames:
     def test_known_tool_allows_declared_params_only(self):
         allowed = self._server()._allowed_argument_names("focus_window")
         assert allowed is not None
-        assert {"title", "app", "hwnd"} <= allowed
-        assert "window_title" not in allowed
+        # #900: window_title is now the canonical selector; title kept as a
+        # deprecated alias, so both are declared and accepted.
+        assert {"title", "app", "hwnd", "window_title"} <= allowed
+        assert "winndow_title" not in allowed
 
     def test_unknown_tool_returns_none(self):
         # None signals "no enforceable allow-list" so dispatch surfaces the
@@ -105,18 +112,19 @@ class TestDispatchRejection:
     """End-to-end rejection through the real JSON-RPC dispatch path."""
 
     def test_mistyped_param_name_rejected(self):
-        """The #891 repro: focus_window with ``window_title`` must fail loudly.
+        """The #891 repro: focus_window with a mistyped selector must fail loudly.
 
-        Previously this silently dropped ``window_title``, fell back to the
+        Previously an undeclared arg was silently dropped, fell back to the
         foreground window, and leaked the ``foreground`` sentinel in a
-        downstream WINDOW_NOT_FOUND message.
+        downstream WINDOW_NOT_FOUND message.  ``window_title`` is now a *valid*
+        selector (#900), so the mistype here is a genuinely-bogus name.
         """
-        result = _dispatch("focus_window", {"window_title": "claude"})
+        result = _dispatch("focus_window", {"winndow_title": "claude"})
 
         assert result.isError is True
         text = result.content[0].text
         assert "Invalid parameters for focus_window" in text
-        assert "window_title" in text
+        assert "winndow_title" in text
         # No silent success and no Pydantic leakage.
         assert '"success": true' not in text.lower()
         assert "pydantic" not in text.lower()

--- a/tests/test_mcp_window_param_unify_900.py
+++ b/tests/test_mcp_window_param_unify_900.py
@@ -1,0 +1,185 @@
+"""Self-maintaining contract: one canonical window-selector name across MCP (#900).
+
+The MCP window-targeting parameter name used to drift across tools —
+``focus_window``/``window_*``/``wait_for_window`` took ``title`` while
+``see_ui_tree``/``capture_window``/``wait_for_element`` took ``window_title`` —
+so an agent had to remember a different name per tool (and, combined with #891's
+unknown-arg drop, a wrong guess failed silently). #900 unifies on
+``window_title`` as the single canonical selector, keeping ``title`` as a
+deprecated alias where a tool's primary name changed.
+
+These tests pin the fix:
+
+* Every window-targeting MCP tool exposes ``window_title`` in its schema.
+* No window-targeting tool exposes ``title`` as its *only* window selector
+  (the drift is gone) — where ``title`` survives it is strictly a back-compat
+  alias sitting alongside ``window_title``.
+* The deprecated ``title`` alias still resolves on the renamed tools, and
+  ``window_title`` wins when both are supplied.
+
+All desktop-independent: schema introspection + a mocked backend.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+mcp_available = True
+try:
+    from naturo.mcp_server import create_server
+except ImportError:  # pragma: no cover - mcp optional
+    mcp_available = False
+
+pytestmark = pytest.mark.skipif(not mcp_available, reason="mcp package not installed")
+
+# The window-targeting MCP tools that MUST expose the canonical ``window_title``
+# selector. These are the surfaces enumerated in #900 (the renamed ``title``
+# outliers) plus the tools that already used ``window_title``. A new
+# window-targeting tool should be added here so the drift cannot silently return.
+_EXPECTED_WINDOW_TARGET_TOOLS = frozenset({
+    # Renamed by #900 (were ``title``):
+    "focus_window", "window_close", "window_minimize", "window_maximize",
+    "window_restore", "window_move", "window_resize", "window_set_bounds",
+    "wait_for_window",
+    # Already canonical:
+    "capture_window", "see_ui_tree", "read_web_text", "find_element",
+    "get_element_value", "set_element_value", "toggle_element",
+    "select_element", "expand_collapse_element", "wait_for_element",
+    "wait_until_gone", "type_text", "press_key",
+})
+
+# Tools that legitimately still declare a ``title`` parameter meaning something
+# other than a window selector, so the "no bare title selector" guard must not
+# flag them.
+_TITLE_MEANS_SOMETHING_ELSE: frozenset = frozenset()
+
+
+def _list_tools():
+    server = create_server()
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(server.list_tools())
+    finally:
+        loop.close()
+
+
+def _props(tool) -> dict:
+    return (tool.inputSchema or {}).get("properties", {})
+
+
+def _call_tool(server, tool_name: str, arguments: dict):
+    async def _run():
+        return await server.call_tool(tool_name, arguments)
+
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(_run())
+    finally:
+        loop.close()
+
+
+@pytest.fixture
+def tools():
+    return {t.name: t for t in _list_tools()}
+
+
+# ── Schema-level unification ─────────────────────────────────────────────
+
+
+def test_expected_window_tools_are_all_registered(tools):
+    """Guard the guard: every tool this contract names must exist."""
+    missing = _EXPECTED_WINDOW_TARGET_TOOLS - set(tools)
+    assert not missing, f"contract names unregistered tools: {sorted(missing)}"
+
+
+@pytest.mark.parametrize("tool_name", sorted(_EXPECTED_WINDOW_TARGET_TOOLS))
+def test_window_tool_exposes_window_title(tool_name, tools):
+    """Every window-targeting tool exposes the canonical ``window_title``."""
+    props = _props(tools[tool_name])
+    assert "window_title" in props, (
+        f"{tool_name} does not expose canonical 'window_title'; params={sorted(props)}"
+    )
+
+
+def test_no_tool_uses_title_as_its_only_window_selector(tools):
+    """The drift is gone: no tool offers ``title`` without ``window_title``.
+
+    Any tool that still declares ``title`` must also declare ``window_title``
+    (i.e. ``title`` survives only as a back-compat alias, never as the sole
+    window-selector name).
+    """
+    offenders = []
+    for name, tool in tools.items():
+        if name in _TITLE_MEANS_SOMETHING_ELSE:
+            continue
+        props = _props(tool)
+        if "title" in props and "window_title" not in props:
+            offenders.append(name)
+    assert not offenders, (
+        f"tools expose 'title' as their only window selector (param drift): {offenders}"
+    )
+
+
+# ── Deprecated-alias behaviour ───────────────────────────────────────────
+
+
+@pytest.fixture
+def mock_backend():
+    return MagicMock()
+
+
+@pytest.fixture
+def server(mock_backend):
+    with patch("naturo.mcp_server.get_backend", return_value=mock_backend):
+        yield create_server()
+
+
+def test_focus_window_window_title_selector(server, mock_backend):
+    """The canonical ``window_title`` selects the target window."""
+    result = _call_tool(server, "focus_window", {"window_title": "Notepad"})
+    assert json.loads(result[0].text)["success"] is True
+    mock_backend.focus_window.assert_called_once_with(title="Notepad", hwnd=None)
+
+
+def test_focus_window_title_alias_still_resolves(server, mock_backend):
+    """The deprecated ``title`` alias keeps working (back-compat)."""
+    result = _call_tool(server, "focus_window", {"title": "Notepad"})
+    assert json.loads(result[0].text)["success"] is True
+    mock_backend.focus_window.assert_called_once_with(title="Notepad", hwnd=None)
+
+
+def test_focus_window_window_title_wins_over_alias(server, mock_backend):
+    """When both are given, canonical ``window_title`` wins over ``title``."""
+    result = _call_tool(
+        server, "focus_window",
+        {"window_title": "Chosen", "title": "Ignored"},
+    )
+    assert json.loads(result[0].text)["success"] is True
+    mock_backend.focus_window.assert_called_once_with(title="Chosen", hwnd=None)
+
+
+def test_wait_for_window_window_title_selector(server, mock_backend):
+    wait_result = MagicMock(found=True, wait_time=0.1)
+    with patch("naturo.wait.wait_for_window", return_value=wait_result) as m:
+        result = _call_tool(server, "wait_for_window", {"window_title": "Notepad"})
+    assert json.loads(result[0].text)["success"] is True
+    assert m.call_args.kwargs["title"] == "Notepad"
+
+
+def test_wait_for_window_title_alias_still_resolves(server, mock_backend):
+    wait_result = MagicMock(found=True, wait_time=0.1)
+    with patch("naturo.wait.wait_for_window", return_value=wait_result) as m:
+        result = _call_tool(server, "wait_for_window", {"title": "Notepad"})
+    assert json.loads(result[0].text)["success"] is True
+    assert m.call_args.kwargs["title"] == "Notepad"
+
+
+def test_wait_for_window_missing_selector_is_invalid(server, mock_backend):
+    """With neither selector supplied the tool reports INVALID_INPUT, not a crash."""
+    result = _call_tool(server, "wait_for_window", {})
+    data = json.loads(result[0].text)
+    assert data["success"] is False
+    assert data["error"]["code"] == "INVALID_INPUT"

--- a/tests/test_mcp_window_selector_contract_957.py
+++ b/tests/test_mcp_window_selector_contract_957.py
@@ -51,10 +51,16 @@ _BOGUS_TITLE = "__no_such_window_zzz__"
 _SEMANTIC_EXCEPTIONS = {
     # Wait tools: a window that is not (yet) present is a valid target, not an
     # immediate error. ``wait_until_gone`` on an absent window even succeeds
-    # immediately ("already gone"); ``wait_for_element`` times out. Neither is
-    # the silent-foreground-fallback bug this contract guards against.
+    # immediately ("already gone"); ``wait_for_element``/``wait_for_window``
+    # time out (TIMEOUT, not WINDOW_NOT_FOUND). None is the silent-foreground-
+    # fallback bug this contract guards against.
     "wait_for_element",
     "wait_until_gone",
+    # (#900) wait_for_window gained the canonical ``window_title`` selector
+    # (renamed from ``title``), so it now enters this registry probe. Waiting
+    # for a not-yet-present window is a valid target → TIMEOUT, same family as
+    # the other wait tools above.
+    "wait_for_window",
 }
 
 
@@ -114,6 +120,18 @@ def _make_backend():
     # find_element resolves window_title internally via _resolve_hwnd (#963), so
     # an unmatched title raises here exactly as the real backend does.
     backend.find_element.side_effect = not_found
+    # (#900) The window-mutation tools (focus_window, window_close/minimize/
+    # maximize/restore/move/resize/set_bounds) gained the canonical
+    # ``window_title`` selector and so enter this registry probe. They delegate
+    # resolution to the backend, whose real implementation resolves the title
+    # via _resolve_hwnd and raises WindowNotFoundError on no match — never
+    # falling back to the foreground window. Mirror that here so the mock is
+    # faithful and the loud-failure contract is genuinely exercised.
+    for _method in (
+        "focus_window", "close_window", "minimize_window", "maximize_window",
+        "restore_window", "move_window", "resize_window", "set_bounds",
+    ):
+        getattr(backend, _method).side_effect = not_found
     return backend
 
 


### PR DESCRIPTION
The MCP window-targeting parameter name drifted: `focus_window` and the 8 window-mutation tools used `title`, while `see_ui_tree`/`capture_window`/`wait_for_*`/etc. used `window_title`. An agent had to remember a different name per tool.

## Fix
All 9 outlier tools now expose **`window_title`** as the canonical selector, so every window-target MCP tool is consistent.

**Non-breaking:** `title` is kept as a declared deprecated alias on each renamed tool (`title = window_title if window_title is not None else title`; `window_title` wins if both given). The #891 unknown-arg allow-list is schema-derived, so both names keep validating. Existing agent calls using `title` still work.

One behavioral note: `wait_for_window`'s selector went from *required* to optional — omitting it now returns a clean INVALID_INPUT envelope instead of a Pydantic missing-field error; `title` OR `window_title` both work.

## Verification
- `pytest -m 'not ui and not integration and not desktop'`: 7081 passed / 169 skipped (6 pre-existing native-DLL host failures unrelated). New `tests/test_mcp_window_param_unify_900.py`; the self-maintaining #957 contract auto-enrolled the 8 window-mutation tools (mock backend made faithful — raises WindowNotFoundError, no silent foreground fallback).
- `ruff check naturo/`: clean. `mypy naturo/`: clean.

(CLI `--window` is out of scope — this unifies the MCP surface; `window_title` is now the single MCP name.)

Closes #900

🤖 Generated with [Claude Code](https://claude.com/claude-code)