### PR TITLE
chore(npm): sync wrapper version to engine 0.3.2 (#52)

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "naturo",
-  "version": "0.1.0",
+  "version": "0.3.2",
   "description": "Cross-platform desktop automation engine for AI agents — see, click, type, automate. MCP server included.",
   "keywords": [
     "automation",


### PR DESCRIPTION
Preps #52 (npm `npx naturo mcp`) for publish. The `npm/` wrapper package already exists and works — verified here: `node npm/bin/naturo.js --version` correctly delegates to the pip-installed engine (prints `naturo, version 0.3.2`), and `npm test` passes. Its only staleness was the version pinned at `0.1.0` while the engine is `0.3.2`; this syncs it so the published wrapper matches the pip package it shells out to.

Note: the `version-check` CI job asserts version.py/CMakeLists/version.cpp/pyproject agree but does **not** yet cover `npm/package.json` — worth adding to that job (a `.github` change) so npm stays in lockstep on future bumps.

After merge, `npm publish` (maintainer npm credentials) closes #52 — see the issue for the ready-to-publish checklist.

Refs #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)