### PR TITLE
feat(cli): 'naturo run' — execute user scripts with the resolved Python (#42)

### DIFF
--- a/examples/scripts/hello_windows.py
+++ b/examples/scripts/hello_windows.py
@@ -1,0 +1,23 @@
+"""Minimal `naturo run` example — count open windows via the naturo SDK.
+
+Run it with::
+
+    naturo run examples/scripts/hello_windows.py
+
+The script imports the #924 in-process SDK and calls ``windows()``, which only
+*enumerates* the open top-level windows — it drives no input, so it is safe to
+run on a live desktop.
+"""
+from __future__ import annotations
+
+from naturo import windows
+
+
+def main() -> None:
+    """Print how many top-level windows are currently open."""
+    open_windows = windows()
+    print("OK", len(open_windows))
+
+
+if __name__ == "__main__":
+    main()

--- a/naturo/cli/__init__.py
+++ b/naturo/cli/__init__.py
@@ -51,6 +51,7 @@ from naturo.cli.visual_cmd import visual
 from naturo.cli.recording_cmd import record
 from naturo.cli.config_cmd import config_cmd as _config_cmd_group
 from naturo.cli.doctor_cmd import doctor, info
+from naturo.cli.run_cmd import run_cmd
 
 
 # Accept ``-h`` as the POSIX synonym for ``--help`` (#899). Declaring it on the
@@ -129,7 +130,6 @@ def _patch_all_commands(group: click.Command) -> None:
 _COMMAND_INTENT_ALIASES = {
     "launch": "app launch",
     "open": "app launch",
-    "run": "app launch",
     "start": "app launch",
     "screenshot": "capture",
 }
@@ -220,6 +220,9 @@ main.add_command(excel)
 
 # ── Browser Automation ─────────────────────────
 main.add_command(browser)
+
+# ── Scripting ──────────────────────────────────
+main.add_command(run_cmd)  # `naturo run script.py` / `naturo run -c` (#42)
 
 # ── Diagnostics ────────────────────────────────
 main.add_command(doctor)

--- a/naturo/cli/run_cmd.py
+++ b/naturo/cli/run_cmd.py
@@ -1,0 +1,99 @@
+"""``naturo run`` — execute a user Python script with the bundled runtime (#42).
+
+Runs ``naturo run script.py`` or ``naturo run -c "code"`` under the interpreter
+chosen by the #41 resolver (system Python preferred, embedded runtime as
+fallback), with the #924 naturo SDK importable inside the script — so a user
+script can simply ``from naturo import click, see, type`` and automate.
+
+The heavy lifting (subprocess, timeout-kill, error classification, exit-code
+propagation) lives in :mod:`naturo.scripting`; this module is the thin Click
+wrapper that parses options and renders the result.
+"""
+from __future__ import annotations
+
+import shlex
+from typing import Optional
+
+import click
+
+from naturo.cli._jsonio import json_dumps
+from naturo.cli.error_helpers import emit_usage_error
+from naturo.scripting import RunResult, run_script
+
+
+def _emit(result: RunResult, json_output: bool) -> None:
+    """Render a :class:`RunResult` to stdout/stderr (text or JSON).
+
+    Text mode forwards the script's own stdout/stderr verbatim (so a traceback
+    is still visible) and, on a classified fault, appends a concise
+    ``naturo run: <message>`` summary line to stderr. JSON mode emits a single
+    envelope carrying the exit code, captured streams, and any fault.
+    """
+    if json_output:
+        payload: dict[str, object] = {
+            "success": result.error_kind is None and result.exit_code == 0,
+            "exit_code": result.exit_code,
+            "stdout": result.stdout,
+            "stderr": result.stderr,
+        }
+        if result.error_kind:
+            payload["error"] = {"kind": result.error_kind, "message": result.message}
+        click.echo(json_dumps(payload))
+        return
+
+    if result.stdout:
+        click.echo(result.stdout, nl=False)
+    if result.stderr:
+        click.echo(result.stderr, nl=False, err=True)
+    if result.error_kind and result.message:
+        click.secho(f"naturo run: {result.message}", fg="red", err=True)
+
+
+@click.command("run")
+@click.argument("script", required=False)
+@click.option("-c", "--code", "code", default=None, help="Execute an inline code string instead of a file.")
+@click.option(
+    "--args",
+    "args_str",
+    default=None,
+    help="Arguments passed to the script as sys.argv[1:] (shell-quoted, e.g. --args \"a b c\").",
+)
+@click.option("--timeout", type=float, default=None, help="Kill the script after N seconds.")
+@click.option("--json", "-j", "json_output", is_flag=True, help="JSON output")
+@click.pass_context
+def run_cmd(
+    ctx: click.Context,
+    script: Optional[str],
+    code: Optional[str],
+    args_str: Optional[str],
+    timeout: Optional[float],
+    json_output: bool,
+) -> None:
+    """Execute a Python script (or -c code) with the naturo SDK importable.
+
+    The script runs in a subprocess under the resolver's interpreter (system
+    Python preferred, embedded runtime fallback). ``import naturo`` works inside
+    it, so a script can drive the desktop with the #924 SDK. The script's own
+    exit code is propagated; --timeout kills a runaway run.
+
+    \b
+    Examples:
+      naturo run automate.py
+      naturo run automate.py --args "input.csv --verbose"
+      naturo run -c "from naturo import windows; print(len(windows()))"
+      naturo run long_task.py --timeout 30
+    """
+    json_output = json_output or (ctx.obj or {}).get("json", False)
+
+    if script and code:
+        emit_usage_error("Pass either a SCRIPT path or -c/--code, not both.", json_output)
+    if not script and not code:
+        emit_usage_error("Provide a SCRIPT path or -c/--code to run.", json_output)
+    if timeout is not None and timeout <= 0:
+        emit_usage_error("--timeout must be a positive number of seconds.", json_output)
+
+    forwarded = shlex.split(args_str) if args_str else []
+
+    result = run_script(script=script, code=code, args=forwarded, timeout=timeout)
+    _emit(result, json_output)
+    ctx.exit(result.exit_code)

--- a/naturo/scripting/__init__.py
+++ b/naturo/scripting/__init__.py
@@ -1,0 +1,32 @@
+"""naturo scripting engine — run user Python scripts under the bundled runtime.
+
+Public surface for ``naturo run`` (#42): :func:`run_script` executes a ``.py``
+file or an inline ``-c`` code string in a subprocess driven by the resolver's
+interpreter (system preferred, embedded fallback — #41), with the #924 naturo
+SDK importable inside the script.
+"""
+from __future__ import annotations
+
+from naturo.scripting.runner import (
+    ERR_FILE_NOT_FOUND,
+    ERR_IMPORT,
+    ERR_RUNTIME,
+    ERR_SYNTAX,
+    ERR_TIMEOUT,
+    EXIT_FILE_NOT_FOUND,
+    EXIT_TIMEOUT,
+    RunResult,
+    run_script,
+)
+
+__all__ = [
+    "run_script",
+    "RunResult",
+    "ERR_FILE_NOT_FOUND",
+    "ERR_SYNTAX",
+    "ERR_IMPORT",
+    "ERR_RUNTIME",
+    "ERR_TIMEOUT",
+    "EXIT_FILE_NOT_FOUND",
+    "EXIT_TIMEOUT",
+]

--- a/naturo/scripting/runner.py
+++ b/naturo/scripting/runner.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional, Sequence
@@ -213,7 +214,13 @@ def run_script(
             )
         cmd = [interpreter, str(script_path), *forwarded]
 
-    creationflags = subprocess.CREATE_NEW_PROCESS_GROUP if os.name == "nt" else 0
+    # An `if` STATEMENT on sys.platform (not a ternary, not os.name) so mypy prunes
+    # the Windows-only branch under --platform linux — CREATE_NEW_PROCESS_GROUP is a
+    # Windows-only subprocess attribute and CI lints on Linux. Runtime is identical.
+    if sys.platform == "win32":
+        creationflags = subprocess.CREATE_NEW_PROCESS_GROUP
+    else:
+        creationflags = 0
     proc = subprocess.Popen(
         cmd,
         stdout=subprocess.PIPE,

--- a/naturo/scripting/runner.py
+++ b/naturo/scripting/runner.py
@@ -1,0 +1,245 @@
+"""Execute user Python scripts under the resolver-chosen interpreter (#42).
+
+The runner drives a **subprocess** rather than an in-process ``exec``. A
+subprocess buys three properties the in-process route cannot give cleanly:
+
+* **timeout-kill** — a runaway ``while True`` or ``time.sleep(3600)`` can be
+  terminated (whole process tree) without leaving the naturo CLI wedged;
+* **isolation** — the user's ``sys.exit``/``os._exit``, global state, signal
+  handlers, and C-level crashes never touch the naturo process;
+* **faithful exit codes** — the child's exit status *is* the script's exit
+  status, so ``sys.exit(3)`` propagates verbatim.
+
+The interpreter is chosen by :func:`naturo.runtime.resolver.resolve_python`
+(system Python preferred, embedded bundle as fallback — issue #41). The naturo
+package directory is injected onto ``PYTHONPATH`` so ``import naturo`` (the #924
+SDK) works in the child regardless of which interpreter was picked, and UTF-8 is
+forced so CJK output cannot crash on a GBK console.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional, Sequence
+
+from naturo.runtime.resolver import resolve_python
+
+# ── Error taxonomy ────────────────────────────────────────────────────────────
+# Distinct kinds so the CLI (and JSON consumers) can render a specific message
+# and so the acceptance criterion "distinct errors" is testable.
+ERR_FILE_NOT_FOUND = "file_not_found"
+ERR_SYNTAX = "syntax"
+ERR_IMPORT = "import"
+ERR_RUNTIME = "runtime"
+ERR_TIMEOUT = "timeout"
+
+# Exit codes for faults naturo itself detects. When the script actually *runs*,
+# its own exit code is propagated verbatim instead of any of these.
+EXIT_FILE_NOT_FOUND = 2
+EXIT_TIMEOUT = 124  # mirrors GNU coreutils `timeout` for scripted dispatchers
+
+_SYNTAX_EXCEPTIONS = frozenset({"SyntaxError", "IndentationError", "TabError"})
+_IMPORT_EXCEPTIONS = frozenset({"ImportError", "ModuleNotFoundError"})
+_TRACEBACK_HEADER = "Traceback (most recent call last):"
+
+
+@dataclass
+class RunResult:
+    """Outcome of a single ``naturo run`` invocation.
+
+    Attributes:
+        exit_code: The process exit code naturo should propagate. Equals the
+            script's own exit code on a normal run; a naturo-detected fault
+            (missing file, timeout) uses the dedicated codes above.
+        stdout: Captured standard output of the script.
+        stderr: Captured standard error of the script (includes any traceback).
+        error_kind: One of the ``ERR_*`` constants when naturo classified a
+            fault, else ``None`` (including an intentional non-zero ``sys.exit``).
+        message: Human-readable naturo-style summary of ``error_kind``, or None.
+        timed_out: True when the script was killed for exceeding ``--timeout``.
+    """
+
+    exit_code: int
+    stdout: str = ""
+    stderr: str = ""
+    error_kind: Optional[str] = None
+    message: Optional[str] = None
+    timed_out: bool = False
+
+
+def _naturo_package_root() -> Path:
+    """Return the directory that must be on ``PYTHONPATH`` to ``import naturo``.
+
+    That is the parent of the installed ``naturo`` package, so the child
+    interpreter resolves the *same* checkout the CLI is running from.
+    """
+    import naturo
+
+    return Path(naturo.__file__).resolve().parent.parent
+
+
+def _build_env() -> dict[str, str]:
+    """Build the child environment: inherit ours, ensure naturo is importable.
+
+    Prepends the naturo package root to ``PYTHONPATH`` (so the #924 SDK imports
+    even under the embedded runtime, which has no naturo installed) and forces
+    UTF-8 so CJK output over the UTF-8 pipes never raises on a GBK host.
+    """
+    env = dict(os.environ)
+    root = str(_naturo_package_root())
+    existing = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = os.pathsep.join([root, existing]) if existing else root
+    env["PYTHONUTF8"] = "1"
+    env["PYTHONIOENCODING"] = "utf-8"
+    return env
+
+
+def _last_nonempty_line(text: str) -> str:
+    """Return the last non-blank line of ``text`` (stripped), or ``""``."""
+    for line in reversed(text.splitlines()):
+        if line.strip():
+            return line.strip()
+    return ""
+
+
+def _last_exception_name(stderr: str) -> Optional[str]:
+    """Best-effort exception class name from a traceback's final line.
+
+    A Python traceback ends with ``"<ExcName>: <message>"`` (or just
+    ``"<ExcName>"``). We take the token before the first colon and, if it reads
+    as a bare identifier, treat it as the exception name.
+    """
+    final = _last_nonempty_line(stderr)
+    if not final:
+        return None
+    head = final.split(":", 1)[0].strip()
+    candidate = head.split(".")[-1]
+    return candidate if candidate.isidentifier() else None
+
+
+def _classify(
+    returncode: int, stderr: str, timed_out: bool, timeout: Optional[float]
+) -> tuple[Optional[str], Optional[str]]:
+    """Map a finished child into ``(error_kind, message)``.
+
+    A zero exit — or a non-zero exit with no traceback (an intentional
+    ``sys.exit(code)``) — is *not* an error to reclassify: it returns
+    ``(None, None)`` and the caller propagates the code as-is.
+    """
+    if timed_out:
+        secs = "" if timeout is None else f" after {timeout:g}s"
+        return ERR_TIMEOUT, f"Script timed out{secs} and was terminated."
+    if returncode == 0:
+        return None, None
+
+    exc = _last_exception_name(stderr)
+    has_traceback = _TRACEBACK_HEADER in stderr
+
+    # SyntaxError/IndentationError are reported at compile time *without* a
+    # "Traceback" header, so they are matched on the exception name alone.
+    if exc in _SYNTAX_EXCEPTIONS:
+        return ERR_SYNTAX, "The script could not be compiled — it has a syntax error."
+    if has_traceback and exc in _IMPORT_EXCEPTIONS:
+        return ERR_IMPORT, f"The script failed to import a module: {_last_nonempty_line(stderr)}"
+    if has_traceback:
+        return ERR_RUNTIME, f"The script raised an unhandled exception: {_last_nonempty_line(stderr)}"
+
+    # Non-zero exit, no traceback: a deliberate sys.exit(code). Propagate it.
+    return None, None
+
+
+def _terminate(proc: "subprocess.Popen[str]") -> None:
+    """Kill the child *and its descendants*.
+
+    On Windows a script may have spawned children; ``taskkill /T`` tears down
+    the whole tree, where ``proc.kill()`` would only reap the direct child.
+    """
+    if os.name == "nt":
+        subprocess.run(
+            ["taskkill", "/F", "/T", "/PID", str(proc.pid)],
+            capture_output=True,
+            check=False,
+        )
+    else:  # pragma: no cover - runner targets the Windows host
+        proc.kill()
+
+
+def run_script(
+    *,
+    script: Optional[str] = None,
+    code: Optional[str] = None,
+    args: Optional[Sequence[str]] = None,
+    timeout: Optional[float] = None,
+    python: Optional[str] = None,
+) -> RunResult:
+    """Run a user script (``script``) or inline ``code`` in a subprocess.
+
+    Exactly one of ``script`` / ``code`` must be given. Extra ``args`` are
+    forwarded as the child's ``sys.argv[1:]`` (``sys.argv[0]`` is the script
+    path, or ``"-c"`` for inline code — Python's own convention). ``timeout``,
+    when set, kills the child (and tree) after that many seconds.
+
+    Args:
+        script: Path to a ``.py`` file to execute.
+        code: Inline Python source to execute (``python -c``).
+        args: Arguments exposed to the script as ``sys.argv[1:]``.
+        timeout: Wall-clock seconds before the child is killed, or None.
+        python: Explicit interpreter path; defaults to :func:`resolve_python`.
+
+    Returns:
+        A :class:`RunResult` with the propagated exit code, captured streams,
+        and any classified fault.
+
+    Raises:
+        ValueError: If not exactly one of ``script``/``code`` is provided.
+    """
+    if (script is None) == (code is None):
+        raise ValueError("Provide exactly one of `script` or `code`.")
+
+    interpreter = python or resolve_python(prefer_system=True)
+    forwarded = [str(a) for a in (args or [])]
+
+    if code is not None:
+        cmd = [interpreter, "-c", code, *forwarded]
+    else:
+        script_path = Path(str(script))
+        if not script_path.is_file():
+            return RunResult(
+                exit_code=EXIT_FILE_NOT_FOUND,
+                error_kind=ERR_FILE_NOT_FOUND,
+                message=f"Script not found: {script}",
+            )
+        cmd = [interpreter, str(script_path), *forwarded]
+
+    creationflags = subprocess.CREATE_NEW_PROCESS_GROUP if os.name == "nt" else 0
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=_build_env(),
+        encoding="utf-8",
+        errors="replace",
+        creationflags=creationflags,
+    )
+
+    timed_out = False
+    try:
+        out, err = proc.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        timed_out = True
+        _terminate(proc)
+        out, err = proc.communicate()
+
+    returncode = proc.returncode if proc.returncode is not None else 1
+    kind, message = _classify(returncode, err or "", timed_out, timeout)
+    exit_code = EXIT_TIMEOUT if timed_out else returncode
+    return RunResult(
+        exit_code=exit_code,
+        stdout=out or "",
+        stderr=err or "",
+        error_kind=kind,
+        message=message,
+        timed_out=timed_out,
+    )

--- a/tests/test_fuzzy_group.py
+++ b/tests/test_fuzzy_group.py
@@ -165,7 +165,6 @@ class TestRealCliIntentAliases:
         [
             ("launch", "app launch"),
             ("open", "app launch"),
-            ("run", "app launch"),
             ("start", "app launch"),
             ("screenshot", "capture"),
         ],

--- a/tests/test_json_envelope_sweep_1142.py
+++ b/tests/test_json_envelope_sweep_1142.py
@@ -95,6 +95,13 @@ _COMPUTE_READS: tuple[tuple[str, ...], ...] = (
     ("browser", "profiles"),
 )
 
+# Script runner (#42): driven with a trivial inline program so the ``-j`` success
+# envelope is asserted hermetically — it spawns a subprocess interpreter (the
+# resolver's system Python), needs no desktop or native DLL. Maps path -> args.
+_SCRIPT_DRIVEN: dict[tuple[str, ...], list[str]] = {
+    ("run",): ["-c", "pass"],
+}
+
 # Browser commands are driven against a mocked CDP page (no Chrome needed), exactly
 # as ``tests/test_browser_cmd.py`` does. Maps path -> extra positional args.
 _BROWSER_DRIVEN: dict[tuple[str, ...], list[str]] = {
@@ -184,9 +191,19 @@ def _drive_browser(path: tuple[str, ...]) -> dict:
     return json.loads(result.output)
 
 
+def _drive_script(path: tuple[str, ...]) -> dict:
+    args = [*path, *_SCRIPT_DRIVEN[path], "-j"]
+    result = CliRunner().invoke(main, args)
+    assert result.exit_code == 0, result.output
+    return json.loads(result.output)
+
+
 # The full set of runtime-driven commands (used by the classification check).
 _DRIVEN: frozenset[tuple[str, ...]] = frozenset(
-    set(_STORE_ROOTS) | set(_COMPUTE_READS) | set(_BROWSER_DRIVEN)
+    set(_STORE_ROOTS)
+    | set(_COMPUTE_READS)
+    | set(_BROWSER_DRIVEN)
+    | set(_SCRIPT_DRIVEN)
 )
 
 
@@ -418,5 +435,15 @@ def test_compute_read_success_envelope(path: tuple[str, ...]) -> None:
 def test_browser_success_envelope(path: tuple[str, ...]) -> None:
     """Browser commands emit the envelope when driven against a mocked page."""
     payload = _drive_browser(path)
+    _assert_envelope(path, payload)
+    assert payload["success"] is True
+
+
+@pytest.mark.parametrize(
+    "path", sorted(_SCRIPT_DRIVEN), ids=lambda p: " ".join(p),
+)
+def test_script_runner_success_envelope(path: tuple[str, ...]) -> None:
+    """`naturo run -c "pass" -j` emits a top-level ``success: true`` envelope."""
+    payload = _drive_script(path)
     _assert_envelope(path, payload)
     assert payload["success"] is True

--- a/tests/test_scripting.py
+++ b/tests/test_scripting.py
@@ -1,0 +1,163 @@
+"""Hermetic tests for ``naturo run`` (#42).
+
+Every test writes a tiny script (or uses ``-c``) that does **not** drive the
+desktop — it prints, reads ``sys.argv``, or at most *imports* the naturo SDK
+without ever calling an input verb. The scripts run under the resolver's system
+Python (fast, deterministic); the embedded runtime is not required.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from naturo.cli.run_cmd import run_cmd
+from naturo.scripting import (
+    ERR_FILE_NOT_FOUND,
+    ERR_IMPORT,
+    ERR_RUNTIME,
+    ERR_SYNTAX,
+    ERR_TIMEOUT,
+    EXIT_TIMEOUT,
+    run_script,
+)
+
+
+def _write(tmp_path: Path, name: str, body: str) -> Path:
+    """Write ``body`` to ``tmp_path/name`` and return the path."""
+    script = tmp_path / name
+    script.write_text(body, encoding="utf-8")
+    return script
+
+
+# ── 1. run a file ────────────────────────────────────────────────────────────
+def test_run_file_prints_marker(tmp_path: Path) -> None:
+    script = _write(tmp_path, "hello.py", "print('MARKER_OK')\n")
+    runner = CliRunner()
+    result = runner.invoke(run_cmd, [str(script)])
+    assert result.exit_code == 0, result.output
+    assert "MARKER_OK" in result.output
+
+
+# ── 2. inline -c ─────────────────────────────────────────────────────────────
+def test_run_dash_c_prints_marker() -> None:
+    runner = CliRunner()
+    result = runner.invoke(run_cmd, ["-c", "print('INLINE_OK')"])
+    assert result.exit_code == 0, result.output
+    assert "INLINE_OK" in result.output
+
+
+# ── 3. the naturo SDK is importable inside a run script (import-only!) ────────
+def test_naturo_api_importable(tmp_path: Path) -> None:
+    # Import the input verbs but NEVER call them — calling would SendInput to the
+    # live desktop. We only assert the names import cleanly under the child.
+    script = _write(
+        tmp_path,
+        "imp.py",
+        "from naturo import click, see, type\nprint('IMPORT_OK')\n",
+    )
+    runner = CliRunner()
+    result = runner.invoke(run_cmd, [str(script)])
+    assert result.exit_code == 0, result.output
+    assert "IMPORT_OK" in result.output
+    assert "ImportError" not in result.output
+    assert "ModuleNotFoundError" not in result.output
+
+
+# ── 4. --args become sys.argv[1:] ────────────────────────────────────────────
+def test_args_forwarded_as_argv(tmp_path: Path) -> None:
+    script = _write(tmp_path, "argv.py", "import sys\nprint(sys.argv[1:])\n")
+    runner = CliRunner()
+    result = runner.invoke(run_cmd, [str(script), "--args", "x y"])
+    assert result.exit_code == 0, result.output
+    assert "['x', 'y']" in result.output
+
+
+def test_argv0_is_script_path(tmp_path: Path) -> None:
+    script = _write(tmp_path, "argv0.py", "import sys, os\nprint(os.path.basename(sys.argv[0]))\n")
+    result = run_script(script=str(script))
+    assert result.exit_code == 0
+    assert "argv0.py" in result.stdout
+
+
+# ── 5. --timeout kills a long run ────────────────────────────────────────────
+def test_timeout_kills_long_script(tmp_path: Path) -> None:
+    script = _write(tmp_path, "slow.py", "import time\ntime.sleep(30)\nprint('SHOULD_NOT_PRINT')\n")
+    runner = CliRunner()
+    result = runner.invoke(run_cmd, [str(script), "--timeout", "2"])
+    assert result.exit_code == EXIT_TIMEOUT
+    assert result.exit_code != 0
+    assert "timed out" in result.output.lower()
+    assert "SHOULD_NOT_PRINT" not in result.output
+
+
+# ── 6. distinct errors ───────────────────────────────────────────────────────
+def test_file_not_found(tmp_path: Path) -> None:
+    missing = tmp_path / "does_not_exist.py"
+    result = run_script(script=str(missing))
+    assert result.exit_code != 0
+    assert result.error_kind == ERR_FILE_NOT_FOUND
+    assert "not found" in (result.message or "").lower()
+
+
+def test_syntax_error() -> None:
+    result = run_script(code="def (")
+    assert result.exit_code != 0
+    assert result.error_kind == ERR_SYNTAX
+
+
+def test_import_error(tmp_path: Path) -> None:
+    script = _write(tmp_path, "bad_import.py", "import nonexistent_xyz\n")
+    result = run_script(script=str(script))
+    assert result.exit_code != 0
+    assert result.error_kind == ERR_IMPORT
+
+
+def test_runtime_error(tmp_path: Path) -> None:
+    script = _write(tmp_path, "boom.py", "raise ValueError('boom')\n")
+    result = run_script(script=str(script))
+    assert result.exit_code != 0
+    assert result.error_kind == ERR_RUNTIME
+    assert "ValueError" in result.stderr
+
+
+def test_error_kinds_are_distinct(tmp_path: Path) -> None:
+    kinds = {
+        run_script(script=str(tmp_path / "nope.py")).error_kind,
+        run_script(code="def (").error_kind,
+        run_script(script=str(_write(tmp_path, "i.py", "import nonexistent_xyz\n"))).error_kind,
+        run_script(script=str(_write(tmp_path, "r.py", "raise RuntimeError('x')\n"))).error_kind,
+    }
+    assert kinds == {ERR_FILE_NOT_FOUND, ERR_SYNTAX, ERR_IMPORT, ERR_RUNTIME}
+
+
+# ── 7. exit-code propagation ─────────────────────────────────────────────────
+def test_exit_code_propagated(tmp_path: Path) -> None:
+    script = _write(tmp_path, "exit7.py", "import sys\nsys.exit(7)\n")
+    runner = CliRunner()
+    result = runner.invoke(run_cmd, [str(script)])
+    assert result.exit_code == 7
+
+
+def test_intentional_exit_is_not_classified_as_error(tmp_path: Path) -> None:
+    # A deliberate non-zero sys.exit is propagated, not reported as a fault.
+    script = _write(tmp_path, "exit3.py", "import sys\nsys.exit(3)\n")
+    result = run_script(script=str(script))
+    assert result.exit_code == 3
+    assert result.error_kind is None
+
+
+# ── usage errors ─────────────────────────────────────────────────────────────
+def test_requires_script_or_code() -> None:
+    result = CliRunner().invoke(run_cmd, [])
+    assert result.exit_code == 2
+
+
+def test_script_and_code_mutually_exclusive(tmp_path: Path) -> None:
+    script = _write(tmp_path, "x.py", "print('x')\n")
+    result = CliRunner().invoke(run_cmd, [str(script), "-c", "print('y')"])
+    assert result.exit_code == 2
+
+
+def test_timeout_error_kind_symbol() -> None:
+    assert ERR_TIMEOUT == "timeout"

--- a/tests/test_surface_guard_coverage_912.py
+++ b/tests/test_surface_guard_coverage_912.py
@@ -214,6 +214,10 @@ _CLI_SESSION_INDEPENDENT = frozenset(
         "help", "list permissions",
         # MCP / daemon management.
         "mcp install", "mcp start", "mcp tools",
+        # Script runner (#42): spawns a subprocess interpreter to run a user
+        # script; the command itself never acquires the desktop backend — any
+        # UI use is the child script's concern, not `naturo run`'s.
+        "run",
         # On-disk recording store management + replay setup.
         "record delete", "record export", "record list", "record play",
         "record show", "record start", "record stop",


### PR DESCRIPTION
Closes #42. Adds `naturo run script.py` / `naturo run -c "code"`, stacking on #41's resolver + #924's SDK.

## All seven acceptance criteria met (16 hermetic tests)
- `naturo run script.py` and `naturo run -c "code"` execute Python via the #41 resolver's interpreter (system preferred, embedded fallback).
- `from naturo import click, see, type` imports in-script (the #924 SDK) — the naturo package root is prepended to the child's PYTHONPATH so it resolves even under the embedded runtime.
- `--args "a b c"` → `sys.argv[1:]` (parsed with `shlex.split`; `argv[0]` = script path or `-c`).
- `--timeout N` kills the whole process tree (`taskkill /F /T`) and exits **124** (GNU-timeout convention).
- Distinct errors + exit codes: file-not-found → **2**; syntax / import / runtime classified from the child's stderr; a script's own `sys.exit(n)` is propagated **verbatim** (not reclassified).
- Subprocess execution (not in-process) for clean timeout-kill, isolation, and faithful exit-code propagation. UTF-8 pipes (`PYTHONUTF8=1`, `errors='replace'`) — GBK-host-safe.

## Layout
- `naturo/scripting/{__init__,runner}.py` — execution engine.
- `naturo/cli/run_cmd.py` wired as top-level `naturo run` in `naturo/cli/__init__.py` (mirrors the `doctor` flat-command pattern). Removed the stale `FuzzyGroup` alias `run→app launch` (now a real command — a fuzzy alias, not a documented command, so no compat break).
- `examples/scripts/hello_windows.py`.

## Verified
ruff + mypy clean; **16/16** hermetic tests (every criterion); `naturo run --help` + top-level `naturo --help` show the command; live `naturo run -c "from naturo import click, see, type, windows … ; print('API_OK')"` → `API_OK`, exit 0.

Note: live `windows()` **enumeration** couldn't be shown in this unbuilt worktree (no compiled `naturo_core.dll` on the checkout's PYTHONPATH) — an environment artifact; pip-installed and embedded-bundle deployments ship the DLL beside the package. The `run` machinery itself is proven by the import-only live run + the full hermetic suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)