### PR TITLE
test(teardown): guaranteed PID-scoped teardown fixtures + session leak-gate (#1202)

### DIFF
--- a/tests/_launch.py
+++ b/tests/_launch.py
@@ -139,4 +139,13 @@ def tracked_launch(cmd, image_names, settle: float = 0.0, pid_lister: PidLister 
     proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
     if settle:
         time.sleep(settle)
+    # Register the launcher PID with the session-end safety-net sweeper (#1202)
+    # so a test that crashes before its ``finally: proc.terminate()`` still gets
+    # reaped. Lazy import keeps this module dependency-light and Linux-safe.
+    try:
+        from tests._teardown_registry import register
+
+        register(proc.pid)
+    except Exception:
+        pass
     return TrackedProc(proc, image_names, baseline, pid_lister)

--- a/tests/_teardown_registry.py
+++ b/tests/_teardown_registry.py
@@ -1,0 +1,123 @@
+"""Session-scoped PID registry + safety-net sweeper for test-launched apps (#1202).
+
+The launch fixtures (``naturo_browser``, ``launched_app``, ``tracked_launch``)
+each **append the PID(s) they started** to a shared, session-lived ledger via
+:func:`register`. Two guarantees ride on that ledger:
+
+1. **Safety-net sweeper** (:func:`sweep`): at session end a session-scoped
+   fixture kills any *still-alive* registered PID. So even a fixture that
+   crashes *before* its own ``finally`` teardown runs — leaving its app orphaned
+   — is reaped. The sweeper only ever touches PIDs a fixture itself recorded, so
+   it can never kill a window the human already had open (the #1197 non-negotiable).
+
+2. **Leak gate**: any registered PID still alive at session end is, by
+   definition, a process a test launched and failed to clean up. :func:`sweep`
+   returns that leaked set (after killing it) so the session fixture can assert
+   it was empty — a leaking test fails the run instead of silently polluting the
+   next one. This also catches a #226-class *silent* teardown failure where an
+   ``app quit`` reported success but left the process alive.
+
+The ledger is an append-only record of everything launched: a PID is **not**
+removed when a fixture tears it down. A well-behaved teardown leaves the PID
+*dead*, so the sweeper simply finds it already gone. This is deliberate — it
+means both "crashed before teardown" and "teardown silently failed" surface as
+the same signal (still-alive registered PID), with no way for a fixture to hide
+a leak by unregistering.
+
+The kill / liveness primitives are injectable, so the sweep logic is fully
+unit-testable headlessly (no real process is launched or killed) and collectable
+on Linux; the defaults use Win32 ``OpenProcess`` + :func:`tests._launch.kill_pid`.
+"""
+from __future__ import annotations
+
+import threading
+from typing import Callable, Iterable
+
+# Session-lived, append-only ledger of PIDs the launch fixtures started.
+_lock = threading.Lock()
+_registry: "set[int]" = set()
+
+AliveFn = Callable[[int], bool]
+KillFn = Callable[[int], object]
+
+
+def register(pid: "int | None") -> None:
+    """Append *pid* to the session ledger (idempotent; ``None`` is ignored)."""
+    if pid is None:
+        return
+    with _lock:
+        _registry.add(int(pid))
+
+
+def registered_pids() -> "set[int]":
+    """Snapshot of every PID registered this session (defensive copy)."""
+    with _lock:
+        return set(_registry)
+
+
+def clear() -> None:
+    """Reset the ledger. For test isolation of the registry itself."""
+    with _lock:
+        _registry.clear()
+
+
+def pid_alive(pid: int) -> bool:
+    """Return True if *pid* is a live process. False off-Windows / on any error.
+
+    Uses ``OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION)`` +
+    ``GetExitCodeProcess``: a process is alive iff the handle opens and its exit
+    code is ``STILL_ACTIVE`` (259). This never shells out, so it is robust on a
+    host whose ``tasklist``/``taskkill`` CLI is broken.
+    """
+    try:
+        import ctypes
+
+        PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+        STILL_ACTIVE = 259
+        kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+        handle = kernel32.OpenProcess(
+            PROCESS_QUERY_LIMITED_INFORMATION, False, int(pid),
+        )
+        if not handle:
+            return False
+        try:
+            code = ctypes.c_ulong(0)
+            if not kernel32.GetExitCodeProcess(handle, ctypes.byref(code)):
+                return False
+            return code.value == STILL_ACTIVE
+        finally:
+            kernel32.CloseHandle(handle)
+    except Exception:
+        return False
+
+
+def _default_kill(pid: int) -> None:
+    # Imported lazily so this module stays import-safe on Linux CI (tests._launch
+    # is pure Python, but keep the dependency edge lazy and one-directional).
+    from tests._launch import kill_pid
+
+    kill_pid(pid)
+
+
+def sweep(
+    pids: "Iterable[int] | None" = None,
+    alive_fn: AliveFn = pid_alive,
+    kill_fn: KillFn = _default_kill,
+) -> "set[int]":
+    """Kill every still-alive registered PID; return the set that had leaked.
+
+    Args:
+        pids: PIDs to sweep. Defaults to the whole session ledger.
+        alive_fn: ``(pid) -> bool`` liveness probe (injectable for tests).
+        kill_fn: ``(pid) -> None`` PID-scoped killer (injectable for tests).
+
+    Returns:
+        The set of registered PIDs that were **still alive** — i.e. leaked past
+        their fixture's own teardown — each of which has now been killed. An
+        empty set means no test leaked.
+    """
+    candidates = registered_pids() if pids is None else {int(p) for p in pids}
+    leaked = {pid for pid in candidates if alive_fn(pid)}
+    for pid in leaked:
+        kill_fn(pid)
+    return leaked

--- a/tests/browser/conftest.py
+++ b/tests/browser/conftest.py
@@ -11,6 +11,9 @@ from __future__ import annotations
 
 import functools
 import http.server
+import shutil
+import socket
+import tempfile
 import threading
 from pathlib import Path
 from typing import Iterator
@@ -18,6 +21,65 @@ from typing import Iterator
 import pytest
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+def _free_tcp_port() -> int:
+    """Return a currently-free loopback TCP port for the CDP endpoint."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+@pytest.fixture
+def naturo_browser() -> Iterator["object"]:
+    """Launch a headless browser via naturo with GUARANTEED teardown (#1202).
+
+    Every browser test that needs a real browser must take this fixture instead
+    of calling ``launch_chrome`` / ``naturo browser launch`` raw. It:
+
+    * launches headless Chrome in its **own throwaway ``user_data_dir`` on a free
+      debug port**, so it never touches the real Chrome profile and concurrent
+      desktop runs (Dev + QA) never share a profile;
+    * **registers the launched PID** with the session-end safety-net sweeper
+      (``tests._teardown_registry``), so a crash before this fixture's own
+      teardown still gets the browser reaped; and
+    * in ``finally`` (runs even when the test fails/raises) **quits then
+      hard-kills the tracked PID and its child tree** via ``kill_pid``
+      (``taskkill /F /T``) — force-close so a beforeunload/prompt cannot strand
+      it — and removes the temp profile dir.
+
+    Teardown is strictly PID-scoped: it only ever kills the exact PID this
+    fixture launched, never by image name, so the human's real Chrome/Edge
+    windows are untouched.
+
+    Yields:
+        The :class:`naturo.browser.ChromeProcess` handle. ``.port`` is the CDP
+        port — build a ``BrowserPage(port=browser.port)`` to drive it.
+    """
+    from naturo.browser import launch_chrome
+    from tests._launch import kill_pid
+    from tests._teardown_registry import register
+
+    user_data_dir = tempfile.mkdtemp(prefix="naturo_browser_1202_")
+    port = _free_tcp_port()
+    chrome = launch_chrome(
+        port=port,
+        headless=True,
+        user_data_dir=user_data_dir,
+        timeout=30.0,
+    )
+    register(chrome.pid)
+    try:
+        yield chrome
+    finally:
+        try:
+            chrome.terminate()
+            chrome.wait(timeout=10)
+        except Exception:
+            pass
+        # Hard-kill the tracked PID + its Chrome child tree, PID-scoped only.
+        kill_pid(chrome.pid)
+        shutil.rmtree(user_data_dir, ignore_errors=True)
 
 
 class _QuietHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):

--- a/tests/browser/test_migration_equivalence.py
+++ b/tests/browser/test_migration_equivalence.py
@@ -95,6 +95,12 @@ def _headless_chrome_page() -> Iterator[BrowserPage]:
         user_data_dir=user_data_dir,
         timeout=30.0,
     )
+    # Register with the session-end safety-net sweeper (#1202) so a crash before
+    # this ``finally`` still gets the browser reaped.
+    from tests._launch import kill_pid
+    from tests._teardown_registry import register
+
+    register(chrome.pid)
     page = BrowserPage(port=port)
     try:
         yield page
@@ -105,6 +111,9 @@ def _headless_chrome_page() -> Iterator[BrowserPage]:
             chrome.wait(timeout=10)
         except subprocess.TimeoutExpired:
             chrome.kill()
+        # Hard-kill the tracked PID + Chrome child tree (renderer/GPU procs that
+        # ``chrome.terminate()`` leaves running), PID-scoped only.
+        kill_pid(chrome.pid)
         shutil.rmtree(user_data_dir, ignore_errors=True)
 
 

--- a/tests/browser/test_screenshot_first_frame_1124.py
+++ b/tests/browser/test_screenshot_first_frame_1124.py
@@ -146,6 +146,8 @@ def test_first_screenshot_after_headless_launch_writes_png(tmp_path: Path) -> No
     import shutil
 
     from naturo.browser import launch_chrome
+    from tests._launch import kill_pid
+    from tests._teardown_registry import register
 
     fixture = (Path(__file__).parent / "fixtures" / "basic.html").resolve().as_uri()
     user_data_dir = tempfile.mkdtemp(prefix="naturo_first_frame_")
@@ -156,6 +158,7 @@ def test_first_screenshot_after_headless_launch_writes_png(tmp_path: Path) -> No
         user_data_dir=user_data_dir,
         timeout=30.0,
     )
+    register(chrome.pid)  # session-end safety-net sweeper (#1202)
     try:
         # Load content the way ``browser launch --url`` does, then drop the
         # connection — navigating does not warm the compositor (only a capture
@@ -180,4 +183,6 @@ def test_first_screenshot_after_headless_launch_writes_png(tmp_path: Path) -> No
             chrome.wait(timeout=10)
         except subprocess.TimeoutExpired:
             chrome.kill()
+        # Hard-kill the tracked PID + Chrome child tree, PID-scoped only (#1202).
+        kill_pid(chrome.pid)
         shutil.rmtree(user_data_dir, ignore_errors=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -234,6 +234,80 @@ def _assert_no_orphaned_processes():
     )
 
 
+@pytest.fixture(autouse=True, scope="session")
+def _pid_registry_sweeper():
+    """Session-scoped safety-net sweeper + leak gate for launched apps (#1202).
+
+    The launch fixtures (``naturo_browser``, ``launched_app``, ``tracked_launch``)
+    append every PID they start to the shared ledger in
+    ``tests._teardown_registry``. At session end this fixture:
+
+    1. **Safety net** — kills any registered PID that is *still alive*, so a
+       fixture that crashed before its own ``finally`` teardown (or whose
+       ``app quit`` silently failed, #1197/#226-class) does not leave an orphan.
+       Only PIDs a fixture itself recorded are ever touched, so a window the
+       human already had open can never be killed (PID-scoped, never by name).
+    2. **Leak gate** — a still-alive registered PID *is* a test that failed to
+       clean up; the sweep returns that set and we assert it was empty, so a
+       leaking test fails the run instead of silently corrupting the next one.
+
+    Always-on and harmless in the default headless gate: no launch fixture runs
+    there, so the ledger is empty and the sweep is a no-op. The kill runs before
+    the assert (in ``finally``), so even a failed gate still leaves the machine
+    clean.
+    """
+    from tests import _teardown_registry as reg
+
+    yield
+    leaked = reg.sweep()
+    assert not leaked, (
+        f"Leaked test-launched processes survived teardown (#1202): {sorted(leaked)}. "
+        "A launch fixture registered these PIDs but they were still alive at "
+        "session end — the test's teardown crashed or its close/quit silently "
+        "failed. The sweeper has now killed them (PID-scoped); fix the offending "
+        "fixture/test so teardown is guaranteed."
+    )
+
+
+@pytest.fixture
+def launched_app():
+    """Factory for desktop tests: launch an app with guaranteed PID-scoped teardown.
+
+    Usage::
+
+        def test_x(launched_app):
+            from tests._launch import NOTEPAD_IMAGES
+            proc = launched_app(["notepad.exe"], NOTEPAD_IMAGES, settle=1.0)
+            ...  # proc.pid, proc.poll(), etc. proxy to the real Popen
+
+    Each launch goes through :func:`tests._launch.tracked_launch`, so teardown
+    reaps exactly the PIDs this launch introduced (the launcher plus any *new*
+    window-owner that appeared — e.g. a UWP broker child), never a pre-existing
+    window. The PID is also registered with the session sweeper, so a mid-test
+    crash before this fixture's own teardown still gets cleaned up. Teardown runs
+    even if the test raises.
+    """
+    from tests._launch import tracked_launch
+    from tests._teardown_registry import register
+
+    launched = []
+
+    def _launch(cmd, image_names=(), settle: float = 0.0):
+        proc = tracked_launch(cmd, image_names, settle=settle)
+        register(proc.pid)
+        launched.append(proc)
+        return proc
+
+    try:
+        yield _launch
+    finally:
+        for proc in launched:
+            try:
+                proc.terminate()  # PID-scoped reap (TrackedProc)
+            except Exception:
+                pass
+
+
 def cli_stdout(result):
     """Extract stdout-only text from a Click CliRunner result.
 

--- a/tests/test_teardown_registry_1202.py
+++ b/tests/test_teardown_registry_1202.py
@@ -1,0 +1,124 @@
+"""Hermetic unit tests for the #1202 PID-registry safety-net sweeper.
+
+These drive the registry + :func:`sweep` with a **stub process launcher** — a
+plain in-memory set of "alive" PIDs and a recording kill function. No real
+process is ever launched or killed, so this runs in the default (headless) CI
+gate and is Linux-collectable. It proves the two guarantees #1202 requires:
+
+  * the sweeper kills a tracked, still-alive PID (crash-before-teardown safety
+    net), and reports it as leaked (the leak gate), and
+  * it NEVER kills a PID it does not have in the ledger, and never touches a
+    registered-but-already-dead PID (the "PID-scoped, only what we launched"
+    non-negotiable — a bug here could kill the developer's real Chrome).
+"""
+from __future__ import annotations
+
+import pytest
+
+from tests import _teardown_registry as reg
+
+
+@pytest.fixture(autouse=True)
+def _isolate_registry():
+    """Each test gets a clean ledger and leaves one behind."""
+    reg.clear()
+    yield
+    reg.clear()
+
+
+class _StubProcessWorld:
+    """A fake process table: which PIDs are alive, and which got killed."""
+
+    def __init__(self, alive: "set[int]") -> None:
+        self.alive = set(alive)
+        self.killed: "list[int]" = []
+
+    def alive_fn(self, pid: int) -> bool:
+        return pid in self.alive
+
+    def kill_fn(self, pid: int) -> None:
+        self.killed.append(pid)
+        self.alive.discard(pid)
+
+
+def test_register_and_snapshot_is_defensive_copy():
+    reg.register(100)
+    reg.register(200)
+    reg.register(None)  # ignored
+    snap = reg.registered_pids()
+    assert snap == {100, 200}
+    snap.add(999)  # mutating the snapshot must not affect the ledger
+    assert reg.registered_pids() == {100, 200}
+
+
+def test_sweep_kills_tracked_alive_pid_and_reports_it_leaked():
+    """The core safety-net: a fixture registered a PID that is still alive at
+    session end (its teardown never ran) -> sweep kills it AND flags the leak."""
+    reg.register(4242)
+    world = _StubProcessWorld(alive={4242})
+
+    leaked = reg.sweep(alive_fn=world.alive_fn, kill_fn=world.kill_fn)
+
+    assert leaked == {4242}
+    assert world.killed == [4242]
+    assert 4242 not in world.alive
+
+
+def test_sweep_skips_registered_but_already_dead_pid():
+    """A well-behaved test tore its app down: the PID is registered but dead, so
+    sweep neither kills it nor reports a leak (no false positive)."""
+    reg.register(500)
+    world = _StubProcessWorld(alive=set())  # already dead
+
+    leaked = reg.sweep(alive_fn=world.alive_fn, kill_fn=world.kill_fn)
+
+    assert leaked == set()
+    assert world.killed == []
+
+
+def test_sweep_never_touches_unregistered_pid():
+    """SAFETY: a live process that was never registered (the human's real Chrome)
+    is invisible to the sweep — never probed as leaked, never killed."""
+    reg.register(10)  # the only thing we launched; already dead
+    world = _StubProcessWorld(alive={10, 99999})  # 99999 = user's real app
+
+    world.alive.discard(10)  # our launch was cleanly torn down
+    leaked = reg.sweep(alive_fn=world.alive_fn, kill_fn=world.kill_fn)
+
+    assert leaked == set()
+    assert 99999 not in world.killed
+    assert world.killed == []
+
+
+def test_sweep_mixed_ledger_kills_only_the_leakers():
+    for pid in (1, 2, 3, 4):
+        reg.register(pid)
+    # 2 and 4 leaked (still alive); 1 and 3 were torn down cleanly.
+    world = _StubProcessWorld(alive={2, 4, 555})  # 555 never registered
+
+    leaked = reg.sweep(alive_fn=world.alive_fn, kill_fn=world.kill_fn)
+
+    assert leaked == {2, 4}
+    assert set(world.killed) == {2, 4}
+    assert 555 not in world.killed  # untracked bystander untouched
+
+
+def test_sweep_explicit_pids_argument_overrides_ledger():
+    reg.register(1)
+    world = _StubProcessWorld(alive={7})
+    leaked = reg.sweep(pids=[7], alive_fn=world.alive_fn, kill_fn=world.kill_fn)
+    assert leaked == {7}
+    assert world.killed == [7]
+
+
+def test_clear_empties_the_ledger():
+    reg.register(1)
+    reg.register(2)
+    reg.clear()
+    assert reg.registered_pids() == set()
+
+
+def test_pid_alive_is_false_for_impossible_pid():
+    """Real liveness probe: an impossible PID is never 'alive' and never raises
+    (returns False off-Windows, and on Windows OpenProcess fails)."""
+    assert reg.pid_alive(4294967295) is False


### PR DESCRIPTION
Implements #1202 — guaranteed test teardown so desktop/browser tests never leak the processes they launch (which both pollute the operator's machine and corrupt later window-counting tests). Also addresses the harness half of #1197.

## What
- **New fixtures** (`naturo_browser`, `launched_app`) launch via naturo with a dedicated temp user-data-dir + tracked PID(s), `yield`, and in `finally` quit + **hard-kill the tracked PID tree** — runs even when the test fails/raises.
- **Session sweeper** (`_pid_registry_sweeper`, autouse, session-scoped): fixtures register launched PIDs into an append-only `tests/_teardown_registry.py` ledger; at session end `sweep()` kills any still-alive **registered** PIDs and the fixture asserts the leaked set is empty → a test that fails to tear down fails the run.
- **Safety**: teardown is strictly PID-scoped to processes the fixtures started — NEVER kills by process name, so the operator's real Chrome/Notepad are never touched. Proven hermetically (kills tracked-alive, skips registered-dead, never touches unregistered bystanders).
- **Migration**: the two actually-leaking browser sites (`test_migration_equivalence._headless_chrome_page` shared by ~20 tests, and `test_screenshot_first_frame_1124`) now hard-kill the Chrome child tree (their prior `terminate()` only reaped the launcher Popen, leaking renderer/GPU children); `tracked_launch` now also registers with the sweeper so the M4-3 desktop tests get the net with no per-test edits.

## Verification
- `pytest -m 'not ui and not integration and not desktop'`: 7212 passed / 169 skipped (6 pre-existing native-DLL host failures unrelated). New `tests/test_teardown_registry_1202.py` (8 hermetic tests).
- `ruff` (changed files) + `mypy naturo/`: clean.
- The fixture LOGIC is unit-covered headlessly; the full real-desktop zero-orphans acceptance run needs a live Windows desktop (the desktop/browser suites are deselected from CI).

Closes #1202

🤖 Generated with [Claude Code](https://claude.com/claude-code)