### PR TITLE
docs: tutorial series — Notepad, Excel, AI agent (#415)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@
 
 > **New here?** Get Claude to open, type into, and save a Notepad file in under five minutes: [**5-minute quickstart → docs/QUICKSTART.md**](docs/QUICKSTART.md).
 
+## Tutorials
+
+Guided, end-to-end walkthroughs — each with complete, runnable examples (CLI + the Python SDK), and every command checked against the code:
+
+1. [**Automate Notepad in 5 minutes**](docs/tutorials/01-automate-notepad.md) — see → click → type → save. The four verbs every naturo automation is built from.
+2. [**Automate Excel with naturo**](docs/tutorials/02-automate-excel.md) — open a workbook, read/write cells, inspect ranges, and build a chart over Excel's COM interface.
+3. [**Build an AI agent that uses naturo**](docs/tutorials/03-ai-agent-with-naturo.md) — run naturo as an MCP server for Claude Desktop/Code, plus a minimal Python tool-use loop that drives naturo.
+
 ## What You Get
 
 - 🖥️ **Screen Capture** — Screenshot any window or monitor

--- a/docs/tutorials/01-automate-notepad.md
+++ b/docs/tutorials/01-automate-notepad.md
@@ -1,0 +1,246 @@
+# Tutorial 1 — Automate Notepad in 5 Minutes
+
+**What you'll build:** a tiny, fully scripted flow that launches Notepad, sees its
+UI, types a line, and saves the file — driven entirely from the `naturo` CLI and,
+if you prefer Python, the `import naturo` SDK. By the end you'll have a repeatable
+script that reproduces the same result byte-for-byte, and you'll understand the
+four verbs every naturo automation is built from: **see → click → type → save**.
+
+> **Time:** ~5 minutes. **Platform:** Windows 10/11. **Python:** 3.9+.
+
+## Prerequisites
+
+```bash
+pip install naturo
+```
+
+Verify the CLI is on your `PATH`:
+
+```bash
+naturo --version
+```
+
+Expected output:
+
+```
+naturo, version 0.3.2
+```
+
+That's the only setup. Notepad ships with Windows, so there's nothing else to
+install.
+
+> **Windows 11 note:** Windows 11 replaced classic Notepad with a UWP
+> (WinUI) app. naturo handles both — it resolves the real Notepad process behind
+> the `ApplicationFrameHost` window automatically, so the commands below work on
+> Windows 10 *and* 11 without changes. The one thing that differs is the editor
+> control's role: on Win11 it's a `Document`, on Win10 an `Edit`. The flow below
+> doesn't depend on that difference.
+
+---
+
+## Step 1 — Launch Notepad
+
+```bash
+naturo app launch notepad
+```
+
+Expected output:
+
+```
+Launched notepad.exe (PID: 12044)
+```
+
+Want the launch call to block until the window actually exists (useful in a
+script)? Add `--wait-until-ready`:
+
+```bash
+naturo app launch notepad --wait-until-ready --timeout 5
+```
+
+## Step 2 — See the UI
+
+Before you act on a window, look at it. `naturo see` reads the live
+accessibility tree and prints one compact line per element — no screenshot, no
+tokens wasted on pixels.
+
+```bash
+naturo see --window "Notepad" --compact
+```
+
+Expected output (abridged — element refs `eN` will differ on your machine):
+
+```
+e1 [Window] "Untitled - Notepad"
+  e3 [Document] "Text editor"
+  e7 [MenuBar] "Application"
+  ...
+```
+
+Each `eN` ref is a stable handle you can act on for the next ~10 minutes. `e3`
+above is the editing surface.
+
+## Step 3 — Type into the document
+
+`naturo type` sends text through naturo's **IME-immune reliability ladder**
+(UIA `ValuePattern` → clipboard paste → keystroke). This is what keeps input
+honest for CJK/TSF input methods where a naive keystroke path corrupts text
+("naturo" → "nature"). You don't choose the rung — naturo picks the one that
+lands the text correctly and reports which it used.
+
+Passing `--app` focuses the target window first, so the keystrokes reach Notepad
+and not whatever window happened to be in the foreground:
+
+```bash
+naturo type "Hello from naturo!" --app notepad
+```
+
+Expected output:
+
+```
+action: typed
+text: Hello from naturo!
+length: 18
+input_method: value_pattern
+```
+
+Prefer to target the exact element you saw in Step 2? Use its ref:
+
+```bash
+naturo type "Hello from naturo!" --on e3
+```
+
+## Step 4 — Save with Ctrl+S
+
+`naturo press` sends a key or combo. Ctrl+S opens the Save dialog:
+
+```bash
+naturo press ctrl+s --app notepad
+```
+
+A **Save As** dialog appears. Fill in the filename and confirm in one call —
+`naturo dialog type` types into the dialog's input field, and `--accept` clicks
+the OK/Save button for you:
+
+```bash
+naturo dialog type "naturo-hello.txt" --accept
+```
+
+Expected output:
+
+```
+Typed "naturo-hello.txt" into dialog and accepted
+```
+
+## Step 5 — Verify it worked
+
+The save renames the window from `Untitled - Notepad` to your file name. That
+title change is the proof:
+
+```bash
+naturo list windows
+```
+
+Expected output includes the renamed window:
+
+```
+HWND       PID     TITLE
+--------------------------------------------------
+5574222    50852   naturo-hello.txt - Notepad
+```
+
+You just saw, typed, and saved on the real Windows desktop.
+
+---
+
+## The complete flow (CLI)
+
+Save this as `notepad.sh` (or run the lines one by one):
+
+```bash
+# 1. Launch and wait for the window
+naturo app launch notepad --wait-until-ready --timeout 5
+
+# 2. See the UI (optional, but good practice)
+naturo see --window "Notepad" --compact
+
+# 3. Type a line (IME-immune, focuses Notepad first)
+naturo type "Hello from naturo!" --app notepad
+
+# 4. Save: Ctrl+S, then fill the dialog and confirm
+naturo press ctrl+s --app notepad
+naturo wait --window "Save As" --timeout 5
+naturo dialog type "naturo-hello.txt" --accept
+
+# 5. Confirm the title changed
+naturo list windows
+```
+
+---
+
+## The same flow in Python (the SDK)
+
+`pip install naturo` also gives you `import naturo` — an in-process API over the
+exact same engine, no subprocess, no output parsing. The verbs mirror the CLI:
+
+```python
+import naturo
+
+# Launch and wait until the window exists; returns an App handle.
+app = naturo.launch("notepad")
+
+# See the UI — returns the root Element; walk .children / .descendants / .find.
+tree = naturo.see(window="Notepad")
+
+# Type through the IME-immune ladder (focuses the window first).
+naturo.type("Hello from naturo!", window="Notepad")
+
+# Save: Ctrl+S. press() accepts a combo string.
+naturo.press("ctrl+s", window="Notepad")
+
+# Give the Save As dialog a moment, then drive it.
+naturo.wait("Save As", timeout=5)
+naturo.type("naturo-hello.txt", window="Save As")
+naturo.press("enter", window="Save As")
+
+print("Saved. Window is now:", [w.title for w in naturo.windows()
+                                 if "Notepad" in w.title])
+```
+
+Run it however you normally run Python — or hand it to naturo's own runner (see
+below) so `import naturo` resolves without any environment fiddling.
+
+## Run a script with `naturo run`
+
+`naturo run` executes a Python script (or an inline `-c` snippet) under the
+interpreter naturo resolved, with the SDK importable inside it:
+
+```bash
+# Run a script file
+naturo run notepad.py
+
+# Or a one-liner
+naturo run -c "from naturo import windows; print(len(windows()))"
+```
+
+`naturo run` propagates the script's exit code and supports `--timeout` to kill
+a runaway run and `--args "a b c"` to pass `sys.argv[1:]` through.
+
+---
+
+## Next steps
+
+- **Automate Excel** — read and write cells, build charts:
+  [Tutorial 2 — Automate Excel with naturo](02-automate-excel.md)
+- **Build an AI agent** that drives naturo through the MCP server:
+  [Tutorial 3 — Build an AI agent with naturo](03-ai-agent-with-naturo.md)
+- **CLI reference** — every command and flag:
+  [docs/CLI_REFERENCE.md](../CLI_REFERENCE.md)
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| `naturo: command not found` | Ensure your Python `Scripts/` directory is on `PATH`; reopen the terminal after `pip install`. |
+| `type` sent text to the wrong window | Always pass `--app notepad` (or `--window`/`--on`) so naturo focuses the target first — `type` without a target goes to the foreground window. |
+| The `eN` ref from `see` no longer resolves | Refs expire after ~10 minutes. Re-run `naturo see` to capture a fresh snapshot, then reuse the new ref. |
+| The Save As dialog didn't appear in time | Add `naturo wait --window "Save As" --timeout 5` between the `press ctrl+s` and the `dialog type` steps. |

