### PR TITLE
chore(registry): add server.json for the official MCP registry (#928)

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.acepeak/naturo",
+  "title": "Naturo",
+  "description": "Windows desktop automation for AI agents — see, click, type across native, Java, Excel, browser.",
+  "version": "0.3.2",
+  "websiteUrl": "https://github.com/AcePeak/naturo",
+  "repository": {
+    "url": "https://github.com/AcePeak/naturo",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "naturo",
+      "version": "0.3.2",
+      "runtimeHint": "uvx",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
+        { "type": "positional", "value": "mcp" },
+        { "type": "positional", "value": "start" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Advances #928 (list naturo on MCP registries; part of #922 distribution). Adds a canonical `server.json` at repo root — the official MCP registry manifest (schema `2025-12-11`).

- `name`: `io.github.acepeak/naturo` (reverse-DNS; the `io.github.acepeak/*` namespace is GitHub-auth authorized for the AcePeak org).
- Declares the **PyPI** package `naturo` @ 0.3.2, stdio transport, `runtimeHint: uvx`, and `packageArguments: [mcp, start]` — i.e. `uvx naturo mcp start`.
- Validated: parses, description 96 chars (under the 100 cap), `naturo mcp start` confirmed as a real CLI path.

This is the committable half of #928. The actual publish is a maintainer action:
```bash
# one-time: install the publisher CLI, then
mcp-publisher login github        # authorizes the io.github.acepeak/* namespace
mcp-publisher publish             # reads ./server.json
```
The other registries (mcp.so / glama.ai / mcpservers.org) + the awesome-mcp-servers PR are tracked in a checklist on #928.

Refs #928, #922

🤖 Generated with [Claude Code](https://claude.com/claude-code)