### PR TITLE
feat(cli): scriptable --field selection for list/app commands (#1206)

### DIFF
--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -315,6 +315,7 @@ List running applications (delegates to 'app list').
 |------|------|-------------|
 | `--all` | boolean | Show all processes (not just apps with windows) |
 | `--json`, `-j` | boolean | JSON output |
+| `--field`, `-F` | text | Print only these columns (comma-separated for multiple; tab-separated output). A single field of a single row prints the bare value for `$(...)` capture. |
 
 ### `naturo list screens`
 
@@ -325,6 +326,7 @@ List connected screens/monitors.
 | Flag | Type | Description |
 |------|------|-------------|
 | `--json`, `-j` | boolean | JSON output |
+| `--field`, `-F` | text | Print only these columns (comma-separated for multiple; tab-separated output). A single field of a single row prints the bare value for `$(...)` capture. |
 
 ### `naturo list windows`
 
@@ -340,6 +342,15 @@ List open windows.
 | `--app-id` | text | Stable app/window ID from "naturo app list" output (e.g. a1) |
 | `--pid` | integer | Process ID |
 | `--json`, `-j` | boolean | JSON output |
+| `--field`, `-F` | text | Print only these columns (comma-separated for multiple; tab-separated output). A single field of a single row prints the bare value for `$(...)` capture. |
+
+**Examples:**
+
+```bash
+naturo list windows --app "SOLIDWORKS" --field hwnd    # bare HWND for $(...)
+naturo list windows --field hwnd,pid,title             # multi-column, tab-separated
+naturo list windows --field hwnd -j                    # projected JSON envelope
+```
 
 ## `naturo menu-inspect`
 
@@ -757,6 +768,7 @@ Find a running application by name or PID.
 |------|------|-------------|
 | `--pid` | integer | Search by PID instead of name |
 | `--json`, `-j` | boolean | JSON output |
+| `--field`, `-F` | text | Print only these process columns (comma-separated for multiple; tab-separated output). Valid: pid, name, path, is_running, window_count. |
 
 ### `naturo app focus`
 
@@ -850,6 +862,7 @@ List running applications with visible windows.
 |------|------|-------------|
 | `--all` | boolean | Show all processes (not just apps with windows) |
 | `--json`, `-j` | boolean | JSON output |
+| `--field`, `-F` | text | Print only these columns (comma-separated for multiple; tab-separated output). A single field of a single row prints the bare value for `$(...)` capture. |
 
 ### `naturo app maximize`
 
@@ -1033,6 +1046,7 @@ List open windows (optionally filtered by app name or PID).
 |------|------|-------------|
 | `--pid` | integer | Process ID |
 | `--json`, `-j` | boolean | JSON output |
+| `--field`, `-F` | text | Print only these columns (comma-separated for multiple; tab-separated output). A single field of a single row prints the bare value for `$(...)` capture. |
 
 **Examples:**
 

--- a/naturo/cli/_app/lifecycle.py
+++ b/naturo/cli/_app/lifecycle.py
@@ -8,11 +8,19 @@ import sys
 import click
 
 from naturo.cli.error_helpers import json_error as _json_error_str
+from naturo.cli._field import emit_projection, field_option, parse_fields, resolve_fields
 from naturo.cli._app._common import (
     _APP_ID_RE,
     _resolve_app_id,
     _safe_echo,
 )
+
+# Row schemas for --field projection (#1206), kept beside the emitters below.
+_APP_LIST_FIELDS = (
+    "id", "handle", "hwnd", "pid", "process_name", "title",
+    "x", "y", "width", "height", "is_visible", "is_minimized",
+)
+_FIND_FIELDS = ("pid", "name", "path", "is_running", "window_count")
 
 
 @click.command("launch")
@@ -278,8 +286,9 @@ def app_relaunch(ctx, name, app_name, wait_until_ready, timeout, json_output) ->
 @click.command("list")
 @click.option("--all", "show_all", is_flag=True, help="Show all processes (not just apps with windows)")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
+@field_option
 @click.pass_context
-def app_list(ctx, show_all, json_output) -> None:
+def app_list(ctx, show_all, json_output, field) -> None:
     """List running applications with visible windows.
 
     By default, shows user-facing applications with visible windows
@@ -384,26 +393,36 @@ def app_list(ctx, show_all, json_output) -> None:
         window_pids = {w.pid for w in windows}
         background_apps = [a for a in all_procs if a.pid not in window_pids]
 
+    # Canonical per-window row schema, built once and shared by the `-j`
+    # payload and `--field` projection so their keys never drift (#1206).
+    window_rows = [
+        {
+            "id": f"a{i}",
+            "handle": w.handle,
+            # `hwnd` alias mirrors `list windows` so the two commands
+            # share one interchangeable window schema (#952).
+            "hwnd": w.handle,
+            "pid": w.pid,
+            "process_name": w.process_name,
+            "title": w.title,
+            "x": w.x, "y": w.y,
+            "width": w.width, "height": w.height,
+            "is_visible": w.is_visible,
+            "is_minimized": w.is_minimized,
+        }
+        for i, w in enumerate(windows, start=1)
+    ]
+
+    fields = parse_fields(field)
+    if fields is not None:
+        resolve_fields(fields, _APP_LIST_FIELDS, json_output)
+        emit_projection(window_rows, fields, "windows", json_output)
+        return
+
     if json_output:
         result = {
             "success": True,
-            "windows": [
-                {
-                    "id": f"a{i}",
-                    "handle": w.handle,
-                    # `hwnd` alias mirrors `list windows` so the two commands
-                    # share one interchangeable window schema (#952).
-                    "hwnd": w.handle,
-                    "pid": w.pid,
-                    "process_name": w.process_name,
-                    "title": w.title,
-                    "x": w.x, "y": w.y,
-                    "width": w.width, "height": w.height,
-                    "is_visible": w.is_visible,
-                    "is_minimized": w.is_minimized,
-                }
-                for i, w in enumerate(windows, start=1)
-            ],
+            "windows": window_rows,
             "count": len(windows),
         }
         if show_all:
@@ -441,8 +460,9 @@ def app_list(ctx, show_all, json_output) -> None:
 @click.argument("name")
 @click.option("--pid", type=int, help="Search by PID instead of name")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
+@field_option
 @click.pass_context
-def app_find(ctx, name, pid, json_output) -> None:
+def app_find(ctx, name, pid, json_output, field) -> None:
     """Find a running application by name or PID."""
     json_output = json_output or (ctx.obj or {}).get("json", False)
 
@@ -470,16 +490,32 @@ def app_find(ctx, name, pid, json_output) -> None:
 
     proc = find_process(name=name, pid=pid)
     if proc:
+        # `find` resolves a single process; `--field` projects that one row —
+        # under -j into the `process` object, in text mode to a bare tab-joined
+        # value line so a lookup like `--field pid` is $(...)-capturable (#1206).
+        proc_row = {
+            "pid": proc.pid,
+            "name": proc.name,
+            "path": proc.path,
+            "is_running": proc.is_running,
+            "window_count": proc.window_count,
+        }
+        fields = parse_fields(field)
+        if fields is not None:
+            resolve_fields(fields, _FIND_FIELDS, json_output)
+            if json_output:
+                click.echo(json_dumps(
+                    {"success": True, "process": {f: proc_row[f] for f in fields}},
+                    indent=2,
+                ))
+            else:
+                from naturo.cli._field import format_value
+                click.echo("\t".join(format_value(proc_row[f]) for f in fields))
+            return
         if json_output:
             click.echo(json_dumps({
                 "success": True,
-                "process": {
-                    "pid": proc.pid,
-                    "name": proc.name,
-                    "path": proc.path,
-                    "is_running": proc.is_running,
-                    "window_count": proc.window_count,
-                },
+                "process": proc_row,
             }, indent=2))
         else:
             _safe_echo(f"Found: {proc.name} (PID: {proc.pid})")

--- a/naturo/cli/_app/window_ops.py
+++ b/naturo/cli/_app/window_ops.py
@@ -8,6 +8,7 @@ import click
 
 from naturo.cli.error_helpers import json_error as _json_error_str
 from naturo.cli.core._common import _enforce_desktop_session
+from naturo.cli._field import emit_projection, field_option, parse_fields, resolve_fields
 from naturo.cli._app._common import (
     _handle_generic_error,
     _handle_naturo_error,
@@ -388,12 +389,20 @@ def app_move(ctx, name, app_name, window_title, hwnd, pid, x, y, width, height, 
         _handle_generic_error(exc, json_output)
 
 
+# Row schema for `app windows` --field projection (#1206).
+_APP_WINDOWS_FIELDS = (
+    "handle", "title", "process_name", "pid",
+    "x", "y", "width", "height", "is_visible", "is_minimized",
+)
+
+
 @click.command("windows")
 @click.argument("name", required=False, default=None)
 @click.option("--pid", type=int, help="Process ID")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
+@field_option
 @click.pass_context
-def app_windows(ctx, name, pid, json_output) -> None:
+def app_windows(ctx, name, pid, json_output, field) -> None:
     """List open windows (optionally filtered by app name or PID).
 
     \b
@@ -431,22 +440,28 @@ def app_windows(ctx, name, pid, json_output) -> None:
         if pid is not None:
             windows = [w for w in windows if w.pid == pid]
 
-        if json_output:
+        window_rows = [
+            {
+                "handle": w.handle,
+                "title": w.title,
+                "process_name": w.process_name,
+                "pid": w.pid,
+                "x": w.x, "y": w.y,
+                "width": w.width, "height": w.height,
+                "is_visible": w.is_visible,
+                "is_minimized": w.is_minimized,
+            }
+            for w in windows
+        ]
+
+        fields = parse_fields(field)
+        if fields is not None:
+            resolve_fields(fields, _APP_WINDOWS_FIELDS, json_output)
+            emit_projection(window_rows, fields, "windows", json_output)
+        elif json_output:
             click.echo(json_dumps({
                 "success": True,
-                "windows": [
-                    {
-                        "handle": w.handle,
-                        "title": w.title,
-                        "process_name": w.process_name,
-                        "pid": w.pid,
-                        "x": w.x, "y": w.y,
-                        "width": w.width, "height": w.height,
-                        "is_visible": w.is_visible,
-                        "is_minimized": w.is_minimized,
-                    }
-                    for w in windows
-                ],
+                "windows": window_rows,
                 "count": len(windows),
             }, indent=2))
         else:

--- a/naturo/cli/_field.py
+++ b/naturo/cli/_field.py
@@ -1,0 +1,104 @@
+"""Scriptable ``--field`` projection for list-style commands (#1206).
+
+Common scripting lookups ("get the HWND of the SolidWorks main window") used to
+force a pipe into ``jq``/Python because ``-j`` emits the whole row schema. A
+``--field NAME[,NAME...]`` selector lets the value come straight out of naturo:
+
+* text mode prints only the selected columns, one row per line, tab-separated in
+  the order requested — so a single field of a single row is a **bare value**,
+  capturable directly with ``HWND=$(naturo list windows --app X --field hwnd)``;
+* ``-j`` still returns the canonical collection success envelope, but with each
+  item projected down to exactly the requested fields.
+
+Field names are validated against the command's row schema up front: an unknown
+name fails loudly (``INVALID_INPUT``, listing the valid fields) instead of
+silently emitting blank columns.
+"""
+from __future__ import annotations
+
+from typing import Any, Sequence, TypeVar
+
+import click
+
+from naturo.cli._jsonio import json_dumps
+from naturo.cli.error_helpers import emit_error, success_envelope
+
+_CommandT = TypeVar("_CommandT")
+
+_FIELD_HELP = (
+    "Print only these columns (comma-separated for multiple, e.g. "
+    "--field title,pid). Output is one row per line, tab-separated; a single "
+    "field of a single row prints the bare value for $(...) capture."
+)
+
+
+def field_option(func: _CommandT) -> _CommandT:
+    """Attach the shared ``-F/--field`` option to a Click command."""
+    return click.option("-F", "--field", "field", default=None, help=_FIELD_HELP)(func)  # type: ignore[return-value]
+
+
+def parse_fields(field: str | None) -> list[str] | None:
+    """Parse a ``--field`` spec into an ordered list of names, or ``None``.
+
+    ``None`` (the option was not given) is returned unchanged so callers can
+    branch on "no projection requested". A provided spec is split on commas and
+    stripped; empty tokens are dropped (an all-empty spec yields ``[]``, which
+    :func:`resolve_fields` rejects as INVALID_INPUT).
+    """
+    if field is None:
+        return None
+    return [name.strip() for name in field.split(",") if name.strip()]
+
+
+def format_value(value: Any) -> str:
+    """Render a single projected cell for text output (``None`` -> empty)."""
+    if value is None:
+        return ""
+    return str(value)
+
+
+def resolve_fields(
+    fields: list[str],
+    valid_fields: Sequence[str],
+    json_output: bool,
+) -> None:
+    """Validate requested ``fields`` against the row schema, or exit loudly.
+
+    Emits an ``INVALID_INPUT`` error (JSON envelope or ``Error:`` line) and
+    exits when no field is given or when any requested name is not a column, so
+    a typo surfaces immediately instead of producing blank output.
+    """
+    if not fields:
+        emit_error(
+            "INVALID_INPUT",
+            f"Specify at least one --field name. Valid fields: {', '.join(valid_fields)}",
+            json_output,
+        )
+    unknown = [f for f in fields if f not in valid_fields]
+    if unknown:
+        emit_error(
+            "INVALID_INPUT",
+            f"Unknown --field name(s): {', '.join(unknown)}. "
+            f"Valid fields: {', '.join(valid_fields)}",
+            json_output,
+        )
+
+
+def emit_projection(
+    rows: Sequence[dict[str, Any]],
+    fields: list[str],
+    collection_key: str,
+    json_output: bool,
+) -> None:
+    """Emit the projected collection (call after :func:`resolve_fields`).
+
+    Under ``-j`` returns the canonical success envelope with each item reduced
+    to the requested fields; in text mode prints one row per line, the fields
+    tab-separated in requested order.
+    """
+    if json_output:
+        projected = [{f: row.get(f) for f in fields} for row in rows]
+        click.echo(json_dumps(success_envelope(collection_key, projected), indent=2))
+    else:
+        for row in rows:
+            click.echo("\t".join(format_value(row.get(f)) for f in fields))

--- a/naturo/cli/core/_list.py
+++ b/naturo/cli/core/_list.py
@@ -8,6 +8,18 @@ import platform
 import click
 
 import naturo.cli.core._common as _common
+from naturo.cli._field import emit_projection, field_option, parse_fields, resolve_fields
+
+# Row schemas for --field projection (#1206). Kept next to the emitters below so
+# the valid-field set stays in lockstep with the dicts those emitters build.
+_WINDOW_FIELDS = (
+    "id", "handle", "hwnd", "title", "process_name", "pid",
+    "x", "y", "width", "height", "is_visible", "is_minimized",
+)
+_SCREEN_FIELDS = (
+    "index", "name", "device_path", "x", "y", "width", "height",
+    "is_primary", "scale_factor", "dpi", "work_area",
+)
 
 
 def _window_state(w) -> str:
@@ -60,11 +72,12 @@ def list_cmd() -> None:
 @list_cmd.command()
 @click.option("--all", "show_all", is_flag=True, help="Show all processes (not just apps with windows)")
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
+@field_option
 @click.pass_context
-def apps(ctx, show_all, json_output) -> None:
+def apps(ctx, show_all, json_output, field) -> None:
     """List running applications (delegates to 'app list')."""
     from naturo.cli.app_cmd import app_list
-    ctx.invoke(app_list, show_all=show_all, json_output=json_output)
+    ctx.invoke(app_list, show_all=show_all, json_output=json_output, field=field)
 
 
 @list_cmd.command()
@@ -81,7 +94,8 @@ def apps(ctx, show_all, json_output) -> None:
               help="Show every raw HWND. By default, duplicate handles of the "
                    "same window (UWP frames/helper strips sharing one pid+title) "
                    "are collapsed to one usable handle per window.")
