### PR TITLE
fix(cli): usage/arg-validation failures exit 2, not 1 (#897)

### DIFF
--- a/naturo/cli/_app/lifecycle.py
+++ b/naturo/cli/_app/lifecycle.py
@@ -31,12 +31,10 @@ def app_launch(ctx, name, app_name, path, wait_until_ready, timeout, no_focus, a
     if not name and app_name:
         name = app_name
     if not name and not path:
-        msg = "Specify application name or --path"
-        if json_output:
-            click.echo(_json_error_str("INVALID_INPUT", msg))
-        else:
-            click.echo(f"Error: {msg}", err=True)
-        sys.exit(1)
+        # No app name or --path → missing required arg → usage error, exit 2 (#897).
+        # Envelope code stays INVALID_INPUT; only the exit code differs.
+        from naturo.cli.error_helpers import emit_usage_error
+        emit_usage_error("Specify application name or --path", json_output)
         return
 
     # (#776) Reject app IDs — launch requires an app name/path, not a running-app ID

--- a/naturo/cli/core/_find.py
+++ b/naturo/cli/core/_find.py
@@ -343,14 +343,13 @@ def find_cmd(query: str | None, query_opt: str | None, find_all: bool, role: str
         if actionable or role:
             query = "*"
         else:
+            # Missing required positional → usage error, exit 2 (#897). Envelope
+            # code stays INVALID_INPUT; only the exit code differs from a fault.
+            from naturo.cli.error_helpers import emit_usage_error
             msg = ("Missing or empty argument 'QUERY'. Provide a non-empty query "
                    "as a positional arg or --query/-q option, or use --all to "
                    "match every element.")
-            if json_output:
-                click.echo(_common._json_error_str("INVALID_INPUT", msg))
-            else:
-                click.echo(f"Error: {msg}", err=True)
-            raise SystemExit(1)
+            emit_usage_error(msg, json_output)
 
     # Auto-enable AI mode when --provider or --model is explicitly set (#287)
     if not ai and (ai_provider != "auto" or ai_model is not None or ai_api_key is not None):

--- a/naturo/cli/error_helpers.py
+++ b/naturo/cli/error_helpers.py
@@ -19,6 +19,16 @@ from naturo.errors import NaturoError, category_for_code
 
 _CommandT = TypeVar("_CommandT", bound=click.Command)
 
+# POSIX reserves exit code 2 for usage errors ("the caller invoked me wrong").
+# Click's own argument parser already exits 2 for the errors it catches (unknown
+# subcommand, missing flag value, no subcommand on a group). naturo's *custom*
+# pre-execution validators — missing required positional, missing required flag —
+# must exit with the same code so a scripter's `case $? in 2) usage ;; 1) retry`
+# dispatcher classifies every usage mistake identically. This is distinct from an
+# operation failure (exit 1) and from a runtime-invalid *value* (called correctly,
+# value rejected during execution), which both stay on exit 1. See issue #897.
+USAGE_ERROR_EXIT = 2
+
 
 def success_envelope(collection_key: str, items: Iterable[Any]) -> dict[str, Any]:
     """Build the canonical ``-j`` success envelope for a collection read.
@@ -510,6 +520,43 @@ def emit_error(
     else:
         click.echo(f"Error: {message}", err=True)
     sys.exit(exit_code)
+
+
+def emit_usage_error(
+    message: str,
+    json_output: bool,
+    *,
+    code: str = "INVALID_INPUT",
+    suggested_action: Optional[str] = None,
+) -> NoReturn:
+    """Emit a pre-execution usage / argument-validation error and exit **2** (#897).
+
+    Use this for the *usage* class only: a required positional or required flag is
+    absent, so the caller invoked the command wrong. POSIX reserves exit code 2 for
+    this, matching Click's own parser (which already exits 2 for unknown
+    subcommands / missing flag values). The emitted output — JSON envelope under
+    ``-j`` (default ``code`` ``INVALID_INPUT``) or a plain ``Error: <message>`` line
+    — is byte-for-byte identical to :func:`emit_error`; **only the process exit code
+    differs** (2 instead of 1). The envelope ``code`` and the exit code are
+    independent (issue #897): the envelope keeps ``INVALID_INPUT``.
+
+    Do NOT route runtime-invalid *values* here (e.g. ``--wpm 0``, a duration out of
+    range, an unresolvable ref): those are called-correctly-but-rejected operation
+    failures and stay on :func:`emit_error`'s exit-1 path.
+
+    Args:
+        message: Human-readable message (identical to what ``emit_error`` prints).
+        json_output: Whether to emit the JSON envelope instead of plain text.
+        code: JSON envelope error code. Stays ``INVALID_INPUT`` for the arg class.
+        suggested_action: Optional recovery hint override for the envelope.
+    """
+    emit_error(
+        code,
+        message,
+        json_output,
+        suggested_action=suggested_action,
+        exit_code=USAGE_ERROR_EXIT,
+    )
 
 
 def emit_exception_error(

--- a/naturo/cli/interaction/_press.py
+++ b/naturo/cli/interaction/_press.py
@@ -152,8 +152,10 @@ def press(keys: tuple[str, ...], count: int, delay: float, hold_duration: float 
     if ref_alias and not on_element:
         on_element = ref_alias
     if not keys:
-        _common._json_err("Missing argument 'KEY'. Provide a key name (e.g., enter, tab, ctrl+c).",
-                  json_output, code="INVALID_INPUT")
+        # Missing required positional → usage error, exit 2 (#897).
+        from naturo.cli.error_helpers import emit_usage_error
+        emit_usage_error("Missing argument 'KEY'. Provide a key name (e.g., enter, tab, ctrl+c).",
+                         json_output)
         return
 
     if count < 1:
@@ -473,7 +475,9 @@ def hotkey(keys, keys_option, hold_duration, app, window_title, hwnd,
     elif keys_option:
         combo = "+".join(keys_option)
     else:
-        _common._json_err("Specify keys as 'ctrl+c' or via --keys ctrl --keys c", json_output, code="INVALID_INPUT")
+        # No key combo supplied → usage error, exit 2 (#897).
+        from naturo.cli.error_helpers import emit_usage_error
+        emit_usage_error("Specify keys as 'ctrl+c' or via --keys ctrl --keys c", json_output)
         return
 
     # Delegate to press via Click context invoke

--- a/naturo/cli/interaction/_type.py
+++ b/naturo/cli/interaction/_type.py
@@ -112,8 +112,11 @@ def type_cmd(text, delay, profile, wpm, press_return, tab_count, escape,
     if paste_mode and not text:
         text = None  # Signal clipboard-only paste (no text to set)
     elif not text:
-        _common._json_err("TEXT argument is required (or use --paste to paste clipboard)",
-                  json_output, code="INVALID_INPUT")
+        # Missing required positional → usage error, exit 2 (#897). The envelope
+        # code stays INVALID_INPUT; only the exit code differs from a runtime fault.
+        from naturo.cli.error_helpers import emit_usage_error
+        emit_usage_error("TEXT argument is required (or use --paste to paste clipboard)",
+                         json_output)
         return
 
     # (#661) Text is typed literally by default — Windows paths like

--- a/naturo/cli/values/_get.py
+++ b/naturo/cli/values/_get.py
@@ -13,6 +13,7 @@ import click
 from naturo.cli.error_helpers import (
     emit_error,
     emit_exception_error,
+    emit_usage_error,
     success_envelope,
 )
 from naturo.errors import NaturoError
@@ -183,8 +184,8 @@ def get_cmd(ctx, target, ref, automation_id, role, name, get_all, prop, app,
     # ── --all mode: return all matching elements ─────────────────────────
     if get_all:
         if not role and not name:
-            emit_error(
-                "INVALID_INPUT",
+            # Missing required flag for --all mode → usage error, exit 2 (#897).
+            emit_usage_error(
                 "--all requires --role or --name to specify what to search for",
                 json_output,
                 suggested_action="Add --role (e.g. --role Button) or --name "
@@ -264,8 +265,8 @@ def get_cmd(ctx, target, ref, automation_id, role, name, get_all, prop, app,
 
     # ── Single element mode (default) ────────────────────────────────────
     if not ref and not automation_id and not role and not name:
-        emit_error(
-            "INVALID_INPUT",
+        # No target supplied → missing required arg → usage error, exit 2 (#897).
+        emit_usage_error(
             "Specify a target: element ref (e47), --automation-id, or --role/--name",
             json_output,
             suggested_action="Provide a target element using a ref (e47), "

--- a/naturo/cli/values/_set.py
+++ b/naturo/cli/values/_set.py
@@ -10,7 +10,7 @@ import platform
 
 import click
 
-from naturo.cli.error_helpers import emit_error, emit_exception_error
+from naturo.cli.error_helpers import emit_error, emit_exception_error, emit_usage_error
 from naturo.errors import NaturoError, StaleSnapshotCacheError
 
 
@@ -197,8 +197,8 @@ def set_cmd(ctx, target, value, ref, automation_id, role, name, toggle,
 
     # Validate: need a target element
     if not ref and not automation_id and not role and not name:
-        emit_error(
-            "INVALID_INPUT",
+        # No target supplied → missing required arg → usage error, exit 2 (#897).
+        emit_usage_error(
             "Specify a target: element ref (e47), --automation-id, "
             "or --role/--name",
             json_output,
@@ -218,8 +218,8 @@ def set_cmd(ctx, target, value, ref, automation_id, role, name, toggle,
         )
 
     if action_flags == 0 and value is None:
-        emit_error(
-            "INVALID_INPUT",
+        # Neither a value nor an action flag → missing required arg → exit 2 (#897).
+        emit_usage_error(
             "Specify a value to set, or use --toggle/--select/"
             "--expand/--collapse",
             json_output,

--- a/naturo/cli/wait_cmd.py
+++ b/naturo/cli/wait_cmd.py
@@ -134,12 +134,11 @@ def wait(ctx, duration, element, window_title, gone, timeout, interval,
         return
 
     if not has_condition:
+        # Nothing to wait on — required positional/flag absent → usage error,
+        # exit 2 (#897). Envelope code stays INVALID_INPUT; only exit code differs.
+        from naturo.cli.error_helpers import emit_usage_error
         msg = "Specify a duration (e.g. 'naturo wait 3') or a condition (--element, --window, --gone)"
-        if json_output:
-            click.echo(_json_error_str("INVALID_INPUT", msg))
-        else:
-            click.echo(f"Error: {msg}", err=True)
-        sys.exit(1)
+        emit_usage_error(msg, json_output)
         return
 
     if timeout < 0:

--- a/tests/test_cli_phase3.py
+++ b/tests/test_cli_phase3.py
@@ -24,12 +24,14 @@ class TestWaitCommand:
 
     def test_wait_no_args(self, runner):
         result = runner.invoke(main, ["wait"])
-        assert result.exit_code == 1
+        # #897: missing required arg (no duration/condition) is a usage error → exit 2.
+        assert result.exit_code == 2
         assert "Specify" in result.output or "error" in result.output.lower()
 
     def test_wait_json_no_args(self, runner):
         result = runner.invoke(main, ["wait", "--json"])
-        assert result.exit_code == 1
+        # #897: exit code moves to 2 for the usage class; envelope code stays INVALID_INPUT.
+        assert result.exit_code == 2
         data = json.loads(result.output)
         assert data["success"] is False
         assert "INVALID_INPUT" in data["error"]["code"]
@@ -327,7 +329,8 @@ class TestSnapshotCleanValidation:
 class TestGlobalJsonFlag:
     def test_json_flag_propagates(self, runner):
         result = runner.invoke(main, ["--json", "wait"])
-        assert result.exit_code == 1
+        # #897: `wait` with no duration/condition is a usage error → exit 2.
+        assert result.exit_code == 2
         # Should produce JSON error output
         data = json.loads(result.output)
         assert "success" in data

--- a/tests/test_usage_error_exit_code_897.py
+++ b/tests/test_usage_error_exit_code_897.py
@@ -1,0 +1,127 @@
+"""Exit-code contract for argument/usage validation failures (#897).
+
+POSIX reserves exit code **2** for usage errors ("the caller invoked me
+wrong") and exit code 1 for operation failures ("called correctly, operation
+failed"). Click's own parser already exits 2 for the errors it catches (unknown
+subcommand, missing flag value). naturo's *custom* pre-execution validators —
+which reject a missing required positional or a missing required flag — used to
+exit 1 with an ``INVALID_INPUT`` envelope, so a scripter's standard
+``case $? in 2) usage ;; 1) retry ;; esac`` dispatcher misclassified the most
+common authoring mistake (forgot the positional) as a transient op failure and
+could infinite-retry.
+
+This module pins BOTH sides of the boundary so the contract can't silently
+drift again:
+
+* **Usage class → exit 2** — every command with a custom "specify a
+  target / a duration / a name" validator (``type``/``press``/``find``/
+  ``wait``/``get``/``set``/``app launch``), plus the two Click-level cases
+  (unknown subcommand, missing flag value) that already exit 2.
+* **Runtime-invalid *value* → exit 1** — a value supplied but rejected during
+  execution (``--wpm 0``, a negative duration, ``--limit 0``, ``--count 0``)
+  stays an operation failure.
+
+The JSON envelope ``error.code`` stays ``INVALID_INPUT`` throughout — only the
+process exit code changed. Envelope code and exit code are independent.
+
+Pure CLI level: no DLL, no desktop session, no input injection. Every case
+fails during pre-execution validation, before any command body acts.
+
+Closes #897.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+
+def _run(argv):
+    """Invoke the naturo CLI with *argv* and return the Click result."""
+    from naturo.cli import main
+
+    return CliRunner().invoke(main, argv, catch_exceptions=False)
+
+
+# ── Usage class: missing required positional / flag → exit 2 ─────────────────
+# naturo's custom validators (each command invoked with the required arg absent).
+_MISSING_ARG_COMMANDS = [
+    pytest.param(["type"], id="type-missing-text"),
+    pytest.param(["press"], id="press-missing-key"),
+    pytest.param(["find"], id="find-missing-query"),
+    pytest.param(["wait"], id="wait-missing-duration-or-condition"),
+    pytest.param(["get"], id="get-missing-target"),
+    pytest.param(["set"], id="set-missing-target"),
+    pytest.param(["app", "launch"], id="app-launch-missing-name"),
+    pytest.param(["get", "--all"], id="get-all-missing-role-or-name"),
+    pytest.param(["set", "e47"], id="set-missing-value-or-action"),
+]
+
+# Click's own parser path — already exit 2, pinned here so the whole
+# usage-error axis is asserted in one place and can't regress the other way.
+_CLICK_USAGE_COMMANDS = [
+    pytest.param(["nonexistentcmd"], id="unknown-subcommand"),
+    pytest.param(["see", "--app"], id="missing-flag-value"),
+]
+
+
+@pytest.mark.parametrize("argv", _MISSING_ARG_COMMANDS)
+def test_missing_arg_exits_2_plain(argv):
+    """Each custom missing-arg validator exits 2 (POSIX usage error)."""
+    result = _run(argv)
+    assert result.exit_code == 2, result.output
+
+
+@pytest.mark.parametrize("argv", _CLICK_USAGE_COMMANDS)
+def test_click_usage_exits_2_plain(argv):
+    """Click's own parse-time usage errors exit 2 — the code we align to."""
+    result = _run(argv)
+    assert result.exit_code == 2, result.output
+
+
+@pytest.mark.parametrize("argv", _MISSING_ARG_COMMANDS)
+def test_missing_arg_json_envelope_and_exit_2(argv):
+    """Under -j the envelope stays INVALID_INPUT while the exit code is 2.
+
+    Envelope ``code`` and process exit code are independent (#897): only the
+    exit code changed, so a JSON consumer still sees ``INVALID_INPUT``.
+    """
+    result = _run([*argv, "-j"])
+    assert result.exit_code == 2, result.output
+    data = json.loads(result.output)
+    assert data["success"] is False
+    assert data["error"]["code"] == "INVALID_INPUT"
+
+
+# ── Runtime-invalid *value* → stays exit 1 ───────────────────────────────────
+# Called correctly (the required arg IS present) but the value is out of range;
+# this is an operation failure, NOT a usage error, so it stays on exit 1.
+_INVALID_VALUE_COMMANDS = [
+    pytest.param(["type", "hello", "--wpm", "0"], id="type-wpm-zero"),
+    pytest.param(["wait", "--", "-3"], id="wait-negative-duration"),
+    pytest.param(["find", "button", "--limit", "0"], id="find-limit-zero"),
+    pytest.param(["press", "enter", "--count", "0"], id="press-count-zero"),
+]
+
+
+@pytest.mark.parametrize("argv", _INVALID_VALUE_COMMANDS)
+def test_runtime_invalid_value_stays_exit_1(argv):
+    """A supplied-but-rejected value is an operation failure → exit 1, not 2."""
+    result = _run(argv)
+    assert result.exit_code == 1, result.output
+
+
+@pytest.mark.parametrize("argv", _INVALID_VALUE_COMMANDS)
+def test_runtime_invalid_value_json_envelope_and_exit_1(argv):
+    """The runtime-invalid-value class keeps INVALID_INPUT + exit 1 under -j.
+
+    The global ``--json`` flag is placed *before* the subcommand so it is never
+    swallowed by a ``--`` end-of-options marker (e.g. the negative-duration
+    case ``wait -- -3``).
+    """
+    result = _run(["--json", *argv])
+    assert result.exit_code == 1, result.output
+    data = json.loads(result.output)
+    assert data["success"] is False
+    assert data["error"]["code"] == "INVALID_INPUT"


### PR DESCRIPTION
Implements the Ace-approved contract (Option A) for #897: naturo's custom `INVALID_INPUT` **usage/argument-validation** path now exits **2** (POSIX usage-error convention), matching Click's own parser path — while genuine runtime-value failures stay exit 1.

## Contract
- **Pre-execution usage / missing-arg** → **exit 2**: `type` (missing TEXT), `press` (missing KEY / combo), `find` (missing QUERY), `wait` (no duration/condition), `get` (no target; `--all` without `--role/--name`), `set` (no target; no value/action), `app launch` (no name/--path). Plus Click's own unknown-subcommand / missing-flag-value (already 2, now pinned).
- **Runtime-invalid *value*** → stays **exit 1**: `type --wpm 0`, negative `wait` duration, `find --limit 0`, `press --count 0`, `set` action conflict, `app launch` by-app-id rejection, all not-found/platform faults.
- **JSON envelope `error.code` is UNCHANGED** (still `INVALID_INPUT`) — only the process exit code moved. Envelope code and exit code are independent.

Implemented via a single-source-of-truth `emit_usage_error()` + `USAGE_ERROR_EXIT=2` in `error_helpers.py` (byte-identical output to `emit_error`, differs only in `sys.exit(2)`), routed through every missing-arg callsite.

## ⚠️ Behavior change (CHANGELOG)
Scripts using `case $? in 2) usage_error ;; 1) op_failed ;; esac` now classify forgotten-argument mistakes correctly. Any script hard-coding `exit==1` for these missing-arg cases must update to 2.

## Verification
- New `tests/test_usage_error_exit_code_897.py` (28 tests) pins BOTH classes. Full gate: 7104 passed / 169 skipped (6 pre-existing native-DLL host failures unrelated). 3 existing `wait` no-arg assertions flipped 1→2 (envelope-code assertions unchanged).
- `ruff check naturo/`: clean. `mypy naturo/`: clean.

Closes #897

🤖 Generated with [Claude Code](https://claude.com/claude-code)