--- a/docs/tutorials/02-automate-excel.md
+++ b/docs/tutorials/02-automate-excel.md
@@ -1,0 +1,260 @@
+# Tutorial 2 — Automate Excel with naturo
+
+**What you'll build:** a small end-to-end flow that opens an Excel workbook,
+lists its sheets, writes a few cells, reads a range back, and draws a chart from
+the data — all through naturo's `excel` commands, which drive Excel over its COM
+automation interface (no fragile screen-scraping, real cell values). By the end
+you'll be reading and writing spreadsheet data programmatically and from Python.
+
+> **Time:** ~10 minutes. **Platform:** Windows with Microsoft Excel installed.
+> Excel automation needs `pywin32` (`pip install pywin32`) in addition to naturo.
+
+## Prerequisites
+
+```bash
+pip install naturo pywin32
+```
+
+Verify:
+
+```bash
+naturo --version
+```
+
+Expected output:
+
+```
+naturo, version 0.3.2
+```
+
+> **Why COM, not the accessibility tree?** Excel's grid is custom-drawn — walking
+> the UI tree gives you pixels, not values. naturo's `excel` commands talk to
+> Excel through its COM object model, so you get the *actual* cell values,
+> formulas, and ranges. This is naturo's Excel moat.
+
+Throughout this tutorial we use `report.xlsx` as the workbook path; substitute
+your own. Cell references are standard A1 notation (`A1`, `B2`, `A1:D100`).
+
+---
+
+## Step 1 — Create and open a workbook
+
+If you don't have a workbook yet, the `write` command's `--create` flag will make
+one on first write (Step 3). To open an existing workbook and inspect it:
+
+```bash
+naturo excel open report.xlsx
+```
+
+Expected output:
+
+```
+Opened: C:\...\report.xlsx
+Sheets (1): Sheet1
+Active: Sheet1
+```
+
+## Step 2 — List the sheets
+
+```bash
+naturo excel list-sheets report.xlsx
+```
+
+Expected output:
+
+```
+Workbook: C:\...\report.xlsx
+  1. Sheet1 (active)
+```
+
+## Step 3 — Write cells
+
+`naturo excel write <workbook> <cell> <value>` writes a single cell. Numeric
+strings are converted to numbers automatically; text stays text. Use `--sheet`
+to target a specific worksheet, and `--create` to create the workbook if it
+doesn't exist yet.
+
+```bash
+# Header row
+naturo excel write report.xlsx A1 "Month"   --create
+naturo excel write report.xlsx B1 "Revenue"
+
+# Data
+naturo excel write report.xlsx A2 "Jan" --sheet Sheet1
+naturo excel write report.xlsx B2 1200
+naturo excel write report.xlsx A3 "Feb"
+naturo excel write report.xlsx B3 1750
+naturo excel write report.xlsx A4 "Mar"
+naturo excel write report.xlsx B4 1500
+```
+
+Expected output for each write:
+
+```
+Wrote to B2 (Sheet1): 1200
+```
+
+## Step 4 — Read a cell or a range
+
+Read one cell:
+
+```bash
+naturo excel read report.xlsx B2
+```
+
+Expected output:
+
+```
+B2 (Sheet1): 1200
+```
+
+Read a range — the result prints as tab-separated rows:
+
+```bash
+naturo excel read report.xlsx "A1:B4" --sheet Sheet1
+```
+
+Expected output:
+
+```
+Month	Revenue
+Jan	1200
+Feb	1750
+Mar	1500
+```
+
+## Step 5 — Inspect the used range
+
+`naturo excel info` reports the dimensions of the data area — handy before
+reading a sheet whose size you don't know:
+
+```bash
+naturo excel info report.xlsx --sheet Sheet1
+```
+
+Expected output:
+
+```
+Sheet: Sheet1
+Used range: A1:B4
+Rows: 4, Columns: 2
+```
+
+## Step 6 — Create a chart from the data
+
+`naturo excel create-chart` draws a chart from a source range. The `--range` is
+required; `--type` is one of `bar`, `column`, `line`, `pie`, `area`, `scatter`
+(default `column`). `--anchor` places the chart's top-left corner, and `--title`
+sets its title.
+
+```bash
+naturo excel create-chart report.xlsx \
+  --type column \
+  --range "A1:B4" \
+  --sheet Sheet1 \
+  --title "Q1 Revenue" \
+  --anchor D2
+```
+
+Expected output:
+
+```
+Created column chart 'Chart 1' on sheet Sheet1 from A1:B4
+Anchor: D2
+```
+
+---
+
+## The complete flow (CLI)
+
+```bash
+# 1. Write a header + three rows (create the workbook on first write)
+naturo excel write report.xlsx A1 "Month"   --create
+naturo excel write report.xlsx B1 "Revenue"
+naturo excel write report.xlsx A2 "Jan"
+naturo excel write report.xlsx B2 1200
+naturo excel write report.xlsx A3 "Feb"
+naturo excel write report.xlsx B3 1750
+naturo excel write report.xlsx A4 "Mar"
+naturo excel write report.xlsx B4 1500
+
+# 2. Read it back
+naturo excel read report.xlsx "A1:B4"
+
+# 3. Inspect the used range
+naturo excel info report.xlsx
+
+# 4. Chart it
+naturo excel create-chart report.xlsx --type column --range "A1:B4" \
+  --title "Q1 Revenue" --anchor D2
+```
+
+Every command accepts `-j`/`--json` for machine-readable output — pipe it into
+`jq` or a script when you're wiring this into a pipeline:
+
+```bash
+naturo excel read report.xlsx "A1:B4" --json
+```
+
+---
+
+## The same flow in Python
+
+The Excel operations live in the `naturo.excel` module — the exact functions the
+CLI calls, so the Python path can't drift from the commands above. Import them
+directly:
+
+```python
+from naturo.excel import (
+    excel_write, excel_read, excel_get_range_info, excel_create_chart,
+)
+
+# Write a header + three data rows (create the workbook if missing).
+excel_write("report.xlsx", "A1", "Month", create=True)
+excel_write("report.xlsx", "B1", "Revenue")
+for i, (month, rev) in enumerate([("Jan", 1200), ("Feb", 1750), ("Mar", 1500)], start=2):
+    excel_write("report.xlsx", f"A{i}", month)
+    excel_write("report.xlsx", f"B{i}", rev)
+
+# Read the range back — returns a dict with a "value" that's a list of rows.
+result = excel_read("report.xlsx", "A1:B4", sheet="Sheet1")
+for row in result["value"]:
+    print(row)
+
+# Inspect the used range.
+info = excel_get_range_info("report.xlsx", sheet="Sheet1")
+print("Used range:", info["used_range"], "-", info["rows"], "rows")
+
+# Chart it.
+excel_create_chart("report.xlsx", "A1:B4", chart_type="column",
+                   sheet="Sheet1", title="Q1 Revenue", anchor="D2")
+```
+
+Run it through naturo's runner so imports resolve cleanly:
+
+```bash
+naturo run excel_report.py
+```
+
+> **Macros:** if your workbook (`.xlsm`) has VBA, run a macro with
+> `naturo excel run-macro report.xlsm "Module1.FormatReport"` — pass macro
+> arguments with repeatable `--arg` flags.
+
+---
+
+## Next steps
+
+- **Automate a native app first?** Start with
+  [Tutorial 1 — Automate Notepad in 5 minutes](01-automate-notepad.md).
+- **Build an AI agent** that reads/writes Excel through naturo's MCP tools:
+  [Tutorial 3 — Build an AI agent with naturo](03-ai-agent-with-naturo.md).
+- **Supported apps & adaptation** — [docs/SUPPORTED_APPS.md](../SUPPORTED_APPS.md).
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| `EXCEL_ERROR` / COM error on any command | Confirm Microsoft Excel is installed and `pip install pywin32` succeeded. |
+| "Workbook not found" on `write`/`read` | Pass `--create` on the first `write` to create the file, or give the full path to an existing workbook. |
+| Range read returns fewer rows than expected | Run `naturo excel info` first to see the true used range, then read that. |
+| A cell you wrote shows as text, not a number | naturo converts numeric *strings* to numbers on write; pass the bare number (`1200`, not `"1200"`) if you want it numeric. |

