### PR TITLE
fix(mcp): bring click hit-window verification to CLI parity (#1318)

### DIFF
--- a/naturo/cli/interaction/_click.py
+++ b/naturo/cli/interaction/_click.py
@@ -8,6 +8,18 @@ from typing import Any
 import click
 
 import naturo.cli.interaction._common as _common
+# (#1318) Shared landing-window hit test + cross-PID verdict, so the CLI and the
+# MCP click tool produce an identical honesty verdict from one implementation.
+# The helpers are re-bound as module-local names below so existing call sites and
+# test patches (naturo.cli.interaction._click._window_root_at_point / _window_pid)
+# keep working unchanged.
+from naturo.hit_verify import (
+    hit_window_dict as _hit_window_dict,
+    is_cross_pid_mismatch as _is_cross_pid_mismatch,
+    window_pid as _window_pid,
+    window_root_at_point as _window_root_at_point,
+    wrong_window_message as _wrong_window_message,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -32,65 +44,6 @@ def _get_screen_bound() -> int:
         except Exception:
             pass
     return 65535
-
-
-def _window_root_at_point(x: int, y: int):
-    """Return the top-level window actually under screen point ``(x, y)``.
-
-    Lets the click command report which window a coordinate click really
-    landed on, so naturo never claims success when an overlapping window — or
-    a failed foreground switch — silently received the click instead (#1207).
-
-    Args:
-        x: Screen X coordinate.
-        y: Screen Y coordinate.
-
-    Returns:
-        ``(root_hwnd, title, pid)`` for the top-level window at the point, or
-        ``None`` if it cannot be determined (e.g. non-Windows or no window).
-    """
-    import sys
-    if sys.platform != "win32":
-        return None
-    try:
-        import ctypes
-        from ctypes import wintypes
-        user32 = ctypes.windll.user32
-        user32.WindowFromPoint.restype = wintypes.HWND
-        user32.WindowFromPoint.argtypes = [wintypes.POINT]
-        user32.GetAncestor.restype = wintypes.HWND
-        user32.GetAncestor.argtypes = [wintypes.HWND, wintypes.UINT]
-        hwnd = user32.WindowFromPoint(wintypes.POINT(int(x), int(y)))
-        if not hwnd:
-            return None
-        root = user32.GetAncestor(hwnd, 2) or hwnd  # GA_ROOT = 2
-        length = user32.GetWindowTextLengthW(root)
-        buf = ctypes.create_unicode_buffer(length + 1)
-        user32.GetWindowTextW(root, buf, length + 1)
-        pid = wintypes.DWORD()
-        user32.GetWindowThreadProcessId(root, ctypes.byref(pid))
-        return int(root), buf.value, int(pid.value)
-    except Exception as exc:  # noqa: BLE001 — ctypes/OS errors vary
-        logger.debug("WindowFromPoint(%s, %s) failed: %s", x, y, exc)
-        return None
-
-
-def _window_pid(hwnd: int):
-    """Return the process ID owning ``hwnd``, or ``None`` if undeterminable."""
-    import sys
-    if sys.platform != "win32" or not hwnd:
-        return None
-    try:
-        import ctypes
-        from ctypes import wintypes
-        pid = wintypes.DWORD()
-        ctypes.windll.user32.GetWindowThreadProcessId(
-            wintypes.HWND(int(hwnd)), ctypes.byref(pid)
-        )
-        return int(pid.value) or None
-    except Exception as exc:  # noqa: BLE001 — ctypes/OS errors vary
-        logger.debug("GetWindowThreadProcessId(%s) failed: %s", hwnd, exc)
-        return None
 
 
 @click.command("click")
@@ -522,19 +475,14 @@ def click_cmd(query: str | None, on_text: str | None, ref_alias: str | None,
     _hit = None
     if x is not None and y is not None:
         _hit = _window_root_at_point(x, y)
-    if _hit and _focus_hwnd:
-        _target_pid = _window_pid(_focus_hwnd)
-        if _target_pid and _hit[2] and _hit[2] != _target_pid:
-            _common._json_err(
-                f"Click at ({x}, {y}) landed on window {_hit[1]!r} "
-                f"(hwnd {_hit[0]}, pid {_hit[2]}), not the target window "
-                f"(hwnd {_focus_hwnd}, pid {_target_pid}). The target is "
-                f"occluded or failed to come to the foreground; the click did "
-                f"not reach it.",
-                json_output,
-                code="CLICK_WRONG_WINDOW",
-            )
-            return
+    _target_pid = _window_pid(_focus_hwnd) if _focus_hwnd else None
+    if _hit is not None and _is_cross_pid_mismatch(_hit, _target_pid):
+        _common._json_err(
+            _wrong_window_message(x, y, _hit, _focus_hwnd, _target_pid),
+            json_output,
+            code="CLICK_WRONG_WINDOW",
+        )
+        return
 
     action = "double-clicked" if double else "clicked"
     if _zero_bounds_element is not None:
@@ -546,9 +494,7 @@ def click_cmd(query: str | None, on_text: str | None, ref_alias: str | None,
     # caller can see when a raw --coords click hit something other than what
     # they intended (naturo cannot know intent for bare coordinates).
     if _hit:
-        result_data["hit_window"] = {
-            "hwnd": _hit[0], "title": _hit[1], "pid": _hit[2],
-        }
+        result_data["hit_window"] = _hit_window_dict(_hit)
     if _image_match_info is not None:
         result_data["image_match"] = _image_match_info
     if _clipboard_action:

--- a/naturo/hit_verify.py
+++ b/naturo/hit_verify.py
@@ -1,0 +1,124 @@
+"""Shared click landing-window hit test and cross-PID verdict (#1207, #1318).
+
+A synthetic coordinate click reaches whatever top-level window sits under the
+point — not necessarily the window the caller intended. When the target was
+occluded or never came to the foreground, the click silently lands on another
+window, yet naturo would still report success (the Never-Lie violation #1207
+fixed on the CLI).
+
+Both the CLI ``naturo click`` and the MCP ``click`` tool run the SAME landing
+check through this module so their honesty verdict is identical (#1318): report
+the window actually under the point, and when a *known* target belongs to a
+different process, fail loudly with ``CLICK_WRONG_WINDOW`` instead of claiming a
+success that did not happen. The ctypes hit-test helpers and the verdict logic
+live here once; each surface binds the helpers as module-local names it can call
+(and tests can patch) and shares the pure verdict functions verbatim.
+"""
+from __future__ import annotations
+
+import logging
+import sys
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Raw error-code string emitted on a cross-process landing mismatch. Not an
+# ErrorCode enum member — both the CLI (_json_err) and MCP (error envelope)
+# surface it by string, and category_for_code degrades unknown codes gracefully.
+CLICK_WRONG_WINDOW = "CLICK_WRONG_WINDOW"
+
+# (root_hwnd, window_title, pid) for the top-level window under a screen point.
+HitWindow = tuple[int, str, int]
+
+
+def window_root_at_point(x: int, y: int) -> Optional[HitWindow]:
+    """Return the top-level window actually under screen point ``(x, y)``.
+
+    Lets a click command report which window a coordinate click really landed
+    on, so naturo never claims success when an overlapping window — or a failed
+    foreground switch — silently received the click instead (#1207).
+
+    Args:
+        x: Screen X coordinate.
+        y: Screen Y coordinate.
+
+    Returns:
+        ``(root_hwnd, title, pid)`` for the top-level window at the point, or
+        ``None`` if it cannot be determined (e.g. non-Windows or no window).
+    """
+    if sys.platform != "win32":
+        return None
+    try:
+        import ctypes
+        from ctypes import wintypes
+        user32 = ctypes.windll.user32
+        user32.WindowFromPoint.restype = wintypes.HWND
+        user32.WindowFromPoint.argtypes = [wintypes.POINT]
+        user32.GetAncestor.restype = wintypes.HWND
+        user32.GetAncestor.argtypes = [wintypes.HWND, wintypes.UINT]
+        hwnd = user32.WindowFromPoint(wintypes.POINT(int(x), int(y)))
+        if not hwnd:
+            return None
+        root = user32.GetAncestor(hwnd, 2) or hwnd  # GA_ROOT = 2
+        length = user32.GetWindowTextLengthW(root)
+        buf = ctypes.create_unicode_buffer(length + 1)
+        user32.GetWindowTextW(root, buf, length + 1)
+        pid = wintypes.DWORD()
+        user32.GetWindowThreadProcessId(root, ctypes.byref(pid))
+        return int(root), buf.value, int(pid.value)
+    except Exception as exc:  # noqa: BLE001 — ctypes/OS errors vary
+        logger.debug("WindowFromPoint(%s, %s) failed: %s", x, y, exc)
+        return None
+
+
+def window_pid(hwnd: Optional[int]) -> Optional[int]:
+    """Return the process ID owning ``hwnd``, or ``None`` if undeterminable."""
+    if sys.platform != "win32" or not hwnd:
+        return None
+    try:
+        import ctypes
+        from ctypes import wintypes
+        pid = wintypes.DWORD()
+        ctypes.windll.user32.GetWindowThreadProcessId(
+            wintypes.HWND(int(hwnd)), ctypes.byref(pid)
+        )
+        return int(pid.value) or None
+    except Exception as exc:  # noqa: BLE001 — ctypes/OS errors vary
+        logger.debug("GetWindowThreadProcessId(%s) failed: %s", hwnd, exc)
+        return None
+
+
+def hit_window_dict(hit: Optional[HitWindow]) -> Optional[dict]:
+    """Serialize a hit tuple into the ``hit_window`` disclosure dict, or ``None``."""
+    if not hit:
+        return None
+    return {"hwnd": hit[0], "title": hit[1], "pid": hit[2]}
+
+
+def is_cross_pid_mismatch(
+    hit: Optional[HitWindow], target_pid: Optional[int]
+) -> bool:
+    """True when a known target's PID differs from the window under the click.
+
+    Only a *positive* cross-process signal returns True: both the hit window's
+    PID and the target PID must be known and differ. An unknown hit, an unknown
+    target (bare coordinates), or a same-process landing all return False.
+    """
+    return bool(hit and target_pid and hit[2] and hit[2] != target_pid)
+
+
+def wrong_window_message(
+    x: Optional[int],
+    y: Optional[int],
+    hit: HitWindow,
+    target_hwnd: Optional[int],
+    target_pid: Optional[int],
+) -> str:
+    """Compose the shared CLICK_WRONG_WINDOW failure message."""
+    return (
+        f"Click at ({x}, {y}) landed on window {hit[1]!r} "
+        f"(hwnd {hit[0]}, pid {hit[2]}), not the target window "
+        f"(hwnd {target_hwnd}, pid {target_pid}). The target is "
+        f"occluded or failed to come to the foreground; the click did "
+        f"not reach it."
+    )

--- a/naturo/mcp/_input.py
+++ b/naturo/mcp/_input.py
@@ -6,6 +6,18 @@ import re
 from typing import Optional
 
 from naturo.mcp._resolve import require_hwnd
+# (#1318) Shared landing-window hit test + cross-PID verdict — the SAME
+# implementation the CLI ``naturo click`` uses (naturo.hit_verify), so both
+# surfaces return an identical honesty verdict. Bound as module-local names so
+# tests can patch them (naturo.mcp._input._window_root_at_point / _window_pid).
+from naturo.hit_verify import (
+    CLICK_WRONG_WINDOW,
+    hit_window_dict as _hit_window_dict,
+    is_cross_pid_mismatch as _is_cross_pid_mismatch,
+    window_pid as _window_pid,
+    window_root_at_point as _window_root_at_point,
+    wrong_window_message as _wrong_window_message,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -68,10 +80,23 @@ def register_input_tools(server, _get_backend, _safe_tool):
         double: bool = False,
         input_mode: str = "normal",
         method: str = "auto",
+        hwnd: Optional[int] = None,
+        window_title: Optional[str] = None,
     ) -> dict:
         """Click at coordinates or on a UI element.
 
         Provide either (x, y) coordinates or an element_id from see_ui_tree/find_element.
+
+        Pass ``hwnd`` (from ``launch_app``/``list_windows``) or ``window_title``
+        to name the target window: naturo focuses it first so the click lands
+        there, and — crucially — after the click it checks the window actually
+        under the point. If the click landed on a *different process'* window
+        (the target was occluded or never came to the foreground), the tool
+        returns ``success:false`` with ``CLICK_WRONG_WINDOW`` instead of a false
+        success (#1318, the Never-Lie parity fix that #1207 shipped on the CLI).
+        A cached eN ref carries its own source window, so eN clicks are verified
+        the same way with no extra argument. For bare (x, y) with no known
+        target, the landing window is disclosed in ``hit_window``.
 
         Args:
             x: X coordinate.
@@ -81,10 +106,23 @@ def register_input_tools(server, _get_backend, _safe_tool):
             double: Double-click if True.
             input_mode: Input method — "normal" (default) or "hardware" (Phys32, bypasses anti-cheat).
             method: Interaction method override — "auto" (default), "cdp", "uia", "msaa", "ia2", "jab", "vision". Bypasses auto-detection when set explicitly.
+            hwnd: Target window handle — focus + verify the click landed on it.
+            window_title: Target window title (partial match) — focus + verify.
 
         Returns:
-            Dict with success flag.
+            Dict with a success flag. On a coordinate/eN click it also carries
+            ``verified`` (True when the click was confirmed to land on the known
+            target's process, else null) and, when determinable, ``hit_window``
+            (the window actually under the click point). On a cross-process
+            landing mismatch it is a ``success:false`` / ``CLICK_WRONG_WINDOW``
+            envelope instead.
         """
+        # (#1207/#1318) Track the intended target window so the post-click hit
+        # test can confirm the click actually reached it. It is known via an
+        # explicit hwnd/window_title selector or a cached eN snapshot; it is
+        # unknown for a bare (x, y) click (naturo cannot infer intent there).
+        target_hwnd: Optional[int] = None
+
         # (#682) Resolve eN refs from see_ui_tree snapshots to coordinates.
         if element_id and _EN_REF_RE.fullmatch(element_id):
             from naturo.snapshot import get_snapshot_manager
@@ -93,6 +131,15 @@ def register_input_tools(server, _get_backend, _safe_tool):
             if resolved:
                 logger.debug("Resolved MCP ref %s → (%d, %d)", element_id, resolved[0], resolved[1])
                 x, y = resolved[0], resolved[1]
+                # (#1318) The snapshot's source window is the known target for
+                # the landing check — mirrors the CLI's cached-HWND path (#448).
+                if len(resolved) >= 3:
+                    try:
+                        snapshot = mgr.get_snapshot(resolved[2])
+                        if getattr(snapshot, "window_handle", None):
+                            target_hwnd = snapshot.window_handle
+                    except Exception as exc:
+                        logger.debug("Snapshot HWND retrieval failed: %s", exc)
                 element_id = None
             else:
                 return {
@@ -106,9 +153,51 @@ def register_input_tools(server, _get_backend, _safe_tool):
                 }
 
         backend = _get_backend()
+
+        # (#957/#1291) When a window selector is supplied, resolve it loudly —
+        # an unresolvable hwnd/window_title raises WindowNotFoundError (mapped to
+        # WINDOW_NOT_FOUND) rather than silently clicking the foreground window —
+        # then focus it so the click lands there (mirrors the CLI, #608).
+        if hwnd is not None or window_title is not None:
+            target_hwnd = require_hwnd(backend, window_title=window_title, hwnd=hwnd)
+        if target_hwnd:
+            try:
+                backend.focus_window(hwnd=target_hwnd, title=window_title)
+            except Exception as exc:
+                logger.debug("Target focus failed (hwnd=%s): %s", target_hwnd, exc)
+
         backend.click(x=x, y=y, element_id=element_id, button=button, double=double,
                       input_mode=input_mode)
-        return {"success": True, "method": method}
+
+        # (#1318) Landing-window honesty check — the SAME verdict the CLI emits,
+        # computed via the shared naturo.hit_verify helpers. When a target was
+        # known and the click landed on a different process' window, fail loudly
+        # instead of reporting a success that did not happen.
+        hit = None
+        if x is not None and y is not None:
+            hit = _window_root_at_point(x, y)
+        verify_target_pid = _window_pid(target_hwnd) if target_hwnd else None
+        if hit is not None and _is_cross_pid_mismatch(hit, verify_target_pid):
+            return {
+                "success": False,
+                "error": {
+                    "code": CLICK_WRONG_WINDOW,
+                    "message": _wrong_window_message(
+                        x, y, hit, target_hwnd, verify_target_pid,
+                    ),
+                },
+            }
+
+        result: dict = {"success": True, "method": method}
+        # (#1207) Disclose the window actually under a coordinate click, so a
+        # caller can see when a bare (x, y) click hit something unexpected.
+        if hit:
+            result["hit_window"] = _hit_window_dict(hit)
+        # (#1318) Mirror the CLI's verified field: a confirmed same-process
+        # landing on a *known* target is a positive verification; a bare-coords
+        # click (no known intent) or an undeterminable hit stays null.
+        result["verified"] = True if (target_hwnd and verify_target_pid and hit) else None
+        return result
 
     @server.tool()
     @_safe_tool

--- a/tests/test_mcp_click_verify_1318.py
+++ b/tests/test_mcp_click_verify_1318.py
@@ -1,0 +1,195 @@
+"""MCP click hit-window verification parity with the CLI (#1318).
+
+Split from #1207, which gave the *CLI* ``naturo click`` a landing-window honesty
+check: after the click it reports the top-level window actually under the point,
+fails loudly with ``CLICK_WRONG_WINDOW`` when a known target belongs to a
+different process (occluded / never foregrounded), and discloses ``hit_window``
+for bare coordinates. #1318 brings the *MCP* ``click`` tool to the same bar,
+reusing the shared ``naturo.hit_verify`` implementation so both surfaces return
+an identical verdict.
+
+Every test patches the window-hit-test helpers (``_window_root_at_point`` /
+``_window_pid``), so they are desktop-independent and send no real input.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from click.testing import CliRunner
+
+mcp_available = True
+try:
+    from naturo.mcp_server import create_server
+except ImportError:  # pragma: no cover - mcp optional
+    mcp_available = False
+
+pytestmark = pytest.mark.skipif(not mcp_available, reason="mcp package not installed")
+
+
+# ── MCP invocation harness ────────────────────────────────────────────────
+
+
+def _call_mcp_click(arguments, *, hit, target_pid):
+    """Call the MCP ``click`` tool with the hit-test helpers patched.
+
+    Args:
+        arguments: kwargs passed to the click tool.
+        hit: tuple returned by _window_root_at_point, or None.
+        target_pid: value returned by _window_pid for the target hwnd.
+
+    Returns:
+        (payload_dict, backend_mock)
+    """
+    backend = MagicMock()
+    with patch("naturo.mcp_server.get_backend", return_value=backend), \
+         patch("naturo.cli.interaction._check_desktop_session"), \
+         patch("naturo.mcp._input._window_root_at_point", return_value=hit), \
+         patch("naturo.mcp._input._window_pid", return_value=target_pid):
+        server = create_server()
+
+        async def _run():
+            return await server.call_tool("click", arguments)
+
+        loop = asyncio.new_event_loop()
+        try:
+            result = loop.run_until_complete(_run())
+        finally:
+            loop.close()
+    content = result[0] if isinstance(result, tuple) else result
+    return json.loads(content[0].text), backend
+
+
+# ── MCP behaviour ─────────────────────────────────────────────────────────
+
+
+def test_mcp_targeted_click_on_other_process_fails_loudly():
+    """A known hwnd target occluded by another process → CLICK_WRONG_WINDOW."""
+    payload, backend = _call_mcp_click(
+        {"x": 500, "y": 300, "hwnd": 349525},
+        hit=(777, "WindowsTerminal", 999),  # different pid under the point
+        target_pid=111,
+    )
+    assert payload["success"] is False
+    assert payload["error"]["code"] == "CLICK_WRONG_WINDOW"
+    # The click was attempted (parity with the CLI, which also injects then
+    # checks) but the tool refuses to claim a success that did not happen.
+    backend.click.assert_called_once()
+
+
+def test_mcp_bare_coords_discloses_hit_window():
+    """Bare coords (no known target) cannot fail, but discloses the hit window."""
+    payload, backend = _call_mcp_click(
+        {"x": 500, "y": 300},
+        hit=(777, "WindowsTerminal", 999),
+        target_pid=None,
+    )
+    assert payload["success"] is True
+    assert payload["hit_window"] == {"hwnd": 777, "title": "WindowsTerminal", "pid": 999}
+    # No known intent for bare coordinates → cannot positively verify.
+    assert payload["verified"] is None
+
+
+def test_mcp_targeted_click_same_process_succeeds_and_verifies():
+    """A click landing on the target's own process is a verified success."""
+    payload, backend = _call_mcp_click(
+        {"x": 500, "y": 300, "hwnd": 349525},
+        hit=(349525, "Target App", 111),  # same pid as the target
+        target_pid=111,
+    )
+    assert payload["success"] is True
+    assert payload["verified"] is True
+    assert payload["hit_window"]["pid"] == 111
+    backend.click.assert_called_once()
+    backend.focus_window.assert_called_once()  # target was brought forward first
+
+
+def test_mcp_no_hit_info_omits_hit_window():
+    """When the hit window is undeterminable, the payload omits hit_window."""
+    payload, backend = _call_mcp_click(
+        {"x": 500, "y": 300},
+        hit=None,
+        target_pid=None,
+    )
+    assert payload["success"] is True
+    assert "hit_window" not in payload
+    assert payload["verified"] is None
+    backend.click.assert_called_once()
+
+
+# ── CLI ↔ MCP contract: identical verdict for the same scenario ───────────
+
+
+def _invoke_cli_click(args, *, hit, target_pid):
+    """Invoke the CLI click_cmd with the window hit-test helpers patched."""
+    from naturo.cli.interaction import click_cmd
+
+    backend = MagicMock()
+    backend._resolve_hwnd.return_value = 349525
+    backend._is_afh_window.return_value = False
+    backend._is_winui_window.return_value = False
+    with patch("naturo.cli.interaction._common._get_backend", return_value=backend), \
+         patch("naturo.cli.interaction._common._auto_route", return_value={}), \
+         patch("naturo.cli.interaction._click._window_root_at_point", return_value=hit), \
+         patch("naturo.cli.interaction._click._window_pid", return_value=target_pid):
+        runner = CliRunner()
+        return runner.invoke(click_cmd, args + ["--no-verify", "-j"])
+
+
+def _cli_verdict(cli_result):
+    """Reduce a CLI click result to a comparable (ok, code) verdict."""
+    data = json.loads(cli_result.output)
+    if cli_result.exit_code == 0 and data.get("success", True):
+        return (True, None)
+    code = (data.get("error") or {}).get("code") or data.get("code")
+    return (False, code)
+
+
+def _mcp_verdict(payload):
+    """Reduce an MCP click payload to a comparable (ok, code) verdict."""
+    if payload.get("success"):
+        return (True, None)
+    return (False, payload.get("error", {}).get("code"))
+
+
+def test_cli_and_mcp_agree_on_wrong_window_verdict():
+    """Contract (#1318 acceptance): same occluded-target scenario, same verdict.
+
+    A coordinate click on a known target (hwnd) that lands on a *different
+    process'* window must fail loudly with CLICK_WRONG_WINDOW on BOTH surfaces.
+    """
+    hit = (777, "WindowsTerminal", 999)
+    target_pid = 111
+
+    cli_result = _invoke_cli_click(
+        ["--coords", "500", "300", "--hwnd", "349525"],
+        hit=hit, target_pid=target_pid,
+    )
+    mcp_payload, _ = _call_mcp_click(
+        {"x": 500, "y": 300, "hwnd": 349525},
+        hit=hit, target_pid=target_pid,
+    )
+
+    cli_verdict = _cli_verdict(cli_result)
+    mcp_verdict = _mcp_verdict(mcp_payload)
+    assert cli_verdict == mcp_verdict == (False, "CLICK_WRONG_WINDOW")
+
+
+def test_cli_and_mcp_agree_on_success_verdict():
+    """Contract: a same-process landing is a success on BOTH surfaces."""
+    hit = (349525, "Target App", 111)
+    target_pid = 111
+
+    cli_result = _invoke_cli_click(
+        ["--coords", "500", "300", "--hwnd", "349525"],
+        hit=hit, target_pid=target_pid,
+    )
+    mcp_payload, _ = _call_mcp_click(
+        {"x": 500, "y": 300, "hwnd": 349525},
+        hit=hit, target_pid=target_pid,
+    )
+
+    assert _cli_verdict(cli_result) == _mcp_verdict(mcp_payload) == (True, None)

--- a/tests/test_mcp_window_param_unify_900.py
+++ b/tests/test_mcp_window_param_unify_900.py
@@ -49,6 +49,8 @@ _EXPECTED_WINDOW_TARGET_TOOLS = frozenset({
     "get_element_value", "set_element_value", "toggle_element",
     "select_element", "expand_collapse_element", "wait_for_element",
     "wait_until_gone", "type_text", "press_key",
+    # (#1318) click gained hwnd/window_title to name + verify its target window.
+    "click",
 })
 
 # Tools that legitimately still declare a ``title`` parameter meaning something


### PR DESCRIPTION
Closes the Never-Lie parity gap split from #1207: the CLI `click` verified its landing window, but the MCP `click` tool returned bare `{success, method}` with no hit-test — a blind MCP click on a non-foreground/occluded target could silently mis-fire and still report success.

## Fix (one shared implementation)
- Extracted the CLI's landing hit-test + verdict (was module-local in `_click.py`) into a new shared `naturo/hit_verify.py`: `window_root_at_point`, `window_pid`, `hit_window_dict`, `is_cross_pid_mismatch`, `wrong_window_message`, and the `CLICK_WRONG_WINDOW` constant. CLI `_click.py` now imports these (behavior from #1207 preserved) — no logic duplicated.
- MCP `click` now: (a) accepts optional `hwnd`/`window_title` selectors resolved loudly via `require_hwnd` (auto-covered by the #957 WINDOW_NOT_FOUND contract) and focuses the target first (mirrors CLI); (b) for cached `eN` refs, uses the snapshot's window handle as the known target; (c) after the click, hit-tests the point — cross-PID mismatch → `success:false`/`CLICK_WRONG_WINDOW`, bare coords → `hit_window` disclosed, confirmed same-process landing → `verified:true` else `null` (mirrors CLI).
- A **contract test** drives both `click` (CLI) and the MCP click tool with the same mocked hit/target and asserts identical (ok, code) verdicts — the #1318 acceptance criterion.

## Result shape (additive)
Success path still `{success, method}`, now also `verified` (true|null) and, when determinable, `hit_window` ({hwnd,title,pid}). New optional inputs `hwnd`/`window_title`. New failure mode: `success:false` / `CLICK_WRONG_WINDOW`. Same-PID/correct-target and bare-coords success values unchanged; `backend.click` signature unchanged.

## Verification
- `pytest -m 'not ui and not integration and not desktop'`: 7115 passed / 169 skipped (6 pre-existing native-DLL host failures unrelated). New `tests/test_mcp_click_verify_1318.py` (6 tests).
- `ruff check naturo/`: clean. `mypy naturo/`: clean.
- The moved ctypes hit-test logic is verbatim from the CLI (validated on real desktop by #1207); only live-desktop occlusion behavior is smoke-only.

Closes #1318

🤖 Generated with [Claude Code](https://claude.com/claude-code)