-def windows(app, window_title, hwnd, app_id, pid, json_output, show_all) -> None:
+@field_option
+def windows(app, window_title, hwnd, app_id, pid, json_output, show_all, field) -> None:
     """List open windows.
 
     Shows all visible top-level windows with their handles, titles,
@@ -183,7 +197,11 @@ def windows(app, window_title, hwnd, app_id, pid, json_output, show_all) -> None
                     err=True,
                 )
 
-        if json_output:
+        # Build the canonical row schema whenever it is needed — for the `-j`
+        # payload or for `--field` projection (which reuses these exact rows so
+        # the projected keys never drift from the emitted schema, #1206).
+        fields = parse_fields(field)
+        if json_output or fields is not None:
             # Assign stable session-scoped IDs (a1, a2, ...) on the listed
             # windows so each entry is directly targetable with --app-id, matching
             # `list apps` / `app list` (#952). Without this the emitted `id` would
@@ -210,6 +228,11 @@ def windows(app, window_title, hwnd, app_id, pid, json_output, show_all) -> None
                 }
                 for i, w in enumerate(win_list, start=1)
             ]
+
+        if fields is not None:
+            resolve_fields(fields, _WINDOW_FIELDS, json_output)
+            emit_projection(data, fields, "windows", json_output)
+        elif json_output:
             click.echo(json_dumps({"success": True, "windows": data, "count": len(data)}, indent=2))
         else:
             if not win_list:
@@ -232,7 +255,8 @@ def windows(app, window_title, hwnd, app_id, pid, json_output, show_all) -> None
 
 @list_cmd.command()
 @click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
-def screens(json_output) -> None:
+@field_option
+def screens(json_output, field) -> None:
     """List connected screens/monitors.
 
     Shows monitor index, resolution, position, DPI scale factor, and