--- a/docs/tutorials/03-ai-agent-with-naturo.md
+++ b/docs/tutorials/03-ai-agent-with-naturo.md
@@ -1,0 +1,239 @@
+# Tutorial 3 — Build an AI Agent That Uses naturo
+
+**What you'll build:** an AI agent that can see and drive the Windows desktop by
+calling naturo. You'll do it two ways: (1) the **zero-code** path — run naturo as
+an MCP server and point Claude Desktop (or Claude Code) at it, so Claude gets
+60+ desktop tools automatically; and (2) the **code** path — a minimal Python
+tool-use loop that hands Claude a couple of naturo actions and lets it decide
+when to call them. By the end you'll understand how naturo turns any MCP-capable
+model into a desktop agent, and how to wire naturo tools into your own agent loop.
+
+> **Time:** ~15 minutes. **Platform:** Windows 10/11. **Python:** 3.9+.
+
+## Prerequisites
+
+```bash
+pip install naturo
+```
+
+naturo's MCP server ships in the box. Pull in the MCP runtime dependency once:
+
+```bash
+naturo mcp install
+```
+
+Confirm the server can enumerate its tools without starting a session:
+
+```bash
+naturo mcp tools
+```
+
+Expected output (truncated):
+
+```
+Naturo MCP Server — 60+ tools available:
+
+  launch_app            Launch an application by name.
+  see_ui_tree           Read a window's UI as a structured element tree...
+  type_text             Type text into a target window (or the focused window).
+  press_key             Press a key or key combination.
+  click                 Click at coordinates or on a UI element.
+  capture_window        Capture a screenshot of a specific window.
+  list_windows          List all visible windows on the desktop.
+  ...
+```
+
+Those tool names (`launch_app`, `see_ui_tree`, `type_text`, `press_key`,
+`click`, `capture_window`, `list_windows`, …) are the real MCP surface — they're
+what an AI agent calls.
+
+---
+
+## Path 1 — Run naturo as an MCP server (zero code)
+
+### (a) The one-liner
+
+The MCP server speaks stdio by default (the transport AI agents expect):
+
+```bash
+naturo mcp start
+```
+
+That's the whole server. Agents launch it for you via their MCP config, so you
+rarely run it by hand — but this is the command every config below invokes.
+
+### (b) Point Claude Code at it
+
+One line, then restart Claude Code:
+
+```bash
+claude mcp add naturo -- naturo mcp start
+```
+
+### (c) Point Claude Desktop at it
+
+Add naturo to `claude_desktop_config.json`, then restart Claude Desktop:
+
+```json
+{
+  "mcpServers": {
+    "naturo": {
+      "command": "naturo",
+      "args": ["mcp", "start"]
+    }
+  }
+}
+```
+
+> **Config file location:**
+> - Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+> - macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+
+This config is exactly what naturo's shipped Claude Desktop bundle
+(`packaging/mcpb/manifest.json`) and its MCP registry manifest (`server.json`)
+declare — both run `naturo mcp start` over stdio. So whether you install the
+`.mcpb` bundle or hand-write the config above, the agent ends up talking to the
+same server.
+
+### (d) Try it
+
+Open a chat with Claude (Desktop or Code) and ask:
+
+> Open Notepad, type "Hello from my agent", and save it as `agent-demo.txt`.
+> Tell me when the title bar shows the saved file name.
+
+Claude drives naturo's MCP tools to do it — under the hood it runs the same
+`launch_app` → `type_text` → `press_key` sequence you'd script by hand, and every
+naturo input tool re-reads the UI after acting and reports `"verified": true`
+only when the change actually landed. If an action didn't take effect, the tool
+returns `"success": false` instead of pretending — so the agent never claims it
+worked when it didn't.
+
+---
+
+## Path 2 — Drive naturo from your own agent loop (Python)
+
+If you're building your own agent instead of using Claude Desktop, you give the
+model a set of tools and run the tool-use loop yourself. The example below is a
+**minimal, illustrative** agent: it defines two tools that map to real naturo SDK
+functions (`naturo.launch` and `naturo.type`), then lets Claude decide when to
+call them. It is deliberately small — a starting point, not a framework.
+
+```python
+# agent.py — illustrative: an Anthropic tool-use loop that drives naturo.
+# Requires: pip install naturo anthropic   (and an ANTHROPIC_API_KEY)
+import anthropic
+import naturo
+
+# Two naturo actions, exposed to the model as tools. Each maps to a REAL naturo
+# SDK function — no invented APIs.
+TOOLS = [
+    {
+        "name": "launch_app",
+        "description": "Launch a Windows application by name (e.g. 'notepad').",
+        "input_schema": {
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+            "required": ["name"],
+        },
+    },
+    {
+        "name": "type_text",
+        "description": "Type text into a target window (focuses it first).",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "text": {"type": "string"},
+                "window": {"type": "string", "description": "Window title (partial match)"},
+            },
+            "required": ["text", "window"],
+        },
+    },
+]
+
+
+def run_tool(name, args):
+    """Execute a tool call against naturo's SDK, return a short result string."""
+    if name == "launch_app":
+        app = naturo.launch(args["name"])
+        return f"launched {app.name} (pid {app.pid})"
+    if name == "type_text":
+        method = naturo.type(args["text"], window=args["window"])
+        return f"typed via {method}"
+    return f"unknown tool: {name}"
+
+
+client = anthropic.Anthropic()
+messages = [{
+    "role": "user",
+    "content": "Open Notepad and type 'Hello from my agent' into it.",
+}]
+
+# Standard tool-use loop: call the model, run any tools it asks for, feed the
+# results back, repeat until it stops calling tools.
+while True:
+    resp = client.messages.create(
+        model="claude-opus-5",
+        max_tokens=1024,
+        tools=TOOLS,
+        messages=messages,
+    )
+    messages.append({"role": "assistant", "content": resp.content})
+
+    if resp.stop_reason != "tool_use":
+        break
+
+    results = []
+    for block in resp.content:
+        if block.type == "tool_use":
+            output = run_tool(block.name, block.input)
+            results.append({
+                "type": "tool_result",
+                "tool_use_id": block.id,
+                "content": output,
+            })
+    messages.append({"role": "user", "content": results})
+
+# Print the model's final text.
+print("".join(b.text for b in resp.content if b.type == "text"))
+```
+
+Run it with naturo's runner so `import naturo` resolves without any environment
+setup:
+
+```bash
+naturo run agent.py
+```
+
+> **Why this stays honest:** the tool bodies call `naturo.launch` and
+> `naturo.type` — the same SDK verbs from
+> [Tutorial 1](01-automate-notepad.md). `naturo.type` routes through the
+> IME-immune ladder and returns the delivery method, so the tool result tells the
+> model *how* the text landed. Add more tools (`naturo.see`, `naturo.press`,
+> `naturo.click`, `naturo.capture`) the same way to widen what the agent can do.
+
+> **MCP vs. your own loop:** Path 1 gives the agent *all* 60+ naturo tools with
+> zero glue code and is the right default. Path 2 is for when you're embedding
+> desktop control inside your own application and want to choose exactly which
+> actions the model may take.
+
+---
+
+## Next steps
+
+- **Learn the verbs** the agent is calling, by hand first:
+  [Tutorial 1 — Automate Notepad](01-automate-notepad.md) and
+  [Tutorial 2 — Automate Excel](02-automate-excel.md).
+- **Full MCP tool reference** — every tool, its parameters, and worked examples:
+  [docs/MCP_SERVER.md](../MCP_SERVER.md).
+- **Agent integration guide** — [docs/AGENT_INTEGRATION.md](../AGENT_INTEGRATION.md).
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| Claude does not see naturo's tools | Restart the client after editing its MCP config; run `naturo mcp tools` to confirm the server starts and lists tools. |
+| `naturo mcp start` exits immediately | Run `naturo mcp install` to pull the MCP runtime dependency. |
+| `naturo: command not found` inside the config | naturo must be on the `PATH` the agent launches with. It is after `pip install naturo`; if the agent runs in a different environment, give the full path to the `naturo` executable in the config `command`. |
+| A tool reports `"success": false` | naturo refuses to fake success — read `error.message`; the window may not be focused yet or the target may not exist. |
+| The Python agent can't authenticate | Set `ANTHROPIC_API_KEY` in the environment before `naturo run agent.py`. The API example is illustrative — swap in whatever model/provider your app uses. |


