### PR TITLE
refactor(uia): consolidate value read/write onto one UIA pattern gate + fix NULL-ValuePattern read bug (#1212)

### DIFF
--- a/naturo/backends/windows/_input/_uia_interact.py
+++ b/naturo/backends/windows/_input/_uia_interact.py
@@ -481,6 +481,51 @@ class UIAInteractMixin:
                     best, best_area = el, area
         return best
 
+    @staticmethod
+    def _get_uia_pattern(elem, pattern_id, iface):
+        """Acquire a UIA pattern interface off ``elem``, or ``None`` if unsupported.
+
+        The single gate shared by the value READ
+        (:meth:`get_element_value_uia`) and WRITE (:meth:`set_element_value`)
+        paths — plus :meth:`toggle_element`, :meth:`select_element` and
+        :meth:`expand_collapse_element` — so the directions can never drift on
+        the one subtlety that already bit them (#1212).
+
+        comtypes returns a **non-None NULL COM pointer** for a pattern the
+        element does not support (e.g. a Slider has no ValuePattern). This must
+        be gated on *truthiness* — ``if not ptr`` is ``True`` for a NULL pointer
+        — because ``ptr is not None`` is ``True`` for it and then
+        ``QueryInterface`` raises ``ValueError: NULL COM pointer access``.
+        Before this gate was centralised the write side used the correct
+        ``if ptr`` check while the read side used ``is not None`` and bailed the
+        whole read to ``None`` on any element lacking ValuePattern, never
+        reaching its TextPattern / TogglePattern / Name fallbacks.
+
+        Args:
+            elem: The resolved UIA element.
+            pattern_id: The ``UIA_*PatternId`` to request.
+            iface: The ``IUIAutomation*Pattern`` interface to query for.
+
+        Returns:
+            The queried pattern interface, or ``None`` when the element does
+            not support it (or the query errored).
+        """
+        try:
+            from comtypes import COMError  # type: ignore[import-untyped]
+        except ImportError:  # pragma: no cover - comtypes always present here
+            COMError = Exception  # type: ignore[assignment,misc]
+        try:
+            ptr = elem.GetCurrentPattern(pattern_id)
+        except (COMError, AttributeError, OSError):
+            return None
+        # NULL COM pointer for an unsupported pattern is non-None but falsy.
+        if not ptr:
+            return None
+        try:
+            return ptr.QueryInterface(iface)
+        except (COMError, AttributeError, OSError, ValueError):
+            return None
+
     def set_element_value(
         self,
         text: str,
@@ -558,14 +603,12 @@ class UIAInteractMixin:
                                  name, automation_id, role)
                     return False
 
-            # 1) ValuePattern — text/edit controls. NB: comtypes returns a
-            #    non-None NULL COM pointer for an UNSUPPORTED pattern (a Slider has
-            #    no ValuePattern), so gate on truthiness — `if ptr:` is False for a
-            #    NULL pointer — not `is not None`, which would QueryInterface a NULL
-            #    pointer and raise "NULL COM pointer access".
-            pat_unk = elem.GetCurrentPattern(mod.UIA_ValuePatternId)
-            if pat_unk:
-                vp = pat_unk.QueryInterface(mod.IUIAutomationValuePattern)
+            # 1) ValuePattern — text/edit controls. The NULL-COM-pointer gate for
+            #    an unsupported pattern lives in the shared ``_get_uia_pattern``
+            #    helper, so read and write can't drift on it (#1212).
+            vp = self._get_uia_pattern(
+                elem, mod.UIA_ValuePatternId, mod.IUIAutomationValuePattern)
+            if vp is not None:
                 if not vp.CurrentIsReadOnly:
                     vp.SetValue(text)
                     logger.info("SetValue: set via ValuePattern (name=%r, len=%d)",
@@ -576,9 +619,10 @@ class UIAInteractMixin:
             # 2) RangeValuePattern — Slider/Spinner/ProgressBar carry a numeric
             #    value and do NOT support ValuePattern. Parse the number and clamp
             #    to the control's [min, max] so an out-of-range request still lands.
-            rv_unk = elem.GetCurrentPattern(mod.UIA_RangeValuePatternId)
-            if rv_unk:
-                rv = rv_unk.QueryInterface(mod.IUIAutomationRangeValuePattern)
+            rv = self._get_uia_pattern(
+                elem, mod.UIA_RangeValuePatternId,
+                mod.IUIAutomationRangeValuePattern)
+            if rv is not None:
                 if rv.CurrentIsReadOnly:
                     logger.debug("SetValue: RangeValuePattern is read-only")
                     return False
@@ -631,10 +675,10 @@ class UIAInteractMixin:
             elem = uia.GetFocusedElement()
             if elem is None:
                 return False
-            pat_unk = elem.GetCurrentPattern(mod.UIA_ValuePatternId)
-            if pat_unk is None:
+            vp = self._get_uia_pattern(
+                elem, mod.UIA_ValuePatternId, mod.IUIAutomationValuePattern)
+            if vp is None:
                 return False
-            vp = pat_unk.QueryInterface(mod.IUIAutomationValuePattern)
             if vp.CurrentIsReadOnly:
                 return False
             new_value = ((vp.CurrentValue or "") + text) if append else text
@@ -717,11 +761,19 @@ class UIAInteractMixin:
 
             value = None
             pattern = None
+            # Pattern acquisition uses the same NULL-COM-pointer-safe gate as
+            # the WRITE path (:meth:`set_element_value`) via ``_get_uia_pattern``
+            # (#1212). Previously this read used ``if pat is not None`` — the
+            # exact trap the write side documents against — so an element that
+            # lacked ValuePattern raised "NULL COM pointer access" and the whole
+            # read bailed to None instead of falling through to TextPattern /
+            # TogglePattern / Name.
             try:
-                pat = elem.GetCurrentPattern(mod.UIA_ValuePatternId)
-                if pat is not None:
-                    value = pat.QueryInterface(
-                        mod.IUIAutomationValuePattern).CurrentValue
+                vp = self._get_uia_pattern(
+                    elem, mod.UIA_ValuePatternId,
+                    mod.IUIAutomationValuePattern)
+                if vp is not None:
+                    value = vp.CurrentValue
                     pattern = "ValuePattern"
             except (COMError, AttributeError):
                 pass
@@ -730,11 +782,11 @@ class UIAInteractMixin:
             # (not just None) value. (#1208)
             if not value:
                 try:
-                    pat = elem.GetCurrentPattern(mod.UIA_TextPatternId)
-                    if pat is not None:
-                        rng = pat.QueryInterface(
-                            mod.IUIAutomationTextPattern).DocumentRange
-                        _text = rng.GetText(-1)
+                    tp = self._get_uia_pattern(
+                        elem, mod.UIA_TextPatternId,
+                        mod.IUIAutomationTextPattern)
+                    if tp is not None:
+                        _text = tp.DocumentRange.GetText(-1)
                         if _text:
                             value = _text
                             pattern = "TextPattern"
@@ -742,10 +794,11 @@ class UIAInteractMixin:
                     pass
             if not value:
                 try:
-                    pat = elem.GetCurrentPattern(mod.UIA_TogglePatternId)
-                    if pat is not None:
-                        state = pat.QueryInterface(
-                            mod.IUIAutomationTogglePattern).CurrentToggleState
+                    tg = self._get_uia_pattern(
+                        elem, mod.UIA_TogglePatternId,
+                        mod.IUIAutomationTogglePattern)
+                    if tg is not None:
+                        state = tg.CurrentToggleState
                         value = {0: "Off", 1: "On", 2: "Indeterminate"}.get(
                             state, "Unknown")
                         pattern = "TogglePattern"
@@ -887,12 +940,12 @@ class UIAInteractMixin:
                 logger.debug("Toggle: target element not found")
                 return None
 
-            pat_unk = elem.GetCurrentPattern(mod.UIA_TogglePatternId)
-            if pat_unk is None:
+            tp = self._get_uia_pattern(
+                elem, mod.UIA_TogglePatternId, mod.IUIAutomationTogglePattern)
+            if tp is None:
                 logger.debug("Toggle: element does not support TogglePattern")
                 return None
 
-            tp = pat_unk.QueryInterface(mod.IUIAutomationTogglePattern)
             tp.Toggle()
 
             # Read new state: 0=Off, 1=On, 2=Indeterminate
@@ -945,12 +998,13 @@ class UIAInteractMixin:
                 logger.debug("Select: target element not found")
                 return False
 
-            pat_unk = elem.GetCurrentPattern(mod.UIA_SelectionItemPatternId)
-            if pat_unk is None:
+            sp = self._get_uia_pattern(
+                elem, mod.UIA_SelectionItemPatternId,
+                mod.IUIAutomationSelectionItemPattern)
+            if sp is None:
                 logger.debug("Select: element does not support SelectionItemPattern")
                 return False
 
-            sp = pat_unk.QueryInterface(mod.IUIAutomationSelectionItemPattern)
             sp.Select()
             logger.info("Select: selected element (name=%r)", name)
             return True
@@ -1001,12 +1055,13 @@ class UIAInteractMixin:
                 logger.debug("ExpandCollapse: target element not found")
                 return False
 
-            pat_unk = elem.GetCurrentPattern(mod.UIA_ExpandCollapsePatternId)
-            if pat_unk is None:
+            ecp = self._get_uia_pattern(
+                elem, mod.UIA_ExpandCollapsePatternId,
+                mod.IUIAutomationExpandCollapsePattern)
+            if ecp is None:
                 logger.debug("ExpandCollapse: element does not support ExpandCollapsePattern")
                 return False
 
-            ecp = pat_unk.QueryInterface(mod.IUIAutomationExpandCollapsePattern)
             if expand:
                 ecp.Expand()
                 logger.info("ExpandCollapse: expanded element (name=%r)", name)

--- a/tests/test_uia_value_layer_1212.py
+++ b/tests/test_uia_value_layer_1212.py
@@ -1,0 +1,185 @@
+"""Regression tests for #1212 — one UIA gate for value read AND write.
+
+Element value read (:meth:`get_element_value_uia`) and write
+(:meth:`set_element_value`), plus toggle/select/expand, now acquire their UIA
+patterns through a single shared helper, :meth:`WindowsBackend._get_uia_pattern`.
+That helper owns the one subtlety the two directions had already drifted on
+(#1212): comtypes returns a **non-None NULL COM pointer** for a pattern an
+element does not support, so it must be gated on truthiness — ``is not None``
+is ``True`` for it and then ``QueryInterface`` raises "NULL COM pointer access".
+
+Before consolidation the WRITE side used the correct ``if ptr`` gate while the
+READ side used ``if pat is not None`` and bailed the *entire* read to ``None``
+for any element lacking ValuePattern — never reaching its TextPattern/Toggle/
+Name fallbacks. These tests instantiate the backend and mock UIA, so they are
+desktop-independent and send no input.
+"""
+
+import platform
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    platform.system() != "Windows",
+    reason="UIA value read/write is Windows-only",
+)
+
+
+def _backend():
+    from naturo.backends.windows import WindowsBackend
+    return WindowsBackend.__new__(WindowsBackend)
+
+
+def _null_ptr():
+    """A comtypes-style NULL COM pointer: non-None but falsy."""
+    p = MagicMock()
+    p.__bool__.return_value = False
+    return p
+
+
+def _live_ptr(iface_obj):
+    """A live (truthy) COM pointer whose QueryInterface yields ``iface_obj``."""
+    p = MagicMock()
+    p.__bool__.return_value = True
+    p.QueryInterface.return_value = iface_obj
+    return p
+
+
+def _mod():
+    mod = MagicMock()
+    mod.UIA_ValuePatternId = 10002
+    mod.UIA_RangeValuePatternId = 10003
+    mod.UIA_TextPatternId = 10014
+    mod.UIA_TogglePatternId = 10015
+    return mod
+
+
+# ── the shared gate itself ───────────────────────────────────────────────────
+
+class TestGetUiaPatternGate:
+    def test_null_pointer_returns_none_not_raise(self):
+        """A NULL (falsy) pattern pointer must be skipped, never QueryInterface'd."""
+        b = _backend()
+        null = _null_ptr()
+        elem = MagicMock()
+        elem.GetCurrentPattern.return_value = null
+        out = b._get_uia_pattern(elem, 10002, MagicMock())
+        assert out is None
+        null.QueryInterface.assert_not_called()
+
+    def test_live_pointer_is_queried(self):
+        b = _backend()
+        iface = MagicMock()
+        elem = MagicMock()
+        elem.GetCurrentPattern.return_value = _live_ptr(iface)
+        assert b._get_uia_pattern(elem, 10002, MagicMock()) is iface
+
+    def test_none_pattern_returns_none(self):
+        b = _backend()
+        elem = MagicMock()
+        elem.GetCurrentPattern.return_value = None
+        assert b._get_uia_pattern(elem, 10002, MagicMock()) is None
+
+
+# ── read-side drift fix: no ValuePattern must fall through, not bail ──────────
+
+class TestReadFallsThroughOnNullValuePattern:
+    def test_checkbox_without_valuepattern_reads_toggle(self):
+        """The exact drift bug: ValuePattern is a NULL pointer (CheckBox has
+        none) but TogglePattern is live. The read must fall through to Toggle
+        and return "On" — before #1212 it raised on the NULL pointer and the
+        whole read returned None."""
+        b = _backend()
+        mod = _mod()
+
+        toggle_pat = MagicMock()
+        toggle_pat.CurrentToggleState = 1  # On
+
+        def _get(pid):
+            if pid == mod.UIA_TogglePatternId:
+                return _live_ptr(toggle_pat)
+            return _null_ptr()  # ValuePattern + TextPattern unsupported
+
+        elem = MagicMock()
+        elem.GetCurrentPattern.side_effect = _get
+        elem.CurrentControlType = 50002  # CheckBox
+        elem.CurrentName = "Bold"
+        elem.CurrentAutomationId = ""
+
+        with patch.object(b, "_init_comtypes_uia", return_value=(MagicMock(), mod)), \
+             patch.object(b, "_resolve_interaction_element", return_value=elem):
+            out = b.get_element_value_uia(hwnd=1, name="Bold")
+
+        assert out is not None, "read bailed on NULL ValuePattern (the #1212 bug)"
+        assert out["value"] == "On"
+        assert out["pattern"] == "TogglePattern"
+
+    def test_edit_with_live_valuepattern_reads_value(self):
+        """Sanity: a live ValuePattern still reads through the shared gate."""
+        b = _backend()
+        mod = _mod()
+        vp = MagicMock()
+        vp.CurrentValue = "hello"
+        elem = MagicMock()
+        elem.GetCurrentPattern.side_effect = (
+            lambda pid: _live_ptr(vp) if pid == mod.UIA_ValuePatternId
+            else _null_ptr()
+        )
+        elem.CurrentControlType = 50004  # Edit
+        elem.CurrentName = ""
+        elem.CurrentAutomationId = "txt"
+
+        with patch.object(b, "_init_comtypes_uia", return_value=(MagicMock(), mod)), \
+             patch.object(b, "_resolve_interaction_element", return_value=elem):
+            out = b.get_element_value_uia(hwnd=1, automation_id="txt")
+
+        assert out["value"] == "hello"
+        assert out["pattern"] == "ValuePattern"
+
+
+# ── shared-path guarantee: one gate fix reaches BOTH read and write ──────────
+
+class TestReadAndWriteShareOneGate:
+    def test_both_directions_route_through_get_uia_pattern(self):
+        """Read and write both acquire ValuePattern via ``_get_uia_pattern``, so
+        a single fix to the gate (or the resolver it sits behind) covers both.
+
+        Patching the gate to report "no pattern" makes the write fail cleanly
+        and the read skip ValuePattern — and the spy proves each direction went
+        through the one shared helper with the ValuePatternId."""
+        b = _backend()
+        mod = _mod()
+        elem = MagicMock()
+        # Empty name so the read's Name fallback does not fabricate a value.
+        elem.CurrentName = ""
+        elem.CurrentAutomationId = ""
+        elem.CurrentControlType = 50004  # Edit
+
+        gate = MagicMock(return_value=None)  # every pattern reported unsupported
+        with patch.object(b, "_init_comtypes_uia", return_value=(MagicMock(), mod)), \
+             patch.object(b, "_resolve_interaction_element", return_value=elem), \
+             patch.object(b, "_get_uia_pattern", gate):
+            wrote = b.set_element_value("x", hwnd=1, name="F", role="Edit")
+            read = b.get_element_value_uia(hwnd=1, name="F")
+
+        assert wrote is False          # no writable ValuePattern/RangeValue
+        assert read is None            # no readable pattern, no name value
+        value_pat_calls = [
+            c for c in gate.call_args_list if c.args[1] == mod.UIA_ValuePatternId
+        ]
+        # At least one ValuePattern acquisition from the write path AND one from
+        # the read path — the same helper served both directions.
+        assert len(value_pat_calls) >= 2
+
+    def test_both_directions_share_one_resolver(self):
+        """Read and write both resolve their target element through the single
+        ``_resolve_interaction_element`` — the shared locator behind the gate."""
+        b = _backend()
+        mod = _mod()
+        resolver = MagicMock(return_value=None)  # element not found either way
+        with patch.object(b, "_init_comtypes_uia", return_value=(MagicMock(), mod)), \
+             patch.object(b, "_resolve_interaction_element", resolver):
+            b.set_element_value("x", hwnd=7, name="F")
+            b.get_element_value_uia(hwnd=7, name="F")
+        assert resolver.call_count == 2


### PR DESCRIPTION
Partial (safe) consolidation toward #1212, plus a real correctness fix.

## What
Extracted ONE shared UIA pattern-acquisition gate `_get_uia_pattern(elem, pattern_id, iface)` and routed **every** comtypes pattern acquisition through it — the value READ ladder (`get_element_value_uia`: Value/Text/Toggle), the WRITE ladder (`set_element_value`: Value/RangeValue), `set_focused_element_value`, and `toggle/select/expand_collapse`. Read and write now share both the resolver (`_resolve_interaction_element`, shared since #1208) **and** the pattern gate, so a fix in one reaches both directions — directly addressing #1212's drift harm.

**Bug fixed by the unification:** the write side correctly gated comtypes' non-None NULL COM pointer with `if ptr:`, but the read side used `if pat is not None:` — so reading an element **without** ValuePattern raised 'NULL COM pointer access' and bailed the whole read to `None` instead of falling through to TextPattern/Toggle/Name. Now impossible (both go through the one gate). Regression: a checkbox without ValuePattern now correctly reads its TogglePattern value.

## Honestly partial
The single-element **primary** read in `_tree.py::get_element_value` still delegates to the **C++ core** (which is richer — RangeValue for sliders, SelectionPattern, TextPattern-first for editors), with the Python reader as the no-aid/no-name fallback. I did NOT promote the Python reader to primary: that's a real capability/precedence change I can't verify headlessly. So two entry readers still exist by design — **#1212 stays open** for that final merge (needs live-desktop equivalence checks). This PR lands the highest-drift-risk shared code + the bug fix.

## Verification
- Full gate: 7257 passed (6 known native-DLL host failures only). New `tests/test_uia_value_layer_1212.py` (7 tests) proves both directions route through the one gate/resolver + the NULL-ValuePattern fall-through. ruff + mypy clean.

Refs #1212 (partial — shared gate + bug fix; full primary-reader merge deferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)