### PR TITLE
fix(cli): complete the window-target flag matrix — get/set --pid, app quit --window/--hwnd (#871)

### DIFF
--- a/naturo/cli/_app/lifecycle.py
+++ b/naturo/cli/_app/lifecycle.py
@@ -82,16 +82,74 @@ def app_launch(ctx, name, app_name, path, wait_until_ready, timeout, no_focus, a
         sys.exit(1)
 
 
+def _resolve_pid_from_window(window_title, hwnd, json_output):
+    """Resolve a ``--window``/``--hwnd`` target to its owning process ID (#871).
+
+    ``quit`` terminates a process, so a window target is first resolved to a
+    concrete handle through the backend's canonical ``_resolve_hwnd`` (the same
+    resolver the gold-standard commands use), then mapped to the PID that owns
+    that handle via the backend's window list.
+
+    Args:
+        window_title: ``--window`` value, or ``None``.
+        hwnd: ``--hwnd`` value, or ``None``.
+        json_output: Whether to emit a JSON error envelope on failure.
+
+    Returns:
+        The owning process ID, or ``None`` when resolution failed (an error
+        envelope has already been emitted and the process has exited via
+        :func:`sys.exit`).
+    """
+    from naturo.backends.base import get_backend
+    from naturo.errors import NaturoError
+
+    try:
+        backend = get_backend()
+        resolved_hwnd = backend._resolve_hwnd(window_title=window_title, hwnd=hwnd)
+        pid = next(
+            (w.pid for w in backend.list_windows() if w.handle == resolved_hwnd),
+            None,
+        )
+    except NaturoError as exc:
+        if json_output:
+            click.echo(json_dumps(exc.to_json_response(), indent=2))
+        else:
+            _safe_echo(f"Error: {exc.message}", err=True)
+        sys.exit(1)
+        return None
+    except Exception as exc:
+        if json_output:
+            click.echo(_json_error_str("UNKNOWN_ERROR", str(exc)))
+        else:
+            _safe_echo(f"Error: {exc}", err=True)
+        sys.exit(1)
+        return None
+
+    if pid is None:
+        target = window_title or f"hwnd {hwnd}"
+        msg = f"No running window matched '{target}'."
+        if json_output:
+            click.echo(_json_error_str("WINDOW_NOT_FOUND", msg))
+        else:
+            _safe_echo(f"Error: {msg}", err=True)
+        sys.exit(1)
+        return None
+    return pid
+
+
 @click.command("quit")
 @click.argument("name", required=False, default=None)
 @click.option("--name", "name_option", hidden=True, help="Application name (deprecated, use positional)")
 @click.option("--app", "app_name", default=None, help="Application name (alternative to positional NAME)")
+@click.option("--window", "window_title", default=None, help="Window title pattern (substring match)")
+@click.option("--hwnd", type=int, default=None, help="Window handle (HWND)")
 @click.option("--pid", type=int, help="Process ID")
 @click.option("--force", is_flag=True, help="Force kill immediately")
 @click.option("--timeout", type=float, default=10.0, help="Graceful shutdown timeout")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
 @click.pass_context
-def app_quit(ctx, name, name_option, app_name, pid, force, timeout, json_output) -> None:
+def app_quit(ctx, name, name_option, app_name, window_title, hwnd, pid, force,
+             timeout, json_output) -> None:
     """Quit an application gracefully (or force kill).
 
     NAME is the application name to quit.
@@ -101,6 +159,8 @@ def app_quit(ctx, name, name_option, app_name, pid, force, timeout, json_output)
       naturo app quit notepad
       naturo app quit chrome --force
       naturo app quit --pid 12345
+      naturo app quit --window "Untitled - Notepad"
+      naturo app quit --hwnd 12345
     """
     json_output = json_output or (ctx.obj or {}).get("json", False)
 
@@ -120,8 +180,21 @@ def app_quit(ctx, name, name_option, app_name, pid, force, timeout, json_output)
         if pid is None:
             pid = entry.pid
 
+    # (#871) Accept the window-targeting family (--window/--hwnd) that the
+    # gold-standard commands expose. ``quit`` acts on a *process*, so a window
+    # target is resolved to its owning PID via the canonical ``_resolve_hwnd``
+    # resolver — the same path see/capture/click use — rather than a
+    # signature change. An explicit NAME/--pid still wins; a window target that
+    # matches no window fails loudly (WINDOW_NOT_FOUND) instead of silently
+    # quitting nothing.
+    if not name and pid is None and (hwnd is not None or window_title):
+        resolved_pid = _resolve_pid_from_window(window_title, hwnd, json_output)
+        if resolved_pid is None:
+            return  # error already emitted
+        pid = resolved_pid
+
     if not name and pid is None:
-        msg = "Specify application name or --pid"
+        msg = "Specify application name, --pid, --window, or --hwnd"
         if json_output:
             click.echo(_json_error_str("INVALID_INPUT", msg))
         else:

--- a/naturo/cli/values/_get.py
+++ b/naturo/cli/values/_get.py
@@ -31,6 +31,34 @@ def _get_backend():
     return get_backend()
 
 
+def _resolve_pid_to_hwnd(backend, app, window_title, hwnd, pid):
+    """Resolve ``--pid`` to a concrete window handle (#871).
+
+    ``get``/``set`` target a window by ``hwnd`` through the UIA value-pattern
+    path (``get_element_value`` / ``set_element_value`` take no ``pid``), so
+    ``--pid`` is threaded the same way the ``app`` window-state commands thread
+    it: through the backend's canonical ``_resolve_hwnd`` resolver — the exact
+    path ``see``/``capture``/``click`` use.  An explicit ``--hwnd`` wins and
+    short-circuits resolution; an unresolvable ``--pid`` raises
+    :class:`~naturo.errors.WindowNotFoundError` (loud failure), never a silent
+    fall-through to the foreground window.
+
+    Args:
+        backend: Active backend instance (provides ``_resolve_hwnd``).
+        app: ``--app`` value, or ``None`` (narrows the PID match).
+        window_title: ``--window`` value, or ``None`` (narrows the PID match).
+        hwnd: Current ``--hwnd`` value; returned as-is when set.
+        pid: ``--pid`` value, or ``None``.
+
+    Returns:
+        The resolved window handle, or the passed-through ``hwnd`` when no
+        ``--pid`` was supplied.
+    """
+    if pid is not None and hwnd is None:
+        return backend._resolve_hwnd(app=app, window_title=window_title, pid=pid)
+    return hwnd
+
+
 def _collect_matching_elements(tree, role=None, name=None):
     """Walk the element tree and collect all elements matching role/name.
 
@@ -81,11 +109,12 @@ def _collect_matching_elements(tree, role=None, name=None):
 @click.option("--title", "window_title", default=None, hidden=True, help="")
 @click.option("--hwnd", default=None, type=int,
               help="Window handle (HWND)")
+@click.option("--pid", default=None, type=int, help="Process ID")
 @click.option("--json", "-j", "json_output", is_flag=True, default=None,
               help="JSON output")
 @click.pass_context
 def get_cmd(ctx, target, ref, automation_id, role, name, get_all, prop, app,
-            app_id, window_title, hwnd, json_output) -> None:
+            app_id, window_title, hwnd, pid, json_output) -> None:
     """Read element text/value.
 
     Read the current value of a UI element. Accepts an element ref (e47),
@@ -102,6 +131,7 @@ def get_cmd(ctx, target, ref, automation_id, role, name, get_all, prop, app,
       naturo get --aid txtSearch          # By AutomationId
       naturo get --role Edit --name Search # By role + name
       naturo get e47 -p value             # Just the value text
+      naturo get --pid 1234 e47           # Scope the ref to a process
       naturo get --role Button --app explorer --all -j  # All buttons
       naturo get --role Edit --all        # All edit fields
     """
@@ -170,6 +200,8 @@ def get_cmd(ctx, target, ref, automation_id, role, name, get_all, prop, app,
 
         try:
             backend = _get_backend()
+            # (#871) Thread --pid through the canonical window resolver.
+            hwnd = _resolve_pid_to_hwnd(backend, app, window_title, hwnd, pid)
             tree = backend.get_element_tree(
                 app=app, window_title=window_title, hwnd=hwnd,
                 depth=20, backend="auto",
@@ -250,6 +282,8 @@ def get_cmd(ctx, target, ref, automation_id, role, name, get_all, prop, app,
 
     try:
         backend = _get_backend()
+        # (#871) Thread --pid through the canonical window resolver.
+        hwnd = _resolve_pid_to_hwnd(backend, app, window_title, hwnd, pid)
         result = backend.get_element_value(
             ref=ref,
             automation_id=automation_id,

--- a/naturo/cli/values/_set.py
+++ b/naturo/cli/values/_set.py
@@ -122,12 +122,13 @@ def _resolve_element_identifiers(ref, automation_id, role, name):
 @click.option("--title", "window_title", default=None, hidden=True, help="")
 @click.option("--hwnd", default=None, type=int,
               help="Window handle (HWND)")
+@click.option("--pid", default=None, type=int, help="Process ID")
 @click.option("--json", "-j", "json_output", is_flag=True, default=None,
               help="JSON output")
 @click.pass_context
 def set_cmd(ctx, target, value, ref, automation_id, role, name, toggle,
             select, expand, collapse, app, app_id, window_title, hwnd,
-            json_output) -> None:
+            pid, json_output) -> None:
     """Set element value/state.
 
     Write a value to a UI element, toggle a checkbox, select a list item,
@@ -143,6 +144,7 @@ def set_cmd(ctx, target, value, ref, automation_id, role, name, toggle,
       naturo set e8 --select             # Select a list/radio item
       naturo set e5 --expand             # Expand a combo box
       naturo set e5 --collapse           # Collapse a combo box
+      naturo set --pid 1234 e47 "hello"  # Scope the ref to a process
       naturo set --role Edit --name Search "test" --app notepad
     """
     if json_output is None:
@@ -241,10 +243,10 @@ def set_cmd(ctx, target, value, ref, automation_id, role, name, toggle,
             _resolve_element_identifiers(ref, automation_id, role, name)
         )
 
-        # Resolve app/window to HWND
+        # Resolve app/window/pid to HWND
         target_hwnd = hwnd or 0
-        if (app or window_title) and not target_hwnd:
-            target_hwnd = _resolve_hwnd(backend, app, window_title)
+        if (app or window_title or pid) and not target_hwnd:
+            target_hwnd = _resolve_hwnd(backend, app, window_title, pid)
         # Fall back to the snapshot's source window so point resolution can walk
         # the correct window's UIA tree (occlusion-independent). (#1208)
         if not target_hwnd and resolved_snap_hwnd:
@@ -277,22 +279,29 @@ def set_cmd(ctx, target, value, ref, automation_id, role, name, toggle,
         emit_exception_error(exc, json_output, fallback_code="UNKNOWN_ERROR")
 
 
-def _resolve_hwnd(backend, app, window_title):
-    """Resolve an explicitly-supplied app/window_title selector to a handle.
+def _resolve_hwnd(backend, app, window_title, pid=None):
+    """Resolve an explicitly-supplied app/window_title/pid selector to a handle.
 
-    Called only when ``app`` or ``window_title`` was provided, so an unmatched
-    selector is an error, not a cue to fall back to the foreground window:
-    ``backend._resolve_hwnd`` raises :class:`~naturo.errors.WindowNotFoundError`
-    on no match and the exception propagates to the command's error handler,
-    which emits a ``WINDOW_NOT_FOUND`` envelope. Swallowing it and returning
-    ``0`` (foreground) was the silent-failure bug #964 — for ``set`` it wrote
-    the value to whatever window happened to be focused. Mirrors the MCP #957
+    Called only when ``app``, ``window_title``, or ``pid`` was provided, so an
+    unmatched selector is an error, not a cue to fall back to the foreground
+    window: ``backend._resolve_hwnd`` raises
+    :class:`~naturo.errors.WindowNotFoundError` on no match and the exception
+    propagates to the command's error handler, which emits a
+    ``WINDOW_NOT_FOUND`` envelope. Swallowing it and returning ``0``
+    (foreground) was the silent-failure bug #964 — for ``set`` it wrote the
+    value to whatever window happened to be focused. Mirrors the MCP #957
     ``require_hwnd`` loud-failure contract.
+
+    ``--pid`` (#871) resolves through the same canonical resolver the
+    gold-standard ``see``/``capture``/``click`` commands use, so the whole
+    window-targeting flag family behaves identically across commands.
 
     Args:
         backend: Backend instance.
         app: Application name (partial match), or ``None``.
         window_title: Window title pattern (partial match), or ``None``.
+        pid: Process ID to target (narrowed by app/window_title when given),
+            or ``None``.
 
     Returns:
         The resolved window handle (int).
@@ -300,7 +309,7 @@ def _resolve_hwnd(backend, app, window_title):
     Raises:
         WindowNotFoundError: When the supplied selector matches no window.
     """
-    return backend._resolve_hwnd(app=app, window_title=window_title)
+    return backend._resolve_hwnd(app=app, window_title=window_title, pid=pid)
 
 
 def _do_set_value(backend, hwnd, automation_id, role, name, ref, value,

--- a/tests/test_set_cmd.py
+++ b/tests/test_set_cmd.py
@@ -164,8 +164,10 @@ class TestSetValue:
             ])
 
         assert result.exit_code == 0
+        # (#871) ``set`` now threads --pid through the same canonical resolver,
+        # so the call carries ``pid`` (None here — no --pid was supplied).
         mock._resolve_hwnd.assert_called_once_with(
-            app="notepad", window_title=None,
+            app="notepad", window_title=None, pid=None,
         )
         mock.set_element_value.assert_called_once_with(
             text="hello",

--- a/tests/test_window_targeting_getset_quit_871.py
+++ b/tests/test_window_targeting_getset_quit_871.py
@@ -1,0 +1,293 @@
+"""#871: close the last window-targeting-flag gaps — ``get``/``set`` ``--pid``
+and ``app quit`` ``--window``/``--hwnd``.
+
+The window-targeting flag family (``--app``, ``--window``, ``--hwnd``, ``--pid``,
+``--app-id``) is the "gold standard" exposed by ``see``/``capture``/``click``.
+Sibling modules already harmonised the discovery commands
+(:mod:`test_window_targeting_flags_871`) and the ``app`` window-state subgroup
+(:mod:`test_app_window_targeting_871`).  This module closes the two rows those
+modules explicitly deferred as follow-ups:
+
+* ``get`` / ``set`` — the UIA *value-pattern* path.  ``get_element_value`` /
+  ``set_element_value`` target a window by ``hwnd`` and take no ``pid``, so
+  ``--pid`` is resolved to a concrete handle in the CLI via the canonical
+  ``_resolve_hwnd`` resolver (the same path the app window-state commands use),
+  needing no backend method-signature change.
+* ``app quit`` — the process-lifecycle path.  ``quit`` terminates a process, so
+  a ``--window``/``--hwnd`` target is resolved to its owning PID via the same
+  resolver plus the backend window list.
+
+All mock-based, CI-safe (no real desktop / DLL).
+"""
+from __future__ import annotations
+
+import json
+import platform
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from naturo.backends.base import WindowInfo
+from naturo.cli import main
+from naturo.cli.app_cmd import app_quit
+
+runner = CliRunner()
+
+_get_mod = sys.modules["naturo.cli.values._get"]
+_set_mod = sys.modules["naturo.cli.values._set"]
+
+
+# ── get / set : --pid flag surface ───────────────────────────────────────────
+
+_VALUE_COMMANDS = [["get"], ["set"]]
+
+
+@pytest.mark.parametrize("cmd_args", _VALUE_COMMANDS)
+def test_pid_flag_in_help(cmd_args):
+    """``get``/``set`` --help must now advertise ``--pid`` (the last gap in the
+    window-targeting family for the value-pattern path)."""
+    result = runner.invoke(main, cmd_args + ["--help"])
+    assert result.exit_code == 0, result.output
+    assert "--pid" in result.output, (
+        f"naturo {' '.join(cmd_args)} --help missing --pid:\n{result.output}"
+    )
+
+
+@pytest.mark.parametrize("cmd_args", _VALUE_COMMANDS)
+def test_pid_flag_not_rejected(cmd_args):
+    """``--pid`` must reach the handler, not abort at the Click layer."""
+    result = runner.invoke(main, cmd_args + ["--pid", "4321", "e1"])
+    assert "No such option" not in result.output, (
+        f"naturo {' '.join(cmd_args)} --pid rejected the flag:\n{result.output}"
+    )
+
+
+@pytest.mark.parametrize("cmd_args", _VALUE_COMMANDS)
+def test_full_window_target_family_present(cmd_args):
+    """The full gold-standard family (minus --app-id, tracked #522) is exposed."""
+    result = runner.invoke(main, cmd_args + ["--help"])
+    for flag in ["--app", "--window", "--hwnd", "--pid"]:
+        assert flag in result.output, (
+            f"naturo {' '.join(cmd_args)} --help missing {flag}:\n{result.output}"
+        )
+
+
+# ── get : --pid resolves to a concrete hwnd ──────────────────────────────────
+
+
+def _windows_platform_patch(module):
+    """Force the module's platform gate to see Windows on non-Windows CI."""
+    if platform.system() == "Windows":
+        from contextlib import nullcontext
+        return nullcontext()
+    mock_plat = MagicMock()
+    mock_plat.system.return_value = "Windows"
+    return patch.object(module, "platform", mock_plat)
+
+
+def test_get_pid_resolves_to_hwnd_single_element():
+    """``get --pid`` resolves the PID to a handle via ``_resolve_hwnd`` and reads
+    the element value scoped to that handle."""
+    backend = MagicMock()
+    backend._resolve_hwnd.return_value = 999
+    backend.get_element_value.return_value = {
+        "value": "hi", "role": "Edit", "name": "Search",
+        "pattern": "ValuePattern", "automation_id": "x",
+        "x": 0, "y": 0, "width": 1, "height": 1,
+    }
+    with patch.object(_get_mod, "_get_backend", return_value=backend), \
+            _windows_platform_patch(_get_mod):
+        result = runner.invoke(main, ["get", "--pid", "4321", "e1"])
+    assert result.exit_code == 0, result.output
+    backend._resolve_hwnd.assert_called_once_with(
+        app=None, window_title=None, pid=4321
+    )
+    assert backend.get_element_value.call_args.kwargs["hwnd"] == 999
+
+
+def test_get_pid_resolves_to_hwnd_all_mode():
+    """``get --all --pid`` threads the resolved handle into ``get_element_tree``."""
+    backend = MagicMock()
+    backend._resolve_hwnd.return_value = 999
+    backend.get_element_tree.return_value = None  # no elements → clean exit
+    with patch.object(_get_mod, "_get_backend", return_value=backend), \
+            _windows_platform_patch(_get_mod):
+        result = runner.invoke(
+            main, ["get", "--all", "--role", "Button", "--pid", "4321", "-j"]
+        )
+    backend._resolve_hwnd.assert_called_once_with(
+        app=None, window_title=None, pid=4321
+    )
+    assert backend.get_element_tree.call_args.kwargs["hwnd"] == 999
+
+
+def test_get_explicit_hwnd_wins_over_pid():
+    """An explicit ``--hwnd`` short-circuits PID resolution (most specific wins)."""
+    backend = MagicMock()
+    backend.get_element_value.return_value = {
+        "value": "hi", "role": "Edit", "name": None,
+        "pattern": "ValuePattern", "automation_id": None,
+        "x": 0, "y": 0, "width": 1, "height": 1,
+    }
+    with patch.object(_get_mod, "_get_backend", return_value=backend), \
+            _windows_platform_patch(_get_mod):
+        result = runner.invoke(main, ["get", "--hwnd", "555", "--pid", "4321", "e1"])
+    assert result.exit_code == 0, result.output
+    backend._resolve_hwnd.assert_not_called()
+    assert backend.get_element_value.call_args.kwargs["hwnd"] == 555
+
+
+def test_get_pid_not_found_exits_nonzero():
+    """An unresolvable ``--pid`` surfaces WindowNotFoundError loudly (exit 1)."""
+    from naturo.errors import WindowNotFoundError
+
+    backend = MagicMock()
+    backend._resolve_hwnd.side_effect = WindowNotFoundError("PID 4321")
+    with patch.object(_get_mod, "_get_backend", return_value=backend), \
+            _windows_platform_patch(_get_mod):
+        result = runner.invoke(main, ["get", "--pid", "4321", "e1"])
+    assert result.exit_code != 0
+    backend.get_element_value.assert_not_called()
+
+
+# ── set : --pid resolves to a concrete hwnd ──────────────────────────────────
+
+
+def _patch_set(backend):
+    """Patch set_cmd's backend + ref resolver (identity mode, no cached point)."""
+    return (
+        patch.object(_set_mod, "_get_backend", return_value=backend),
+        patch.object(
+            _set_mod, "_resolve_element_identifiers",
+            return_value=("aid", "Edit", "Search", None, None),
+        ),
+        _windows_platform_patch(_set_mod),
+    )
+
+
+def test_set_pid_resolves_to_hwnd():
+    """``set --pid`` resolves the PID to a handle and writes the value there."""
+    backend = MagicMock()
+    backend._resolve_hwnd.return_value = 999
+    backend.set_element_value.return_value = True
+    p1, p2, p3 = _patch_set(backend)
+    with p1, p2, p3:
+        result = runner.invoke(main, ["set", "--pid", "4321", "e1", "hello"])
+    assert result.exit_code == 0, result.output
+    backend._resolve_hwnd.assert_called_once_with(
+        app=None, window_title=None, pid=4321
+    )
+    assert backend.set_element_value.call_args.kwargs["hwnd"] == 999
+
+
+def test_set_pid_combined_with_window_filter():
+    """``--pid`` + ``--window`` narrows the PID match through the resolver."""
+    backend = MagicMock()
+    backend._resolve_hwnd.return_value = 999
+    backend.set_element_value.return_value = True
+    p1, p2, p3 = _patch_set(backend)
+    with p1, p2, p3:
+        result = runner.invoke(
+            main, ["set", "--pid", "4321", "--window", "Chat", "e1", "hi"]
+        )
+    assert result.exit_code == 0, result.output
+    backend._resolve_hwnd.assert_called_once_with(
+        app=None, window_title="Chat", pid=4321
+    )
+
+
+def test_set_explicit_hwnd_wins_over_pid():
+    """An explicit ``--hwnd`` short-circuits PID resolution for ``set`` too."""
+    backend = MagicMock()
+    backend.set_element_value.return_value = True
+    p1, p2, p3 = _patch_set(backend)
+    with p1, p2, p3:
+        result = runner.invoke(main, ["set", "--hwnd", "555", "--pid", "4321", "e1", "hi"])
+    assert result.exit_code == 0, result.output
+    backend._resolve_hwnd.assert_not_called()
+    assert backend.set_element_value.call_args.kwargs["hwnd"] == 555
+
+
+# ── app quit : --window / --hwnd resolve to the owning PID ────────────────────
+
+
+def _make_window(handle, pid, title="Untitled - Notepad"):
+    return WindowInfo(
+        handle=handle, title=title, process_name="notepad.exe", pid=pid,
+        x=0, y=0, width=800, height=600, is_visible=True, is_minimized=False,
+    )
+
+
+@pytest.mark.parametrize("flag", ["--window", "--hwnd"])
+def test_quit_window_target_in_help(flag):
+    """``app quit --help`` must advertise the window-targeting flags."""
+    result = runner.invoke(app_quit, ["--help"])
+    assert result.exit_code == 0, result.output
+    assert flag in result.output, f"app quit --help missing {flag}:\n{result.output}"
+
+
+def test_quit_hwnd_resolves_to_owning_pid():
+    """``app quit --hwnd`` resolves the handle to its process and quits by PID."""
+    backend = MagicMock()
+    backend._resolve_hwnd.return_value = 999
+    backend.list_windows.return_value = [_make_window(999, 4321)]
+    with patch("naturo.backends.base.get_backend", return_value=backend), \
+            patch("naturo.process.quit_app") as mock_quit:
+        result = runner.invoke(app_quit, ["--hwnd", "999"])
+    assert result.exit_code == 0, result.output
+    backend._resolve_hwnd.assert_called_once_with(window_title=None, hwnd=999)
+    assert mock_quit.call_args.kwargs["pid"] == 4321
+
+
+def test_quit_window_resolves_to_owning_pid():
+    """``app quit --window`` resolves the title to a handle then to its PID."""
+    backend = MagicMock()
+    backend._resolve_hwnd.return_value = 999
+    backend.list_windows.return_value = [_make_window(999, 4321)]
+    with patch("naturo.backends.base.get_backend", return_value=backend), \
+            patch("naturo.process.quit_app") as mock_quit:
+        result = runner.invoke(app_quit, ["--window", "Notepad"])
+    assert result.exit_code == 0, result.output
+    backend._resolve_hwnd.assert_called_once_with(window_title="Notepad", hwnd=None)
+    assert mock_quit.call_args.kwargs["pid"] == 4321
+
+
+def test_quit_explicit_name_wins_over_window():
+    """A positional NAME still wins — no window resolution when a name is given."""
+    backend = MagicMock()
+    with patch("naturo.backends.base.get_backend", return_value=backend), \
+            patch("naturo.process.quit_app") as mock_quit:
+        result = runner.invoke(app_quit, ["notepad", "--hwnd", "999"])
+    assert result.exit_code == 0, result.output
+    backend._resolve_hwnd.assert_not_called()
+    assert mock_quit.call_args.kwargs["name"] == "notepad"
+
+
+def test_quit_window_not_found_exits_nonzero():
+    """A window target that matches no window fails loudly (exit 1), not silently."""
+    from naturo.errors import WindowNotFoundError
+
+    backend = MagicMock()
+    backend._resolve_hwnd.side_effect = WindowNotFoundError("hwnd 999")
+    with patch("naturo.backends.base.get_backend", return_value=backend), \
+            patch("naturo.process.quit_app") as mock_quit:
+        result = runner.invoke(app_quit, ["--hwnd", "999"])
+    assert result.exit_code != 0
+    mock_quit.assert_not_called()
+
+
+def test_quit_hwnd_no_matching_pid_exits_nonzero():
+    """When the resolved handle owns no listed window, quit errors (no silent no-op)."""
+    backend = MagicMock()
+    backend._resolve_hwnd.return_value = 999
+    backend.list_windows.return_value = [_make_window(111, 4321)]  # different handle
+    with patch("naturo.backends.base.get_backend", return_value=backend), \
+            patch("naturo.process.quit_app") as mock_quit:
+        result = runner.invoke(app_quit, ["--hwnd", "999", "-j"])
+    assert result.exit_code != 0
+    mock_quit.assert_not_called()
+    payload = json.loads(result.output)
+    assert payload["success"] is False
+    assert payload["error"]["code"] == "WINDOW_NOT_FOUND"


### PR DESCRIPTION
Closes the last inconsistent rows of the window-targeting flag matrix (#871). (#864, the `--id eN` half, was already fully implemented + tested on develop — verified and closed separately.)

## Before → After
- `get` / `set`: had {--app, --window, --hwnd, --app-id} but **missing `--pid`** → now both expose {--app, --window, --hwnd, --pid, --app-id, --id}. `--pid` resolves to a concrete handle via the canonical `backend._resolve_hwnd` (same path the app window-state commands use; explicit `--hwnd` wins; unresolvable `--pid` → loud WINDOW_NOT_FOUND).
- `app quit`: had {--app, --pid} but **missing `--window`/`--hwnd`** → now {--app, --window, --hwnd, --pid}. A `--window`/`--hwnd` target resolves to its owning PID via `_resolve_hwnd` + `list_windows` (loud failure when nothing matches; quit is process-level).
- (find / highlight / menu-inspect / list-windows / app focus·close·min·max·restore·move were already harmonized + tested on develop.)

Purely additive flags; no backend signature changes. One stale exact-call assertion in `test_set_cmd.py` updated (set's `_resolve_hwnd` now carries `pid=None` when `--pid` omitted — behavior unchanged).

## Verification
- `pytest -m 'not ui and not integration and not desktop'`: 7063 passed / 169 skipped (6 pre-existing native-DLL host failures unrelated). New `tests/test_window_targeting_getset_quit_871.py` (20 tests).
- `ruff check naturo/`: clean. `mypy naturo/`: clean.

Closes #871

🤖 Generated with [Claude Code](https://claude.com/claude-code)