### PR DESCRIPTION
Closes #415. Three guided walkthroughs in `docs/tutorials/`, linked from the README:
1. **01-automate-notepad.md** — "Automate Notepad in 5 minutes": see → click → type → save (notes the Win11 UWP/ApplicationFrameHost specifics, the IME-immune `type` path, and the Ctrl+S flow).
2. **02-automate-excel.md** — open → navigate → read/write cells with the real `excel` subcommands (exact A1/range syntax) + `excel create-chart`.
3. **03-ai-agent-with-naturo.md** — MCP server (`naturo mcp start`) + a Claude Desktop config matching the shipped `packaging/mcpb/manifest.json` + `server.json`, and an illustrative Anthropic tool-use example calling only real naturo SDK functions.

Each has a what-you'll-build intro, prerequisites, numbered steps with commands + expected output, a complete end-to-end script, and troubleshooting.

**API-grounded, not invented:** every CLI command, flag, SDK function (`naturo/sdk.py`), Excel command (`naturo/excel.py`), and MCP tool name (`naturo/mcp/`) was read/grepped against the source before use. Verified surfaces include `app launch --wait-until-ready`, `see --window --compact`, `type --app`, `press ctrl+s`, `wait --window`, `naturo run`, `excel read/write/create-chart`, `mcp start`, and MCP tools `launch_app/see_ui_tree/type_text/click/capture_window/list_windows`.

Docs-only (no code/tests/.github). Honest caveat: "expected output" strings (PIDs/HWNDs/exact success wording) are shape-illustrative — naturo wasn't run live (no desktop-input in the build) — but every command/flag/function/tool **name** is code-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)