### PR TITLE
feat(excel): COM create-chart on CLI + MCP (#1319)

### DIFF
--- a/naturo/cli/extensions.py
+++ b/naturo/cli/extensions.py
@@ -205,6 +205,52 @@ def run_macro(path, macro_name, macro_args, json_output) -> None:
             click.echo(f"Result: {result['result']}")
 
 
+@excel.command("create-chart")
+@click.argument("path", type=click.Path())
+@click.option("--type", "chart_type", default="column", show_default=True,
+              type=click.Choice(["bar", "column", "line", "pie", "area", "scatter"]),
+              help="Chart type")
+@click.option("--range", "range_", required=True,
+              help="Source data range (e.g. A1:B10)")
+@click.option("--sheet", help="Sheet name (default: active sheet)")
+@click.option("--title", help="Chart title")
+@click.option("--anchor", help="Cell to anchor the chart's top-left corner (e.g. D2)")
+@click.option("--create", is_flag=True, help="Create workbook if it doesn't exist")
+@click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
+def create_chart(path, chart_type, range_, sheet, title, anchor, create, json_output) -> None:
+    """Create a chart from a data range on a worksheet.
+
+    PATH is the workbook file. --range is the source data (e.g. A1:B10).
+
+    \b
+    Examples:
+
+      naturo excel create-chart report.xlsx --type bar --range "A1:B10"
+
+      naturo excel create-chart data.xlsx --type line --range "A1:C20" \\
+        --sheet Sales --title "Q1 Revenue" --json
+    """
+    from naturo.cli.error_helpers import emit_exception_error
+
+    try:
+        from naturo.excel import excel_create_chart
+        result = excel_create_chart(
+            path, range_, chart_type=chart_type, sheet=sheet,
+            title=title, anchor=anchor, create=create,
+        )
+    except Exception as exc:
+        emit_exception_error(exc, json_output, fallback_code="EXCEL_ERROR")
+        return
+
+    if json_output:
+        click.echo(json_dumps({"success": True, **result}))
+    else:
+        click.echo(f"Created {result['chart_type']} chart '{result['chart']}' "
+                   f"on sheet {result['sheet']} from {result['range']}")
+        if result.get("anchor"):
+            click.echo(f"Anchor: {result['anchor']}")
+
+
 @excel.command("info")
 @click.argument("path", type=click.Path())
 @click.option("--sheet", help="Sheet name (default: active sheet)")

--- a/naturo/excel.py
+++ b/naturo/excel.py
@@ -247,6 +247,18 @@ def _cell_value_to_python(value: Any) -> Any:
     return str(value)
 
 
+# xlChartType constants (Excel VBA enum) keyed by friendly name. Values are the
+# stable numeric COM constants so we never need early-bound win32com typelibs.
+_CHART_TYPES: dict[str, int] = {
+    "column": 51,     # xlColumnClustered
+    "bar": 57,        # xlBarClustered
+    "line": 4,        # xlLine
+    "pie": 5,         # xlPie
+    "area": 1,        # xlArea
+    "scatter": -4169,  # xlXYScatter
+}
+
+
 # ── Public API ───────────────────────────────────────────────────────────────
 
 
@@ -609,6 +621,138 @@ def excel_get_range_info(
         raise
     except Exception as exc:
         raise ExcelError(f"Failed to get range info: {exc}", context={"path": abs_path})
+    finally:
+        try:
+            excel.Quit()
+        except Exception as exc:
+            logger.debug("COM cleanup failed: %s", exc)
+
+
+@_com_apartment
+def excel_create_chart(
+    path: str,
+    data_range: str,
+    chart_type: str = "column",
+    sheet: str | None = None,
+    title: str | None = None,
+    anchor: str | None = None,
+    create: bool = False,
+) -> dict[str, Any]:
+    """Create a chart from a data range on a worksheet.
+
+    Uses COM ``Worksheet.Shapes.AddChart2`` and ``Chart.SetSourceData``.
+
+    Args:
+        path: Path to the .xlsx/.xlsm file.
+        data_range: Source data range (e.g. 'A1:B10').
+        chart_type: One of bar/column/line/pie/area/scatter (default: column).
+        sheet: Sheet name that holds the data / hosts the chart
+            (default: active sheet).
+        title: Optional chart title.
+        anchor: Optional cell (e.g. 'D2') to move the chart's top-left corner to.
+        create: Create the workbook if it does not exist.
+
+    Returns:
+        Dict with chart name, chart_type, range, sheet, anchor, and position.
+
+    Raises:
+        ExcelError(INVALID_INPUT): Invalid chart type or missing range.
+        WorkbookNotFoundError: If the file does not exist and create is False.
+        SheetNotFoundError: If the sheet does not exist.
+        ExcelError: If chart creation fails.
+    """
+    # ── Validate inputs first (pure, host-independent → clear INVALID_INPUT) ──
+    type_key = (chart_type or "").strip().lower()
+    if type_key not in _CHART_TYPES:
+        raise ExcelError(
+            f"Invalid chart type: {chart_type!r}. "
+            f"Supported: {', '.join(sorted(_CHART_TYPES))}",
+            code=ErrorCode.INVALID_INPUT,
+            context={"chart_type": chart_type, "supported": sorted(_CHART_TYPES)},
+        )
+    if not data_range or not str(data_range).strip():
+        raise ExcelError(
+            "A source data range is required (e.g. 'A1:B10')",
+            code=ErrorCode.INVALID_INPUT,
+            context={"range": data_range},
+        )
+
+    _require_windows()
+    abs_path = _normalize_path(path)
+    if not os.path.isfile(abs_path) and not create:
+        raise WorkbookNotFoundError(path)
+
+    xl_type = _CHART_TYPES[type_key]
+    excel = _get_excel(visible=False)
+    try:
+        if os.path.isfile(abs_path):
+            wb = excel.Workbooks.Open(abs_path)
+        else:
+            wb = excel.Workbooks.Add()
+
+        ws = _get_worksheet(wb, sheet)
+
+        # AddChart2(Style, XlChartType, ...) — Style=-1 keeps the default style.
+        shape = ws.Shapes.AddChart2(-1, xl_type)
+        chart = shape.Chart
+        chart.SetSourceData(Source=ws.Range(data_range))
+
+        if title:
+            chart.HasTitle = True
+            chart.ChartTitle.Text = title
+
+        # Optionally re-anchor the chart's top-left corner to a target cell.
+        if anchor:
+            anchor_cell = ws.Range(anchor)
+            shape.Left = anchor_cell.Left
+            shape.Top = anchor_cell.Top
+
+        # Capture the chart's identity/geometry while the COM proxy is still
+        # live — after wb.Close the proxy is dead (see c9d070b4 / d5b99e54).
+        chart_name = shape.Name
+        position = {
+            "left": shape.Left,
+            "top": shape.Top,
+            "width": shape.Width,
+            "height": shape.Height,
+        }
+        try:
+            anchor_addr = shape.TopLeftCell.Address
+        except Exception as exc:
+            logger.debug("TopLeftCell resolve failed: %s", exc)
+            anchor_addr = None
+        sheet_name = ws.Name
+
+        # Persist the workbook so the chart round-trips on re-open.
+        if os.path.isfile(abs_path):
+            wb.Save()
+        else:
+            wb.SaveAs(abs_path)
+        wb.Close(SaveChanges=False)
+
+        return {
+            "path": abs_path,
+            "sheet": sheet_name,
+            "chart": chart_name,
+            "chart_type": type_key,
+            "range": data_range,
+            "title": title,
+            "anchor": anchor_addr,
+            "position": position,
+        }
+
+    except (WorkbookNotFoundError, SheetNotFoundError, ExcelError):
+        raise
+    except Exception as exc:
+        raise ExcelError(
+            f"Failed to create chart: {exc}",
+            context={"range": data_range, "chart_type": type_key},
+            suggested_action=(
+                "Excel COM automation failed. Ensure Microsoft Excel is installed "
+                "and activated, the sheet name is correct, and the range points at "
+                "real tabular data (e.g. 'A1:B10')."
+            ),
+        )
     finally:
         try:
             excel.Quit()

--- a/naturo/mcp/_excel.py
+++ b/naturo/mcp/_excel.py
@@ -122,6 +122,38 @@ def register_excel_tools(server, _get_backend, _safe_tool):
 
     @server.tool()
     @_safe_tool
+    def excel_create_chart(
+        path: str,
+        data_range: str,
+        chart_type: str = "column",
+        sheet: Optional[str] = None,
+        title: Optional[str] = None,
+        anchor: Optional[str] = None,
+        create: bool = False,
+    ) -> dict:
+        """Create a chart from a data range in an Excel workbook.
+
+        Args:
+            path: Path to the .xlsx/.xlsm file.
+            data_range: Source data range (e.g. 'A1:B10').
+            chart_type: bar/column/line/pie/area/scatter (default: column).
+            sheet: Sheet name (default: active sheet).
+            title: Optional chart title.
+            anchor: Optional cell to anchor the chart top-left (e.g. 'D2').
+            create: Create the workbook if it doesn't exist.
+
+        Returns:
+            Dict with chart name, chart_type, range, sheet, anchor, position.
+        """
+        from naturo.excel import excel_create_chart as _excel_create_chart
+        result = _excel_create_chart(
+            path, data_range, chart_type=chart_type, sheet=sheet,
+            title=title, anchor=anchor, create=create,
+        )
+        return {"success": True, **result}
+
+    @server.tool()
+    @_safe_tool
     def excel_info(
         path: str,
         sheet: Optional[str] = None,

--- a/packaging/mcpb/manifest.json
+++ b/packaging/mcpb/manifest.json
@@ -119,6 +119,10 @@
       "description": "Drag from one point to another."
     },
     {
+      "name": "excel_create_chart",
+      "description": "Create a chart from a data range in an Excel workbook."
+    },
+    {
       "name": "excel_info",
       "description": "Get used range info for an Excel worksheet."
     },

--- a/tests/test_excel.py
+++ b/tests/test_excel.py
@@ -159,6 +159,93 @@ class TestExcelBackend:
         assert result["result"] == "Done"
 
     @pytest.mark.skipif(not is_windows, reason="Excel COM requires Windows")
+    @patch("naturo.excel._get_excel")
+    def test_excel_create_chart(self, mock_get_excel):
+        """excel_create_chart adds a chart with the right type/range/sheet."""
+        from naturo.excel import excel_create_chart
+
+        mock_excel = MagicMock()
+        mock_wb = MagicMock()
+        mock_ws = MagicMock()
+        mock_ws.Name = "Sheet1"
+        mock_shape = MagicMock()
+        mock_shape.Name = "Chart 1"
+        mock_shape.Left = 100
+        mock_shape.Top = 50
+        mock_shape.Width = 480
+        mock_shape.Height = 288
+        mock_shape.TopLeftCell.Address = "$D$1"
+        mock_ws.Shapes.AddChart2.return_value = mock_shape
+        mock_wb.ActiveSheet = mock_ws
+        mock_excel.Workbooks.Open.return_value = mock_wb
+        mock_get_excel.return_value = mock_excel
+
+        result = excel_create_chart(self.test_path, "A1:B10", chart_type="bar")
+
+        # xlBarClustered == 57; Style=-1 keeps the default style.
+        mock_ws.Shapes.AddChart2.assert_called_once_with(-1, 57)
+        # Source data range was set to the requested range.
+        mock_shape.Chart.SetSourceData.assert_called_once()
+        assert result["chart"] == "Chart 1"
+        assert result["chart_type"] == "bar"
+        assert result["range"] == "A1:B10"
+        assert result["sheet"] == "Sheet1"
+        assert result["anchor"] == "$D$1"
+
+    @pytest.mark.skipif(not is_windows, reason="Excel COM requires Windows")
+    @patch("naturo.excel._get_excel")
+    def test_excel_create_chart_resolves_sheet_and_title(self, mock_get_excel):
+        """excel_create_chart resolves a named sheet and sets the title."""
+        from naturo.excel import excel_create_chart
+
+        mock_excel = MagicMock()
+        mock_wb = MagicMock()
+        mock_wb.Sheets.Count = 2
+        target_ws = MagicMock()
+        target_ws.Name = "Data"
+        mock_shape = MagicMock()
+        mock_shape.Name = "Chart 5"
+        target_ws.Shapes.AddChart2.return_value = mock_shape
+
+        def _sheets(i):
+            return MagicMock(Name=["Summary", "Data"][i - 1])
+
+        mock_wb.Sheets.side_effect = lambda i: (
+            target_ws if isinstance(i, str) and i == "Data" else _sheets(i)
+        )
+        mock_excel.Workbooks.Open.return_value = mock_wb
+        mock_get_excel.return_value = mock_excel
+
+        result = excel_create_chart(
+            self.test_path, "A1:C20", chart_type="line",
+            sheet="Data", title="Revenue",
+        )
+
+        target_ws.Shapes.AddChart2.assert_called_once_with(-1, 4)  # xlLine == 4
+        assert mock_shape.Chart.HasTitle is True
+        mock_shape.Chart.ChartTitle.Text = "Revenue"
+        assert result["sheet"] == "Data"
+        assert result["title"] == "Revenue"
+
+    def test_excel_create_chart_invalid_type(self):
+        """excel_create_chart rejects an unknown chart type with INVALID_INPUT."""
+        from naturo.excel import excel_create_chart, ExcelError
+        from naturo.errors import ErrorCode
+
+        with pytest.raises(ExcelError) as exc_info:
+            excel_create_chart(self.test_path, "A1:B10", chart_type="donut")
+        assert exc_info.value.code == ErrorCode.INVALID_INPUT
+
+    def test_excel_create_chart_missing_range(self):
+        """excel_create_chart rejects an empty range with INVALID_INPUT."""
+        from naturo.excel import excel_create_chart, ExcelError
+        from naturo.errors import ErrorCode
+
+        with pytest.raises(ExcelError) as exc_info:
+            excel_create_chart(self.test_path, "  ", chart_type="bar")
+        assert exc_info.value.code == ErrorCode.INVALID_INPUT
+
+    @pytest.mark.skipif(not is_windows, reason="Excel COM requires Windows")
     def test_workbook_not_found(self):
         """excel_open raises WorkbookNotFoundError for missing file."""
         from naturo.excel import excel_open, WorkbookNotFoundError
@@ -319,6 +406,26 @@ class TestExcelCLI:
         assert result.exit_code == 0
         assert "used range" in result.output.lower()
 
+    def test_excel_create_chart_help(self, runner, cli):
+        """Excel create-chart shows help."""
+        result = runner.invoke(cli, ["excel", "create-chart", "--help"])
+        assert result.exit_code == 0
+        assert "chart" in result.output.lower()
+
+    def test_excel_create_chart_invalid_type_rejected(self, runner, cli):
+        """create-chart rejects a chart type outside the allowed choices."""
+        result = runner.invoke(
+            cli, ["excel", "create-chart", "x.xlsx", "--type", "donut", "--range", "A1:B2"]
+        )
+        assert result.exit_code != 0
+        assert "donut" in result.output or "Invalid value" in result.output
+
+    def test_excel_create_chart_missing_range_rejected(self, runner, cli):
+        """create-chart requires --range."""
+        result = runner.invoke(cli, ["excel", "create-chart", "x.xlsx", "--type", "bar"])
+        assert result.exit_code != 0
+        assert "range" in result.output.lower()
+
     @pytest.mark.skipif(not is_windows, reason="Excel COM requires Windows")
     def test_excel_read_nonexistent_file_json(self, runner, cli):
         """Excel read on missing file returns JSON error."""
@@ -340,7 +447,7 @@ class TestExcelCLI:
         """All expected Excel subcommands are registered."""
         result = runner.invoke(cli, ["excel", "--help"])
         assert result.exit_code == 0
-        for cmd in ["open", "read", "write", "list-sheets", "run-macro", "info"]:
+        for cmd in ["open", "read", "write", "list-sheets", "run-macro", "info", "create-chart"]:
             assert cmd in result.output, f"Missing subcommand: {cmd}"
 
 
@@ -363,7 +470,8 @@ class TestExcelMCP:
         # Check tool names include excel tools
         tool_names = [t.name for t in server._tool_manager.list_tools()]
         expected = ["excel_open", "excel_read", "excel_write",
-                     "excel_list_sheets", "excel_run_macro", "excel_info"]
+                     "excel_list_sheets", "excel_run_macro", "excel_info",
+                     "excel_create_chart"]
         for name in expected:
             assert name in tool_names, f"MCP tool '{name}' not registered"
 

--- a/tests/test_json_envelope_sweep_1142.py
+++ b/tests/test_json_envelope_sweep_1142.py
@@ -276,6 +276,7 @@ REQUIRES_LIVE_ENV: dict[tuple[str, ...], str] = {
     ("browser", "stealth"): _REASON_BROWSER,
     ("browser", "stealth-check"): _REASON_BROWSER,
     # Excel COM.
+    ("excel", "create-chart"): _REASON_EXCEL,
     ("excel", "info"): _REASON_EXCEL,
     ("excel", "list-sheets"): _REASON_EXCEL,
     ("excel", "open"): _REASON_EXCEL,

--- a/tests/test_mcp_excel.py
+++ b/tests/test_mcp_excel.py
@@ -188,6 +188,47 @@ class TestExcelRunMacro:
         mock_macro.assert_called_once_with("macros.xlsm", "Calculate", args=["10", "20"])
 
 
+# ── excel_create_chart ───────────────────────────────────────────────
+
+
+class TestExcelCreateChart:
+
+    @patch("naturo.excel.excel_create_chart")
+    def test_create_chart(self, mock_chart, server):
+        mock_chart.return_value = {
+            "path": "data.xlsx", "sheet": "Sheet1", "chart": "Chart 1",
+            "chart_type": "bar", "range": "A1:B10", "title": None,
+            "anchor": "$A$1", "position": {"left": 0, "top": 0, "width": 480, "height": 288},
+        }
+        result = _call_tool(server, "excel_create_chart", {
+            "path": "data.xlsx", "data_range": "A1:B10", "chart_type": "bar",
+        })
+        data = json.loads(result[0].text)
+        assert data["success"] is True
+        assert data["chart"] == "Chart 1"
+        assert data["chart_type"] == "bar"
+        mock_chart.assert_called_once_with(
+            "data.xlsx", "A1:B10", chart_type="bar", sheet=None,
+            title=None, anchor=None, create=False,
+        )
+
+    @patch("naturo.excel.excel_create_chart")
+    def test_create_chart_full_options(self, mock_chart, server):
+        mock_chart.return_value = {
+            "path": "data.xlsx", "sheet": "Data", "chart": "Chart 2",
+            "chart_type": "line", "range": "A1:C20", "title": "Rev",
+            "anchor": "$D$2", "position": {},
+        }
+        _call_tool(server, "excel_create_chart", {
+            "path": "data.xlsx", "data_range": "A1:C20", "chart_type": "line",
+            "sheet": "Data", "title": "Rev", "anchor": "D2", "create": True,
+        })
+        mock_chart.assert_called_once_with(
+            "data.xlsx", "A1:C20", chart_type="line", sheet="Data",
+            title="Rev", anchor="D2", create=True,
+        )
+
+
 # ── excel_info ───────────────────────────────────────────────────────
 
 

--- a/tests/test_mcp_window_param_unify_900.py
+++ b/tests/test_mcp_window_param_unify_900.py
@@ -56,7 +56,10 @@ _EXPECTED_WINDOW_TARGET_TOOLS = frozenset({
 # Tools that legitimately still declare a ``title`` parameter meaning something
 # other than a window selector, so the "no bare title selector" guard must not
 # flag them.
-_TITLE_MEANS_SOMETHING_ELSE: frozenset = frozenset()
+_TITLE_MEANS_SOMETHING_ELSE: frozenset = frozenset({
+    # excel_create_chart's ``title`` is the CHART title, not a window selector.
+    "excel_create_chart",
+})
 
 
 def _list_tools():

--- a/tests/test_surface_guard_coverage_912.py
+++ b/tests/test_surface_guard_coverage_912.py
@@ -208,8 +208,8 @@ _CLI_SESSION_INDEPENDENT = frozenset(
         # hidden alias of ``doctor`` (#1048) sharing the same code path.
         "doctor", "info",
         # Excel COM automation -- its own backend, not desktop UIA.
-        "excel info", "excel list-sheets", "excel open", "excel read",
-        "excel run-macro", "excel write",
+        "excel create-chart", "excel info", "excel list-sheets", "excel open",
+        "excel read", "excel run-macro", "excel write",
         # Pure help; permissions listing is an unimplemented stub (no backend).
         "help", "list permissions",
         # MCP / daemon management.


### PR DESCRIPTION
Adds the one remaining Excel COM bullet from #38 — chart creation — across CLI + MCP, mirroring the existing `excel_write`/`excel_run_macro` patterns (COM connect, workbook resolution, error wrapping, the capture-identity-before-`wb.Close` dead-proxy guard).

- **CLI**: `naturo excel create-chart PATH --type {bar|column|line|pie|area|scatter} --range A1:B10 [--sheet NAME] [--title TEXT] [--anchor D2] [--create] [-j]`
- **MCP**: `excel_create_chart(path, data_range, chart_type='column', sheet=None, title=None, anchor=None, create=False)`
- Uses `AddChart2` + `SetSourceData` with stable xlChartType constants (column=51/bar=57/line=4/pie=5/area=1/scatter=-4169). Invalid type / missing range → INVALID_INPUT. Registered in the envelope-sweep / desktop-guard / mcpb-manifest / window-param allowlists.

## Verification
- Hermetic (mocked win32com): 50/50 in test_excel.py + test_mcp_excel.py; full gate 7250 passed (6 known native-DLL host failures unrelated). ruff + mypy clean.
- **Live Excel COM verification by the orchestrator in progress** (real AddChart2 → chart round-trips on re-open, the #38 acceptance).

Closes #1319

🤖 Generated with [Claude Code](https://claude.com/claude-code)