### PR TITLE
feat(sdk): ergonomic in-process Python SDK + Terminator-parity examples (#924)

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,46 @@ naturo highlight e11 --app notepad         # Highlight specific ref
 naturo highlight --app notepad -A out.png  # Save annotated screenshot
 ```
 
+## Python SDK
+
+Prefer to stay in Python? `import naturo` gives you an ergonomic, in-process API
+over the same engine the CLI and MCP server use — no subprocess, no output
+parsing. Import-and-go in under 10 lines:
+
+```python
+import naturo
+
+app = naturo.launch("notepad")           # App handle; waits until ready
+naturo.type("hello", window="Notepad")   # IME-immune type ladder (ValuePattern→clipboard→keystroke)
+tree = naturo.see(window="Notepad")      # root Element; walk .children / .descendants / .find
+el = naturo.find("Button:Save", window="Notepad")
+if el:
+    el.click()                           # elements act on themselves
+naturo.capture("shot.png", window="Notepad")
+app.quit()
+```
+
+Core verbs are available both as module-level functions and as methods on a
+reusable `Desktop` / `Session` session (or a launched `App`):
+`see`, `find`, `click`, `type`, `press`, `get_value`, `set_value`, `capture`,
+`launch`, `quit`, `wait`, `windows`.
+
+```python
+import naturo
+
+# Context-managed app quits on exit; the fused cascade tree is one flag away.
+with naturo.launch("calculator") as app:
+    for key in ("4", "2", "multiply", "7", "enter"):
+        app.press(key)
+    tree = app.see()                      # or app.see(cascade=True) for UIA+CDP+JAB+COM
+    for el in tree.descendants():
+        if el.role == "Text" and el.name:
+            print(el.name)
+```
+
+Runnable scripts live in [`examples/`](examples/) (`notepad_hello.py`,
+`form_filler.py`, `ui_inspector.py`, `window_capture.py`).
+
 ## Cascade Recognition
 
 Most desktop automation tools rely on a single accessibility API (UIA) — when

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,14 +2,18 @@
 
 Working example scripts demonstrating naturo automation patterns.
 
+The first four use the ergonomic **in-process Python SDK** — `import naturo`
+and automate directly, no subprocess and no CLI parsing. The two agent scripts
+cover MCP / agent-framework wiring.
+
 ## Scripts
 
 | Script | Description | Complexity |
 |--------|-------------|------------|
-| `notepad_hello.py` | Launch Notepad, type text, capture screenshot, close | Beginner |
-| `window_capture.py` | Capture screenshots of all visible windows | Beginner |
-| `ui_inspector.py` | Interactive UI element tree explorer | Intermediate |
-| `form_filler.py` | Auto-fill form controls (Calculator demo) | Intermediate |
+| `notepad_hello.py` | Launch Notepad, type text, capture screenshot, close (SDK) | Beginner |
+| `window_capture.py` | Capture screenshots of all visible windows (SDK) | Beginner |
+| `ui_inspector.py` | Interactive UI element tree explorer (SDK) | Intermediate |
+| `form_filler.py` | Drive form controls, read the tree (Calculator demo, SDK) | Intermediate |
 | `agent_demo.py` | AI agent integration patterns (CLI, MCP, vision) | Advanced |
 | `agent_frameworks.py` | Plug naturo's tools into OpenAI / Anthropic / LangChain | Advanced |
 
@@ -28,7 +32,7 @@ python notepad_hello.py
 # Capture all visible windows
 python window_capture.py --output-dir ./screenshots
 
-# Explore an app's UI tree interactively
+# Explore an app's UI tree interactively (add --cascade for the fused tree)
 python ui_inspector.py notepad
 
 # Calculator automation
@@ -46,36 +50,68 @@ python agent_frameworks.py anthropic   # Anthropic tool-use wiring
 python agent_frameworks.py langchain   # LangChain StructuredTool wiring
 ```
 
-## Common Patterns
+## The Python SDK
 
-### Run a command and parse JSON output
+`import naturo` gives you an ergonomic, in-process API over the same engine the
+CLI and MCP server use. Import-and-go in under 10 lines:
 
 ```python
-import json, subprocess
+import naturo
 
-result = subprocess.run(
-    ["naturo", "app", "list", "--json"],
-    capture_output=True, text=True,
-)
-data = json.loads(result.stdout)
-for app in data["apps"]:
-    print(app["process_name"], app["title"])
+app = naturo.launch("notepad")          # App handle (waits until ready)
+naturo.type("hello", window="Notepad")  # IME-immune type ladder
+tree = naturo.see(window="Notepad")     # root Element; walk .children / .descendants
+el = naturo.find("Button:Save", window="Notepad")
+if el:
+    el.click()                          # elements act on themselves
+naturo.capture("shot.png", window="Notepad")
+app.quit()
 ```
 
-### Launch, interact, close
+Core verbs (module-level, or as `Desktop`/`Session`/`App` methods):
+`see`, `find`, `click`, `type`, `press`, `get_value`, `set_value`,
+`capture`, `launch`, `quit`, `wait`, `windows`.
+
+### Reusable session
 
 ```python
-subprocess.run(["naturo", "app", "launch", "notepad", "--wait-until-ready"])
-subprocess.run(["naturo", "type", "Hello!"])
-subprocess.run(["naturo", "app", "quit", "notepad"])
+import naturo
+
+desktop = naturo.Desktop()              # or naturo.Session() — reuses one backend
+for win in desktop.windows():
+    print(win.process_name, win.title)
 ```
 
-### Target by app ID
+### Context-managed app
 
 ```python
-# List apps to assign IDs
-subprocess.run(["naturo", "app", "list"])
-# Use the assigned ID
-subprocess.run(["naturo", "app", "focus", "a1"])
-subprocess.run(["naturo", "click", "--on", "e3", "--app", "a1"])
+import naturo
+
+with naturo.launch("calculator") as app:   # quits on exit
+    for key in ("4", "2", "multiply", "7", "enter"):
+        app.press(key)
+    tree = app.see()
+    for el in tree.descendants():
+        if el.role == "Text" and el.name:
+            print(el.name)
+```
+
+### The fused, correctness-tagged tree (the moat)
+
+```python
+import naturo
+
+# UIA + web (CDP) + Java (JAB) + Excel cells (COM) merged into one tree,
+# each node tagged deterministic vs uncertain.
+tree = naturo.see(app="chrome", cascade=True)
+```
+
+### Still prefer the CLI?
+
+The `naturo` command remains a first-class surface for shell / subprocess use:
+
+```bash
+naturo app launch notepad --wait-until-ready
+naturo type "Hello!"
+naturo app quit notepad
 ```

--- a/examples/form_filler.py
+++ b/examples/form_filler.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
-"""Auto-fill form fields in a Windows application.
+"""Drive form-style controls in a Windows application.
 
-Demonstrates element discovery, clicking, and typing into form controls.
-Uses Calculator as a demo target (available on all Windows systems).
+Demonstrates key presses, reading the UI tree, and capturing — all via the
+in-process SDK. Uses Calculator as a demo target (present on every Windows
+system).
 
 Requirements:
     - Windows 10/11 with a desktop session
@@ -12,54 +13,47 @@ Usage:
     python form_filler.py
 """
 
-import subprocess
-import sys
 import time
 
-
-def run(cmd: str) -> str:
-    """Run a naturo CLI command and return stdout."""
-    result = subprocess.run(
-        ["naturo"] + cmd.split(),
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        print(f"Command failed: naturo {cmd}", file=sys.stderr)
-        print(result.stderr, file=sys.stderr)
-    return result.stdout.strip()
+import naturo
 
 
 def main() -> None:
-    # 1. Launch Calculator
+    # 1. Launch Calculator.
     print("Launching Calculator...")
-    run("app launch calculator --wait-until-ready")
-    time.sleep(1)
+    with naturo.launch("calculator") as app:
+        time.sleep(1)
 
-    # 2. Perform a calculation: 42 * 7 =
-    print("Entering calculation: 42 * 7 =")
+        # 2. Perform a calculation: 42 * 7 = . Keys are sent to Calculator's
+        #    window explicitly, so they land there even if focus drifts.
+        print("Entering calculation: 42 * 7 =")
+        for key in ("4", "2", "multiply", "7", "enter"):
+            app.press(key)
+            time.sleep(0.05)
 
-    # Type digits and operators using keyboard
-    run("press 4")
-    run("press 2")
-    run("press multiply")  # * key
-    run("press 7")
-    run("press enter")     # = key
+        time.sleep(0.5)
 
-    time.sleep(0.5)
+        # 3. Read the result straight from the UI tree — `see` returns the root
+        #    Element; walk its descendants for the display text.
+        print("Reading result...")
+        tree = app.see()
+        if tree is not None:
+            texts = [
+                f'{el.role}: {el.name}'
+                for el in tree.descendants()
+                if el.role in ("Text", "Edit") and el.name
+            ]
+            print("Display elements:")
+            for line in texts[:10]:
+                print(f"  {line}")
 
-    # 3. Read the result from the display
-    print("Reading result...")
-    output = run("see --app calculator --json")
-    print(f"Calculator output: {output[:200]}...")
+        # 4. Capture the result.
+        shot = app.capture("calculator_result.png")
+        print(f"Screenshot saved to {shot.path}")
 
-    # 4. Take a screenshot of the result
-    run("capture --app calculator --path calculator_result.png")
-    print("Screenshot saved to calculator_result.png")
+        # 5. Leaving the context manager closes Calculator.
+        print("Closing Calculator...")
 
-    # 5. Close Calculator
-    print("Closing Calculator...")
-    run("app quit calculator")
     print("Done!")
 
 

--- a/examples/notepad_hello.py
+++ b/examples/notepad_hello.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 """Open Notepad, type a greeting, and close it.
 
-Demonstrates the full app lifecycle: launch → interact → quit.
+Demonstrates the full app lifecycle with the ergonomic in-process SDK:
+launch -> interact -> capture -> quit. No subprocess, no CLI parsing — just
+``import naturo``.
 
 Requirements:
     - Windows 10/11 with a desktop session
@@ -11,51 +13,39 @@ Usage:
     python notepad_hello.py
 """
 
-import subprocess
-import sys
 import time
 
-
-def run(cmd: str) -> str:
-    """Run a naturo CLI command and return stdout."""
-    result = subprocess.run(
-        ["naturo"] + cmd.split(),
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        print(f"Command failed: naturo {cmd}", file=sys.stderr)
-        print(result.stderr, file=sys.stderr)
-        sys.exit(1)
-    return result.stdout.strip()
+import naturo
 
 
 def main() -> None:
-    # 1. Launch Notepad and wait for its window
+    # 1. Launch Notepad — `launch` waits until its window is ready and returns
+    #    an App handle usable as a context manager (quits on exit).
     print("Launching Notepad...")
-    run("app launch notepad --wait-until-ready")
-    time.sleep(0.5)
+    with naturo.launch("notepad") as app:
+        time.sleep(0.5)
 
-    # 2. Type a greeting
-    print("Typing text...")
-    run("type Hello from naturo!")
-    run("press enter")
-    run("type This text was typed by an automation script.")
+        # 2. Type a greeting into Notepad's window. `type` routes through the
+        #    IME-immune ladder (ValuePattern -> clipboard -> keystroke), so it
+        #    stays correct even on CJK/TSF input hosts.
+        print("Typing text...")
+        app.type("Hello from naturo!")
+        app.press("enter")
+        app.type("This text was typed by an automation script.")
 
-    # 3. Take a screenshot to verify
-    print("Capturing screenshot...")
-    run("capture --app notepad --path notepad_result.png")
-    print("Screenshot saved to notepad_result.png")
+        # 3. Capture a screenshot to verify.
+        print("Capturing screenshot...")
+        shot = app.capture("notepad_result.png")
+        print(f"Screenshot saved to {shot.path} ({shot.width}x{shot.height})")
 
-    # 4. Close without saving — dismiss the save dialog
-    print("Closing Notepad...")
-    run("app quit notepad")
+        # 4. Leaving the `with` block quits Notepad. Notepad may raise a
+        #    "Save?" dialog; dismiss it so the app really closes.
+        print("Closing Notepad...")
 
-    # If a "Save?" dialog appears, dismiss it
     time.sleep(0.5)
     try:
-        run("dialog dismiss --app notepad")
-    except SystemExit:
+        naturo.press("alt+n")  # "Don't Save" accelerator on Win11 Notepad
+    except naturo.NaturoError:
         pass  # No dialog — already closed
 
     print("Done!")

--- a/examples/ui_inspector.py
+++ b/examples/ui_inspector.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """Interactive UI tree exploration for a target application.
 
-Lists the UI element tree, lets you inspect elements by reference,
-and demonstrates the see → find → click workflow.
+Reads the UI element tree with the in-process SDK, prints it, and lets you
+inspect elements interactively — demonstrating the see -> find -> click
+workflow without any subprocess.
 
 Requirements:
     - Windows 10/11 with a desktop session
@@ -11,83 +12,68 @@ Requirements:
 Usage:
     python ui_inspector.py notepad
     python ui_inspector.py calculator --depth 3
+    python ui_inspector.py chrome --cascade      # fused UIA+CDP+JAB+COM tree
 """
 
 import argparse
-import json
-import subprocess
 import sys
 
-
-def run(cmd: str) -> str:
-    """Run a naturo CLI command and return stdout."""
-    result = subprocess.run(
-        ["naturo"] + cmd.split(),
-        capture_output=True,
-        text=True,
-    )
-    return result.stdout.strip()
+import naturo
 
 
-def run_json(cmd: str) -> dict:
-    """Run a naturo CLI command with --json and parse the output."""
-    result = subprocess.run(
-        ["naturo"] + cmd.split() + ["--json"],
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        return {"success": False, "error": result.stderr.strip()}
-    return json.loads(result.stdout)
+def print_tree(element: naturo.Element, depth: int = 0) -> int:
+    """Print an element and its descendants; return the node count."""
+    indent = "  " * depth
+    name = element.name or ""
+    print(f"{indent}[{element.role}]  {name}")
+    count = 1
+    for child in element.children:
+        count += print_tree(child, depth + 1)
+    return count
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Explore UI element tree")
     parser.add_argument("app", help="Application name (e.g. notepad, calculator)")
-    parser.add_argument("--depth", type=int, default=5,
-                        help="Maximum tree depth to display (default: 5)")
+    parser.add_argument("--depth", type=int, default=0,
+                        help="Maximum tree depth (0 = unlimited, the default)")
+    parser.add_argument("--cascade", action="store_true",
+                        help="Fuse UIA + web (CDP) + Java (JAB) + Excel (COM)")
     args = parser.parse_args()
 
     print(f"Inspecting UI tree for '{args.app}'...\n")
 
-    # Get the UI element tree
-    data = run_json(f"see --app {args.app} --depth {args.depth}")
-    if not data.get("success"):
+    desktop = naturo.Desktop()
+    root = desktop.see(app=args.app, depth=args.depth, cascade=args.cascade)
+    if root is None:
         print(f"Failed to inspect {args.app}. Is it running?", file=sys.stderr)
         sys.exit(1)
 
-    elements = data.get("elements", [])
-    print(f"Found {len(elements)} UI elements:\n")
+    total = print_tree(root)
+    print(f"\nFound {total} UI elements.")
 
-    for elem in elements:
-        ref = elem.get("ref", "")
-        role = elem.get("role", "")
-        name = elem.get("name", "")
-        indent = "  " * elem.get("depth", 0)
-        print(f"{indent}{ref:>4}  [{role}]  {name}")
-
-    # Interactive exploration loop
+    # Interactive exploration: search for elements by "Role:Name" selector.
     print("\n--- Interactive Mode ---")
-    print("Enter an element ref (e.g. e1) to inspect, or 'q' to quit.\n")
+    print("Enter a selector (e.g. Button:Save) to find an element, or 'q' to quit.\n")
 
     while True:
         try:
-            ref = input("Inspect ref> ").strip()
+            query = input("Find> ").strip()
         except (EOFError, KeyboardInterrupt):
             break
 
-        if ref.lower() in ("q", "quit", "exit"):
+        if query.lower() in ("q", "quit", "exit"):
             break
-
-        if not ref:
+        if not query:
             continue
 
-        info = run_json(f"find --on {ref} --app {args.app}")
-        if info.get("success"):
-            elem = info.get("element", info)
-            print(json.dumps(elem, indent=2))
+        match = root.find(query)
+        if match is not None:
+            x, y, w, h = match.bounds
+            print(f"  [{match.role}] {match.name!r}  "
+                  f"bounds=({x},{y},{w},{h})  value={match.value!r}")
         else:
-            print(f"Element {ref} not found.")
+            print(f"  No element matching {query!r}.")
 
     print("Done.")
 

--- a/examples/window_capture.py
+++ b/examples/window_capture.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 """Capture screenshots of all visible application windows.
 
-Demonstrates window enumeration and per-app screenshot capture.
+Demonstrates window enumeration and per-window capture via the in-process SDK —
+no subprocess, no JSON parsing.
 
 Requirements:
     - Windows 10/11 with a desktop session
@@ -13,23 +14,9 @@ Usage:
 """
 
 import argparse
-import json
 import os
-import subprocess
-import sys
 
-
-def run_json(cmd: str) -> dict:
-    """Run a naturo CLI command with --json and parse the output."""
-    result = subprocess.run(
-        ["naturo"] + cmd.split() + ["--json"],
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        print(f"Command failed: naturo {cmd} --json", file=sys.stderr)
-        return {"success": False}
-    return json.loads(result.stdout)
+import naturo
 
 
 def main() -> None:
@@ -40,35 +27,26 @@ def main() -> None:
 
     os.makedirs(args.output_dir, exist_ok=True)
 
-    # List all visible application windows
-    data = run_json("app list")
-    if not data.get("success"):
-        print("Failed to list applications.", file=sys.stderr)
-        sys.exit(1)
+    desktop = naturo.Desktop()
 
-    apps = data.get("apps", [])
-    print(f"Found {len(apps)} application(s)")
+    # Enumerate every visible top-level window.
+    wins = [w for w in desktop.windows() if w.is_visible and not w.is_minimized]
+    print(f"Found {len(wins)} visible window(s)")
 
-    for app in apps:
-        app_id = app.get("id", "")
-        title = app.get("title", "unknown")
-        process = app.get("process_name", "unknown")
-
-        # Sanitize filename
-        safe_name = "".join(c if c.isalnum() or c in "-_ " else "_" for c in process)
-        path = os.path.join(args.output_dir, f"{safe_name}_{app_id}.png")
-
-        print(f"  Capturing {process}: {title[:50]}...")
-        result = subprocess.run(
-            ["naturo", "capture", "--hwnd", str(app.get("handle", 0)),
-             "--path", path],
-            capture_output=True,
-            text=True,
+    for win in wins:
+        # Sanitize the process name into a filename.
+        safe_name = "".join(
+            c if c.isalnum() or c in "-_ " else "_" for c in win.process_name
         )
-        if result.returncode == 0:
-            print(f"    Saved: {path}")
-        else:
-            print("    Failed to capture")
+        path = os.path.join(args.output_dir, f"{safe_name}_{win.handle}.png")
+
+        print(f"  Capturing {win.process_name}: {win.title[:50]}...")
+        try:
+            # Target the exact window by its handle — no title guessing.
+            result = desktop.capture(path, hwnd=win.handle)
+            print(f"    Saved: {result.path} ({result.width}x{result.height})")
+        except naturo.NaturoError as exc:
+            print(f"    Failed to capture: {exc}")
 
     print(f"\nScreenshots saved to {args.output_dir}/")
 

--- a/naturo/__init__.py
+++ b/naturo/__init__.py
@@ -18,6 +18,21 @@ from naturo.process import ProcessInfo, launch_app, quit_app, relaunch_app, find
 from naturo.cache import ElementCache
 from naturo.diff import ElementChange, TreeDiff, diff_trees
 
+# Ergonomic in-process Python SDK (#924) — `import naturo` and automate without
+# subprocess. Thin wrappers that delegate to the same backend/actions/cascade
+# the CLI and MCP surfaces use. Imported last so the base exports above are in
+# place before the SDK module (which pulls in backend/actions/mcp helpers).
+from naturo import sdk as sdk
+# NOTE: `wait` is intentionally NOT re-exported at the top level — it would
+# shadow the existing `naturo.wait` submodule (public API, monkeypatched by
+# tests). Use ``naturo.Desktop().wait(...)`` (or ``naturo.sdk.wait``) instead.
+from naturo.sdk import (
+    Desktop, Session, App, Element,
+    see, find, click, type, press,
+    get_value, set_value, capture,
+    launch, quit, windows,
+)
+
 # Fail loudly (opt-in via NATURO_EXPECTED_ROOT) if a stale editable install
 # resolved this import to a sibling worktree instead of the checkout under test
 # (#971). No-op for ordinary installs where the env var is unset.
@@ -45,4 +60,10 @@ __all__ = [
     "ElementCache",
     # Diff
     "ElementChange", "TreeDiff", "diff_trees",
+    # Python SDK (#924) — `wait` stays a submodule; use Desktop().wait()
+    "sdk",
+    "Desktop", "Session", "App", "Element",
+    "see", "find", "click", "type", "press",
+    "get_value", "set_value", "capture",
+    "launch", "quit", "windows",
 ]

--- a/naturo/sdk.py
+++ b/naturo/sdk.py
@@ -1,0 +1,657 @@
+"""Ergonomic in-process Python SDK — ``import naturo`` and automate, no subprocess.
+
+naturo ships a CLI and an MCP server; this module adds the third first-class
+surface Terminator's SDKs set the bar for: a clean importable API you drive from
+Python without shelling out to ``naturo <cmd>``.
+
+It is a *thin* wrapper. Every verb delegates to the exact code the CLI and MCP
+surfaces already use, so the SDK cannot drift from them:
+
+* windows/see/find/click/press/capture → the platform :class:`Backend`
+  (``naturo.backends.base.get_backend``);
+* ``type`` → :func:`naturo.actions.smart_type_text`, the shared IME-immune
+  reliability ladder (ValuePattern → clipboard → keystroke) that keeps CJK/TSF
+  input honest (#1219);
+* ``see(cascade=True)`` → :func:`naturo.cascade.run_cascade`, the unified
+  correctness-tagged tree (the moat);
+* window-selector resolution → :func:`naturo.mcp._resolve.require_hwnd`, so a
+  named-but-unresolvable window fails loudly instead of acting on the wrong one;
+* launch/quit/wait → :mod:`naturo.process` and :func:`naturo.wait.wait_for_element`.
+
+Two styles, same thin core:
+
+    import naturo
+
+    # module-level functions — quick, stateless
+    tree = naturo.see(window="Notepad")
+    naturo.type("hello", window="Notepad")
+    el = naturo.find("Button:Save", window="Notepad")
+    if el:
+        el.click()
+    naturo.capture("shot.png", window="Notepad")
+
+    # or a reusable session / context-managed app
+    with naturo.launch("notepad") as app:
+        app.type("hello from naturo")
+        app.capture("notepad.png")
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Iterator, Optional, cast
+
+from naturo.actions import smart_type_text
+from naturo.backends.base import (
+    Backend,
+    CaptureResult,
+    ElementInfo,
+    MonitorInfo,
+    WindowInfo,
+    get_backend,
+)
+from naturo.mcp._resolve import require_hwnd
+
+if TYPE_CHECKING:  # pragma: no cover — import only for type checkers
+    from naturo.process import ProcessInfo
+    from naturo.wait import WaitResult
+
+__all__ = [
+    "Desktop",
+    "Session",
+    "App",
+    "Element",
+    "see",
+    "find",
+    "click",
+    "type",
+    "press",
+    "get_value",
+    "set_value",
+    "capture",
+    "launch",
+    "quit",
+    "wait",
+    "windows",
+]
+
+
+class Element:
+    """A single UI element — a Pythonic wrapper over :class:`ElementInfo`.
+
+    Carries the element's data (``role``, ``name``, ``value``, ``bounds``) plus
+    the session it came from, so actions like :meth:`click` and :meth:`type`
+    read naturally: ``sess.find("Button:Save").click()``.
+    """
+
+    def __init__(self, info: ElementInfo, desktop: "Desktop") -> None:
+        self._info = info
+        self._desktop = desktop
+
+    # ── data accessors ───────────────────────────────────────────────
+    @property
+    def info(self) -> ElementInfo:
+        """The underlying :class:`ElementInfo` dataclass."""
+        return self._info
+
+    @property
+    def id(self) -> str:
+        """Backend element identifier."""
+        return self._info.id
+
+    @property
+    def role(self) -> str:
+        """Control type / role (e.g. ``"Button"``, ``"Edit"``)."""
+        return self._info.role
+
+    @property
+    def name(self) -> str:
+        """Accessible name."""
+        return self._info.name
+
+    @property
+    def value(self) -> Optional[str]:
+        """Current value/text, if the element exposes one."""
+        return self._info.value
+
+    @property
+    def bounds(self) -> tuple[int, int, int, int]:
+        """Screen bounds as ``(x, y, width, height)``."""
+        i = self._info
+        return (i.x, i.y, i.width, i.height)
+
+    @property
+    def center(self) -> tuple[int, int]:
+        """Center point ``(x, y)`` of the element in screen coordinates."""
+        i = self._info
+        return (i.x + i.width // 2, i.y + i.height // 2)
+
+    @property
+    def children(self) -> list["Element"]:
+        """Direct child elements, each wrapped as an :class:`Element`."""
+        return [Element(c, self._desktop) for c in (self._info.children or [])]
+
+    def descendants(self) -> Iterator["Element"]:
+        """Yield every descendant element depth-first (self excluded)."""
+        for child in self._info.children or []:
+            wrapped = Element(child, self._desktop)
+            yield wrapped
+            yield from wrapped.descendants()
+
+    def find(self, selector: str) -> Optional["Element"]:
+        """Find a descendant by ``"Role:Name"`` or bare name (in-memory walk).
+
+        This searches the already-fetched subtree — no new backend call. Use
+        :meth:`Desktop.find` to query the live backend instead.
+        """
+        want_role, want_name = _parse_selector(selector)
+        for el in self.descendants():
+            if _element_matches(el.role, el.name, want_role, want_name):
+                return el
+        return None
+
+    # ── actions ──────────────────────────────────────────────────────
+    def click(self, button: str = "left", double: bool = False,
+              input_mode: str = "normal") -> "Element":
+        """Click the element's center. Returns ``self`` for chaining."""
+        x, y = self.center
+        self._desktop.backend.click(
+            x=x, y=y, button=button, double=double, input_mode=input_mode,
+        )
+        return self
+
+    def type(self, text: str, *, wpm: int = 120,
+             input_mode: str = "normal") -> str:
+        """Focus (via click) and type ``text`` through the IME-immune ladder.
+
+        Returns the delivery method (``"value_pattern"`` | ``"clipboard_paste"``
+        | ``"keystroke"``).
+        """
+        self.click()
+        return smart_type_text(
+            self._desktop.backend, text, input_mode=input_mode, wpm=wpm,
+        )
+
+    def get_value(self) -> Optional[dict]:
+        """Read this element's current value via UIA patterns."""
+        return self._desktop.backend.get_element_value(
+            role=self._info.role, name=self._info.name,
+        )
+
+    def set_value(self, value: str) -> bool:
+        """Set this element's value via UIA ValuePattern (no keystrokes)."""
+        return bool(self._desktop._ext.set_element_value(
+            text=value, role=self._info.role, name=self._info.name,
+        ))
+
+    def __repr__(self) -> str:
+        return f"Element(role={self._info.role!r}, name={self._info.name!r})"
+
+
+class Desktop:
+    """A reusable automation session bound to one platform backend.
+
+    All the core verbs live here as methods; the module-level functions
+    (:func:`see`, :func:`type`, …) are thin shims that forward to a throwaway
+    ``Desktop`` per call. Construct one explicitly to reuse a backend across
+    many operations, or pass a fake backend for testing::
+
+        d = naturo.Desktop()
+        d.launch("notepad")
+        d.type("hi", window="Notepad")
+    """
+
+    def __init__(self, backend: Optional[Backend] = None) -> None:
+        self._backend = backend
+
+    @property
+    def backend(self) -> Backend:
+        """The platform backend, auto-detected and cached on first use."""
+        if self._backend is None:
+            self._backend = get_backend()
+        return self._backend
+
+    @property
+    def _ext(self) -> Any:
+        """The backend viewed as ``Any`` for backend-specific surface.
+
+        The abstract :class:`Backend` ABC deliberately under-specifies methods
+        the concrete platform backends extend — ``get_element_tree(app=…, hwnd=…,
+        pid=…)``, ``find_element(hwnd=…)``, ``hotkey(input_mode=…)`` and
+        ``set_element_value(…)`` all live on the real backends (the MCP layer
+        calls them the same way through an untyped handle). Routing those calls
+        through this handle keeps the SDK honest about using that concrete
+        surface without weakening typing on the ABC-defined verbs.
+        """
+        return cast(Any, self.backend)
+
+    # ── observe ──────────────────────────────────────────────────────
+    def windows(self) -> list[WindowInfo]:
+        """List all visible top-level windows."""
+        return self.backend.list_windows()
+
+    def monitors(self) -> list[MonitorInfo]:
+        """List all connected monitors/displays."""
+        return self.backend.list_monitors()
+
+    def see(
+        self,
+        *,
+        window: Optional[str] = None,
+        app: Optional[str] = None,
+        hwnd: Optional[int] = None,
+        pid: Optional[int] = None,
+        depth: int = 0,
+        accessibility_backend: str = "uia",
+        cascade: bool = False,
+    ) -> Optional[Element]:
+        """Read a window's UI as a structured element tree.
+
+        Returns the root :class:`Element` (walk ``.children`` / ``.descendants``
+        / ``.find``), or ``None`` if no matching window. With ``cascade=True``
+        runs the unified multi-framework recognition (UIA + CDP/JAB/COM), each
+        node correctness-tagged — the fused tree that reaches web, Java and
+        Excel-cell content plain accessibility misses.
+
+        Args:
+            window: Target window title (partial match). None = foreground.
+            app: Target application name (partial match).
+            hwnd: Window handle. Overrides app/window.
+            pid: Process ID filter.
+            depth: Tree depth; 0 = unlimited (default).
+            accessibility_backend: "uia" (default), "msaa", "ia2", "jab", "auto".
+            cascade: Run the unified correctness-tagged cascade.
+        """
+        if cascade:
+            from naturo.cascade import run_cascade
+
+            result = run_cascade(
+                self.backend, app=app, window_title=window, hwnd=hwnd, pid=pid,
+                depth=depth, backend_name="auto",
+            )
+            root = result.tree
+        else:
+            root = self._ext.get_element_tree(
+                app=app, window_title=window, hwnd=hwnd, pid=pid,
+                depth=depth, backend=accessibility_backend,
+            )
+        if root is None:
+            return None
+        return Element(root, self)
+
+    def find(
+        self,
+        selector: str,
+        *,
+        window: Optional[str] = None,
+        hwnd: Optional[int] = None,
+    ) -> Optional[Element]:
+        """Find one element by ``"Role:Name"`` selector via the live backend.
+
+        Returns an :class:`Element`, or ``None`` if nothing matches.
+        """
+        info = self._ext.find_element(
+            selector=selector, window_title=window, hwnd=hwnd,
+        )
+        if info is None:
+            return None
+        return Element(info, self)
+
+    # ── act ──────────────────────────────────────────────────────────
+    def _focus(self, window: Optional[str], hwnd: Optional[int]) -> None:
+        """Resolve a window selector loudly and focus it before acting.
+
+        Mirrors the MCP surface (#957/#1291): a supplied-but-unresolvable
+        selector raises ``WindowNotFoundError`` rather than silently acting on
+        the foreground window.
+        """
+        if window is None and hwnd is None:
+            return
+        target = require_hwnd(self.backend, window_title=window, hwnd=hwnd)
+        self.backend.focus_window(hwnd=target, title=window)
+
+    def click(
+        self,
+        *,
+        x: Optional[int] = None,
+        y: Optional[int] = None,
+        element_id: Optional[str] = None,
+        button: str = "left",
+        double: bool = False,
+        input_mode: str = "normal",
+        window: Optional[str] = None,
+        hwnd: Optional[int] = None,
+    ) -> None:
+        """Click at coordinates or on an element (by backend selector/ref).
+
+        Pass ``window``/``hwnd`` to focus a specific window first.
+        """
+        self._focus(window, hwnd)
+        self.backend.click(
+            x=x, y=y, element_id=element_id, button=button, double=double,
+            input_mode=input_mode,
+        )
+
+    def type(
+        self,
+        text: str,
+        *,
+        window: Optional[str] = None,
+        hwnd: Optional[int] = None,
+        wpm: int = 120,
+        input_mode: str = "normal",
+    ) -> str:
+        """Type ``text`` through the shared IME-immune ladder.
+
+        Optionally focus ``window``/``hwnd`` first (atomic focus+type, no
+        cross-call foreground race). Returns the delivery method string.
+        """
+        self._focus(window, hwnd)
+        return smart_type_text(self.backend, text, input_mode=input_mode, wpm=wpm)
+
+    def press(
+        self,
+        key: str,
+        *,
+        count: int = 1,
+        window: Optional[str] = None,
+        hwnd: Optional[int] = None,
+        input_mode: str = "normal",
+    ) -> None:
+        """Press a key or combo (``"enter"``, ``"ctrl+s"``) ``count`` times."""
+        self._focus(window, hwnd)
+        is_combo = "+" in key
+        for _ in range(max(1, count)):
+            if is_combo:
+                keys = [k.strip() for k in key.replace("+", " ").split()]
+                self._ext.hotkey(*keys, input_mode=input_mode)
+            else:
+                self.backend.press_key(key=key, input_mode=input_mode)
+
+    def hotkey(self, *keys: str, input_mode: str = "normal") -> None:
+        """Press a key combination given as separate keys (``"ctrl", "c"``)."""
+        self._ext.hotkey(*keys, input_mode=input_mode)
+
+    def scroll(self, direction: str = "down", amount: int = 3,
+               x: Optional[int] = None, y: Optional[int] = None) -> None:
+        """Scroll the mouse wheel ``amount`` units up/down."""
+        self.backend.scroll(direction=direction, amount=amount, x=x, y=y)
+
+    def get_value(
+        self,
+        *,
+        ref: Optional[str] = None,
+        automation_id: Optional[str] = None,
+        role: Optional[str] = None,
+        name: Optional[str] = None,
+        window: Optional[str] = None,
+        hwnd: Optional[int] = None,
+    ) -> Optional[dict]:
+        """Read a UI element's current value via UIA patterns."""
+        return self.backend.get_element_value(
+            ref=ref, automation_id=automation_id, role=role, name=name,
+            window_title=window, hwnd=hwnd,
+        )
+
+    def set_value(
+        self,
+        value: str,
+        *,
+        automation_id: Optional[str] = None,
+        role: Optional[str] = None,
+        name: Optional[str] = None,
+        window: Optional[str] = None,
+        hwnd: Optional[int] = None,
+    ) -> bool:
+        """Set a UI element's value via UIA ValuePattern (bypasses SendInput)."""
+        target = require_hwnd(self.backend, window_title=window, hwnd=hwnd)
+        return bool(self._ext.set_element_value(
+            text=value, hwnd=target, automation_id=automation_id,
+            role=role, name=name,
+        ))
+
+    def capture(
+        self,
+        path: str = "capture.png",
+        *,
+        window: Optional[str] = None,
+        hwnd: Optional[int] = None,
+        screen: Optional[int] = None,
+    ) -> CaptureResult:
+        """Capture a screenshot to ``path``.
+
+        Pass ``window``/``hwnd`` to capture one window, or ``screen`` (monitor
+        index) for a specific display; with none of them, captures the primary
+        screen. Returns a :class:`CaptureResult`.
+        """
+        if hwnd is not None:
+            return self.backend.capture_window(hwnd=hwnd, output_path=path)
+        if window is not None:
+            if hasattr(self.backend, "_resolve_hwnd"):
+                resolved = require_hwnd(self.backend, window_title=window)
+                return self.backend.capture_window(hwnd=resolved, output_path=path)
+            return self.backend.capture_window(window_title=window, output_path=path)
+        return self.backend.capture_screen(
+            screen_index=screen or 0, output_path=path,
+        )
+
+    # ── lifecycle ────────────────────────────────────────────────────
+    def launch(
+        self,
+        name: Optional[str] = None,
+        *,
+        path: Optional[str] = None,
+        wait: bool = True,
+        timeout: float = 30.0,
+        args: Optional[list[str]] = None,
+        no_focus: bool = False,
+    ) -> "App":
+        """Launch an application and return an :class:`App` handle.
+
+        By default waits until the app has created a window (``wait=True``).
+        """
+        from naturo.process import launch_app
+
+        info = launch_app(
+            name=name, path=path, wait_until_ready=wait, timeout=timeout,
+            args=args, no_focus=no_focus,
+        )
+        return App(self, info)
+
+    def quit(self, name: str, *, force: bool = False) -> None:
+        """Quit an application by name (verified gone before returning)."""
+        from naturo.process import quit_app
+
+        quit_app(name, force=force)
+
+    def wait(
+        self,
+        selector: str,
+        *,
+        timeout: float = 10.0,
+        poll_interval: float = 0.1,
+        window: Optional[str] = None,
+        hwnd: Optional[int] = None,
+    ) -> "WaitResult":
+        """Poll until an element matching ``selector`` appears (or timeout).
+
+        Returns a :class:`~naturo.wait.WaitResult` (``.found`` / ``.element``).
+        """
+        from naturo.wait import wait_for_element
+
+        return wait_for_element(
+            selector, timeout=timeout, poll_interval=poll_interval,
+            window_title=window, hwnd=hwnd, backend=self.backend,
+        )
+
+
+# ``Session`` reads well for a long-lived automation script; same class.
+Session = Desktop
+
+
+class App:
+    """A handle to a launched application, scoping verbs to that app.
+
+    Returned by :meth:`Desktop.launch` / :func:`launch`. Doubles as a context
+    manager that quits the app on exit::
+
+        with naturo.launch("notepad") as app:
+            app.type("hello")
+    """
+
+    def __init__(self, desktop: Desktop, info: "ProcessInfo") -> None:
+        self._desktop = desktop
+        self._info = info
+
+    @property
+    def info(self) -> "ProcessInfo":
+        """The :class:`~naturo.process.ProcessInfo` for the launched app."""
+        return self._info
+
+    @property
+    def name(self) -> str:
+        """Resolved application/process name."""
+        return self._info.name
+
+    @property
+    def pid(self) -> int:
+        """Process ID."""
+        return self._info.pid
+
+    @property
+    def desktop(self) -> Desktop:
+        """The owning :class:`Desktop` session."""
+        return self._desktop
+
+    def see(self, **kwargs) -> Optional[Element]:
+        """:meth:`Desktop.see` scoped to this app."""
+        kwargs.setdefault("app", self.name)
+        return self._desktop.see(**kwargs)
+
+    def find(self, selector: str, **kwargs) -> Optional[Element]:
+        """:meth:`Desktop.find` scoped to this app's window title."""
+        kwargs.setdefault("window", self.name)
+        return self._desktop.find(selector, **kwargs)
+
+    def type(self, text: str, **kwargs) -> str:
+        """:meth:`Desktop.type` targeting this app's window."""
+        kwargs.setdefault("window", self.name)
+        return self._desktop.type(text, **kwargs)
+
+    def press(self, key: str, **kwargs) -> None:
+        """:meth:`Desktop.press` targeting this app's window."""
+        kwargs.setdefault("window", self.name)
+        self._desktop.press(key, **kwargs)
+
+    def click(self, **kwargs) -> None:
+        """:meth:`Desktop.click` targeting this app's window."""
+        kwargs.setdefault("window", self.name)
+        self._desktop.click(**kwargs)
+
+    def capture(self, path: str = "capture.png", **kwargs) -> CaptureResult:
+        """:meth:`Desktop.capture` of this app's window."""
+        kwargs.setdefault("window", self.name)
+        return self._desktop.capture(path, **kwargs)
+
+    def quit(self, *, force: bool = False) -> None:
+        """Quit this application."""
+        self._desktop.quit(self.name, force=force)
+
+    def __enter__(self) -> "App":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.quit()
+
+    def __repr__(self) -> str:
+        return f"App(name={self.name!r}, pid={self.pid})"
+
+
+# ── selector helpers (in-memory Element.find) ────────────────────────
+def _parse_selector(selector: str) -> tuple[Optional[str], Optional[str]]:
+    """Split a ``"Role:Name"`` selector into ``(role, name)``.
+
+    A bare string with no ``:`` is treated as a name filter.
+    """
+    if ":" in selector:
+        role, name = selector.split(":", 1)
+        return (role.strip() or None, name.strip() or None)
+    return (None, selector.strip() or None)
+
+
+def _element_matches(role: str, name: str, want_role: Optional[str],
+                     want_name: Optional[str]) -> bool:
+    """Case-insensitive role/name match, ``*`` wildcards allowed in the name."""
+    if want_role is not None and want_role.lower() != (role or "").lower():
+        return False
+    if want_name is not None:
+        want = want_name.lower()
+        got = (name or "").lower()
+        if "*" in want:
+            core = want.strip("*")
+            if core and core not in got:
+                return False
+        elif want != got:
+            return False
+    return True
+
+
+# ── module-level convenience functions ───────────────────────────────
+# Each forwards to a fresh Desktop (which lazily resolves the backend), so the
+# functions stay stateless and always honour a patched get_backend.
+def see(**kwargs) -> Optional[Element]:
+    """Module-level :meth:`Desktop.see`."""
+    return Desktop().see(**kwargs)
+
+
+def find(selector: str, **kwargs) -> Optional[Element]:
+    """Module-level :meth:`Desktop.find`."""
+    return Desktop().find(selector, **kwargs)
+
+
+def click(**kwargs) -> None:
+    """Module-level :meth:`Desktop.click`."""
+    Desktop().click(**kwargs)
+
+
+def type(text: str, **kwargs) -> str:  # noqa: A001 — deliberate ergonomic verb
+    """Module-level :meth:`Desktop.type` (IME-immune)."""
+    return Desktop().type(text, **kwargs)
+
+
+def press(key: str, **kwargs) -> None:
+    """Module-level :meth:`Desktop.press`."""
+    Desktop().press(key, **kwargs)
+
+
+def get_value(**kwargs) -> Optional[dict]:
+    """Module-level :meth:`Desktop.get_value`."""
+    return Desktop().get_value(**kwargs)
+
+
+def set_value(value: str, **kwargs) -> bool:
+    """Module-level :meth:`Desktop.set_value`."""
+    return Desktop().set_value(value, **kwargs)
+
+
+def capture(path: str = "capture.png", **kwargs) -> CaptureResult:
+    """Module-level :meth:`Desktop.capture`."""
+    return Desktop().capture(path, **kwargs)
+
+
+def launch(name: Optional[str] = None, **kwargs) -> App:
+    """Module-level :meth:`Desktop.launch`."""
+    return Desktop().launch(name, **kwargs)
+
+
+def quit(name: str, **kwargs) -> None:  # noqa: A001 — deliberate ergonomic verb
+    """Module-level :meth:`Desktop.quit`."""
+    Desktop().quit(name, **kwargs)
+
+
+def wait(selector: str, **kwargs) -> "WaitResult":
+    """Module-level :meth:`Desktop.wait`."""
+    return Desktop().wait(selector, **kwargs)
+
+
+def windows() -> list[WindowInfo]:
+    """Module-level :meth:`Desktop.windows`."""
+    return Desktop().windows()

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -1,0 +1,405 @@
+"""Hermetic tests for the in-process Python SDK (#924).
+
+Every test mocks the backend (and, where relevant, the shared helpers the SDK
+delegates to), so no live desktop is touched. The point is to prove each verb
+forwards to the RIGHT backend/actions call with the RIGHT args and returns a
+sensible object — i.e. that the SDK is a faithful thin wrapper, not a fork.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import naturo
+from naturo import sdk
+from naturo.backends.base import CaptureResult, ElementInfo
+
+
+# ── fixtures ──────────────────────────────────────────────────────────
+def _elem(role="Button", name="Save", value=None, x=10, y=20, w=100, h=40,
+          children=None) -> ElementInfo:
+    return ElementInfo(
+        id=f"{role}:{name}", role=role, name=name, value=value,
+        x=x, y=y, width=w, height=h,
+        children=children or [], properties={},
+    )
+
+
+@pytest.fixture
+def backend() -> MagicMock:
+    return MagicMock(name="backend")
+
+
+@pytest.fixture
+def desktop(backend) -> sdk.Desktop:
+    return sdk.Desktop(backend=backend)
+
+
+# ── Desktop.backend resolution ────────────────────────────────────────
+class TestBackendResolution:
+    def test_explicit_backend_used(self, backend):
+        d = sdk.Desktop(backend=backend)
+        assert d.backend is backend
+
+    def test_lazy_backend_autodetected(self):
+        fake = MagicMock()
+        with patch("naturo.sdk.get_backend", return_value=fake) as gb:
+            d = sdk.Desktop()
+            assert d.backend is fake
+            # cached — resolved once
+            assert d.backend is fake
+            gb.assert_called_once()
+
+
+# ── observe: windows / see / find ─────────────────────────────────────
+class TestObserve:
+    def test_windows_delegates_to_list_windows(self, desktop, backend):
+        backend.list_windows.return_value = ["w1", "w2"]
+        assert desktop.windows() == ["w1", "w2"]
+        backend.list_windows.assert_called_once_with()
+
+    def test_monitors_delegates(self, desktop, backend):
+        backend.list_monitors.return_value = ["m0"]
+        assert desktop.monitors() == ["m0"]
+        backend.list_monitors.assert_called_once_with()
+
+    def test_see_calls_get_element_tree_with_args(self, desktop, backend):
+        root = _elem(role="Window", name="Notepad")
+        backend.get_element_tree.return_value = root
+        el = desktop.see(window="Notepad", depth=3)
+        assert isinstance(el, sdk.Element)
+        assert el.info is root
+        backend.get_element_tree.assert_called_once_with(
+            app=None, window_title="Notepad", hwnd=None, pid=None,
+            depth=3, backend="uia",
+        )
+
+    def test_see_returns_none_when_no_window(self, desktop, backend):
+        backend.get_element_tree.return_value = None
+        assert desktop.see(window="Ghost") is None
+
+    def test_see_cascade_uses_run_cascade(self, desktop, backend):
+        root = _elem(role="Window", name="Chrome")
+        fake_result = MagicMock(tree=root)
+        with patch("naturo.cascade.run_cascade", return_value=fake_result) as rc:
+            el = desktop.see(app="chrome", cascade=True)
+        assert isinstance(el, sdk.Element)
+        assert el.info is root
+        rc.assert_called_once()
+        _, kwargs = rc.call_args
+        assert kwargs["app"] == "chrome"
+        assert kwargs["backend_name"] == "auto"
+
+    def test_find_returns_element(self, desktop, backend):
+        backend.find_element.return_value = _elem()
+        el = desktop.find("Button:Save", window="Notepad")
+        assert isinstance(el, sdk.Element)
+        backend.find_element.assert_called_once_with(
+            selector="Button:Save", window_title="Notepad", hwnd=None,
+        )
+
+    def test_find_returns_none(self, desktop, backend):
+        backend.find_element.return_value = None
+        assert desktop.find("Button:Nope") is None
+
+
+# ── Element wrapper ───────────────────────────────────────────────────
+class TestElement:
+    def test_properties(self, desktop):
+        el = sdk.Element(_elem(role="Edit", name="Body", value="hi"), desktop)
+        assert el.role == "Edit"
+        assert el.name == "Body"
+        assert el.value == "hi"
+        assert el.id == "Edit:Body"
+        assert el.bounds == (10, 20, 100, 40)
+
+    def test_center(self, desktop):
+        el = sdk.Element(_elem(x=0, y=0, w=100, h=40), desktop)
+        assert el.center == (50, 20)
+
+    def test_children_and_descendants(self, desktop):
+        leaf = _elem(role="Text", name="leaf")
+        mid = _elem(role="Group", name="mid", children=[leaf])
+        root = _elem(role="Window", name="root", children=[mid])
+        rel = sdk.Element(root, desktop)
+        assert [c.name for c in rel.children] == ["mid"]
+        assert sorted(d.name for d in rel.descendants()) == ["leaf", "mid"]
+
+    def test_find_in_subtree(self, desktop):
+        save = _elem(role="Button", name="Save")
+        root = _elem(role="Window", name="root", children=[save])
+        rel = sdk.Element(root, desktop)
+        found = rel.find("Button:Save")
+        assert found is not None and found.name == "Save"
+        assert rel.find("Button:Missing") is None
+
+    def test_click_uses_center(self, desktop, backend):
+        el = sdk.Element(_elem(x=0, y=0, w=100, h=40), desktop)
+        ret = el.click()
+        assert ret is el  # chainable
+        backend.click.assert_called_once_with(
+            x=50, y=20, button="left", double=False, input_mode="normal",
+        )
+
+    def test_type_focuses_then_types(self, desktop, backend):
+        el = sdk.Element(_elem(x=0, y=0, w=100, h=40), desktop)
+        with patch("naturo.sdk.smart_type_text", return_value="value_pattern") as stt:
+            method = el.type("hello", wpm=90)
+        assert method == "value_pattern"
+        backend.click.assert_called_once()  # focused first
+        stt.assert_called_once_with(backend, "hello", input_mode="normal", wpm=90)
+
+    def test_get_value_delegates(self, desktop, backend):
+        backend.get_element_value.return_value = {"value": "x"}
+        el = sdk.Element(_elem(role="Edit", name="Body"), desktop)
+        assert el.get_value() == {"value": "x"}
+        backend.get_element_value.assert_called_once_with(role="Edit", name="Body")
+
+    def test_set_value_delegates(self, desktop, backend):
+        backend.set_element_value.return_value = True
+        el = sdk.Element(_elem(role="Edit", name="Body"), desktop)
+        assert el.set_value("new") is True
+        backend.set_element_value.assert_called_once_with(
+            text="new", role="Edit", name="Body",
+        )
+
+
+# ── act: click / type / press ─────────────────────────────────────────
+class TestActions:
+    def test_click_coords(self, desktop, backend):
+        desktop.click(x=5, y=6)
+        backend.click.assert_called_once_with(
+            x=5, y=6, element_id=None, button="left", double=False,
+            input_mode="normal",
+        )
+
+    def test_click_focuses_window(self, desktop, backend):
+        backend._resolve_hwnd.return_value = 4242
+        desktop.click(x=5, y=6, window="Notepad")
+        backend.focus_window.assert_called_once_with(hwnd=4242, title="Notepad")
+
+    def test_type_routes_through_ladder(self, desktop, backend):
+        with patch("naturo.sdk.smart_type_text", return_value="clipboard_paste") as stt:
+            method = desktop.type("hi", wpm=200)
+        assert method == "clipboard_paste"
+        stt.assert_called_once_with(backend, "hi", input_mode="normal", wpm=200)
+
+    def test_type_focuses_target_window(self, desktop, backend):
+        backend._resolve_hwnd.return_value = 77
+        with patch("naturo.sdk.smart_type_text", return_value="keystroke"):
+            desktop.type("hi", window="Notepad")
+        backend.focus_window.assert_called_once_with(hwnd=77, title="Notepad")
+
+    def test_press_single_key(self, desktop, backend):
+        desktop.press("enter")
+        backend.press_key.assert_called_once_with(key="enter", input_mode="normal")
+
+    def test_press_combo_uses_hotkey(self, desktop, backend):
+        desktop.press("ctrl+s")
+        backend.hotkey.assert_called_once_with("ctrl", "s", input_mode="normal")
+
+    def test_press_count(self, desktop, backend):
+        desktop.press("tab", count=3)
+        assert backend.press_key.call_count == 3
+
+    def test_hotkey_delegates(self, desktop, backend):
+        desktop.hotkey("ctrl", "c")
+        backend.hotkey.assert_called_once_with("ctrl", "c", input_mode="normal")
+
+    def test_scroll_delegates(self, desktop, backend):
+        desktop.scroll(direction="up", amount=5)
+        backend.scroll.assert_called_once_with(
+            direction="up", amount=5, x=None, y=None,
+        )
+
+
+# ── values ────────────────────────────────────────────────────────────
+class TestValues:
+    def test_get_value(self, desktop, backend):
+        backend.get_element_value.return_value = {"value": "42"}
+        out = desktop.get_value(ref="e5")
+        assert out == {"value": "42"}
+        backend.get_element_value.assert_called_once_with(
+            ref="e5", automation_id=None, role=None, name=None,
+            window_title=None, hwnd=None,
+        )
+
+    def test_set_value_resolves_then_sets(self, desktop, backend):
+        backend._resolve_hwnd.return_value = 999
+        backend.set_element_value.return_value = True
+        assert desktop.set_value("hi", role="Edit", window="Notepad") is True
+        backend.set_element_value.assert_called_once_with(
+            text="hi", hwnd=999, automation_id=None, role="Edit", name=None,
+        )
+
+
+# ── capture ───────────────────────────────────────────────────────────
+class TestCapture:
+    def _result(self):
+        return CaptureResult(path="out.png", width=800, height=600, format="png")
+
+    def test_capture_screen_default(self, desktop, backend):
+        backend.capture_screen.return_value = self._result()
+        res = desktop.capture("out.png")
+        assert res.path == "out.png"
+        backend.capture_screen.assert_called_once_with(
+            screen_index=0, output_path="out.png",
+        )
+
+    def test_capture_screen_index(self, desktop, backend):
+        backend.capture_screen.return_value = self._result()
+        desktop.capture("out.png", screen=1)
+        backend.capture_screen.assert_called_once_with(
+            screen_index=1, output_path="out.png",
+        )
+
+    def test_capture_window_by_hwnd(self, desktop, backend):
+        backend.capture_window.return_value = self._result()
+        desktop.capture("w.png", hwnd=123)
+        backend.capture_window.assert_called_once_with(hwnd=123, output_path="w.png")
+
+    def test_capture_window_by_title_resolves_hwnd(self, desktop, backend):
+        backend._resolve_hwnd.return_value = 456
+        backend.capture_window.return_value = self._result()
+        desktop.capture("w.png", window="Notepad")
+        backend.capture_window.assert_called_once_with(hwnd=456, output_path="w.png")
+
+
+# ── lifecycle: launch / quit / wait ───────────────────────────────────
+class TestLifecycle:
+    def test_launch_returns_app(self, desktop):
+        from naturo.process import ProcessInfo
+        info = ProcessInfo(pid=1234, name="notepad")
+        with patch("naturo.process.launch_app", return_value=info) as la:
+            app = desktop.launch("notepad")
+        assert isinstance(app, sdk.App)
+        assert app.name == "notepad"
+        assert app.pid == 1234
+        la.assert_called_once_with(
+            name="notepad", path=None, wait_until_ready=True, timeout=30.0,
+            args=None, no_focus=False,
+        )
+
+    def test_quit_delegates(self, desktop):
+        with patch("naturo.process.quit_app") as qa:
+            desktop.quit("notepad", force=True)
+        qa.assert_called_once_with("notepad", force=True)
+
+    def test_wait_delegates(self, desktop, backend):
+        sentinel = MagicMock(found=True)
+        with patch("naturo.wait.wait_for_element", return_value=sentinel) as wfe:
+            out = desktop.wait("Button:Save", timeout=5)
+        assert out is sentinel
+        wfe.assert_called_once_with(
+            "Button:Save", timeout=5, poll_interval=0.1,
+            window_title=None, hwnd=None, backend=backend,
+        )
+
+
+class TestApp:
+    def _app(self, desktop):
+        from naturo.process import ProcessInfo
+        return sdk.App(desktop, ProcessInfo(pid=1, name="calc"))
+
+    def test_app_type_targets_own_window(self, desktop, backend):
+        app = self._app(desktop)
+        with patch("naturo.sdk.smart_type_text", return_value="keystroke"):
+            with patch.object(desktop, "type", wraps=desktop.type) as t:
+                app.type("x")
+        t.assert_called_once()
+        assert t.call_args.kwargs["window"] == "calc"
+
+    def test_app_context_manager_quits(self, desktop):
+        app = self._app(desktop)
+        with patch.object(desktop, "quit") as q:
+            with app as entered:
+                assert entered is app
+        q.assert_called_once_with("calc", force=False)
+
+    def test_app_capture_scopes_window(self, desktop, backend):
+        app = self._app(desktop)
+        backend._resolve_hwnd.return_value = 5
+        backend.capture_window.return_value = CaptureResult(
+            path="c.png", width=1, height=1, format="png",
+        )
+        app.capture("c.png")
+        backend.capture_window.assert_called_once_with(hwnd=5, output_path="c.png")
+
+
+# ── selector helpers ──────────────────────────────────────────────────
+class TestSelectorHelpers:
+    def test_parse_role_name(self):
+        assert sdk._parse_selector("Button:Save") == ("Button", "Save")
+
+    def test_parse_bare_name(self):
+        assert sdk._parse_selector("Save") == (None, "Save")
+
+    def test_match_role_and_name(self):
+        assert sdk._element_matches("Button", "Save", "button", "save")
+        assert not sdk._element_matches("Edit", "Save", "Button", "Save")
+
+    def test_match_wildcard(self):
+        assert sdk._element_matches("Edit", "filename box", None, "*file*")
+        assert not sdk._element_matches("Edit", "other", None, "*file*")
+
+
+# ── module-level convenience functions ────────────────────────────────
+class TestModuleFunctions:
+    def test_see_module_fn(self, backend):
+        backend.get_element_tree.return_value = _elem(role="Window", name="N")
+        with patch("naturo.sdk.get_backend", return_value=backend):
+            el = naturo.see(window="N")
+        assert isinstance(el, sdk.Element)
+
+    def test_type_module_fn(self, backend):
+        with patch("naturo.sdk.get_backend", return_value=backend):
+            with patch("naturo.sdk.smart_type_text", return_value="value_pattern") as stt:
+                method = naturo.type("hi")
+        assert method == "value_pattern"
+        stt.assert_called_once()
+
+    def test_press_module_fn(self, backend):
+        with patch("naturo.sdk.get_backend", return_value=backend):
+            naturo.press("enter")
+        backend.press_key.assert_called_once()
+
+    def test_windows_module_fn(self, backend):
+        backend.list_windows.return_value = []
+        with patch("naturo.sdk.get_backend", return_value=backend):
+            assert naturo.windows() == []
+
+    def test_public_exports_present(self):
+        for name in ("Desktop", "Session", "App", "Element", "see", "find",
+                     "click", "type", "press", "get_value", "set_value",
+                     "capture", "launch", "quit", "windows"):
+            assert hasattr(naturo, name), name
+
+    def test_wait_not_shadowing_submodule(self):
+        # Top-level `naturo.wait` must stay the SUBMODULE, not the SDK verb,
+        # so existing `naturo.wait.wait_for_element` (and its monkeypatching)
+        # keep working. The verb lives on Desktop / naturo.sdk instead.
+        import types
+        assert isinstance(naturo.wait, types.ModuleType)
+        assert callable(sdk.wait)
+
+    def test_session_is_desktop(self):
+        assert naturo.Session is naturo.Desktop
+
+
+# ── examples import cleanly ───────────────────────────────────────────
+class TestExamplesImport:
+    @pytest.mark.parametrize("name", [
+        "notepad_hello", "form_filler", "ui_inspector", "window_capture",
+    ])
+    def test_example_imports(self, name):
+        examples_dir = Path(__file__).resolve().parents[1] / "examples"
+        path = examples_dir / f"{name}.py"
+        assert path.exists(), path
+        spec = importlib.util.spec_from_file_location(f"_example_{name}", path)
+        assert spec and spec.loader
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)  # executes top-level; must not raise
+        assert hasattr(module, "main")


### PR DESCRIPTION
Adds the ergonomic `import naturo` SDK #924 asks for — so users automate in-process instead of shelling out to the CLI (which is what the examples did).

## API (`naturo/sdk.py`, re-exported at top level)
- **`Desktop`** (alias `Session`) holds the verbs as methods; module-level `naturo.see/find/click/type/press/hotkey/scroll/get_value/set_value/capture/launch/quit/windows/monitors` forward to a throwaway Desktop each call (stateless, honours patched `get_backend`).
- **`launch()` → `App`** handle (context manager, quits on exit, verbs scoped to its window).
- **`see`/`find` → `Element`** wrappers whose nodes act on themselves: `el.click()`, `el.type()`, `el.find()`, `el.descendants()`.
- `type` routes through `naturo.actions.smart_type_text` (the IME-immune ValuePattern→clipboard→keystroke ladder). No logic duplicated — pure delegation to backend / actions / cascade / process / wait.

Examples (`notepad_hello`, `form_filler`, `ui_inspector`, `window_capture`) rewritten to use it; README gains a Python SDK section. (Design note: `wait` is exposed only as `Desktop.wait()`, not a top-level name, to avoid shadowing the existing `naturo.wait` submodule.)

## Verification
- `tests/test_sdk.py` (53 tests) + full gate 7299 passed (6 known native-DLL host failures only). `import naturo` exposes Desktop/App/Element + verbs. ruff + mypy clean.

Closes #924

🤖 Generated with [Claude Code](https://claude.com/claude-code)