### PR TITLE
fix(read): raw-view fallback for ScrollViewer-wrapped multiline edit values (#1213)

### DIFF
--- a/core/src/element.cpp
+++ b/core/src/element.cpp
@@ -938,6 +938,119 @@ static IUIAutomationElement* find_element_by_id_or_role(
 }
 
 /**
+ * @brief Read an element's text via TextPattern (preferred) then ValuePattern.
+ *
+ * Helper for the raw-view ScrollViewer fallback (#1213). Returns true and fills
+ * @p out (JSON-escaped) only when a pattern yields a NON-EMPTY string; an empty
+ * result leaves @p out untouched and returns false. All COM interfaces are
+ * released on every path.
+ */
+static bool read_element_text_or_value(IUIAutomationElement* el,
+                                       std::string& out) {
+    if (!el) return false;
+
+    // TextPattern first (full document text for multi-line editors).
+    IUnknown* pat_unk = NULL;
+    if (SUCCEEDED(el->GetCurrentPattern(UIA_TextPatternId, &pat_unk)) && pat_unk) {
+        IUIAutomationTextPattern* txp = NULL;
+        if (SUCCEEDED(pat_unk->QueryInterface(
+                __uuidof(IUIAutomationTextPattern), (void**)&txp)) && txp) {
+            IUIAutomationTextRange* range = NULL;
+            if (SUCCEEDED(txp->get_DocumentRange(&range)) && range) {
+                BSTR text = NULL;
+                if (SUCCEEDED(range->GetText(1048576, &text)) && text) {
+                    if (SysStringLen(text) > 0) {
+                        out = json_escape(text);
+                        SysFreeString(text);
+                        range->Release();
+                        txp->Release();
+                        pat_unk->Release();
+                        return true;
+                    }
+                    SysFreeString(text);
+                }
+                range->Release();
+            }
+            txp->Release();
+        }
+        pat_unk->Release();
+    }
+
+    // ValuePattern next.
+    pat_unk = NULL;
+    if (SUCCEEDED(el->GetCurrentPattern(UIA_ValuePatternId, &pat_unk)) && pat_unk) {
+        IUIAutomationValuePattern* vp = NULL;
+        if (SUCCEEDED(pat_unk->QueryInterface(
+                __uuidof(IUIAutomationValuePattern), (void**)&vp)) && vp) {
+            BSTR val = NULL;
+            if (SUCCEEDED(vp->get_CurrentValue(&val)) && val) {
+                if (SysStringLen(val) > 0) {
+                    out = json_escape(val);
+                    SysFreeString(val);
+                    vp->Release();
+                    pat_unk->Release();
+                    return true;
+                }
+                SysFreeString(val);
+            }
+            vp->Release();
+        }
+        pat_unk->Release();
+    }
+
+    return false;
+}
+
+/**
+ * @brief Bounded raw-view DFS for an inner Edit/Document with readable text.
+ *
+ * Helper for the ScrollViewer fallback (#1213). Some multiline controls expose
+ * only a ScrollViewer (Pane, 50033) at the text location in the UIA CONTROL
+ * view; the inner Edit/Document that actually holds the text is hidden from the
+ * control view but present in the RAW view. Walks @p walker (the RawViewWalker)
+ * depth-first under @p element looking for an Edit (50004) or Document (50030)
+ * descendant whose TextPattern/ValuePattern yields non-empty text.
+ *
+ * Bounded to avoid hanging on a huge tree: descends at most @p max_depth levels
+ * and visits at most @p budget nodes total (decremented across the recursion).
+ * Returns true and fills @p out on the first hit.
+ */
+static bool raw_view_find_inner_text(IUIAutomationTreeWalker* walker,
+                                     IUIAutomationElement* element,
+                                     int depth, int max_depth,
+                                     int& budget, std::string& out) {
+    if (!walker || !element || depth > max_depth || budget <= 0) return false;
+
+    IUIAutomationElement* child = NULL;
+    HRESULT hr = walker->GetFirstChildElement(element, &child);
+    while (SUCCEEDED(hr) && child && budget > 0) {
+        --budget;
+
+        CONTROLTYPEID ct = 0;
+        child->get_CurrentControlType(&ct);
+        if (ct == UIA_EditControlTypeId || ct == UIA_DocumentControlTypeId) {
+            if (read_element_text_or_value(child, out)) {
+                child->Release();
+                return true;
+            }
+        }
+
+        if (raw_view_find_inner_text(walker, child, depth + 1, max_depth,
+                                     budget, out)) {
+            child->Release();
+            return true;
+        }
+
+        IUIAutomationElement* next = NULL;
+        hr = walker->GetNextSiblingElement(child, &next);
+        child->Release();
+        child = next;
+    }
+    if (child) child->Release();
+    return false;
+}
+
+/**
  * @brief Query UIA patterns on an element and build a value JSON response.
  *
  * Tries patterns in priority order: Value, Text, Toggle, Selection, RangeValue.
@@ -1182,6 +1295,52 @@ NATURO_API int naturo_get_element_value(uintptr_t hwnd,
                 txp->Release();
             }
             pat_unk->Release();
+        }
+    }
+
+    // 6) (#1213) Raw-view fallback for ScrollViewer-wrapped multiline edits.
+    //    Some multiline controls (e.g. SolidWorks Property Tab Builder) expose
+    //    only a ScrollViewer (Pane, 50033) at the text location in the UIA
+    //    CONTROL view; it advertises Value/Text yet every pattern above reads
+    //    empty, and the inner Edit/Document that holds the text is hidden from
+    //    the control view. ONLY when all control-view attempts returned empty
+    //    AND the element advertises Value/Text (the ScrollViewer signature),
+    //    walk the RAW view for an inner Edit/Document descendant and read its
+    //    text. Strictly additive: elements that already read a value never reach
+    //    this branch, so their behavior is unchanged.
+    if (!has_value) {
+        bool advertises = false;
+        VARIANT v_avail;
+        VariantInit(&v_avail);
+        if (SUCCEEDED(elem->GetCurrentPropertyValue(
+                UIA_IsValuePatternAvailablePropertyId, &v_avail)) &&
+            v_avail.vt == VT_BOOL && v_avail.boolVal == VARIANT_TRUE) {
+            advertises = true;
+        }
+        VariantClear(&v_avail);
+        if (!advertises) {
+            VariantInit(&v_avail);
+            if (SUCCEEDED(elem->GetCurrentPropertyValue(
+                    UIA_IsTextPatternAvailablePropertyId, &v_avail)) &&
+                v_avail.vt == VT_BOOL && v_avail.boolVal == VARIANT_TRUE) {
+                advertises = true;
+            }
+            VariantClear(&v_avail);
+        }
+        if (advertises) {
+            IUIAutomationTreeWalker* raw_walker = NULL;
+            hr = uia->get_RawViewWalker(&raw_walker);
+            if (SUCCEEDED(hr) && raw_walker) {
+                int budget = 200;   // cap total raw-view nodes visited
+                std::string inner;
+                if (raw_view_find_inner_text(raw_walker, elem, 0, 6,
+                                             budget, inner)) {
+                    value = inner;
+                    has_value = true;
+                    pattern_name = "\"RawViewFallback\"";
+                }
+                raw_walker->Release();
+            }
         }
     }
 

--- a/naturo/backends/windows/_input/_uia_interact.py
+++ b/naturo/backends/windows/_input/_uia_interact.py
@@ -526,6 +526,96 @@ class UIAInteractMixin:
         except (COMError, AttributeError, OSError, ValueError):
             return None
 
+    def _read_text_or_value_uia(self, elem, mod) -> Optional[str]:
+        """Read non-empty text from an element via TextPattern then ValuePattern.
+
+        Helper for the raw-view ScrollViewer fallback (#1213). Prefers
+        TextPattern (full document text) and falls back to ValuePattern; returns
+        the text, or ``None`` when neither pattern yields a non-empty string.
+        """
+        try:
+            from comtypes import COMError  # type: ignore[import-untyped]
+        except ImportError:  # pragma: no cover - comtypes always present here
+            COMError = Exception  # type: ignore[assignment,misc]
+        # TextPattern first (full document text for multi-line editors).
+        try:
+            tp = self._get_uia_pattern(
+                elem, mod.UIA_TextPatternId, mod.IUIAutomationTextPattern)
+            if tp is not None:
+                text = tp.DocumentRange.GetText(-1)
+                if text:
+                    return text
+        except (COMError, AttributeError):
+            pass
+        # ValuePattern next.
+        try:
+            vp = self._get_uia_pattern(
+                elem, mod.UIA_ValuePatternId, mod.IUIAutomationValuePattern)
+            if vp is not None:
+                val = vp.CurrentValue
+                if val:
+                    return val
+        except (COMError, AttributeError):
+            pass
+        return None
+
+    def _raw_view_find_inner_text(
+        self, uia, mod, elem, max_depth: int = 6, budget: int = 200,
+    ) -> Optional[str]:
+        """Bounded raw-view DFS for an inner Edit/Document with readable text.
+
+        Helper for the ScrollViewer fallback (#1213). Some multiline controls
+        expose only a ScrollViewer (Pane, 50033) at the text location in the UIA
+        CONTROL view; the inner Edit (50004) / Document (50030) that holds the
+        text is hidden from the control view but present in the RAW view. Walks
+        the RawViewWalker depth-first under ``elem`` for such a descendant whose
+        TextPattern/ValuePattern yields non-empty text.
+
+        Bounded so it cannot hang on a huge tree: descends at most ``max_depth``
+        levels and visits at most ``budget`` nodes total. Returns the text of the
+        first hit, or ``None``.
+        """
+        try:
+            from comtypes import COMError  # type: ignore[import-untyped]
+        except ImportError:  # pragma: no cover - comtypes always present here
+            COMError = Exception  # type: ignore[assignment,misc]
+        try:
+            walker = uia.RawViewWalker
+        except (COMError, AttributeError):
+            return None
+        if not walker:
+            return None
+
+        # Iterative DFS with an explicit (element, depth) stack so a deep tree
+        # cannot blow the Python recursion limit. ``budget`` is shared across the
+        # whole walk to cap total nodes visited.
+        remaining = budget
+        stack = [(elem, 0)]
+        while stack and remaining > 0:
+            node, depth = stack.pop()
+            if depth >= max_depth:
+                continue
+            try:
+                child = walker.GetFirstChildElement(node)
+            except (COMError, AttributeError):
+                child = None
+            while child and remaining > 0:
+                remaining -= 1
+                try:
+                    ct = child.CurrentControlType
+                except (COMError, AttributeError):
+                    ct = 0
+                if ct in (50004, 50030):  # Edit / Document
+                    text = self._read_text_or_value_uia(child, mod)
+                    if text:
+                        return text
+                stack.append((child, depth + 1))
+                try:
+                    child = walker.GetNextSiblingElement(child)
+                except (COMError, AttributeError):
+                    child = None
+        return None
+
     def set_element_value(
         self,
         text: str,
@@ -804,6 +894,32 @@ class UIAInteractMixin:
                         pattern = "TogglePattern"
                 except (COMError, AttributeError):
                     pass
+            # (#1213) Raw-view fallback for ScrollViewer-wrapped multiline edits.
+            # Some controls expose only a ScrollViewer (Pane, 50033) at the text
+            # location in the control view; it advertises Value/Text yet every
+            # pattern above reads empty, and the inner Edit/Document is hidden
+            # from the control view. ONLY when the control-view read is still
+            # empty AND the element advertises Value/Text (the ScrollViewer
+            # signature) walk the raw view for an inner Edit/Document descendant.
+            # Strictly additive: elements that already read a value never reach
+            # this branch, so their behavior is unchanged.
+            if not value:
+                try:
+                    advertises = bool(
+                        getattr(elem, "CurrentIsValuePatternAvailable", False)
+                    ) or bool(
+                        getattr(elem, "CurrentIsTextPatternAvailable", False)
+                    )
+                except (COMError, AttributeError):
+                    advertises = False
+                if advertises:
+                    try:
+                        inner = self._raw_view_find_inner_text(uia, mod, elem)
+                    except (COMError, AttributeError):
+                        inner = None
+                    if inner:
+                        value = inner
+                        pattern = "RawViewFallback"
             if not value and _name:
                 value = _name
                 pattern = "Name"

--- a/tests/test_scrollviewer_read_1213.py
+++ b/tests/test_scrollviewer_read_1213.py
@@ -1,0 +1,262 @@
+"""Regression tests for #1213 — raw-view fallback for ScrollViewer-wrapped edits.
+
+Some multiline text controls expose only a ScrollViewer (ControlType 50033, a
+Pane) at the text location in the UIA *control* view. The ScrollViewer advertises
+Value/Text yet ValuePattern/TextPattern/Legacy all read empty, and the inner
+Edit/Document that actually holds the text is hidden from the control view but
+present in the RAW view. ``get_element_value_uia`` now, ONLY when every
+control-view attempt returned empty AND the element advertises Value/Text, walks
+the raw view for an inner Edit (50004) / Document (50030) descendant and reads
+its TextPattern/ValuePattern.
+
+These tests assert the fallback's SELECTION logic and — crucially — its
+non-regression guarantee (an element that already reads a value never triggers
+the raw-view walk), plus the depth/count bound on the raw-view search. They
+instantiate the backend and mock UIA, so they are desktop-independent and send
+no input.
+"""
+
+import platform
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    platform.system() != "Windows",
+    reason="UIA value read is Windows-only",
+)
+
+
+def _backend():
+    from naturo.backends.windows import WindowsBackend
+    return WindowsBackend.__new__(WindowsBackend)
+
+
+def _null_ptr():
+    """A comtypes-style NULL COM pointer: non-None but falsy."""
+    p = MagicMock()
+    p.__bool__.return_value = False
+    return p
+
+
+def _live_ptr(iface_obj):
+    """A live (truthy) COM pointer whose QueryInterface yields ``iface_obj``."""
+    p = MagicMock()
+    p.__bool__.return_value = True
+    p.QueryInterface.return_value = iface_obj
+    return p
+
+
+def _mod():
+    mod = MagicMock()
+    mod.UIA_ValuePatternId = 10002
+    mod.UIA_TextPatternId = 10014
+    mod.UIA_TogglePatternId = 10015
+    return mod
+
+
+def _text_pattern(text):
+    tp = MagicMock()
+    tp.DocumentRange.GetText.return_value = text
+    return tp
+
+
+def _value_pattern(val):
+    vp = MagicMock()
+    vp.CurrentValue = val
+    return vp
+
+
+def _elem(control_type, mod, patterns=None, name="", aid="",
+          adv_value=False, adv_text=False):
+    """A mock UIA element.
+
+    ``patterns`` maps a ``UIA_*PatternId`` to its live pattern iface; any pattern
+    not listed reports a NULL COM pointer (unsupported), exactly as comtypes does.
+    """
+    patterns = patterns or {}
+    e = MagicMock()
+    e.CurrentControlType = control_type
+    e.CurrentName = name
+    e.CurrentAutomationId = aid
+    e.CurrentIsValuePatternAvailable = adv_value
+    e.CurrentIsTextPatternAvailable = adv_text
+
+    def _get(pid):
+        if pid in patterns:
+            return _live_ptr(patterns[pid])
+        return _null_ptr()
+
+    e.GetCurrentPattern.side_effect = _get
+    return e
+
+
+def _walker(children_of):
+    """A RawViewWalker over ``children_of``: ``{id(parent): [child, ...]}``."""
+    walker = MagicMock()
+
+    def first(node):
+        kids = children_of.get(id(node), [])
+        return kids[0] if kids else None
+
+    def sibling(node):
+        for kids in children_of.values():
+            for i, k in enumerate(kids):
+                if k is node:
+                    return kids[i + 1] if i + 1 < len(kids) else None
+        return None
+
+    walker.GetFirstChildElement.side_effect = first
+    walker.GetNextSiblingElement.side_effect = sibling
+    return walker
+
+
+# ── the fallback engages when the control view reads empty ───────────────────
+
+
+class TestScrollViewerFallback:
+    def test_reads_inner_edit_via_raw_view(self):
+        """The #1213 case: a ScrollViewer (Pane, 50033) whose control-view read
+        is empty but advertises Text — the raw-view inner Edit carries the text.
+        The read must fall through to the raw-view fallback and return it."""
+        b = _backend()
+        mod = _mod()
+
+        inner_edit = _elem(
+            50004, mod, patterns={mod.UIA_TextPatternId: _text_pattern(
+                "line one\nline two")},
+        )
+        scrollviewer = _elem(
+            50033, mod, patterns={}, name="", adv_text=True,
+        )
+        walker = _walker({id(scrollviewer): [inner_edit]})
+        uia = MagicMock()
+        uia.RawViewWalker = walker
+
+        with patch.object(b, "_init_comtypes_uia", return_value=(uia, mod)), \
+             patch.object(b, "_resolve_interaction_element",
+                          return_value=scrollviewer):
+            out = b.get_element_value_uia(hwnd=1, x=10, y=20)
+
+        assert out is not None
+        assert out["value"] == "line one\nline two"
+        assert out["pattern"] == "RawViewFallback"
+
+    def test_inner_edit_read_via_valuepattern_when_no_text(self):
+        """The raw-view helper prefers TextPattern but falls back to ValuePattern
+        on the inner descendant."""
+        b = _backend()
+        mod = _mod()
+        inner_edit = _elem(
+            50004, mod,
+            patterns={mod.UIA_ValuePatternId: _value_pattern("val text")},
+        )
+        scrollviewer = _elem(50033, mod, adv_value=True)
+        walker = _walker({id(scrollviewer): [inner_edit]})
+        uia = MagicMock()
+        uia.RawViewWalker = walker
+
+        with patch.object(b, "_init_comtypes_uia", return_value=(uia, mod)), \
+             patch.object(b, "_resolve_interaction_element",
+                          return_value=scrollviewer):
+            out = b.get_element_value_uia(hwnd=1)
+
+        assert out["value"] == "val text"
+        assert out["pattern"] == "RawViewFallback"
+
+
+# ── non-regression: an element that already reads never triggers the walk ────
+
+
+class TestNonRegression:
+    def test_live_value_skips_raw_view_fallback(self):
+        """A normal Edit with a live ValuePattern reads through the existing path;
+        the raw-view fallback must NOT be invoked (proves it is strictly
+        additive)."""
+        b = _backend()
+        mod = _mod()
+        elem = _elem(
+            50004, mod,
+            patterns={mod.UIA_ValuePatternId: _value_pattern("visible")},
+            aid="txt", adv_value=True, adv_text=True,
+        )
+
+        spy = MagicMock()
+        with patch.object(b, "_init_comtypes_uia",
+                          return_value=(MagicMock(), mod)), \
+             patch.object(b, "_resolve_interaction_element", return_value=elem), \
+             patch.object(b, "_raw_view_find_inner_text", spy):
+            out = b.get_element_value_uia(hwnd=1, automation_id="txt")
+
+        assert out["value"] == "visible"
+        assert out["pattern"] == "ValuePattern"
+        spy.assert_not_called()
+
+    def test_no_advertised_patterns_skips_raw_view_fallback(self):
+        """An empty element that does NOT advertise Value/Text (not a
+        ScrollViewer) must not trigger the raw-view walk — the gate keeps the
+        fallback targeted."""
+        b = _backend()
+        mod = _mod()
+        elem = _elem(50033, mod, patterns={}, name="",
+                     adv_value=False, adv_text=False)
+
+        spy = MagicMock()
+        with patch.object(b, "_init_comtypes_uia",
+                          return_value=(MagicMock(), mod)), \
+             patch.object(b, "_resolve_interaction_element", return_value=elem), \
+             patch.object(b, "_raw_view_find_inner_text", spy):
+            out = b.get_element_value_uia(hwnd=1)
+
+        assert out is None
+        spy.assert_not_called()
+
+
+# ── the raw-view search is bounded (depth + count) ───────────────────────────
+
+
+class TestSearchBound:
+    def test_count_budget_stops_search(self):
+        """With a small node budget the walk stops before reaching a late Edit."""
+        b = _backend()
+        mod = _mod()
+        edit = _elem(
+            50004, mod,
+            patterns={mod.UIA_TextPatternId: _text_pattern("found")},
+        )
+        groups = [_elem(50026, mod) for _ in range(4)]  # four empty Groups
+        root = _elem(50033, mod, adv_text=True)
+        walker = _walker({id(root): groups + [edit]})  # Edit is the 5th child
+        uia = MagicMock()
+        uia.RawViewWalker = walker
+
+        # budget=3 visits only the first three Groups; the Edit is never reached.
+        assert b._raw_view_find_inner_text(uia, mod, root, budget=3) is None
+        # A generous budget finds it.
+        assert b._raw_view_find_inner_text(
+            uia, mod, root, budget=10) == "found"
+
+    def test_depth_bound_stops_search(self):
+        """An Edit nested below ``max_depth`` levels is not reached."""
+        b = _backend()
+        mod = _mod()
+        edit = _elem(
+            50004, mod,
+            patterns={mod.UIA_TextPatternId: _text_pattern("deep")},
+        )
+        n3 = _elem(50026, mod)
+        n2 = _elem(50026, mod)
+        n1 = _elem(50026, mod)
+        root = _elem(50033, mod, adv_text=True)
+        walker = _walker({
+            id(root): [n1], id(n1): [n2], id(n2): [n3], id(n3): [edit],
+        })
+        uia = MagicMock()
+        uia.RawViewWalker = walker
+
+        # Edit sits at level 4; a max_depth of 2 cannot reach it.
+        assert b._raw_view_find_inner_text(
+            uia, mod, root, max_depth=2) is None
+        # A deeper cap finds it.
+        assert b._raw_view_find_inner_text(
+            uia, mod, root, max_depth=10) == "deep"


### PR DESCRIPTION
Advances #1213. Some multiline controls expose only a **ScrollViewer** (ControlType 50033) in the UIA control view — ValuePattern/TextPattern/Legacy all read empty. Both readers now, **only when the control-view read returns empty** and the element advertises Value/Text, walk the **raw** view for an inner Edit/Document descendant (bounded depth 6 / 200 nodes) and read its TextPattern/ValuePattern.

- Native `core/src/element.cpp` — new step 6 via `RawViewWalker` + a `GetCurrentPropertyValue(UIA_Is*PatternAvailablePropertyId)` availability gate. DLL compiles clean.
- Python comtypes `get_element_value_uia` — mirror via `uia.RawViewWalker`, before the Name fallback.
- **Strictly additive / non-regressing**: guarded by `if (!has_value)` / `if not value:` so any element that already yields a value never reaches the branch. 6 new hermetic tests (fallback selection + non-regression + search bound) + 9 existing value-read regression tests pass; ruff + mypy clean.

**Refs #1213** (not Closes): the exact repro is SolidWorks Property Tab Builder, which isn't installed here, so the real ScrollViewer case can't be live-verified — this is a bounded, non-regressing best-effort fallback whose final verification against the real control is deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)