### PR TITLE
feat(runtime): embedded Python 3.12 bundler + system/embedded resolver (#41)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,11 @@ naturo/bin/*.so
 naturo/bin/*.dylib
 naturo-screen-*.png
 
+# Embedded Python runtime — a ~40MB build artifact assembled by
+# scripts/bundle_python.py (#41). Never committed; rebuilt on demand.
+dist/runtime/
+get-pip.py
+
 # Working directory debug artifacts
 .work/*.png
 .work/*.log

--- a/docs/EMBEDDED_RUNTIME.md
+++ b/docs/EMBEDDED_RUNTIME.md
@@ -1,0 +1,150 @@
+# Embedded Python runtime (#41)
+
+Naturo can ship as a **self-contained bundle** that carries its own CPython 3.12
+interpreter, so a target machine can run naturo without any pre-installed Python.
+This document describes how that runtime is assembled, why it is a build
+artifact (never committed), the one embed gotcha that makes it work, and the rule
+that decides between a system Python and the bundled one at runtime.
+
+## Two pieces
+
+| Piece | Location | Committed? | Role |
+| --- | --- | --- | --- |
+| Bundler script | `scripts/bundle_python.py` | yes (source) | Assembles the runtime at build time |
+| Runtime resolver | `naturo/runtime/resolver.py` | yes (source) | Picks system vs. embedded interpreter |
+| The runtime itself | `dist/runtime/python/` | **no — gitignored** | ~40MB build artifact, rebuilt on demand |
+
+The ~40MB runtime is a **build artifact**. It is produced by CI (or locally) and
+never lands in git — `dist/` (and `dist/runtime/` explicitly) is gitignored.
+
+## How `scripts/bundle_python.py` assembles the runtime
+
+```
+python scripts/bundle_python.py                 # published wheel -> dist/runtime/python
+python scripts/bundle_python.py --from-local    # install the local checkout instead
+python scripts/bundle_python.py --check         # validate the plan, download nothing
+```
+
+Pipeline:
+
+1. **Download** the official Windows embeddable zip from python.org
+   (`python-<ver>-embed-amd64.zip`), pinned to a known-good `3.12.x`
+   (`DEFAULT_PYTHON_VERSION`, overridable with `--python-version`).
+2. **Extract** it into the destination (`--dest`, default `dist/runtime/python/`).
+3. **Enable `site`** (see the gotcha below).
+4. **Bootstrap pip** via `get-pip.py` — the embeddable distribution has no
+   `ensurepip`, so `get-pip.py` is the supported bootstrap path.
+5. **Install naturo** into the embedded `site-packages`. By default this installs
+   the **published wheel** (`naturo==<version>`, version read from
+   `naturo/version.py`) so naturo's native C++ core is **not** rebuilt from
+   source. `--from-local` instead installs the working checkout (`pip install .`),
+   which may trigger the native build.
+6. **Verify** by running `<dest>/python.exe -m naturo --version` and asserting the
+   expected version prints — proof that naturo runs on an interpreter the system
+   did not provide.
+7. **Report size** and warn if the runtime exceeds the **50MB budget**.
+
+### The `._pth` `site` gotcha
+
+The Windows embeddable distribution ships a path-configuration file named
+`python3xx._pth` (e.g. `python312._pth`) with this line **commented out**:
+
+```
+#import site
+```
+
+While `import site` is commented, Python's `site` module never initialises. The
+practical consequence is that **`site-packages` is not added to `sys.path`**, so
+anything `pip` installs is invisible to `import`. The bundler rewrites the file to
+
+```
+import site
+```
+
+*before* bootstrapping pip. This is the single well-known step that turns an
+embeddable Python into one that can host installed packages. `enable_site()` in
+`scripts/bundle_python.py` performs this rewrite (uncommenting, or appending the
+line if it is absent).
+
+### Proxy handling
+
+Downloads use `urllib`, which honors `HTTP_PROXY` / `HTTPS_PROXY` from the
+environment automatically. Nothing is hardcoded. On a host whose only outbound
+path is a proxy, export it before running:
+
+```
+HTTPS_PROXY=http://127.0.0.1:PORT python scripts/bundle_python.py
+```
+
+### Note on optional extras
+
+The default install pulls naturo and its declared runtime dependency (`click`).
+naturo's Windows-only extras (`pywin32`, `comtypes` via `naturo[windows]`) are
+**not** installed by default to keep the runtime lean. The embedded interpreter
+can import naturo and run the CLI (`--version`, `--help`, and the pure-Python
+paths) out of the box; deployments that need the full native UIA/COM surface
+should extend the install to `naturo[windows]==<version>` (a follow-up may add a
+flag for this). The native core DLL itself already ships inside the wheel as
+package data, so it is present regardless.
+
+## Runtime resolution: system vs. embedded
+
+`naturo/runtime/resolver.py` implements issue #41's acceptance rule:
+
+> **Prefer a system Python when available; fall back to the embedded runtime.**
+
+Public API (`from naturo.runtime import ...`):
+
+- `find_system_python(min_version=(3, 9)) -> str | None` — first suitable Python
+  on `PATH` (≥ 3.9), probed by actually querying its version.
+- `find_embedded_python(base: Path) -> str | None` — the bundled `python.exe`
+  under `base`, checking the known bundle layouts
+  (`_runtime/python/`, `dist/runtime/python/`, …).
+- `resolve_python(prefer_system=True, base=None) -> str` — applies the rule and
+  returns the chosen interpreter, or raises `RuntimeError` if neither exists.
+  `prefer_system=False` inverts the order (embedded first).
+
+The module is pure and filesystem-injectable (every function accepts the lookup
+surface it depends on), has **no import-time side effects**, and is covered by
+hermetic unit tests in `tests/test_runtime_resolver.py` (no network, no real
+runtime, no desktop).
+
+## Size budget
+
+Acceptance criterion: the assembled runtime stays within **50MB**. A default
+build (published wheel, CPython 3.12.7) measures **~39MB**, comfortably under
+budget. `bundle_python.py` prints the total and emits a warning to stderr if a
+build exceeds 50MB.
+
+## CI wiring (ships as a separate patch — workflow scope)
+
+The bundling step belongs in a GitHub Actions workflow. That change is
+**workflow-scoped and ships as a separate patch** (this PR does not touch
+`.github/`). The intended step, for a maintainer to add to a Windows job:
+
+```yaml
+# .github/workflows/<release-or-build>.yml  (add under a windows-latest job)
+  bundle-embedded-runtime:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      # Dry-run the plan on every PR (no network) so the bundler stays valid.
+      - name: Validate bundler plan
+        run: python scripts/bundle_python.py --check
+      # Full build only where a runtime artifact is wanted (e.g. release).
+      - name: Build embedded runtime
+        run: python scripts/bundle_python.py
+      - name: Upload runtime artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: naturo-embedded-runtime
+          path: dist/runtime/python
+          if-no-files-found: error
+```
+
+`--check` is safe to run on every PR (validates inputs and prints the plan,
+downloads nothing); the full build runs only where the ~40MB artifact is
+actually needed.

--- a/naturo/runtime/__init__.py
+++ b/naturo/runtime/__init__.py
@@ -1,0 +1,22 @@
+"""Runtime resolution for naturo.
+
+Decides which Python interpreter should drive naturo: a system Python when one
+is available, otherwise the embedded CPython runtime produced by
+``scripts/bundle_python.py``. See :mod:`naturo.runtime.resolver` for the pure,
+testable implementation and :doc:`docs/EMBEDDED_RUNTIME` for the architecture.
+"""
+from __future__ import annotations
+
+from naturo.runtime.resolver import (
+    MIN_PYTHON,
+    find_embedded_python,
+    find_system_python,
+    resolve_python,
+)
+
+__all__ = [
+    "MIN_PYTHON",
+    "find_embedded_python",
+    "find_system_python",
+    "resolve_python",
+]

--- a/naturo/runtime/resolver.py
+++ b/naturo/runtime/resolver.py
@@ -1,0 +1,184 @@
+"""Locate the Python interpreter naturo should run under.
+
+Naturo can be deployed two ways:
+
+* as a normal ``pip install`` into a **system** Python, or
+* as a self-contained bundle that ships an **embedded** CPython runtime
+  (see ``scripts/bundle_python.py``) so the machine needs no pre-installed
+  Python at all.
+
+This module answers a single question — *which* ``python.exe`` should drive
+naturo — and implements the acceptance rule for issue #41:
+
+    Prefer a system Python when one is available; fall back to the bundled
+    embedded runtime otherwise.
+
+The logic is deliberately pure and filesystem-injectable (every entry point
+accepts the lookup surface it depends on) so it can be unit-tested without a
+real interpreter, a network, or a desktop session. Nothing here has import-time
+side effects.
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Callable, Optional, Sequence, Tuple
+
+# Minimum interpreter naturo supports, mirroring ``requires-python = ">=3.9"``
+# in pyproject.toml. A system Python older than this is treated as unusable.
+MIN_PYTHON: Tuple[int, int] = (3, 9)
+
+# Executable names to probe on PATH, in priority order.
+_SYSTEM_CANDIDATES: Tuple[str, ...] = ("python", "python3")
+
+# Locations (relative to a supplied ``base``) where an embedded runtime's
+# ``python.exe`` may live. ``bundle_python.py`` writes to ``dist/runtime/python``
+# during a build, while a shipped bundle nests the runtime beside the package as
+# ``_runtime/python``. Both layouts (and a couple of flatter variants) are
+# probed so the resolver works regardless of how the bundle was staged.
+_EMBEDDED_SUBPATHS: Tuple[Path, ...] = (
+    Path("_runtime") / "python" / "python.exe",
+    Path("dist") / "runtime" / "python" / "python.exe",
+    Path("runtime") / "python" / "python.exe",
+    Path("python") / "python.exe",
+    Path("python.exe"),
+)
+
+# Callable that returns the ``(major, minor)`` version of the interpreter at a
+# path, or ``None`` if it cannot be determined. Injectable for tests.
+VersionProbe = Callable[[str], Optional[Tuple[int, int]]]
+# Callable that resolves an executable name to a full path (``shutil.which``).
+PathLookup = Callable[[str], Optional[str]]
+
+
+def _probe_version(executable: str) -> Optional[Tuple[int, int]]:
+    """Return the ``(major, minor)`` version of ``executable``.
+
+    Runs the interpreter with a tiny one-liner rather than trusting the file
+    name, so an ambiguously named ``python`` is classified correctly. Any
+    failure (missing binary, non-zero exit, unparseable output) yields
+    ``None`` — the caller then treats the candidate as unusable.
+
+    Args:
+        executable: Path to a Python interpreter.
+
+    Returns:
+        The interpreter's ``(major, minor)`` version, or ``None``.
+    """
+    try:
+        proc = subprocess.run(
+            [executable, "-c", "import sys;print(sys.version_info[0], sys.version_info[1])"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode != 0:
+        return None
+    parts = proc.stdout.split()
+    if len(parts) < 2:
+        return None
+    try:
+        return int(parts[0]), int(parts[1])
+    except ValueError:
+        return None
+
+
+def find_system_python(
+    min_version: Tuple[int, int] = MIN_PYTHON,
+    *,
+    candidates: Sequence[str] = _SYSTEM_CANDIDATES,
+    which: PathLookup = shutil.which,
+    probe: VersionProbe = _probe_version,
+) -> Optional[str]:
+    """Locate a suitable system Python on ``PATH``.
+
+    Probes ``candidates`` in order, resolving each with ``which`` and checking
+    its version with ``probe``. The first interpreter that is present and at
+    least ``min_version`` wins.
+
+    Args:
+        min_version: Lowest acceptable ``(major, minor)`` version.
+        candidates: Executable names to try, in priority order.
+        which: Name-to-path resolver (defaults to :func:`shutil.which`).
+        probe: Version probe (defaults to running the interpreter).
+
+    Returns:
+        The absolute path to a usable system Python, or ``None`` if none found.
+    """
+    for name in candidates:
+        path = which(name)
+        if not path:
+            continue
+        version = probe(path)
+        if version is not None and version >= min_version:
+            return path
+    return None
+
+
+def find_embedded_python(base: Path) -> Optional[str]:
+    """Locate a bundled embedded ``python.exe`` under ``base``.
+
+    Checks the known bundle layouts (see :data:`_EMBEDDED_SUBPATHS`) and returns
+    the first ``python.exe`` that exists on disk. Purely a filesystem check — the
+    interpreter is not executed here.
+
+    Args:
+        base: Directory the embedded runtime is staged relative to (typically
+            the naturo package dir or a repo/dist root).
+
+    Returns:
+        The path to the embedded interpreter, or ``None`` if absent.
+    """
+    for sub in _EMBEDDED_SUBPATHS:
+        candidate = base / sub
+        if candidate.is_file():
+            return str(candidate)
+    return None
+
+
+def _default_base() -> Path:
+    """Return the default search base: the naturo package's parent directory.
+
+    A shipped bundle stages the embedded runtime beside the installed package,
+    so the package's parent is the natural anchor for :func:`find_embedded_python`.
+    """
+    return Path(__file__).resolve().parent.parent
+
+
+def resolve_python(prefer_system: bool = True, base: Optional[Path] = None) -> str:
+    """Resolve which Python interpreter naturo should run under.
+
+    Implements issue #41's acceptance rule: **prefer a system Python, fall back
+    to the embedded runtime**. Pass ``prefer_system=False`` to invert the order
+    (embedded first) — useful when a caller wants the pinned, bundled runtime.
+
+    Args:
+        prefer_system: When ``True`` (default) a usable system Python wins; when
+            ``False`` the embedded runtime is preferred.
+        base: Directory to search for the embedded runtime. Defaults to the
+            naturo package's parent directory.
+
+    Returns:
+        The path to the chosen interpreter.
+
+    Raises:
+        RuntimeError: If neither a system nor an embedded interpreter is found.
+    """
+    search_base = _default_base() if base is None else base
+    system = find_system_python()
+    embedded = find_embedded_python(search_base)
+
+    order = (system, embedded) if prefer_system else (embedded, system)
+    for chosen in order:
+        if chosen is not None:
+            return chosen
+
+    raise RuntimeError(
+        "No suitable Python runtime found: neither a system Python "
+        f">= {MIN_PYTHON[0]}.{MIN_PYTHON[1]} on PATH nor a bundled embedded "
+        f"runtime under {search_base}. Build one with scripts/bundle_python.py "
+        "or install a supported Python."
+    )

--- a/scripts/bundle_python.py
+++ b/scripts/bundle_python.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+"""Assemble naturo's embedded Python 3.12 runtime (a build artifact, issue #41).
+
+This script produces a self-contained CPython runtime with naturo pre-installed,
+so a target machine can run naturo without a system Python. The output (~40MB) is
+a BUILD ARTIFACT — it is gitignored, never committed. CI rebuilds it on demand
+(see docs/EMBEDDED_RUNTIME.md).
+
+Pipeline
+--------
+1. Download the official Windows embeddable zip from python.org
+   (``python-<ver>-embed-amd64.zip``), pinned to a known-good 3.12.x.
+2. Extract it into the destination directory.
+3. Enable ``site`` by uncommenting ``import site`` in the ``python3xx._pth``
+   file. The embeddable distribution ships with ``site`` DISABLED, which also
+   makes ``site-packages`` invisible to ``import`` — the well-known embed gotcha
+   that breaks ``pip install`` targets unless fixed first.
+4. Bootstrap pip via ``get-pip.py`` (the embeddable build has no ``ensurepip``).
+5. ``pip install`` naturo into the embedded ``site-packages`` — by default the
+   PUBLISHED wheel (``naturo==<version>``) so naturo's native C++ core is NOT
+   rebuilt from source; ``--from-local`` instead installs the local checkout.
+6. Verify by running ``<dest>/python.exe -m naturo --version`` and asserting the
+   expected version prints.
+7. Report the total runtime size and warn if it exceeds the 50MB budget.
+
+Usage::
+
+    python scripts/bundle_python.py                       # published wheel -> dist/runtime/python
+    python scripts/bundle_python.py --from-local          # install the local checkout instead
+    python scripts/bundle_python.py --python-version 3.12.7 --naturo-version 0.3.2
+    python scripts/bundle_python.py --check               # validate the plan, download nothing
+
+Proxy: ``urllib`` honors ``HTTP_PROXY`` / ``HTTPS_PROXY`` from the environment
+automatically. Nothing is hardcoded here.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import urllib.request
+import zipfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+VERSION_FILE = REPO_ROOT / "naturo" / "version.py"
+
+# Pinned, known-good CPython 3.12.x. Overridable via --python-version. Kept as a
+# constant so the default bump is a one-line, reviewable change.
+DEFAULT_PYTHON_VERSION = "3.12.7"
+
+# Default output. Lives under dist/ (gitignored) so the artifact never lands in
+# git. See .gitignore and docs/EMBEDDED_RUNTIME.md.
+DEFAULT_DEST = REPO_ROOT / "dist" / "runtime" / "python"
+
+# Acceptance-criteria size budget for the assembled runtime.
+SIZE_BUDGET_MB = 50.0
+
+# Official, deterministic download URLs. get-pip.py has no per-version pin; the
+# canonical bootstrap URL is versionless and tracks a current pip.
+_EMBED_URL = "https://www.python.org/ftp/python/{version}/python-{version}-embed-amd64.zip"
+_GET_PIP_URL = "https://bootstrap.pypa.io/get-pip.py"
+
+_VERSION_RE = re.compile(r"^3\.12\.\d+$")
+
+
+def read_naturo_version() -> str:
+    """Return naturo's version from ``naturo/version.py`` without importing it.
+
+    A regex read keeps this build working on any platform even when the native
+    core is absent (mirrors ``scripts/build_mcpb.py``).
+
+    Returns:
+        The ``__version__`` string (e.g. ``"0.3.2"``).
+
+    Raises:
+        ValueError: If ``__version__`` cannot be found.
+    """
+    text = VERSION_FILE.read_text(encoding="utf-8")
+    match = re.search(r'__version__\s*=\s*"([^"]+)"', text)
+    if not match:
+        raise ValueError(f"Could not find __version__ in {VERSION_FILE}")
+    return match.group(1)
+
+
+def embed_url(python_version: str) -> str:
+    """Return the python.org embeddable-zip URL for ``python_version``."""
+    return _EMBED_URL.format(version=python_version)
+
+
+def _download(url: str, dest: Path) -> None:
+    """Download ``url`` to ``dest``.
+
+    ``urllib`` reads ``HTTP_PROXY``/``HTTPS_PROXY`` from the environment on its
+    own, so a proxied host works without any special handling here.
+
+    Args:
+        url: Source URL.
+        dest: Local file path to write.
+    """
+    print(f"  downloading {url}")
+    with urllib.request.urlopen(url) as response:  # noqa: S310 (trusted python.org/pypa URLs)
+        data = response.read()
+    dest.write_bytes(data)
+    print(f"    -> {dest} ({len(data) / 1_000_000:.1f} MB)")
+
+
+def _find_pth_file(dest: Path) -> Path:
+    """Return the ``python3xx._pth`` path-config file inside ``dest``.
+
+    Raises:
+        FileNotFoundError: If no ``._pth`` file is present (unexpected layout).
+    """
+    matches = sorted(dest.glob("python*._pth"))
+    if not matches:
+        raise FileNotFoundError(f"No python*._pth file found under {dest}")
+    return matches[0]
+
+
+def enable_site(pth_file: Path) -> None:
+    """Enable ``site`` in an embeddable distribution's ``._pth`` file.
+
+    The embeddable build ships ``._pth`` with ``import site`` commented out. While
+    commented, ``site`` never initialises, so ``site-packages`` is not added to
+    ``sys.path`` and ``pip``-installed packages are invisible. Uncommenting it
+    (or appending it if absent) is the fix that makes the runtime pip-usable.
+
+    Args:
+        pth_file: Path to the ``python3xx._pth`` file to rewrite.
+    """
+    lines = pth_file.read_text(encoding="utf-8").splitlines()
+    out: list[str] = []
+    seen_import_site = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped in ("#import site", "# import site"):
+            out.append("import site")
+            seen_import_site = True
+        elif stripped == "import site":
+            out.append("import site")
+            seen_import_site = True
+        else:
+            out.append(line)
+    if not seen_import_site:
+        out.append("import site")
+    pth_file.write_text("\n".join(out) + "\n", encoding="utf-8")
+    print(f"  enabled site in {pth_file.name}")
+
+
+def _run(cmd: list[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    """Run ``cmd``, streaming a short banner; return the completed process."""
+    print(f"  $ {' '.join(cmd)}")
+    return subprocess.run(cmd, cwd=str(cwd) if cwd else None, capture_output=True, text=True)
+
+
+def _dir_size_mb(path: Path) -> float:
+    """Return the recursive size of ``path`` in megabytes (base-10 MB)."""
+    total = 0
+    for entry in path.rglob("*"):
+        if entry.is_file():
+            total += entry.stat().st_size
+    return total / 1_000_000
+
+
+def build_runtime(
+    dest: Path,
+    python_version: str,
+    naturo_version: str,
+    *,
+    from_local: bool,
+    workdir: Path,
+) -> float:
+    """Assemble the embedded runtime at ``dest`` and return its size in MB.
+
+    Args:
+        dest: Destination directory for the runtime (recreated fresh).
+        python_version: CPython version to fetch (e.g. ``"3.12.7"``).
+        naturo_version: naturo version to install when using the published wheel.
+        from_local: Install the local checkout (``pip install .``) instead of the
+            published wheel.
+        workdir: Scratch directory for downloads.
+
+    Returns:
+        The assembled runtime's total size in megabytes.
+
+    Raises:
+        RuntimeError: If pip bootstrap, install, or the verification step fails.
+    """
+    # 1. Fresh destination.
+    if dest.exists():
+        shutil.rmtree(dest)
+    dest.mkdir(parents=True, exist_ok=True)
+
+    # 2. Download + extract the embeddable zip.
+    embed_zip = workdir / f"python-{python_version}-embed-amd64.zip"
+    _download(embed_url(python_version), embed_zip)
+    print(f"  extracting to {dest}")
+    with zipfile.ZipFile(embed_zip) as archive:
+        archive.extractall(dest)
+
+    python_exe = dest / "python.exe"
+    if not python_exe.is_file():
+        raise RuntimeError(f"python.exe not found after extraction at {python_exe}")
+
+    # 3. Enable site so pip's site-packages become importable.
+    enable_site(_find_pth_file(dest))
+
+    # 4. Bootstrap pip via get-pip.py (embeddable build has no ensurepip).
+    get_pip = workdir / "get-pip.py"
+    _download(_GET_PIP_URL, get_pip)
+    proc = _run([str(python_exe), str(get_pip), "--no-warn-script-location"])
+    if proc.returncode != 0:
+        raise RuntimeError(f"get-pip.py failed:\n{proc.stdout}\n{proc.stderr}")
+    print("  pip bootstrapped")
+
+    # 5. Install naturo. Published wheel by default so the native C++ core is not
+    #    rebuilt; --from-local installs the working checkout instead.
+    if from_local:
+        target = str(REPO_ROOT)
+        print(f"  installing local checkout: {target}")
+    else:
+        target = f"naturo=={naturo_version}"
+        print(f"  installing published wheel: {target}")
+    proc = _run([str(python_exe), "-m", "pip", "install", "--no-warn-script-location", target])
+    if proc.returncode != 0:
+        raise RuntimeError(f"pip install {target} failed:\n{proc.stdout}\n{proc.stderr}")
+    print("  naturo installed")
+
+    # 6. Verify: the embedded interpreter must run naturo standalone.
+    proc = _run([str(python_exe), "-m", "naturo", "--version"])
+    output = (proc.stdout + proc.stderr).strip()
+    if proc.returncode != 0:
+        raise RuntimeError(f"embedded `python.exe -m naturo --version` failed:\n{output}")
+    expected = naturo_version if not from_local else read_naturo_version()
+    if expected not in output:
+        raise RuntimeError(
+            f"embedded naturo version mismatch: expected '{expected}' in output, got: {output!r}"
+        )
+    print(f"  verified: {output}")
+
+    # 7. Size.
+    return _dir_size_mb(dest)
+
+
+def _plan_summary(dest: Path, python_version: str, naturo_version: str, from_local: bool) -> str:
+    """Return a one-line human-readable summary of the build plan."""
+    source = "local checkout" if from_local else f"naturo=={naturo_version}"
+    return (
+        f"python={python_version} naturo={source} "
+        f"dest={dest} url={embed_url(python_version)}"
+    )
+
+
+def main() -> int:
+    """CLI entry point. Returns a process exit code."""
+    default_naturo = read_naturo_version()
+    parser = argparse.ArgumentParser(
+        description="Assemble naturo's embedded Python 3.12 runtime (build artifact, #41).",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--python-version",
+        default=DEFAULT_PYTHON_VERSION,
+        help="CPython 3.12.x to embed.",
+    )
+    parser.add_argument(
+        "--naturo-version",
+        default=default_naturo,
+        help="naturo version to install as the published wheel (ignored with --from-local).",
+    )
+    parser.add_argument(
+        "--dest",
+        type=Path,
+        default=DEFAULT_DEST,
+        help="Destination directory for the runtime.",
+    )
+    parser.add_argument(
+        "--from-local",
+        action="store_true",
+        help="Install the local checkout (pip install .) instead of the published wheel. "
+        "May trigger naturo's native C++ build.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Validate inputs and print the plan; download and install nothing.",
+    )
+    args = parser.parse_args()
+
+    if not _VERSION_RE.match(args.python_version):
+        parser.error(f"--python-version must be a 3.12.x release, got '{args.python_version}'")
+
+    plan = _plan_summary(args.dest, args.python_version, args.naturo_version, args.from_local)
+
+    if os.environ.get("HTTPS_PROXY") or os.environ.get("HTTP_PROXY"):
+        print(f"(using proxy from environment: "
+              f"{os.environ.get('HTTPS_PROXY') or os.environ.get('HTTP_PROXY')})")
+
+    if args.check:
+        print(f"OK  plan: {plan}")
+        print(f"    size budget: {SIZE_BUDGET_MB:.0f} MB")
+        return 0
+
+    print(f"Building embedded runtime: {plan}")
+    with tempfile.TemporaryDirectory(prefix="naturo-embed-") as tmp:
+        size_mb = build_runtime(
+            args.dest,
+            args.python_version,
+            args.naturo_version,
+            from_local=args.from_local,
+            workdir=Path(tmp),
+        )
+
+    print(f"\nRuntime assembled at {args.dest}")
+    print(f"Total size: {size_mb:.1f} MB (budget {SIZE_BUDGET_MB:.0f} MB)")
+    if size_mb > SIZE_BUDGET_MB:
+        print(
+            f"WARNING: runtime size {size_mb:.1f} MB exceeds the {SIZE_BUDGET_MB:.0f} MB budget.",
+            file=sys.stderr,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_runtime_resolver.py
+++ b/tests/test_runtime_resolver.py
@@ -1,0 +1,125 @@
+"""Hermetic tests for :mod:`naturo.runtime.resolver`.
+
+No network, no real embedded runtime, no desktop session: a fake ``python.exe``
+is materialised under ``tmp_path`` and the interpreter/PATH probes are stubbed
+with monkeypatch so the acceptance rule (prefer system, fall back to embedded)
+is exercised deterministically on any platform.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from naturo.runtime import resolver
+from naturo.runtime.resolver import (
+    find_embedded_python,
+    find_system_python,
+    resolve_python,
+)
+
+
+def _make_embedded(base: Path, subpath: str = "_runtime/python/python.exe") -> Path:
+    """Create a fake embedded ``python.exe`` under ``base`` and return its path."""
+    exe = base / subpath
+    exe.parent.mkdir(parents=True, exist_ok=True)
+    exe.write_text("fake interpreter", encoding="utf-8")
+    return exe
+
+
+# --------------------------------------------------------------------------- #
+# find_embedded_python — path construction
+# --------------------------------------------------------------------------- #
+
+def test_find_embedded_returns_none_when_absent(tmp_path: Path) -> None:
+    assert find_embedded_python(tmp_path) is None
+
+
+def test_find_embedded_locates_nested_runtime_layout(tmp_path: Path) -> None:
+    exe = _make_embedded(tmp_path, "_runtime/python/python.exe")
+    assert find_embedded_python(tmp_path) == str(exe)
+
+
+def test_find_embedded_locates_dist_runtime_layout(tmp_path: Path) -> None:
+    exe = _make_embedded(tmp_path, "dist/runtime/python/python.exe")
+    assert find_embedded_python(tmp_path) == str(exe)
+
+
+def test_find_embedded_locates_flat_layout(tmp_path: Path) -> None:
+    exe = _make_embedded(tmp_path, "python.exe")
+    assert find_embedded_python(tmp_path) == str(exe)
+
+
+# --------------------------------------------------------------------------- #
+# find_system_python — injected which/probe
+# --------------------------------------------------------------------------- #
+
+def test_find_system_python_selects_first_suitable() -> None:
+    def which(name: str) -> str | None:
+        return {"python": "/usr/bin/python"}.get(name)
+
+    def probe(path: str) -> tuple[int, int] | None:
+        return (3, 12)
+
+    assert find_system_python(which=which, probe=probe) == "/usr/bin/python"
+
+
+def test_find_system_python_rejects_too_old() -> None:
+    def which(name: str) -> str | None:
+        return f"/usr/bin/{name}"
+
+    def probe(path: str) -> tuple[int, int] | None:
+        return (3, 8)  # below MIN_PYTHON
+
+    assert find_system_python(which=which, probe=probe) is None
+
+
+def test_find_system_python_skips_missing_and_unprobeable() -> None:
+    def which(name: str) -> str | None:
+        # "python" is not on PATH; only "python3" resolves.
+        return "/usr/bin/python3" if name == "python3" else None
+
+    def probe(path: str) -> tuple[int, int] | None:
+        return (3, 11)
+
+    assert find_system_python(which=which, probe=probe) == "/usr/bin/python3"
+
+
+def test_find_system_python_none_when_nothing_on_path() -> None:
+    assert find_system_python(which=lambda name: None, probe=lambda path: (3, 12)) is None
+
+
+# --------------------------------------------------------------------------- #
+# resolve_python — the acceptance rule
+# --------------------------------------------------------------------------- #
+
+def test_prefers_system_when_present(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _make_embedded(tmp_path)  # embedded also available...
+    monkeypatch.setattr(resolver, "find_system_python", lambda: "/usr/bin/python")
+    # ...but system wins by default.
+    assert resolve_python(base=tmp_path) == "/usr/bin/python"
+
+
+def test_embedded_fallback_when_no_system(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    exe = _make_embedded(tmp_path)
+    monkeypatch.setattr(resolver, "find_system_python", lambda: None)
+    assert resolve_python(base=tmp_path) == str(exe)
+
+
+def test_error_when_neither_available(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(resolver, "find_system_python", lambda: None)
+    with pytest.raises(RuntimeError, match="No suitable Python runtime"):
+        resolve_python(base=tmp_path)
+
+
+def test_prefer_system_false_inverts_to_embedded(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    exe = _make_embedded(tmp_path)
+    monkeypatch.setattr(resolver, "find_system_python", lambda: "/usr/bin/python")
+    # System is present, but prefer_system=False makes the embedded runtime win.
+    assert resolve_python(prefer_system=False, base=tmp_path) == str(exe)
+
+
+def test_prefer_system_false_falls_back_to_system(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # No embedded runtime staged; embedded-first still falls back to system.
+    monkeypatch.setattr(resolver, "find_system_python", lambda: "/usr/bin/python")
+    assert resolve_python(prefer_system=False, base=tmp_path) == "/usr/bin/python"


### PR DESCRIPTION
Implements the core of #41 (embedded Python 3.12 runtime), the prerequisite for the self-contained `.mcpb` (#997) and standalone `naturo.exe` (#43).

## What's here (committable + tested)
- **`scripts/bundle_python.py`** — repeatable bundler: downloads the official `python-3.12.7-embed-amd64.zip`, enables `site` via the `python312._pth` rewrite (the embed gotcha), bootstraps pip with `get-pip.py`, and installs the **published** `naturo` wheel (default — no native C++ rebuild; `--from-local` installs the checkout instead). `--check` dry-run, `--python-version`/`--dest` flags, honors `HTTP_PROXY`/`HTTPS_PROXY`, warns if the runtime exceeds the 50MB budget.
- **`naturo/runtime/resolver.py`** — the acceptance rule: **system Python preferred, embedded fallback**, clear error when neither; filesystem-injectable (no import side effects).
- **`tests/test_runtime_resolver.py`** — 13 hermetic tests (system-preferred / embedded-fallback / error-when-neither / path construction / `prefer_system=False` inversion).
- **`docs/EMBEDDED_RUNTIME.md`** — architecture, the `._pth` gotcha, size budget, resolution rule, and the CI bundling step as a fenced YAML snippet (ships as a `.github` patch — workflow scope).
- **`.gitignore`** — `dist/runtime/` + `get-pip.py` (the ~40MB runtime is a build artifact, never committed).

## Live-verified on this Windows host
Ran the bundler for real: assembled **CPython 3.12.7 → `dist/runtime/python` (38.9 MB, under the 50MB budget)**, then `dist/runtime/python/python.exe -m naturo --version` → **`naturo, version 0.3.2`** on an interpreter with its own base_prefix (not system Python). `git status` confirmed clean of artifacts. ruff + mypy + pytest all green.

## Deferred (honest)
- **CI wiring** — the bundle-Python build step is a YAML snippet in the docs; it needs a `.github/workflows/build.yml` edit (workflow-scope push, maintainer).
- **Package-layout staging** — copying the runtime into the shipped `<pkg>/_runtime/` at package time (resolver already probes that path) is downstream packaging (#43-class).
- **`naturo[windows]` extras** — the lean default bundles `naturo + click`; pulling pywin32/comtypes for the full native UIA/COM surface is a one-line install-spec extension, documented.

Host note for CI: on this box only `all_proxy=socks5://…7897` was set, which stdlib urllib can't use — the bundler needs an `http://` proxy (`HTTPS_PROXY=http://127.0.0.1:7897`). Documented.

Refs #41, #997

🤖 Generated with [Claude Code](https://claude.com/claude-code)