### PR TITLE
feat(packaging): standalone naturo.exe via PyInstaller (#43)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,13 @@ naturo-screen-*.png
 dist/runtime/
 get-pip.py
 
+# Standalone naturo.exe (#43) — a PyInstaller onefile build artifact, rebuilt on
+# demand via scripts/build_exe.py / naturo.spec. build/ and dist/ are already
+# ignored above; these cover PyInstaller's onefile outputs explicitly.
+*.exe
+*.toc
+*.pkg
+
 # Working directory debug artifacts
 .work/*.png
 .work/*.log

--- a/docs/STANDALONE_EXE.md
+++ b/docs/STANDALONE_EXE.md
@@ -1,0 +1,145 @@
+# Standalone `naturo.exe` (#43)
+
+Naturo can ship as a **single-file Windows executable** — `naturo.exe` — that
+runs on a machine with **no pre-installed Python**. It is produced by
+[PyInstaller](https://pyinstaller.org/) in `--onefile` mode from the committed,
+reviewable spec `naturo.spec`.
+
+The exe is a **build artifact**: it is gitignored and never committed
+(`*.exe` in `.gitignore`, plus `build/` and `dist/`). Only the build tooling is
+committed.
+
+## Two pieces
+
+| Piece | Location | Committed? | Role |
+| --- | --- | --- | --- |
+| PyInstaller spec | `naturo.spec` | yes (source) | Declares the freeze: entry point, bundled DLL, hidden imports, data |
+| Build wrapper | `scripts/build_exe.py` | yes (source) | Runs the build, reports size, `--check` preflight |
+| The exe itself | `dist/naturo.exe` | **no — gitignored** | ~single-file build artifact, rebuilt on demand |
+
+## Build
+
+```
+python -m pip install pyinstaller     # one-time, into the build environment
+python scripts/build_exe.py           # -> dist/naturo.exe
+python scripts/build_exe.py --check   # validate spec + DLL, build nothing
+python scripts/build_exe.py --clean   # wipe build/ and dist/ first
+# equivalently, straight PyInstaller:
+pyinstaller naturo.spec
+```
+
+The wrapper prints the output path, the size, and warns if the exe exceeds the
+**80 MB** acceptance budget.
+
+### Size
+
+The onefile exe is **~79.5 MB** (verified build, naturo 0.3.2). The bulk is
+naturo's OCR / vision stack — OpenCV, NumPy, and ONNX Runtime (rapidocr) — which
+backs `see --ocr`, `find --image`, and cascade OCR. `naturo.spec` drops OpenCV's
+~29 MB FFmpeg video-I/O DLL (`opencv_videoio_ffmpeg*.dll`): naturo does
+still-image matching, never video decode, so it is dead weight. That trim is
+what keeps the exe under the 80 MB budget. Cold start is ~3.3 s (onefile
+unpacks to a temp dir on each launch).
+
+## What gets bundled
+
+PyInstaller's static import analysis finds most of naturo, but several things
+are pulled in dynamically or live outside the Python import graph. `naturo.spec`
+declares them explicitly:
+
+- **The native engine `naturo_core.dll`.** naturo loads it at runtime via
+  `Path(__file__).parent.parent / "bin" / "naturo_core.dll"`
+  (`naturo/bridge/_core.py`). Under a onefile freeze `__file__` resolves inside
+  the extracted `_MEIPASS` tree, so the spec bundles the DLL at `naturo/bin/`
+  and the **existing loader finds it with no code change**. The DLL is located
+  from the installed package (wheel RECORD / editable finder / package `bin/`),
+  never a hardcoded path.
+- **Dynamic-import deps** — `comtypes` (+ `comtypes.client`, `comtypes.gen`) for
+  COM/Excel, the `win32*` / `pywin32` family (`win32com.client`, `pythoncom`,
+  `win32gui`, …), `click`, and `PIL`. Declared as hidden imports;
+  `collect_submodules('comtypes')` sweeps its submodules.
+- **The MCP server** (`naturo mcp start`) — `collect_submodules('mcp')` so
+  FastMCP and its stdio transport resolve when frozen.
+- **naturo's own submodules** — `collect_submodules('naturo')` for backends/CLI
+  subcommands that import lazily.
+- **Package data** — the built-in selector JSON under
+  `naturo/selectors_builtin/` via `collect_data_files('naturo')`.
+- **Distribution metadata** — `copy_metadata('naturo')` (and `mcp`) so
+  `importlib.metadata.version(...)` resolves inside the frozen app.
+
+## Verify it runs standalone
+
+```
+dist\naturo.exe --version     # -> naturo, version 0.3.2
+dist\naturo.exe --help        # -> full CLI help (click command tree bundled)
+```
+
+`--version` printing on its own proves the frozen CPython interpreter and the
+naturo import both work with **no system Python invoked**. A brief
+`naturo mcp start` stdio `initialize` handshake additionally proves the native
+DLL and the `mcp` deps loaded.
+
+## Relationship to the embedded runtime (#41) and the resolver (#997)
+
+Naturo has **two** "no system Python" delivery mechanisms; they are
+complementary, not duplicates:
+
+| | `naturo.exe` (#43) | Embedded runtime (#41) |
+| --- | --- | --- |
+| Shape | one frozen executable | a `~40 MB` CPython tree with naturo installed |
+| Built by | `naturo.spec` / `scripts/build_exe.py` | `scripts/bundle_python.py` |
+| Interpreter | PyInstaller's frozen bootloader | a real, unpacked `python.exe` |
+| Best for | drop-in CLI, easiest distribution | running arbitrary `python -m ...`, extensibility |
+
+The runtime **resolver** (`naturo/runtime/resolver.py`, #997) decides, at
+runtime, between a system Python and the embedded one. `naturo.exe` sidesteps
+that choice entirely: it carries its own frozen interpreter, so no resolution
+happens. The DLL-loading contract, however, is shared — both paths rely on the
+same `naturo/bin/naturo_core.dll` layout, which is why bundling the DLL at
+`naturo/bin/` inside the freeze is all that is required.
+
+## CI release step (workflow-scope — maintainer applies)
+
+The exe is not built in CI yet. A release job would install the published wheel
+(so the native DLL is present) and PyInstaller, then build and upload the exe as
+a release asset. Add to the release workflow (`.github/workflows/…`):
+
+```yaml
+  build-standalone-exe:
+    runs-on: windows-latest
+    needs: [build]  # after the wheel is built/published
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install naturo (wheel, brings the native DLL) + PyInstaller
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "naturo==${{ github.ref_name }}" pyinstaller
+      - name: Build naturo.exe
+        run: python scripts/build_exe.py
+      - name: Smoke-test the exe
+        run: |
+          dist\naturo.exe --version
+          dist\naturo.exe --help
+      - name: Upload standalone exe
+        uses: actions/upload-artifact@v4
+        with:
+          name: naturo-exe
+          path: dist/naturo.exe
+      # For a tagged release, attach it instead:
+      # - uses: softprops/action-gh-release@v2
+      #   with: { files: dist/naturo.exe }
+```
+
+## Deferred
+
+- **Code-signing** (#50) — the exe is unsigned, so SmartScreen/AV will warn on
+  first run on a clean machine. Signing needs an Authenticode certificate;
+  `naturo.spec` leaves `codesign_identity=None` for a signing step to fill in.
+- **Clean-machine test** — building here proves the freeze works on the build
+  host. Confirming it runs on a machine with **no Python at all** is a manual
+  step (a fresh VM / a colleague's box) tracked separately.
+- **CI artifact upload** — the YAML above is the intended shape; a maintainer
+  wires it into the release workflow (this change does not touch `.github/`).

--- a/naturo.spec
+++ b/naturo.spec
@@ -1,0 +1,188 @@
+# -*- mode: python ; coding: utf-8 -*-
+"""PyInstaller spec for the standalone naturo.exe (issue #43).
+
+Freezes ``naturo/__main__.py`` (``from naturo.cli import run; run()``) into a
+single-file ``naturo.exe`` that runs on a machine with NO system Python. The
+produced exe is a BUILD ARTIFACT — gitignored, never committed (see .gitignore
+and docs/STANDALONE_EXE.md). This spec is the committed, reviewable source.
+
+Build:
+    pyinstaller naturo.spec
+    # or the wrapper, which also reports size / budget:
+    python scripts/build_exe.py
+
+What this spec takes care of that PyInstaller's static analysis misses:
+
+* The native engine ``naturo_core.dll``. naturo loads it at runtime via
+  ``Path(__file__).parent.parent / "bin" / "naturo_core.dll"`` (see
+  naturo/bridge/_core.py). Under a onefile freeze ``__file__`` resolves inside
+  the extracted _MEIPASS tree, so bundling the DLL at ``naturo/bin/`` makes the
+  EXISTING loader find it with no code change.
+* Dynamic-import deps: ``comtypes`` (COM / Excel), the ``win32*`` / pywin32
+  family, and ``mcp`` (the ``naturo mcp start`` server). These are imported
+  lazily / conditionally, so they are declared as hidden imports and collected.
+* naturo's own submodules — CLI subcommands and backends are wired up at import
+  time but some backends import lazily; ``collect_submodules('naturo')`` pulls
+  them all in.
+* Package data: the built-in selector JSON under ``naturo/selectors_builtin/``
+  and any other bundled resources, via ``collect_data_files('naturo')``.
+* Distribution metadata for ``naturo`` (and ``mcp``) so ``importlib.metadata``
+  version lookups resolve inside the frozen app.
+"""
+import sys
+from pathlib import Path
+
+from PyInstaller.utils.hooks import (
+    collect_data_files,
+    collect_submodules,
+    copy_metadata,
+)
+
+
+def _resolve_core_dll() -> Path:
+    """Locate ``naturo_core.dll`` from the INSTALLED naturo package.
+
+    Resolved from the package (never a hardcoded path) so the build works
+    wherever naturo is installed. The DLL ships in the wheel under
+    ``naturo/bin/``. Tried in order, first existing wins — robust across a
+    normal wheel install, an editable install, and a source checkout that
+    shadows the install on ``sys.path``:
+
+    1. the imported package's ``bin/`` (the wheel-install case);
+    2. the distribution's RECORD (wheel install, even when the import above is
+       shadowed by a source checkout on the path);
+    3. the setuptools editable finder's ``MAPPING`` (editable install whose real
+       source dir differs from the shadowing checkout).
+    """
+    candidates: list[Path] = []
+
+    try:
+        import naturo
+
+        candidates.append(Path(naturo.__file__).resolve().parent / "bin" / "naturo_core.dll")
+    except Exception:
+        pass
+
+    try:
+        from importlib import metadata
+
+        dist = metadata.distribution("naturo")
+        for f in dist.files or []:
+            if f.name.lower() == "naturo_core.dll":
+                candidates.append(Path(dist.locate_file(f)))
+    except Exception:
+        pass
+
+    for finder in list(sys.meta_path):
+        mod = sys.modules.get(getattr(finder, "__module__", ""))
+        mapping = getattr(mod, "MAPPING", None)
+        if isinstance(mapping, dict) and "naturo" in mapping:
+            candidates.append(Path(mapping["naturo"]) / "bin" / "naturo_core.dll")
+
+    for cand in candidates:
+        if cand.exists():
+            return cand.resolve()
+
+    raise SystemExit(
+        "naturo_core.dll not found (searched: "
+        + ", ".join(str(c) for c in candidates)
+        + "). Install the naturo wheel (which bundles the native engine) before "
+        "building: pip install naturo"
+    )
+
+
+_dll = _resolve_core_dll()
+
+# Bundle the DLL at naturo/bin/ INSIDE the frozen tree so the existing runtime
+# loader (Path(__file__).parent.parent / 'bin') finds it unchanged.
+binaries = [(str(_dll), "naturo/bin")]
+
+# --- Data files + metadata ----------------------------------------------------
+datas = []
+datas += collect_data_files("naturo")  # selectors_builtin/*.json, etc.
+datas += copy_metadata("naturo")       # importlib.metadata.version("naturo")
+try:
+    datas += copy_metadata("mcp")
+except Exception:
+    pass  # mcp metadata optional; the mcp server still imports without it
+
+# --- Hidden imports -----------------------------------------------------------
+# PyInstaller's static analysis misses lazy / conditional imports. Declare them.
+hiddenimports = []
+hiddenimports += collect_submodules("naturo")     # all naturo subpackages
+hiddenimports += collect_submodules("comtypes")   # comtypes.client, comtypes.gen, ...
+hiddenimports += [
+    # pywin32 family naturo touches (win32com.client, pythoncom, win32gui, ...)
+    "win32com",
+    "win32com.client",
+    "win32gui",
+    "win32api",
+    "pythoncom",
+    "pywintypes",
+    # CLI + imaging + protocol deps that may be pulled in dynamically
+    "click",
+    "PIL",
+    "PIL.Image",
+]
+# The MCP server (naturo mcp start) — collect the whole package so FastMCP and
+# its transports resolve when frozen. Guarded: a build without mcp still works
+# for the non-mcp CLI surface.
+try:
+    hiddenimports += collect_submodules("mcp")
+except Exception:
+    pass
+
+
+block_cipher = None
+
+a = Analysis(
+    ["naturo/__main__.py"],
+    pathex=[],
+    binaries=binaries,
+    datas=datas,
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+
+# --- Trim safe-to-drop bloat --------------------------------------------------
+# opencv-python ships a ~29 MB FFmpeg video-I/O DLL (opencv_videoio_ffmpeg*.dll).
+# naturo uses OpenCV only for still-image template matching and OCR
+# pre-processing (find --image, see --ocr) — never video decode — so this DLL is
+# dead weight in the freeze. Dropping it keeps OpenCV fully functional for
+# naturo's use and brings the exe under the size budget.
+_EXCLUDE_BINARY_SUBSTRINGS = ("opencv_videoio_ffmpeg",)
+a.binaries = [
+    b for b in a.binaries
+    if not any(sub in b[0].lower() for sub in _EXCLUDE_BINARY_SUBSTRINGS)
+]
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    [],
+    name="naturo",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)

--- a/scripts/build_exe.py
+++ b/scripts/build_exe.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Build the standalone ``naturo.exe`` via PyInstaller (issue #43).
+
+Freezes ``naturo/__main__.py`` into a single-file ``naturo.exe`` that runs on a
+machine with NO system Python, bundling the native ``naturo_core.dll`` and the
+dynamic-import deps (comtypes / pywin32 / mcp) PyInstaller's static analysis
+misses. The build is driven by the committed, reviewable ``naturo.spec``.
+
+The produced exe (``dist/naturo.exe``) is a BUILD ARTIFACT — gitignored, never
+committed (see .gitignore and docs/STANDALONE_EXE.md).
+
+Usage::
+
+    python scripts/build_exe.py           # build dist/naturo.exe
+    python scripts/build_exe.py --check    # validate spec + DLL, build nothing
+    python scripts/build_exe.py --clean    # remove build/ and dist/ first
+
+Proxy: not needed — PyInstaller and all deps must already be installed
+(``pip install pyinstaller``). This script only invokes the local toolchain.
+"""
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SPEC = REPO_ROOT / "naturo.spec"
+DIST = REPO_ROOT / "dist"
+BUILD = REPO_ROOT / "build"
+EXE = DIST / "naturo.exe"
+
+# Acceptance-criteria size budget for the onefile exe (issue #43).
+SIZE_BUDGET_MB = 80.0
+
+
+def _resolve_dll() -> Path:
+    """Locate ``naturo_core.dll`` from the installed naturo package.
+
+    Resolved from the package (never a hardcoded path) so the build works
+    wherever naturo is installed. Tried in order, first existing wins — robust
+    across a normal wheel install, an editable install, and a source checkout
+    that shadows the install on ``sys.path`` (mirrors naturo.spec).
+    """
+    candidates: list[Path] = []
+
+    try:
+        import naturo
+
+        candidates.append(Path(naturo.__file__).resolve().parent / "bin" / "naturo_core.dll")
+    except Exception:
+        pass
+
+    try:
+        from importlib import metadata
+
+        dist = metadata.distribution("naturo")
+        for f in dist.files or []:
+            if f.name.lower() == "naturo_core.dll":
+                candidates.append(Path(dist.locate_file(f)))
+    except Exception:
+        pass
+
+    for finder in list(sys.meta_path):
+        mod = sys.modules.get(getattr(finder, "__module__", ""))
+        mapping = getattr(mod, "MAPPING", None)
+        if isinstance(mapping, dict) and "naturo" in mapping:
+            candidates.append(Path(mapping["naturo"]) / "bin" / "naturo_core.dll")
+
+    for cand in candidates:
+        if cand.exists():
+            return cand.resolve()
+
+    raise SystemExit(
+        "naturo_core.dll not found (searched: "
+        + ", ".join(str(c) for c in candidates)
+        + ").\nInstall the naturo wheel (which bundles the native engine) first: "
+        "pip install naturo"
+    )
+
+
+def _check_pyinstaller() -> str:
+    """Return the installed PyInstaller version, or exit with guidance."""
+    try:
+        import PyInstaller  # noqa: N813
+    except ImportError:
+        raise SystemExit(
+            "PyInstaller is not installed. Install it into this environment:\n"
+            "    python -m pip install pyinstaller"
+        )
+    return PyInstaller.__version__
+
+
+def check() -> None:
+    """Validate the build inputs without producing anything."""
+    version = _check_pyinstaller()
+    dll = _resolve_dll()
+    if not SPEC.exists():
+        raise SystemExit(f"Spec not found: {SPEC}")
+    import naturo
+    from naturo.version import __version__ as naturo_version
+
+    print("naturo.exe build — preflight check")
+    print(f"  PyInstaller : {version}")
+    print(f"  naturo      : {naturo_version}  ({Path(naturo.__file__).parent})")
+    print(f"  native DLL  : {dll}  ({dll.stat().st_size / 1024:.0f} KB)")
+    print(f"  spec        : {SPEC}")
+    print("OK — ready to build (run without --check).")
+
+
+def build(clean: bool) -> int:
+    """Run PyInstaller against naturo.spec and report the result."""
+    version = _check_pyinstaller()
+    dll = _resolve_dll()
+    print(f"PyInstaller {version}; bundling native DLL {dll.name}")
+
+    if clean:
+        for path in (BUILD, DIST):
+            if path.exists():
+                print(f"Removing {path}")
+                shutil.rmtree(path, ignore_errors=True)
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "PyInstaller",
+        "--noconfirm",
+        str(SPEC),
+    ]
+    print("Running:", " ".join(cmd))
+    result = subprocess.run(cmd, cwd=str(REPO_ROOT))
+    if result.returncode != 0:
+        print(f"PyInstaller failed (exit {result.returncode}).", file=sys.stderr)
+        return result.returncode
+
+    if not EXE.exists():
+        print(f"Build reported success but {EXE} is missing.", file=sys.stderr)
+        return 1
+
+    size_mb = EXE.stat().st_size / (1024 * 1024)
+    print()
+    print(f"Built: {EXE}")
+    print(f"Size : {size_mb:.1f} MB")
+    if size_mb > SIZE_BUDGET_MB:
+        print(
+            f"WARNING: exceeds the {SIZE_BUDGET_MB:.0f} MB acceptance budget "
+            f"by {size_mb - SIZE_BUDGET_MB:.1f} MB.",
+            file=sys.stderr,
+        )
+    else:
+        print(f"Within the {SIZE_BUDGET_MB:.0f} MB budget.")
+    print()
+    print("Verify it runs standalone:")
+    print(f"    {EXE} --version")
+    print(f"    {EXE} --help")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="validate the spec + DLL presence without building",
+    )
+    parser.add_argument(
+        "--clean",
+        action="store_true",
+        help="remove build/ and dist/ before building",
+    )
+    args = parser.parse_args()
+
+    if args.check:
+        check()
+        return 0
+    return build(clean=args.clean)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Completes the distribution pillar (#41 → #997 → #42 → #43). `naturo.spec` + `scripts/build_exe.py` freeze `naturo/__main__.py` into a single-file **naturo.exe** that runs with no system Python.

## Live-verified on this host
- `dist/naturo.exe --version` → **`naturo, version 0.3.2`** (rc 0) — frozen interpreter + naturo import, no system Python.
- `dist/naturo.exe --help` → full CLI command tree (rc 0).
- `dist/naturo.exe mcp start` → answered MCP **`initialize` + `tools/list`** over stdio (tools incl. `capture_screen`) — proves the bundled **`naturo_core.dll`** + mcp/comtypes/pywin32 deps all load. (Handshake only; no desktop-input tool invoked; tree-killed after.)
- **79.5 MB** (under the 80 MB budget), ~3.3 s cold start.

## Engineering notes
- **DLL resolution** is robust across wheel / editable / shadowed-source layouts (3-tier: imported package `bin/` → distribution RECORD → setuptools editable MAPPING) — the naive `import naturo` picked the DLL-less worktree source under the editable install and failed the first build.
- **Size trim**: the first build was 90.7 MB (OpenCV + NumPy/OpenBLAS + ONNX Runtime, pulled in by naturo's OCR/vision — `see --ocr`, `find --image`). Those stay (core value); the spec drops only the 28.6 MB **FFmpeg video-I/O DLL** (naturo does still-image matching, never video) → 79.5 MB, OCR intact.
- **GBK host fix**: forced `encoding='utf-8'` on the stdio probe and `taskkill /F /T` for the onefile bootloader child.

The exe is a **build artifact** (gitignored); only `naturo.spec` + `scripts/build_exe.py` (`--check`/`--clean`) + `docs/STANDALONE_EXE.md` + `.gitignore` are committed. Nothing under `naturo/` or `.github/` changed.

## Deferred (gated)
- **Code-signing** (#50) — needs an Authenticode cert; spec leaves `codesign_identity=None`.
- **CI artifact upload** — a Windows release job, documented as a YAML snippet in `docs/STANDALONE_EXE.md` (workflow-scope push).
- **Clean-machine test** — a build-host run proves the freeze; the final "no Python at all" install test is manual.

Refs #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)