### PR TITLE
fix(quit): verify by window-ownership before reporting success (#1197)

### DIFF
--- a/naturo/backends/base.py
+++ b/naturo/backends/base.py
@@ -411,6 +411,27 @@ class Backend(ABC):
 
     @abstractmethod
     def quit_app(self, name: str, force: bool = False) -> None:
+        """Quit an application, verifying it is actually gone before returning.
+
+        Contract (the Never-Lie guarantee, #1197): an implementation MUST
+        resolve the real target processes by **window ownership** — the distinct
+        set of PIDs that own the named app's top-level windows, matched by
+        process image name (case-insensitive) — not merely by the launched
+        name/PID, because a launcher/stub PID may have exited while the real
+        windows are owned by a different long-lived process. It MUST terminate
+        that full PID set (graceful first unless ``force``, then a hard kill),
+        then **re-enumerate and verify**. If any window of the app still exists
+        (including a crash-recovery instance respawned under a new PID), it MUST
+        raise (``QuitIncompleteError`` / ``QUIT_INCOMPLETE``) rather than return
+        — returning normally is a promise the app is truly gone.
+
+        Args:
+            name: Application name (friendly / localized names accepted).
+            force: Skip graceful shutdown and hard-kill immediately.
+
+        Raises:
+            QuitIncompleteError: If the app still owns a window after the kill.
+        """
         ...
 
     # === Menu ===

--- a/naturo/backends/windows/_shell/_app.py
+++ b/naturo/backends/windows/_shell/_app.py
@@ -2,6 +2,13 @@
 
 from __future__ import annotations
 
+import logging
+import os
+import subprocess
+import time
+
+logger = logging.getLogger(__name__)
+
 
 class AppMixin:
     """List, launch, and quit applications."""
@@ -15,8 +22,6 @@ class AppMixin:
         Returns:
             List of dicts with keys: name, pid, title, path, process.
         """
-        import os
-
         # Consume the *unresolved* window list: this method runs its own UWP
         # child resolution below, keyed off the ApplicationFrameHost host
         # basename. ``list_windows`` now pre-resolves that host PID (#958), which
@@ -73,17 +78,147 @@ class AppMixin:
         Raises:
             OSError: If the application cannot be launched.
         """
-        import subprocess
         subprocess.Popen([name], shell=True)
 
-    def quit_app(self, name: str = "", force: bool = False) -> None:
-        """Quit an application by name or PID.
+    # === Quit: window-ownership resolution + verify-before-success (#1197) ===
+
+    def _app_windows(self, name_lower: str) -> list:
+        """Enumerate the top-level windows the named app actually owns.
+
+        Matches by process **image name / alias** (case-insensitive), not by a
+        launcher PID — so it finds the real window-owning process even when the
+        launch returned a short-lived stub PID (the #1197 root cause). Also
+        resolves UWP apps hosted by ``ApplicationFrameHost.exe`` via
+        ``list_apps`` (which reports the real child PID and the AFH window
+        title), so packaged apps are matched too.
 
         Args:
-            name: Process name or executable basename.
-            force: If True, kills the process immediately (taskkill /F).
+            name_lower: Lowercased app name (friendly / CJK names accepted).
+
+        Returns:
+            The ``WindowInfo`` objects belonging to the named app.
         """
-        import subprocess
-        flag = "/F" if force else ""
-        cmd = f'taskkill /IM "{name}" {flag}'.strip()
-        subprocess.run(cmd, shell=True, capture_output=True)
+        # Alias/CJK-aware process-name matcher (single source of truth).
+        from naturo.process import _matches_app_by_process_name
+
+        try:
+            windows = list(self.list_windows())
+        except Exception:
+            logger.debug("list_windows() unavailable while quitting %r", name_lower)
+            windows = []
+
+        # Resolve UWP child PIDs + their AFH window titles via list_apps():
+        # list_windows() reports UWP apps as ApplicationFrameHost.exe, which
+        # never matches a user-facing name by process image alone (#750).
+        uwp_titles: set[str] = set()
+        try:
+            for app in self.list_apps():
+                proc_name = os.path.basename(app.get("process", "")).lower()
+                if _matches_app_by_process_name(proc_name, name_lower):
+                    if app.get("title"):
+                        uwp_titles.add(app["title"])
+        except Exception:
+            logger.debug("list_apps() fallback failed while quitting %r", name_lower)
+
+        owned = []
+        for w in windows:
+            proc_name = os.path.basename(w.process_name).lower()
+            match = _matches_app_by_process_name(proc_name, name_lower)
+            if not match and w.title in uwp_titles:
+                if proc_name.removesuffix(".exe") == "applicationframehost":
+                    match = True
+            if match:
+                owned.append(w)
+        return owned
+
+    def _resolve_window_owning_pids(self, name_lower: str) -> set[int]:
+        """Return the DISTINCT set of PIDs that own a window of the named app.
+
+        Args:
+            name_lower: Lowercased app name.
+
+        Returns:
+            Set of owning process IDs (empty if the app owns no windows).
+        """
+        return {w.pid for w in self._app_windows(name_lower)}
+
+    def quit_app(self, name: str = "", force: bool = False) -> None:
+        """Quit an application, verifying it is actually gone before returning.
+
+        Resolves the real target processes by **window ownership** (not just the
+        launched name/PID), terminates that full PID set — graceful WM_CLOSE
+        first unless ``force``, then a hard kill — and then **re-enumerates to
+        verify**. If any window of the app survives (including a Win11 Notepad
+        crash-recovery respawn under a new PID), a truthful
+        :class:`QuitIncompleteError` is raised instead of reporting a false
+        success (#1197, the Never-Lie contract).
+
+        Args:
+            name: Process name or executable basename (friendly / CJK names ok).
+            force: If True, skip the graceful WM_CLOSE and hard-kill immediately.
+
+        Raises:
+            QuitIncompleteError: If the app still owns a window after the kill.
+        """
+        from naturo.errors import QuitIncompleteError
+
+        name_lower = (name or "").lower()
+
+        # 1) Resolve the real window-owning PIDs up front (snapshot the target).
+        targets = self._resolve_window_owning_pids(name_lower)
+
+        # 2) Terminate.
+        if not force and targets:
+            # Graceful: WM_CLOSE every owned window, then wait briefly for the
+            # owning processes to exit on their own.
+            for w in self._app_windows(name_lower):
+                try:
+                    self.close_window(hwnd=w.handle)
+                except Exception:
+                    logger.debug("WM_CLOSE failed for hwnd=%s (%r)", w.handle, name)
+            deadline = time.monotonic() + 3.0
+            while time.monotonic() < deadline:
+                if not self._resolve_window_owning_pids(name_lower):
+                    break
+                time.sleep(0.2)
+            # Hard-kill whatever still owns a window after the graceful window.
+            leftovers = self._resolve_window_owning_pids(name_lower)
+            for pid in leftovers:
+                self._force_kill_pid(pid)
+        elif targets:
+            # force=True: hard-kill the resolved PID set immediately.
+            for pid in targets:
+                self._force_kill_pid(pid)
+        else:
+            # No window-owning process resolved — fall back to a name-based
+            # taskkill so headless / no-window instances are still terminated.
+            flag = "/F" if force else ""
+            cmd = f'taskkill /IM "{name}" {flag}'.strip()
+            try:
+                subprocess.run(cmd, shell=True, capture_output=True)
+            except OSError:
+                logger.debug("Fallback taskkill /IM failed for %r", name)
+
+        # 3) VERIFY (Never-Lie core, #1197). Settle briefly — a crash-recovery
+        # respawn lands within a few hundred ms — then re-enumerate. If the app
+        # still owns any window, report the truth instead of a false success.
+        time.sleep(0.4)
+        survivors = self._resolve_window_owning_pids(name_lower)
+        if survivors:
+            respawned = bool(targets) and not (survivors & targets)
+            raise QuitIncompleteError(name, sorted(survivors), respawned=respawned)
+
+    def _force_kill_pid(self, pid: int) -> None:
+        """Hard-kill a process tree by PID (``taskkill /F /T``).
+
+        ``/T`` kills the whole tree — needed for UWP and tabbed apps like Win11
+        Notepad. Failures (already-dead PID) are swallowed; the post-kill
+        verification is the authority on whether the app is really gone.
+        """
+        try:
+            subprocess.run(
+                ["taskkill", "/F", "/T", "/PID", str(pid)],
+                capture_output=True, timeout=10,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            logger.debug("Force kill of PID %d failed (may be dead): %s", pid, exc)

--- a/naturo/errors.py
+++ b/naturo/errors.py
@@ -44,6 +44,11 @@ class ErrorCode:
     EXPAND_FAILED = "EXPAND_FAILED"
     COLLAPSE_FAILED = "COLLAPSE_FAILED"
 
+    # A quit that terminated its resolved targets but left the app's windows
+    # (or a respawned instance) still present — reported truthfully instead of
+    # a false success (#1197, the Never-Lie contract for ``quit_app``).
+    QUIT_INCOMPLETE = "QUIT_INCOMPLETE"
+
     # A process/PID lookup that matched nothing.
     PROCESS_NOT_FOUND = "PROCESS_NOT_FOUND"
     # A keyboard/mouse input rejected by the safe-input guard.
@@ -151,6 +156,8 @@ _ERROR_CATEGORIES: dict[str, str] = {
     ErrorCode.SELECT_FAILED: ErrorCategory.AUTOMATION,
     ErrorCode.EXPAND_FAILED: ErrorCategory.AUTOMATION,
     ErrorCode.COLLAPSE_FAILED: ErrorCategory.AUTOMATION,
+    # An incomplete quit is an automation operation fault, like INTERACTION_FAILED.
+    ErrorCode.QUIT_INCOMPLETE: ErrorCategory.AUTOMATION,
     # A process lookup is UI/automation target resolution, like APP_NOT_FOUND.
     ErrorCode.PROCESS_NOT_FOUND: ErrorCategory.AUTOMATION,
     # A guard-rejected input is a validation fault, like INVALID_INPUT.
@@ -445,6 +452,55 @@ class InteractionFailedError(NaturoError):
             code=ErrorCode.INTERACTION_FAILED,
             category=ErrorCategory.AUTOMATION,
             is_recoverable=True,
+            **kwargs,
+        )
+
+
+class QuitIncompleteError(NaturoError):
+    """A quit terminated its targets but the application is still present.
+
+    Raised by ``quit_app`` (process layer and Windows backend) when, after
+    terminating every resolved window-owning PID, the app still owns a
+    top-level window on re-enumeration — including the Win11 Notepad case where
+    a crash-recovery instance respawns under a fresh PID. Carries the surviving
+    PIDs in ``context['surviving_pids']`` so callers never see a false success
+    while the app is still running (#1197, the Never-Lie contract).
+    """
+
+    def __init__(
+        self,
+        name: str,
+        surviving_pids: list[int] | None = None,
+        *,
+        respawned: bool = False,
+        **kwargs: Any,
+    ) -> None:
+        pids = surviving_pids or []
+        pid_str = ", ".join(str(p) for p in pids) if pids else "unknown"
+        detail = (
+            f"it is still running under a respawned (crash-recovery) PID ({pid_str})"
+            if respawned
+            else f"it is still running (PID {pid_str})"
+        )
+        ctx = kwargs.pop("context", {})
+        ctx.setdefault("app", name)
+        ctx.setdefault("surviving_pids", pids)
+        ctx.setdefault("respawned", respawned)
+        kwargs.setdefault(
+            "suggested_action",
+            f"Retry with force: 'naturo app quit {name} --force'"
+            + (
+                f", or target the survivor directly: 'naturo app quit --pid {pids[0]} --force'."
+                if pids
+                else "."
+            ),
+        )
+        kwargs.setdefault("is_recoverable", True)
+        super().__init__(
+            message=f"Failed to fully quit '{name}': {detail}.",
+            code=ErrorCode.QUIT_INCOMPLETE,
+            category=ErrorCategory.AUTOMATION,
+            context=ctx,
             **kwargs,
         )
 

--- a/naturo/process.py
+++ b/naturo/process.py
@@ -734,6 +734,7 @@ def quit_app(
 
     Raises:
         AppNotFoundError: If no matching process is found.
+        QuitIncompleteError: If the app (or a respawn) survives the kill (#1197).
     """
     # (#505) For name-based lookup on Windows, first try the backend's
     # window list which has UWP child process resolution.  This avoids
@@ -810,9 +811,9 @@ def _verify_quit(
         timeout: Seconds to wait for process exit.
 
     Raises:
-        InteractionFailedError: If the process is still running.
+        QuitIncompleteError: If the process (or a respawn) is still running.
     """
-    from naturo.errors import InteractionFailedError
+    from naturo.errors import QuitIncompleteError
 
     identifier = name or str(pid or target_pid)
 
@@ -823,15 +824,8 @@ def _verify_quit(
             break
         time.sleep(0.3)
     else:
-        # Target PID survived the kill
-        raise InteractionFailedError(
-            message=(
-                f"Failed to quit '{identifier}' (PID {target_pid}): "
-                f"process is still running after force kill. "
-                f"Try: naturo app quit {identifier} --force, or "
-                f"naturo app quit --pid {target_pid} --force"
-            ),
-        )
+        # Target PID survived the kill — report the truth (#1197).
+        raise QuitIncompleteError(identifier, [target_pid])
 
     # Step 2: If we have a name, verify the app hasn't respawned (#496).
     # Brief settle time — respawns happen within a few hundred ms.
@@ -843,13 +837,10 @@ def _verify_quit(
             # (e.g. lingering ApplicationFrameHost).  The app is effectively
             # closed if no windows remain — only fail if windows exist.
             if _app_has_visible_windows(name, exclude_pid=target_pid):
-                raise InteractionFailedError(
-                    message=(
-                        f"Failed to quit '{name}': target process "
-                        f"(PID {target_pid}) was killed but the application "
-                        f"is still running under PID {surviving.pid}. "
-                        f"Try: naturo app quit --pid {surviving.pid} --force"
-                    ),
+                # The window-owning process differs from the one we killed —
+                # a Win11-Notepad-style crash-recovery respawn (#1197).
+                raise QuitIncompleteError(
+                    name, [surviving.pid], respawned=surviving.pid != target_pid
                 )
 
 

--- a/tests/test_app_cmd.py
+++ b/tests/test_app_cmd.py
@@ -190,6 +190,22 @@ class TestAppQuit:
             result = runner.invoke(app_quit, ["--app", "notepad"])
         assert result.exit_code == 0
 
+    def test_quit_incomplete_surfaces_failure(self, runner):
+        """#1197 Never-Lie: a quit that leaves the app running must surface as a
+        failure (non-zero exit, success:false, QUIT_INCOMPLETE) — never a false
+        'Quit notepad' success message."""
+        from naturo.errors import QuitIncompleteError
+        with patch(
+            "naturo.process.quit_app",
+            side_effect=QuitIncompleteError("notepad", [4242]),
+        ):
+            result = runner.invoke(app_quit, ["notepad", "--json"])
+        assert result.exit_code != 0
+        data = json.loads(result.output)
+        assert data["success"] is False
+        assert data["error"]["code"] == "QUIT_INCOMPLETE"
+        assert 4242 in data["error"]["context"]["surviving_pids"]
+
 
 # ---------------------------------------------------------------------------
 # app relaunch

--- a/tests/test_app_control.py
+++ b/tests/test_app_control.py
@@ -648,10 +648,10 @@ class TestQuitAppVerification:
     """quit_app must verify the process is actually dead (#484)."""
 
     def test_quit_app_raises_when_process_survives_force_kill(self):
-        """quit_app raises InteractionFailedError when process won't die."""
+        """quit_app raises QuitIncompleteError when process won't die (#1197)."""
         from unittest.mock import patch, MagicMock
         from naturo.process import quit_app, ProcessInfo
-        from naturo.errors import InteractionFailedError
+        from naturo.errors import QuitIncompleteError
 
         fake_proc = ProcessInfo(pid=99999, name="stubborn.exe", is_running=True)
 
@@ -674,7 +674,7 @@ class TestQuitAppVerification:
             mock_time.monotonic = fake_monotonic
             mock_time.sleep = MagicMock()
 
-            with pytest.raises(InteractionFailedError, match="still running"):
+            with pytest.raises(QuitIncompleteError, match="still running"):
                 quit_app(name="stubborn", timeout=0.1)
 
     def test_quit_app_succeeds_when_process_dies(self):

--- a/tests/test_mcp_app.py
+++ b/tests/test_mcp_app.py
@@ -216,6 +216,18 @@ class TestQuitApp:
         assert data["success"] is True
         mock_backend.quit_app.assert_called_once_with(name="chrome", force=True)
 
+    def test_quit_app_incomplete_surfaces_failure(self, server, mock_backend):
+        """#1197 Never-Lie: when the backend verifies the app is still running
+        and raises QuitIncompleteError, the MCP tool must report success:false
+        (not the old unconditional {"success": true})."""
+        from naturo.errors import QuitIncompleteError
+
+        mock_backend.quit_app.side_effect = QuitIncompleteError("notepad", [4242])
+        result = _call_tool(server, "quit_app", {"name": "notepad"})
+        data = json.loads(result[0].text)
+        assert data["success"] is False
+        assert data["error"]["code"] == "QUIT_INCOMPLETE"
+
 
 # ── Menu Inspect ──────────────────────────────────────────────────────
 

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -11,7 +11,9 @@ from naturo.process import (
     _resolve_launch_name, _resolve_pid_from_backend, _LAUNCH_ALIASES,
     _matches_app_by_process_name,
 )
-from naturo.errors import AppNotFoundError, InteractionFailedError, TimeoutError
+from naturo.errors import (
+    AppNotFoundError, InteractionFailedError, QuitIncompleteError, TimeoutError,
+)
 
 
 class TestProcessInfo:
@@ -635,15 +637,20 @@ class TestResolveLaunchName:
 
 
 class TestQuitApp:
+    # Patch _resolve_pid_from_backend so name-based quit on a Windows host does
+    # NOT enumerate the live desktop's windows — keeps these unit tests hermetic
+    # and deterministic regardless of what is actually running.
+    @patch("naturo.process._resolve_pid_from_backend", return_value=None)
     @patch("naturo.process.find_process")
-    def test_quit_not_found(self, mock_find):
+    def test_quit_not_found(self, mock_find, mock_resolve):
         mock_find.return_value = None
         with pytest.raises(AppNotFoundError):
             quit_app(name="nonexistent")
 
+    @patch("naturo.process._resolve_pid_from_backend", return_value=None)
     @patch("naturo.process._force_kill")
     @patch("naturo.process.find_process")
-    def test_quit_force(self, mock_find, mock_kill):
+    def test_quit_force(self, mock_find, mock_kill, mock_resolve):
         # First call finds the process; subsequent calls return None (killed)
         mock_find.side_effect = [ProcessInfo(pid=123, name="app"), None, None]
         quit_app(name="app", force=True)
@@ -674,12 +681,17 @@ class TestQuitApp:
         with pytest.raises(InteractionFailedError):
             quit_app(name="notepad", timeout=0.1)
 
+    # Hermetic: patch _app_has_visible_windows so the by-name respawn check does
+    # NOT query the live desktop for a real Notepad window (that made this test
+    # flaky — green only when a Notepad window happened to be visible). Here we
+    # simulate "the respawned app DOES have visible windows" → must fail.
+    @patch("naturo.process._app_has_visible_windows", return_value=True)
     @patch("naturo.process.find_process")
-    def test_verify_quit_app_still_running_by_name(self, mock_find):
+    def test_verify_quit_app_still_running_by_name(self, mock_find, mock_has_windows):
         """#496: _verify_quit must check by name, not just PID.
 
         After force-killing PID 100, if 'notepad' is still running under
-        PID 200 (respawned), verification must fail.
+        PID 200 (respawned) with visible windows, verification must fail.
         """
         # First call: PID lookup returns None (target PID is dead)
         # Second call: name lookup returns a new process (respawned)
@@ -690,7 +702,7 @@ class TestQuitApp:
                 return ProcessInfo(pid=200, name="notepad.exe")
             return None
         mock_find.side_effect = find_side_effect
-        with pytest.raises(InteractionFailedError, match="still running"):
+        with pytest.raises(QuitIncompleteError, match="still running"):
             _verify_quit("notepad", None, target_pid=100, timeout=0.5)
 
     @patch("naturo.process.find_process")
@@ -737,7 +749,7 @@ class TestQuitApp:
                 return ProcessInfo(pid=200, name="notepad.exe")
             return None
         mock_find.side_effect = find_side_effect
-        with pytest.raises(InteractionFailedError, match="still running"):
+        with pytest.raises(QuitIncompleteError, match="still running"):
             _verify_quit("notepad", None, target_pid=100, timeout=0.5)
 
 
@@ -1192,7 +1204,7 @@ class TestUWPQuitResolution:
             ProcessInfo(pid=3000, name="calculatorapp.exe"),  # respawn check
         ]
 
-        with pytest.raises(InteractionFailedError, match="still running"):
+        with pytest.raises(QuitIncompleteError, match="still running"):
             _verify_quit("计算器", None, target_pid=1000, timeout=0.5)
 
 

--- a/tests/test_quit_app_never_lie_1197.py
+++ b/tests/test_quit_app_never_lie_1197.py
@@ -1,0 +1,229 @@
+"""Never-Lie regression tests for ``quit_app`` (#1197).
+
+The confirmed bug: ``quit_app("notepad")`` (and even ``force=True``) returned
+success while Notepad was still running — Win11 Notepad's real windows are
+owned by a long-lived process, not the launcher/stub PID that ``launch_app``
+returned, so quitting by the stale name/PID killed nothing that mattered and
+reported success without verifying.
+
+These tests exercise the Windows backend ``AppMixin.quit_app`` fix entirely
+hermetically: a fake backend supplies the window list and records terminated
+PIDs. No real app is launched or killed, and no live desktop is touched — the
+kill is modelled by mutating the fake's in-memory window list.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from naturo.backends.base import WindowInfo
+from naturo.backends.windows._shell._app import AppMixin
+from naturo.errors import ErrorCode, QuitIncompleteError
+
+
+@pytest.fixture(autouse=True)
+def _fast_clock(monkeypatch):
+    """Drive ``quit_app``'s settle/graceful waits off a virtual clock so the
+    hermetic tests are instant and deterministic (no real wall-clock sleeps)."""
+    import naturo.backends.windows._shell._app as mod
+
+    clock = {"t": 0.0}
+
+    def _monotonic() -> float:
+        clock["t"] += 0.5
+        return clock["t"]
+
+    def _sleep(secs: float) -> None:
+        clock["t"] += secs
+
+    monkeypatch.setattr(mod.time, "monotonic", _monotonic)
+    monkeypatch.setattr(mod.time, "sleep", _sleep)
+
+
+def _win(handle: int, pid: int, process_name: str, title: str = "Untitled") -> WindowInfo:
+    return WindowInfo(
+        handle=handle, title=title, process_name=process_name, pid=pid,
+        x=0, y=0, width=800, height=600, is_visible=True, is_minimized=False,
+    )
+
+
+class FakeAppBackend(AppMixin):
+    """Minimal backend driving ``AppMixin.quit_app`` without any OS calls.
+
+    ``list_windows`` is the single source of truth for "is the app still here".
+    ``close_window`` (WM_CLOSE) and ``_force_kill_pid`` are overridden to mutate
+    that list — modelling a real termination — and to record what they acted on.
+    """
+
+    _SYSTEM_PROCESS_NAMES: set[str] = set()
+    _UWP_HOST_PROCESS: str = "applicationframehost.exe"
+
+    def __init__(
+        self,
+        windows: list[WindowInfo],
+        *,
+        stubborn: bool = False,
+        respawn_as: WindowInfo | None = None,
+    ) -> None:
+        self._windows = list(windows)
+        self._stubborn = stubborn          # kills "succeed" but nothing dies
+        self._respawn_as = respawn_as      # a new window appears after a kill
+        self.closed: list[int] = []
+        self.killed: list[int] = []
+
+    # --- surfaces AppMixin.quit_app consumes -------------------------------
+    def list_windows(self) -> list[WindowInfo]:
+        return list(self._windows)
+
+    def list_apps(self) -> list[dict]:  # no UWP host in these scenarios
+        return []
+
+    def close_window(self, title=None, hwnd=None, force=False) -> None:
+        self.closed.append(hwnd)
+        if self._stubborn:
+            return
+        self._windows = [w for w in self._windows if w.handle != hwnd]
+
+    def _force_kill_pid(self, pid: int) -> None:
+        self.killed.append(pid)
+        if self._stubborn:
+            return
+        self._windows = [w for w in self._windows if w.pid != pid]
+        if self._respawn_as is not None:
+            # Win11 Notepad crash-recovery: a NEW process owns a window again.
+            self._windows.append(self._respawn_as)
+            self._respawn_as = None
+
+
+# ── 1. Window-owned-by-a-different-PID-than-the-stub → resolve, kill, verify ──
+
+def test_resolves_window_owning_pid_not_launch_stub():
+    """The real window is owned by PID 4242 (the launch stub 1111 is irrelevant).
+
+    quit must resolve 4242 from window ownership, kill it, verify gone, succeed.
+    """
+    be = FakeAppBackend([_win(handle=10, pid=4242, process_name=r"C:\Windows\notepad.exe")])
+
+    be.quit_app(name="notepad", force=True)  # must not raise
+
+    assert be.killed == [4242]            # resolved the window owner, not a stub
+    assert be._windows == []              # verified actually gone
+
+
+# ── 2. THE bug: terminate "succeeds" but a window survives → QUIT_INCOMPLETE ──
+
+def test_survivor_window_reports_quit_incomplete_not_success():
+    """Kill returns, but the app still owns a window — must NOT report success.
+
+    This is the exact #1197 regression: never report success while the app
+    survives. A stubborn backend keeps the window on every re-enumeration.
+    """
+    be = FakeAppBackend(
+        [_win(handle=10, pid=4242, process_name=r"C:\Windows\notepad.exe")],
+        stubborn=True,
+    )
+
+    with pytest.raises(QuitIncompleteError) as ei:
+        be.quit_app(name="notepad", force=True)
+
+    assert be.killed == [4242]                      # it did try to kill
+    assert ei.value.code == ErrorCode.QUIT_INCOMPLETE
+    assert 4242 in ei.value.context["surviving_pids"]
+    assert ei.value.context["respawned"] is False   # same PID survived
+
+
+# ── 3. Respawn: after kill a NEW app window appears → not-fully-quit ──────────
+
+def test_crash_recovery_respawn_reported_as_not_quit():
+    """After the kill, a fresh PID owns a Notepad window (crash recovery).
+
+    Verification must detect the surviving window and report the truth, noting
+    it is a respawn (a different PID than the one we terminated).
+    """
+    respawn = _win(handle=99, pid=99999, process_name=r"C:\Windows\notepad.exe", title="Notepad")
+    be = FakeAppBackend(
+        [_win(handle=10, pid=4242, process_name=r"C:\Windows\notepad.exe")],
+        respawn_as=respawn,
+    )
+
+    with pytest.raises(QuitIncompleteError) as ei:
+        be.quit_app(name="notepad", force=True)
+
+    assert be.killed == [4242]                        # original owner killed
+    assert ei.value.context["respawned"] is True      # new PID → respawn
+    assert 99999 in ei.value.context["surviving_pids"]
+
+
+# ── 4. force=False (graceful WM_CLOSE) vs force=True (immediate kill) ─────────
+
+def test_graceful_path_uses_wm_close():
+    """force=False sends WM_CLOSE to owned windows; no hard kill when it works."""
+    be = FakeAppBackend([_win(handle=10, pid=4242, process_name=r"C:\Windows\notepad.exe")])
+
+    be.quit_app(name="notepad", force=False)  # must not raise
+
+    assert be.closed == [10]      # WM_CLOSE sent to the owned window
+    assert be.killed == []        # graceful close sufficed — no taskkill /F
+    assert be._windows == []
+
+
+def test_force_path_hard_kills_without_wm_close():
+    """force=True hard-kills the resolved PID set immediately, no WM_CLOSE."""
+    be = FakeAppBackend([_win(handle=10, pid=4242, process_name=r"C:\Windows\notepad.exe")])
+
+    be.quit_app(name="notepad", force=True)
+
+    assert be.closed == []        # no graceful step
+    assert be.killed == [4242]
+
+
+def test_graceful_falls_back_to_kill_when_close_ignored():
+    """A window that ignores WM_CLOSE is still hard-killed on the graceful path."""
+    be = FakeAppBackend(
+        [_win(handle=10, pid=4242, process_name=r"C:\Windows\notepad.exe")],
+        stubborn=True,
+    )
+
+    with pytest.raises(QuitIncompleteError):
+        be.quit_app(name="notepad", force=False)
+
+    assert be.closed == [10]      # tried graceful first
+    assert 4242 in be.killed      # then escalated to a hard kill
+
+
+# ── 5. Safety: only PIDs that own a window of the NAMED app are killed ────────
+
+def test_never_kills_pid_that_does_not_own_a_named_window():
+    """A co-running app (calc, PID 7777) must never be terminated by quitting
+    notepad — termination is scoped to the resolved window-owning PID set."""
+    be = FakeAppBackend([
+        _win(handle=10, pid=4242, process_name=r"C:\Windows\notepad.exe", title="Untitled - Notepad"),
+        _win(handle=20, pid=7777, process_name=r"C:\Windows\System32\calc.exe", title="Calculator"),
+    ])
+
+    be.quit_app(name="notepad", force=True)  # must not raise
+
+    assert be.killed == [4242]        # only notepad's owner
+    assert 7777 not in be.killed      # the bystander is untouched
+    # calc's window remains, but it is not the named app, so quit still succeeds
+    assert [w.pid for w in be._windows] == [7777]
+
+
+def test_no_window_owner_falls_back_to_name_taskkill(monkeypatch):
+    """When the app owns no window, fall back to a name-based taskkill and,
+    with nothing surviving, report success (no false failure either)."""
+    calls: list = []
+
+    class _Result:
+        returncode = 0
+
+    def _fake_run(cmd, *a, **k):
+        calls.append(cmd)
+        return _Result()
+
+    monkeypatch.setattr("naturo.backends.windows._shell._app.subprocess.run", _fake_run)
+
+    be = FakeAppBackend([])  # no windows at all
+    be.quit_app(name="ghost", force=False)  # must not raise
+
+    assert calls and "ghost" in calls[0]  # fallback taskkill /IM used


### PR DESCRIPTION
Fixes a confirmed Never-Lie bug reproduced live on Win11: `quit_app("notepad")` and even `quit_app(force=True)` returned `success:true` while Notepad was still running/visible.

## Root cause
Win11 Notepad (and UWP/broker apps) are single-instance with crash-recovery: `launch_app` returns a launcher/stub PID that exits, while the real windows are owned by a different long-lived process. `quit_app` killed the stale name/pid (nothing that mattered) and reported success without verifying.

## Fix
The Windows backend `quit_app` now:
1. Resolves the **distinct set of PIDs that actually own the app's top-level windows** (matched by process image/alias, case-insensitive; UWP via `list_apps`) — not the launch stub PID.
2. Terminates that full set — graceful WM_CLOSE per window first (unless `force`), then `taskkill /F /T` on leftovers.
3. **Re-enumerates and VERIFIES** — if any window of the app still exists, raises `QuitIncompleteError` (code `QUIT_INCOMPLETE`) carrying the surviving PID(s) and a `respawned` flag; **never returns a false success**.
Surfaced truthfully: MCP `quit_app` → `{success:false, error:{code:QUIT_INCOMPLETE}}`; CLI `app quit` → error envelope + non-zero exit. The abstract `quit_app` in `base.py` now documents this Never-Lie contract.

## Also (un-flakes #1333)
`test_verify_quit_app_still_running_by_name` mocked only `find_process`, not `_app_has_visible_windows` (which queries the real backend for a live Notepad window) — so it passed only when a Notepad window happened to exist and failed deterministically otherwise (it was reddening PR #1333/#896). Now hermetic (mocks `_app_has_visible_windows`).

## Verification
- Full gate green apart from the ~6 known native-DLL host failures; `test_process.py` 99 passed standalone (clean basetemp). New `tests/test_quit_app_never_lie_1197.py` incl. the survivor→QUIT_INCOMPLETE regression, crash-recovery respawn, and the safety test (never kills a PID that doesn't own a named window). +11 net new passing tests. ruff + mypy clean.
- Live Win11 launch→quit→verify confirmation run by the orchestrator (see PR thread).

Closes #1197

🤖 Generated with [Claude Code](https://claude.com/claude-code)