@@ -243,7 +267,8 @@ def screens(json_output) -> None:
         backend = _common._get_backend(json_output)
         monitors = backend.list_monitors()
 
-        if json_output:
+        fields = parse_fields(field)
+        if json_output or fields is not None:
             items = []
             for m in monitors:
                 # (#359) Use model_name as 'name', keep device path separate
@@ -263,6 +288,11 @@ def screens(json_output) -> None:
                 if m.work_area:
                     item["work_area"] = m.work_area
                 items.append(item)
+
+        if fields is not None:
+            resolve_fields(fields, _SCREEN_FIELDS, json_output)
+            emit_projection(items, fields, "monitors", json_output)
+        elif json_output:
             click.echo(json_dumps({"success": True, "monitors": items, "count": len(items)}, indent=2))
         else:
             from naturo.cli.table import print_table

--- a/tests/test_field_selection_1206.py
+++ b/tests/test_field_selection_1206.py
@@ -1,0 +1,257 @@
+"""#1206 — scriptable ``--field`` selection for list-style commands.
+
+Common scripting lookups ("get the HWND of the SolidWorks main window") used to
+force a pipe into ``jq``/Python. ``--field NAME[,NAME...]`` projects the row down
+to the requested columns so the value comes straight out of naturo:
+
+* text mode prints one row per line, tab-separated in the requested order — a
+  single field of a single row is a bare, ``$(...)``-capturable value;
+* ``-j`` returns the canonical success envelope with each item projected;
+* an unknown field name fails loudly (``INVALID_INPUT``) listing the valid
+  fields, rather than silently emitting blanks;
+* default (no ``--field``) output is unchanged.
+
+All mock-based, CI-safe (no real desktop / DLL).
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from naturo.backends.base import WindowInfo
+from naturo.cli._app.lifecycle import app_find, app_list
+from naturo.cli._app.window_ops import app_windows
+from naturo.cli.core._list import list_cmd
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def _make_window(**overrides):
+    return WindowInfo(
+        handle=overrides.get("handle", 1182906),
+        title=overrides.get("title", "Untitled - Notepad"),
+        process_name=overrides.get("process_name", "notepad.exe"),
+        pid=overrides.get("pid", 31912),
+        x=overrides.get("x", 100),
+        y=overrides.get("y", 100),
+        width=overrides.get("width", 800),
+        height=overrides.get("height", 600),
+        is_visible=overrides.get("is_visible", True),
+        is_minimized=overrides.get("is_minimized", False),
+    )
+
+
+def _invoke_list_windows(runner, args, windows):
+    backend = MagicMock()
+    backend.list_windows.return_value = windows
+    with patch("naturo.cli.core._common._platform_supports_gui", return_value=True), \
+         patch("naturo.cli.core._common._get_backend", return_value=backend), \
+         patch("naturo.app_ids.get_app_id_map", return_value=MagicMock()), \
+         patch("os.getpid", return_value=99999), patch("os.getppid", return_value=99998):
+        return runner.invoke(list_cmd, ["windows", *args], catch_exceptions=False)
+
+
+def _invoke_app_list(runner, args, windows):
+    backend = MagicMock()
+    backend.list_windows.return_value = windows
+    backend._SYSTEM_PROCESS_NAMES = set()
+    backend._UWP_HOST_PROCESS = "applicationframehost.exe"
+    with patch("naturo.backends.base.get_backend", return_value=backend), \
+         patch("naturo.cli.interaction._check_desktop_session"), \
+         patch("naturo.app_ids.get_app_id_map", return_value=MagicMock()):
+        return runner.invoke(app_list, args, obj={}, catch_exceptions=False)
+
+
+def _invoke_app_windows(runner, args, windows):
+    backend = MagicMock()
+    backend.list_windows.return_value = windows
+    with patch("naturo.backends.base.get_backend", return_value=backend), \
+         patch("naturo.cli.core._common._enforce_desktop_session"), \
+         patch("naturo.cli._app.window_ops._enforce_desktop_session"):
+        return runner.invoke(app_windows, args, obj={}, catch_exceptions=False)
+
+
+# ── list windows ────────────────────────────────────────────────────────────
+
+class TestListWindowsField:
+
+    def test_single_field_text_is_bare_value(self, runner):
+        """One field + one row prints the bare value (no header) for $(...)."""
+        result = _invoke_list_windows(runner, ["--field", "hwnd"], [_make_window(handle=70354)])
+        assert result.exit_code == 0, result.output
+        assert result.output.strip() == "70354"
+
+    def test_single_field_multiple_rows_one_per_line(self, runner):
+        wins = [_make_window(handle=1, pid=10, title="A"),
+                _make_window(handle=2, pid=20, title="B")]
+        result = _invoke_list_windows(runner, ["--field", "hwnd"], wins)
+        assert result.exit_code == 0, result.output
+        assert result.output.strip().splitlines() == ["1", "2"]
+
+    def test_multi_field_tab_separated_in_order(self, runner):
+        wins = [_make_window(handle=70354, pid=29388, title="SOLIDWORKS")]
+        result = _invoke_list_windows(runner, ["--field", "hwnd,pid,title"], wins)
+        assert result.exit_code == 0, result.output
+        assert result.output.strip() == "70354\t29388\tSOLIDWORKS"
+
+    def test_field_json_projects_envelope(self, runner):
+        wins = [_make_window(handle=1, pid=10, title="A"),
+                _make_window(handle=2, pid=20, title="B")]
+        result = _invoke_list_windows(runner, ["--field", "hwnd,title", "--json"], wins)
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["success"] is True
+        assert payload["count"] == 2
+        assert payload["windows"] == [
+            {"hwnd": 1, "title": "A"},
+            {"hwnd": 2, "title": "B"},
+        ]
+
+    def test_unknown_field_errors_text(self, runner):
+        result = _invoke_list_windows(runner, ["--field", "bogus"], [_make_window()])
+        assert result.exit_code == 1, result.output
+        assert "bogus" in result.output
+        # Lists the valid fields to guide recovery.
+        assert "title" in result.output
+
+    def test_unknown_field_errors_json(self, runner):
+        result = _invoke_list_windows(runner, ["--field", "hwnd,bogus", "--json"], [_make_window()])
+        assert result.exit_code == 1, result.output
+        payload = json.loads(result.output)
+        assert payload["success"] is False
+        assert payload["error"]["code"] == "INVALID_INPUT"
+        assert "bogus" in payload["error"]["message"]
+
+    def test_default_output_unchanged(self, runner):
+        """No --field: the human table is untouched."""
+        result = _invoke_list_windows(runner, [], [_make_window(handle=70354, title="Untitled - Notepad")])
+        assert result.exit_code == 0, result.output
+        assert "HWND" in result.output
+        assert "70354" in result.output
+        assert "1 windows found" in result.output
+
+    def test_default_json_unchanged(self, runner):
+        result = _invoke_list_windows(runner, ["--json"], [_make_window(handle=70354)])
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        w = payload["windows"][0]
+        # Full schema still present when no projection requested.
+        assert {"id", "handle", "hwnd", "title", "process_name", "pid",
+                "x", "y", "width", "height", "is_visible", "is_minimized"} <= set(w)
+
+
+# ── list apps / app list ────────────────────────────────────────────────────
+
+class TestAppListField:
+
+    def test_single_field_text(self, runner):
+        result = _invoke_app_list(runner, ["--field", "pid"], [_make_window(pid=4242)])
+        assert result.exit_code == 0, result.output
+        assert result.output.strip() == "4242"
+
+    def test_field_json_projects(self, runner):
+        result = _invoke_app_list(runner, ["--field", "pid,title", "--json"],
+                                  [_make_window(pid=4242, title="Doc")])
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["windows"] == [{"pid": 4242, "title": "Doc"}]
+
+    def test_unknown_field_errors(self, runner):
+        result = _invoke_app_list(runner, ["--field", "nope", "--json"], [_make_window()])
+        assert result.exit_code == 1, result.output
+        payload = json.loads(result.output)
+        assert payload["error"]["code"] == "INVALID_INPUT"
+
+    def test_default_unchanged(self, runner):
+        result = _invoke_app_list(runner, ["--json"], [_make_window(pid=4242)])
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["windows"][0]["pid"] == 4242
+        assert "process_name" in payload["windows"][0]
+
+
+# ── app windows ─────────────────────────────────────────────────────────────
+
+class TestAppWindowsField:
+
+    def test_single_field_text(self, runner):
+        result = _invoke_app_windows(runner, ["--field", "handle"], [_make_window(handle=555)])
+        assert result.exit_code == 0, result.output
+        assert result.output.strip() == "555"
+
+    def test_multi_field_json(self, runner):
+        result = _invoke_app_windows(runner, ["--field", "handle,pid", "--json"],
+                                     [_make_window(handle=555, pid=77)])
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["windows"] == [{"handle": 555, "pid": 77}]
+
+    def test_unknown_field_errors(self, runner):
+        result = _invoke_app_windows(runner, ["--field", "hwnd"], [_make_window()])
+        # `app windows` schema exposes `handle`, not the `hwnd` alias.
+        assert result.exit_code == 1, result.output
+        assert "hwnd" in result.output
+
+
+# ── app find (singular) ─────────────────────────────────────────────────────
+
+class TestAppFindField:
+
+    def _proc(self, **kw):
+        from types import SimpleNamespace
+        return SimpleNamespace(
+            pid=kw.get("pid", 1234), name=kw.get("name", "notepad.exe"),
+            path=kw.get("path", "C:\\notepad.exe"),
+            is_running=kw.get("is_running", True),
+            window_count=kw.get("window_count", 1),
+        )
+
+    def test_single_field_text_bare(self, runner):
+        with patch("naturo.process.find_process", return_value=self._proc(pid=999)):
+            result = runner.invoke(app_find, ["notepad", "--field", "pid"], obj={})
+        assert result.exit_code == 0, result.output
+        assert result.output.strip() == "999"
+
+    def test_multi_field_json(self, runner):
+        with patch("naturo.process.find_process", return_value=self._proc(pid=999, name="notepad.exe")):
+            result = runner.invoke(app_find, ["notepad", "--field", "pid,name", "--json"], obj={})
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["process"] == {"pid": 999, "name": "notepad.exe"}
+
+    def test_unknown_field_errors(self, runner):
+        with patch("naturo.process.find_process", return_value=self._proc()):
+            result = runner.invoke(app_find, ["notepad", "--field", "hwnd", "--json"], obj={})
+        assert result.exit_code == 1, result.output
+        payload = json.loads(result.output)
+        assert payload["error"]["code"] == "INVALID_INPUT"
+
+
+# ── shared helper unit coverage ─────────────────────────────────────────────
+
+class TestFieldHelpers:
+
+    def test_parse_fields_none(self):
+        from naturo.cli._field import parse_fields
+        assert parse_fields(None) is None
+
+    def test_parse_fields_splits_and_strips(self):
+        from naturo.cli._field import parse_fields
+        assert parse_fields(" hwnd , pid ,title") == ["hwnd", "pid", "title"]
+
+    def test_parse_fields_all_empty_is_empty_list(self):
+        from naturo.cli._field import parse_fields
+        assert parse_fields(" , ") == []
+
+    def test_empty_field_spec_rejected(self, runner):
+        """--field "" (parses to no names) is INVALID_INPUT, not blank output."""
+        result = _invoke_list_windows(runner, ["--field", ",", "--json"], [_make_window()])
+        assert result.exit_code == 1, result.output
+        payload = json.loads(result.output)
+        assert payload["error"]["code"] == "INVALID_INPUT"


### PR DESCRIPTION
Adds `--field/-F` (comma-separated for multiple) so common lookups are one-liners instead of piping through jq.

## Surface
- Collections: `list windows`, `list apps`, `list screens`, `app list`, `app windows`.
- Singular: `app find` (projects its `{process:{...}}` shape).
- **Text mode**: prints only the selected column(s), one row per line, tab-separated in requested order — a single field of a single row is a bare, `$(...)`-capturable value (no header). E.g. `naturo list windows --field title`.
- **`-j` mode**: canonical `success_envelope` with each item projected to exactly the requested fields.
- Unknown/empty field name → `INVALID_INPUT` (via `error_helpers`) listing the valid fields, in both text and `-j`.
- Default (no `--field`) output is **byte-identical** to before (verified by regressions + the unchanged envelope/schema-parity suites).

Projection is centralized in a new `naturo/cli/_field.py` (parse/resolve/emit) that reuses each command's existing `-j` row dicts, so projected keys can't drift from the canonical schema.

## Verification
- `pytest -m 'not ui and not integration and not desktop'`: 7129 passed / 169 skipped (6 pre-existing native-DLL host failures unrelated). New `tests/test_field_selection_1206.py` (22 hermetic tests).
- `ruff check naturo/`: clean. `mypy naturo/`: clean.
- Note: `docs/CLI_REFERENCE.md` `--field` rows were hand-added (14-line focused diff); the generator `scripts/generate_cli_reference.py` has pre-existing drift (~1600 lines of unrelated churn on a full regen), so I kept the diff scoped rather than regenerating.

Closes #1206

🤖 Generated with [Claude Code](https://claude.com/claude-code)